### PR TITLE
To kick a build off when a tag is created.

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -1,5 +1,9 @@
 name: $(date:yyyy-MM-dd)$(rev:.rr)
-trigger: none
+trigger:
+  branches:
+    include:
+    - refs/tags/*
+
 pr: none
 variables:
   BuildPlatform: 'x86'


### PR DESCRIPTION
This will simplify the process of releasing. 
Just create a tag and it will kick off a build for that tag. 