### PR TITLE
Ensure focus goes to snapshot selected element on app startup

### DIFF
--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
@@ -129,7 +129,6 @@ namespace AccessibilityInsights.Modes
             EnableMenuButtons(this.DataContextMode != DataContextMode.Load);
 
             bool selectionFailure = false;
-            var prevFocus = Keyboard.FocusedElement;
 
             try
             {
@@ -220,10 +219,9 @@ namespace AccessibilityInsights.Modes
                     this.ctrlProgressRing.Deactivate();
                     this.ctrlHierarchy.IsEnabled = true;
 
-                    // if the previously focused element is no longer visible and focus has gone to the window,
-                    // we will set focus back to the hierarchy control. We do this because disabling the hierarchy control
+                    // if focus has gone to the window, we set focus to the hierarchy control. We do this because disabling the hierarchy control
                     // will throw keyboard focus to mainwindow, where it is not very useful.
-                    if (prevFocus is FrameworkElement fe && !fe.IsVisible && Keyboard.FocusedElement is Window)
+                    if (Keyboard.FocusedElement is Window)
                     {
                         this.ctrlHierarchy.Focus();
                     }
@@ -307,7 +305,7 @@ namespace AccessibilityInsights.Modes
                 HighlightImageAction.GetDefaultInstance().Show();
             }
             this.Visibility = Visibility.Visible;
-            Dispatcher.Invoke(() =>
+            Dispatcher.InvokeAsync(() =>
             {
                 this.SetFocusOnDefaultControl();
             }


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 1463898
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable. (delay in beginning)
![gif of focus behavior](https://user-images.githubusercontent.com/7775527/53587156-7fd22380-3b3e-11e9-9c92-6bf49d53418c.gif)

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
(Please provide an overview of the change in this PR)

When opening a file via command-params (as opposed to the file open dialog) focus was not placed on the selected element in snapshot mode. Instead it was placed on the window.

We found code that handled a case similar to this at the end of `SetElement` - we set focus to the hierarchy tree if current focus is on the window and the prior focused element is no longer visible. This PR loosens this check so that window focus is sufficient for us to move to the hierarchy tree - regardless of where focus was beforehand.