### PR TITLE
Bug 1463776: Fix recent regression where server connection isn't restored

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
@@ -143,7 +143,11 @@ namespace AccessibilityInsights.SharedUx.Settings
         /// </summary>
         public IConnectionInfo SavedConnection
         {
-            get => _savedConnection;
+            get
+            {
+                return _savedConnection ??
+                    (_savedConnection = BugReporter.CreateConnectionInfo(SerializedSavedConnection));
+            }
             set
             {
                 _savedConnection = value;
@@ -156,7 +160,11 @@ namespace AccessibilityInsights.SharedUx.Settings
         /// </summary>
         public IConnectionCache CachedConnections
         {
-            get => _savedConnectionCache;
+            get
+            {
+                return _savedConnectionCache ??
+                    (_savedConnectionCache = BugReporter.CreateConnectionCache(SerializedCachedConnections));
+            }
             set
             {
                 _savedConnectionCache = value;
@@ -170,11 +178,7 @@ namespace AccessibilityInsights.SharedUx.Settings
         public string SerializedSavedConnection
         {
             get => GetDataValue<string>(keySerializedSavedConnection);
-            set
-            {
-                SetDataValue<string>(keySerializedSavedConnection, value);
-                _savedConnection = BugReporter.CreateConnectionInfo(value);
-            }
+            set => SetDataValue<string>(keySerializedSavedConnection, value);
         }
 
         /// <summary>
@@ -183,11 +187,7 @@ namespace AccessibilityInsights.SharedUx.Settings
         public string SerializedCachedConnections
         {
             get => GetDataValue<string>(keySerializedCachedConnections);
-            set
-            {
-                SetDataValue<string>(keySerializedSavedConnection, value);
-                _savedConnectionCache = BugReporter.CreateConnectionCache(value);
-            }
+            set => SetDataValue<string>(keySerializedCachedConnections, value);
         }
 
         /// <summary>


### PR DESCRIPTION
Bug 1463776: Fix recent regression where server connection isn't restored after exiting and restarting app

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

When I recently changed the config, I had 2 errors that weren't detectable via unit tests:
1) ConfigurationManager's SavedConnection and CachedConnection properties weren't getting set when loading settings
2) The setter for SerializedCachedConnections was setting the property for SerializedSavedConnection, which then got rejected by the BugReporting implementation

Test:
1) Started the app
2) Connected to bug service
3) Exited the app
4) Confirmed that the correct data was stored in the config file
5) Restarted the app
6) Confirmed that the bug connection (identity and target) were restored after opening app
7) Exited the app
8) Confirmed that the config file was still correct


