### PR TITLE
Wait for visible to finish

### DIFF
--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
@@ -249,7 +249,13 @@ namespace AccessibilityInsights.Modes
                 {
                     MainWin.SetCurrentViewAndUpdateUI(TestView.AutomatedTestResults);
                 }
-                Application.Current.MainWindow.Visibility = Visibility.Visible;
+
+                // Improves the reliability of the rendering but does not solve across the board issues seen with all WPF apps.
+                this.Dispatcher.BeginInvoke(DispatcherPriority.Send, new Action(() =>
+                {
+                    Application.Current.MainWindow.InvalidateVisual();
+                    Application.Current.MainWindow.Visibility = Visibility.Visible;
+                })).Wait();
             });
         }
 


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# -  AB# 1447981
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
We now call invalidatevisual() and wait for it to finish. This helps improve the reliability of the rendering but does not completely solve across the board issues for WPF apps. 

