### PR TITLE
Fix set delay settings accessibility issue

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
@@ -178,7 +178,7 @@
                 <StackPanel Grid.Column="3" Margin="30,0,0,0" Orientation="Horizontal">
                     <Label Name="lblDelay" Content="{x:Static Properties:Resources.lblDelayContent}" Padding="0" Style="{StaticResource LblText}" Target="{Binding ElementName=tbMouseDelay}"/>
                     <TextBox Name="tbMouseDelay" Height="16" Width="28" Margin="5,0,5,0" PreviewTextInput="textboxMouseDelay_PreviewTextInput" MaxLines="1" MaxLength="4" 
-                     VerticalContentAlignment="Center" Style="{StaticResource TxtBxText}" AutomationProperties.LabeledBy="{Binding ElementName=lblDelay}" TextChanged="tbMouseDelay_TextChanged"/>
+                     VerticalContentAlignment="Center" Style="{StaticResource TxtBxText}" AutomationProperties.Name="{x:Static Properties:Resources.tbMouseDelayAutomationName}" TextChanged="tbMouseDelay_TextChanged"/>
                     <Label Content="ms" Padding="0" Style="{StaticResource LblText}"/>
                 </StackPanel>
             </Grid>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3967,6 +3967,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Set delay in MS.
+        /// </summary>
+        public static string tbMouseDelayAutomationName {
+            get {
+                return ResourceManager.GetString("tbMouseDelayAutomationName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Execution result.
         /// </summary>
         public static string tbResultAutomationPropertiesName {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -297,6 +297,9 @@
   <data name="lblDelayContent" xml:space="preserve">
     <value>Set _delay</value>
   </data>
+  <data name="tbMouseDelayAutomationName" xml:space="preserve">
+    <value>Set delay in MS</value>
+  </data>
   <data name="LabelContentOtherOptions" xml:space="preserve">
     <value>Other options</value>
   </data>


### PR DESCRIPTION
The unit for set delay is visible but not read when the set delay textbox gets focus.