### PR TITLE
Switching tests to use Pose in Win32Tests

### DIFF
--- a/src/AccessibilityInsights.Win32Tests/Win32ApisTests.cs
+++ b/src/AccessibilityInsights.Win32Tests/Win32ApisTests.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Collections.Generic;
 using AccessibilityInsights.Win32;
-using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.Win32.Fakes;
+using Microsoft.Win32;
+using Pose;
 
 namespace AccessibilityInsights.Win32Tests
 {
@@ -14,254 +14,325 @@ namespace AccessibilityInsights.Win32Tests
         [TestMethod]
         public void IsWindowsRS3OrLater_OsValueIsMissing_ReturnsFalse()
         {
-            using (ShimsContext.Create())
+            List<string> returnValues = new List<string>();
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
+
+            bool result = true;
+            PoseContext.Isolate(() =>
             {
+                result = NativeMethods.IsWindowsRS3OrLater();
+            }, registryShim);
 
-                List<string> returnValues = new List<string>();
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
-
-                Assert.IsFalse(NativeMethods.IsWindowsRS3OrLater());
-                Assert.AreEqual(1, index);
-            }
+            Assert.IsFalse(result);
+            Assert.AreEqual(1, index);
         }
 
         [TestMethod]
         public void IsWindowsRS3OrLater_OsValueIsBadFormat_ReturnsFalse()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.3 alpha" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.3 alpha" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsFalse(NativeMethods.IsWindowsRS3OrLater());
-                Assert.AreEqual(1, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS3OrLater();
+            }, registryShim);
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(1, index);
         }
 
         [TestMethod]
         public void IsWindowsRS3OrLater_OsValueIsLessThanWindows10_ReturnsFalse()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.2" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.2" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsFalse(NativeMethods.IsWindowsRS3OrLater());
-                Assert.AreEqual(1, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS3OrLater();
+            }, registryShim);
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(1, index);
         }
 
         [TestMethod]
         public void IsWindowsRS3OrLater_OsValueIsGreaterThanWindows10_ReturnsTrue()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.4" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.4" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsTrue(NativeMethods.IsWindowsRS3OrLater());
-                Assert.AreEqual(1, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS3OrLater();
+            }, registryShim);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(1, index);
         }
 
         [TestMethod]
         public void IsWindowsRS3OrLater_BuildValueIsMissing_ReturnsFalse()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.3" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.3" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsFalse(NativeMethods.IsWindowsRS3OrLater());
-                Assert.AreEqual(2, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS3OrLater();
+            }, registryShim);
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(2, index);
         }
 
         [TestMethod]
         public void IsWindowsRS3OrLater_BuildValueIsBadFormat_ReturnsFalse()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.3", "16227-rc1" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.3", "16227-rc1" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsFalse(NativeMethods.IsWindowsRS3OrLater());
-                Assert.AreEqual(2, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS3OrLater();
+            }, registryShim);
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(2, index);
         }
 
         [TestMethod]
         public void IsWindowsRS3OrLater_BuildValueIsLessThanTarget_ReturnsFalse()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.3", "16227" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.3", "16227" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsFalse(NativeMethods.IsWindowsRS3OrLater());
-                Assert.AreEqual(2, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS3OrLater();
+            }, registryShim);
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(2, index);
         }
 
         [TestMethod]
         public void IsWindowsRS3OrLater_BuildValueIsEqualToTarget_ReturnsTrue()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.3", "16228" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.3", "16228" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsTrue(NativeMethods.IsWindowsRS3OrLater());
-                Assert.AreEqual(2, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS3OrLater();
+            }, registryShim);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(2, index);
         }
 
         [TestMethod]
         public void IsWindowsRS3OrLater_BuildValueIsGreaterThanTarget_ReturnsTrue()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.3", "16229" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.3", "16229" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsTrue(NativeMethods.IsWindowsRS3OrLater());
-                Assert.AreEqual(2, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS3OrLater();
+            }, registryShim);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(2, index);
         }
 
         [TestMethod]
         public void IsWindowsRS5OrLater_OsValueIsMissingReturnsFalse()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string>();
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string>();
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsFalse(NativeMethods.IsWindowsRS5OrLater());
-                Assert.AreEqual(1, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS5OrLater();
+            }, registryShim);
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(1, index);
         }
 
         [TestMethod]
         public void IsWindowsRS5OrLater_OsValueIsBadFormat_ReturnsFalse()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.3 alpha" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string>() { "6.3 alpha" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsFalse(NativeMethods.IsWindowsRS5OrLater());
