### PR TITLE
Handle keyboard navigation edge case in telemetry dialog

### DIFF
--- a/src/AccessibilityInsights/Modes/TelemetryApproveModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/TelemetryApproveModeControl.xaml
@@ -8,7 +8,8 @@
         mc:Ignorable="d" KeyboardNavigation.TabNavigation="Cycle"
         xmlns:properties="clr-namespace:AccessibilityInsights.Properties"
              xmlns:controls="clr-namespace:AccessibilityInsights.SharedUx.Controls;assembly=AccessibilityInsights.SharedUx"
-             AutomationProperties.Name="{x:Static properties:Resources.AutomationNameTelemetryMode}">
+             AutomationProperties.Name="{x:Static properties:Resources.AutomationNameTelemetryMode}"
+             KeyboardNavigation.DirectionalNavigation="Cycle">
     <UserControl.Background>
         <SolidColorBrush Opacity="0.25" Color="Black"/>
     </UserControl.Background>


### PR DESCRIPTION
Issue:
- Start app for the first time, or after deleting AppData
- Ensure the TelemetryDialog shows
- Use the directional keys to navigate
- Notice you go out of the dialog and into the app background

Fix: Keep directional navigation contained in the telemetry dialog

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - no
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 