### PR TITLE
Reset the automation name when the test control is being cleared

### DIFF
--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
@@ -288,6 +288,7 @@ namespace AccessibilityInsights.Modes
         /// </summary>
         public void Clear()
         {
+            AutomationProperties.SetName(this, Properties.Resources.TestModeControlAutomationPropertiesName);
             this.ctrlAutomatedChecks.ClearUI();
             this.ctrlTabStop.ClearUI();
         }


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 1458787
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
Reset the automation name when the test control is being cleared so that the narrator doesn't read the failure results if we switch back again when it's not visible anymore

