### PR TITLE
Set system.debug to true in signedbuild.yaml

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -8,6 +8,7 @@ variables:
   PublicRelease: 'true'
   SignAppForRelease: 'true'
   TeamName: 'Accessibility Insights Windows'
+  system.debug: 'true' #set to true in case our signed build flakes out again
 
 jobs:
 - job: Release


### PR DESCRIPTION
We've been having some flakiness in our signed build. This sets system.debug to true in signedbuild.yaml so we can have some more info next time there is an issue.