### PR TITLE
Add brush used in CCA mode to brushes

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -63,6 +63,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="TextHighlightBrush" Color="#FFF2CC"/>
     <SolidColorBrush po:Freeze="True" x:Key="BtnBrderBrush" Color="{x:Static SystemColors.ControlDarkColor}"/>
     <SolidColorBrush x:Key="HLbrushRed" Color="#CC0000"/>
+    <SolidColorBrush x:Key="HLbrushGreen" Color="#107c10"/>
     <SolidColorBrush x:Key="HLbrushPurple" Color="#A45EF4"/>
     <SolidColorBrush x:Key="HLDefaultBrush" Color="#0C5186"/>
     <SolidColorBrush x:Key="HLGreenTextBrush" Color="#00FF00 "/>


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
We lost the green checks on CCA pass with the last PR. This restores them.

Before:
![image](https://user-images.githubusercontent.com/4615491/52805734-1a5d3d80-303c-11e9-94a2-0bcff6075f40.png)

After:
![image](https://user-images.githubusercontent.com/4615491/52805772-2c3ee080-303c-11e9-93c1-c563053b4fe6.png)


