### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# default owners for everything in the repository.
+*   @Microsoft/accessibility-insights-windows-code-owners


### PR DESCRIPTION
Declare our team as [code owners ](https://help.github.com/articles/about-code-owners/) for the entire repo. Eventually, we could do more powerful things with this, like giving certain people more modular ownership. For now, this PR will not actually change any policies, since we already have a required reviewer PR policy. It will, however, auto-assign our team as a reviewer, which is behavior we are currently missing.
