### PR TITLE
Separate links from the outer text-block inline into a different block element so that the narrator doesn't read it twice

### DIFF
--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml
@@ -43,7 +43,11 @@
                 <TextBlock Name="tbInstructions" Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
                     <Run Text="{x:Static properties:Resources.LiveModeControl_HoverOverElement}"/>
                     <Run Name="runHkActivate"/><Run Text="."/>
-                    <Button x:Name="hlInspect" FontSize="{StaticResource ConstStandardTextSize}" Style="{StaticResource btnLink}" Content="{x:Static properties:Resources.LiveModeControl_LearnMoreInspect}" Click="hlInspect_Click" VerticalContentAlignment="Bottom"/>
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2075123" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">
+                             <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreInspect}"/>
+                        </Hyperlink><Run Text="."/>
+                    </TextBlock>
                 </TextBlock>
 
                 <TextBlock Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
@@ -51,7 +55,11 @@
                     <controls1:FabricIconControl GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal"/>
                     <Run Text="{x:Static properties:Resources.LiveModeControl_FocusOnElement}"/>
                     <Run Name="runHkTest"/><Run Text="."/>
-                    <Button x:Name="hlAutomatedChecks" FontSize="{StaticResource ConstStandardTextSize}" Style="{StaticResource btnLink}" Content="{x:Static properties:Resources.LiveModeControl_LearnMoreAutomated}" Click="hlAutomatedChecks_Click" VerticalContentAlignment="Bottom"/>
+                    <TextBlock>
+                        <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077027" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">
+                             <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreAutomated}"/>
+                        </Hyperlink><Run Text="."/>
+                    </TextBlock>
                 </TextBlock>
 
             </StackPanel>

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
@@ -482,23 +482,11 @@ namespace AccessibilityInsights.Modes
             }
         }
 
-        private void hlInspect_Click(object sender, RoutedEventArgs e)
+        private void Hyperlink_RequestNavigate(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
         {
             try
             {
-                Process.Start(new ProcessStartInfo(("https://go.microsoft.com/fwlink/?linkid=2075123")));
-            }
-            catch
-            {
-                MessageDialog.Show(Properties.Resources.hlLink_RequestNavigateException);
-            }
-        }
-
-        private void hlAutomatedChecks_Click(object sender, RoutedEventArgs e)
-        {
-            try
-            {
-                Process.Start(new ProcessStartInfo(("https://go.microsoft.com/fwlink/?linkid=2077027")));
+                Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri));
             }
             catch
             {


### PR DESCRIPTION
…ck element so that the narrator doesn't read the link twice

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 1450994
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
Separate links from the outer text-block inline into a different block element so that the narrator doesn't read it twice

