### PR TITLE
Fix behavior of enter key in automated checks list

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -590,7 +590,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 }
                 e.Handled = true;
             }
-            else if (e.Key == Key.Return)
+            else if (e.Key == Key.Return && Keyboard.FocusedElement is ListViewItem)
             {
                 var btn = GetFirstChildElement<Button>(sender as DependencyObject) as Button;
                 ButtonElem_Click(btn, e);


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
(Please provide an overview of the change in this PR)

