### PR TITLE
Adding a brush for the blue background button. AB# 1454381

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -20,6 +20,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="IconBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="LightIconBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="WindowTextBrush" Color="{x:Static SystemColors.WindowTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonBlueBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedTextBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>


### PR DESCRIPTION
#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 1454381
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
Brush was missing for high contrast modes causing the "Get started" button to show up incorrectly.

Before
![bug1454381-before](https://user-images.githubusercontent.com/45673569/53134341-a33c1380-352b-11e9-8075-5ef3453b394a.gif)

After
![bug1454381-after](https://user-images.githubusercontent.com/45673569/53134349-a6370400-352b-11e9-8cff-ee608dfa1080.gif)

