### PR TITLE
-- Automation properties don't change in data triggers

### DIFF
--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -290,7 +290,8 @@
                             </ComboBox>
                             <Button x:Name="btnHilighter"
                                 VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
-                                Click="onHilightButtonClicked">
+                                Click="onHilightButtonClicked"
+                                AutomationProperties.Name="{x:Static properties:Resources.btnHilighterAutomationPropertiesNameOn}">
                                 <i:Interaction.Behaviors>
                                     <behaviors:KeyboardToolTipButtonBehavior/>
                                 </i:Interaction.Behaviors>
@@ -306,7 +307,6 @@
                                                         </ToolTip>
                                                     </Setter.Value>
                                                 </Setter>
-                                                <Setter Property="AutomationProperties.Name" Value="{x:Static properties:Resources.btnHilighterAutomationPropertiesNameOn}"/>
                                             </DataTrigger>
                                             <DataTrigger Binding="{Binding Path=vmHilighter.State, Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:MainWindow}}" Value="Off">
                                                 <Setter Property="Button.ToolTip">
@@ -316,7 +316,6 @@
                                                         </ToolTip>
                                                     </Setter.Value>
                                                 </Setter>
-                                                <Setter Property="AutomationProperties.Name" Value="{x:Static properties:Resources.btnHilighterAutomationPropertiesNameOff}"/>
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -366,7 +365,8 @@
                             </Button>
                             <Button x:Name="btnPause"
                                 VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
-                                Click="btnPause_Click">
+                                Click="btnPause_Click"
+                                AutomationProperties.Name="{x:Static properties:Resources.btnPauseAutomationPropertiesNameOn}">
                                 <i:Interaction.Behaviors>
                                     <behaviors:KeyboardToolTipButtonBehavior/>
                                 </i:Interaction.Behaviors>
@@ -382,7 +382,6 @@
                                                         </ToolTip>
                                                     </Setter.Value>
                                                 </Setter>
-                                                <Setter Property="AutomationProperties.Name" Value="{x:Static properties:Resources.btnPauseAutomationPropertiesNameOn}"/>
                                             </DataTrigger>
                                             <DataTrigger Binding="{Binding Path=vmLiveModePauseResume.State, Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:MainWindow}}" Value="Off">
                                                 <Setter Property="Button.ToolTip">
@@ -392,7 +391,6 @@
                                                         </ToolTip>
                                                     </Setter.Value>
                                                 </Setter>
-                                                <Setter Property="AutomationProperties.Name" Value="{x:Static properties:Resources.btnPauseAutomationPropertiesNameOff}"/>
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -267,7 +267,16 @@ namespace AccessibilityInsights
         /// <param name="enabled"></param>
         internal void SetHighlightBtnState(bool enabled)
         {
-            this.vmHilighter.State = enabled ? ButtonState.On : ButtonState.Off;
+            if (enabled)
+            {
+                this.vmHilighter.State = ButtonState.On;
+                AutomationProperties.SetName(btnHilighter, Properties.Resources.btnHilighterAutomationPropertiesNameOn);
+            }
+            else
+            {
+                this.vmHilighter.State = ButtonState.Off;
+                AutomationProperties.SetName(btnHilighter, Properties.Resources.btnHilighterAutomationPropertiesNameOff);
+            }
             ConfigurationManager.GetDefaultInstance().AppConfig.IsHighlighterOn = enabled;
         }
 

--- a/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Windows;
+using System.Windows.Automation;
 using AccessibilityInsights.Actions.Sarif;
 
 namespace AccessibilityInsights
@@ -635,11 +636,13 @@ namespace AccessibilityInsights
             {
                 this.vmLiveModePauseResume.State = ButtonState.On;
                 SelectAction.GetDefaultInstance().ResumeUIATreeTracker();
+                AutomationProperties.SetName(btnPause, Properties.Resources.btnPauseAutomationPropertiesNameOn);
             }
             else
             {
                 this.vmLiveModePauseResume.State = ButtonState.Off;
                 SelectAction.GetDefaultInstance().PauseUIATreeTracker();
+                AutomationProperties.SetName(btnPause, Properties.Resources.btnPauseAutomationPropertiesNameOff);
             }
             UpdateMainWindowUI();
         }


### PR DESCRIPTION
- Automation properties don't change in data triggers.
- It needs to be changed in code behind.
- This is not just for the Pause button, but also the Highlighter's
- If you think we have any other automation properties depends on a data-trigger, please mention it in a comment.