### PR TITLE
Switch from file-based updater to Github-based updater.

### DIFF
--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -91,9 +91,9 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                    <!-- HINT: please use the shorest suffix which can distingusish itself for the naming convention of the extension assembly Ids: -->
 
                    <!-- AutoUpdate Extension Assemblies -->
-                   <File Source="..\AccessibilityInsights.Extensions.AutoUpdate\bin\Release\AccessibilityInsights.Extensions.AutoUpdate.dll" Id="autoupdate_extension"/>
-                   <File Source="..\AccessibilityInsights.Extensions.AutoUpdate\bin\Release\Microsoft.Deployment.WindowsInstaller.dll" Id="windowsinstaller_extension"/>
-                   <File Source="..\AccessibilityInsights.Extensions.AutoUpdate\bin\Release\Newtonsoft.Json.dll" Id="newtonsoft_json_extension"/>
+                   <File Source="..\AccessibilityInsights.Extensions.GitHubAutoUpdate\bin\Release\AccessibilityInsights.Extensions.GitHubAutoUpdate.dll" Id="autoupdate_extension"/>
+                   <File Source="..\AccessibilityInsights.Extensions.GitHubAutoUpdate\bin\Release\Microsoft.Deployment.WindowsInstaller.dll" Id="windowsinstaller_extension"/>
+                   <File Source="..\AccessibilityInsights.Extensions.GitHubAutoUpdate\bin\Release\Newtonsoft.Json.dll" Id="newtonsoft_json_extension"/>
 
                    <!-- Telemetry Extension Assemblies -->
                    <File Source="..\AccessibilityInsights.Extensions.Telemetry\bin\Release\AccessibilityInsights.Extensions.Telemetry.dll" Id="telemetry_extension"/>


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 1467598
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
Instead of loading the file-based auto-updater (AccessibilityInsights.AutoUpdate), we need to load the GitHub-based auto-updater (AccessibilityInsights.GitHubAutoUpdate)

Validated by pointing to public repo with the same layout as our Control branch (but a different MSI file) and ensuring correct results. We'll run a final check once we go live, but it should just work.