### PR TITLE
Set focus on Automated Checks tab at the very end after rendering the main window

### DIFF
--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
@@ -234,7 +234,6 @@ namespace AccessibilityInsights.Modes
                 {
                     Application.Current.Dispatcher.Invoke(() => {
                         this.ctrlProgressRing.Deactivate();
-                        this.tbiAutomatedChecks.Focus();
                     });
                 }
             }
@@ -256,6 +255,7 @@ namespace AccessibilityInsights.Modes
                 {
                     Application.Current.MainWindow.InvalidateVisual();
                     Application.Current.MainWindow.Visibility = Visibility.Visible;
+                    this.tbiAutomatedChecks.Focus();
                 })).Wait();
             });
         }


### PR DESCRIPTION
… window

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 1458825
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change

- Set focus on Automated Checks tab at the very end after rendering the main window.
- Now initial tab focus after automated checks run should be on the view results.