-                Assert.AreEqual(1, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS5OrLater();
+            }, registryShim);
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(1, index);
         }
 
         [TestMethod]
         public void IsWindowsRS5OrLater_OsValueIsLessThanWindows10_ReturnsFalse()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.2" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string>() { "6.2" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsFalse(NativeMethods.IsWindowsRS5OrLater());
-                Assert.AreEqual(1, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS5OrLater();
+            }, registryShim);
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(1, index);
         }
 
         [TestMethod]
         public void IsWindowsRS5OrLater_OsValueIsGreaterThanWindows10_ReturnsTrue()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.4" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.4" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsTrue(NativeMethods.IsWindowsRS5OrLater());
-                Assert.AreEqual(1, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS5OrLater();
+            }, registryShim);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(1, index);
         }
 
         [TestMethod]
         public void IsWindowsRS5OrLater_BuildValueIsMissing_ReturnsFalse()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.3" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.3" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsFalse(NativeMethods.IsWindowsRS5OrLater());
-                Assert.AreEqual(2, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS5OrLater();
+            }, registryShim);
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(2, index);
         }
 
         [TestMethod]
         public void IsWindowsRS5OrLater_BuildValueIsBadFormat_ReturnsFalse()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.3", "17713-rc1" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.3", "17713-rc1" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsFalse(NativeMethods.IsWindowsRS5OrLater());
-                Assert.AreEqual(2, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS5OrLater();
+            }, registryShim);
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(2, index);
         }
 
         [TestMethod]
         public void IsWindowsRS5OrLater_BuildValueIsLessThanTarget_ReturnsFalse()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.3", "17712" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.3", "17712" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsFalse(NativeMethods.IsWindowsRS5OrLater());
-                Assert.AreEqual(2, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS5OrLater();
+            }, registryShim);
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(2, index);
         }
 
         [TestMethod]
         public void IsWindowsRS5OrLater_BuildValueIsEqualToTarget_ReturnsTrue()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.3", "17713" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.3", "17713" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsTrue(NativeMethods.IsWindowsRS5OrLater());
-                Assert.AreEqual(2, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS5OrLater();
+            }, registryShim);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(2, index);
         }
 
         [TestMethod]
         public void IsWindowsRS5OrLater_BuildValueIsGreaterThanTarget_ReturnsTrue()
         {
-            using (ShimsContext.Create())
-            {
-                List<string> returnValues = new List<string> { "6.3", "17714" };
-                int index = 0;
-                ShimRegistry.GetValueStringStringObject = (_, __, def) => (++index > returnValues.Count ? def : returnValues[index - 1]);
+            List<string> returnValues = new List<string> { "6.3", "17714" };
+            int index = 0;
+            Shim registryShim = Shim.Replace(() => Registry.GetValue(Is.A<string>(), Is.A<string>(), Is.A<object>())).With(
+                delegate (string _, string __, object def) { return ++index > returnValues.Count ? def : returnValues[index - 1]; });
 
-                Assert.IsTrue(NativeMethods.IsWindowsRS5OrLater());
-                Assert.AreEqual(2, index);
-            }
+            bool result = true;
+            PoseContext.Isolate(() =>
+            {
+                result = NativeMethods.IsWindowsRS5OrLater();
+            }, registryShim);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(2, index);
         }
     }
 }

--- a/src/AccessibilityInsights.Win32Tests/Win32Tests.csproj
+++ b/src/AccessibilityInsights.Win32Tests/Win32Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
@@ -41,16 +41,17 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.QualityTools.Testing.Fakes, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="$(FAKES_SUPPORTED) == 1"/>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib.4.0.0.0.Fakes, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0ae41878053f6703, processorArchitecture=MSIL" Condition="$(FAKES_SUPPORTED) == 1">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\mscorlib.4.0.0.0.Fakes.dll</HintPath>
+    <Reference Include="Mono.Reflection, Version=1.1.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Reflection.Core.1.1.1\lib\net45\Mono.Reflection.dll</HintPath>
+    </Reference>
+    <Reference Include="Pose, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pose.1.2.1\lib\netstandard2.0\Pose.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>
@@ -64,10 +65,12 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Win32ApisTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
+    <Compile Include="Win32ApisTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="..\..\build\delaysign.targets" />
   <ItemGroup>

--- a/src/AccessibilityInsights.Win32Tests/packages.config
+++ b/src/AccessibilityInsights.Win32Tests/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Mono.Reflection.Core" version="1.1.1" targetFramework="net471" />
   <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net471" />
+  <package id="Pose" version="1.2.1" targetFramework="net471" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
This PR switches the tests in Win32Tests.csproj to use Pose instead of using Fakes. The project should no longer have any references to fakes.

I looked into creating a helper method to reduce redundancy but the shim did not seem to apply when the method under test (RS3 vs RS5) was passed in as a parameter.