### PR TITLE
Ensure shift+tab works when focused on Automated Checks tab item

### DIFF
--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml
@@ -60,7 +60,7 @@
             <Run Name="runHotkey"/><Run Text="."/>
             <TextBlock>
                 <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077027" RequestNavigate="Hyperlink_RequestNavigate"
-                            FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">
+                           FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">
                     <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreAutomated}"/>
                 </Hyperlink>
             </TextBlock><Run Text="."/>


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed? [Have done live inspection / test scenarios so far]

- [x] Does this address an existing issue? If yes, Issue# - 1463899
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.
![pr](https://user-images.githubusercontent.com/7775527/53527244-41375d00-3a9b-11e9-9fa9-c9b3f6280692.gif)

#### Describe the change

Tabbing backwards from the automated checks tab item was not working, even though tabbing forward did work. After investigating with John's help, it seems that WPF attempts to set focus on the instruction TextBlock when shift-tabbing and would fail unless that instruction page had been previously loaded.

This change sets a KeyboardNavigation property that ensures tabbing will stay within the tab control.