### PR TITLE
A recent change introduced a new version of NewtonSoft that broke aut…

### DIFF
--- a/src/AccessibilityInsights.Automation/CustomAssemblyResolver.cs
+++ b/src/AccessibilityInsights.Automation/CustomAssemblyResolver.cs
@@ -36,6 +36,10 @@ namespace AccessibilityInsights.Automation
                 "Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed",
                 "Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed"
             },
+            {
+                "Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed",
+                "Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed"
+            },
         };
 
         /// <summary>


### PR DESCRIPTION
…omation from PowerShell. Adding the new version to our mapping table.

#### PR checklist

- [ Only Automation script ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ NO ] Does this address an existing issue? If yes, Issue# - 
- [ NO ] Includes UI changes?
  - [ NO ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ None ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
(Please provide an overview of the change in this PR)

PowerShell can't use the standard NuGet versioning to handle version resolution, so we need to maintain it manually. It's a nuisance, but it works. Added NewtonSoft 9.0 to the mapping table