### PR TITLE
Reduce extra noise in automation name

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1863,7 +1863,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to For questions or feedback: https://aka.ms/accessibilityinsights-stackoverflow.
+        ///   Looks up a localized string similar to questions or feedback.
         /// </summary>
         public static string hlLinkAutomationPropertiesName {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -391,7 +391,7 @@
     <value>10</value>
   </data>
   <data name="hlLinkAutomationPropertiesName" xml:space="preserve">
-    <value>For questions or feedback: https://aka.ms/accessibilityinsights-stackoverflow</value>
+    <value>questions or feedback</value>
   </data>
   <data name="LabelContentAutomatedChecks" xml:space="preserve">
     <value>Automated checks</value>


### PR DESCRIPTION
NVDA reads the 'For questions or feedback: {link}' automatically when focusing. Because the link itself was in the automation name, NVDA would then read it again. This removes the link from the automation name. The side effect is that Narrator now only reads 'questions or feedback link'. This seems better since the user can press the spacebar to invoke the link.