### PR TITLE
adding caret to fix the following text to provide better navigation experience

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -168,6 +168,7 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="IsReadOnly" Value="True"/>
+        <Setter Property="IsReadOnlyCaretVisible" Value="True"/>
         <Setter Property="TextWrapping" Value="Wrap"/>
         <Setter Property="Focusable" Value="True"/>
         <Setter Property="KeyboardNavigation.IsTabStop" Value="True"/>


### PR DESCRIPTION
#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 1448100 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.
![capture](https://user-images.githubusercontent.com/7775527/52667198-0a6f1d80-2ec5-11e9-8a4f-b17a2cc5528e.PNG)
Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
(Please provide an overview of the change in this PR)

Adding the read-only caret to this style allows users to navigate using the arrow keys. Screen readers will then read out the text per character, word, or line.