### PR TITLE
Improve file-opening experience

### DIFF
--- a/src/AccessibilityInsights.Actions/Actions/LoadAction.cs
+++ b/src/AccessibilityInsights.Actions/Actions/LoadAction.cs
@@ -26,8 +26,8 @@ namespace AccessibilityInsights.Actions
         /// <returns></returns>
         internal static LoadActionParts LoadSnapshotZip(string path)
         {
-            using (FileStream str = File.Open(path, FileMode.Open))
-            using (Package package = ZipPackage.Open(str, FileMode.Open))
+            using (FileStream str = File.Open(path, FileMode.Open, FileAccess.Read))
+            using (Package package = ZipPackage.Open(str, FileMode.Open, FileAccess.Read))
             {
                 var parts = package.GetParts();
 

--- a/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
@@ -517,7 +517,7 @@ namespace AccessibilityInsights
 
             var args = Environment.GetCommandLineArgs();
 
-            if (args.Length == 2)
+            if (args.Length > 1)
             {
                 path = args[1];
             }


### PR DESCRIPTION
- get file path even if additional arguments are passed upon startup
- only request read-access when loading snapshot; this allows ai-win to open test files from the windows mail client directly. Prior, we were getting this exception: "Access to the path 'C:\\Users\\...\\AppData\\Local\\Packages\\microsoft.windowscommunicationsapps\\...' is denied."