### PR TITLE
Add UIAutomation as a prefix in front of Name property to emphasize t…

### DIFF
--- a/src/AccessibilityInsights.Rules/Resources/HowToFix.Designer.cs
+++ b/src/AccessibilityInsights.Rules/Resources/HowToFix.Designer.cs
@@ -822,7 +822,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Name property for the given element is empty, but the element isn&apos;t focusable. Please consider whether or not the element should have a name..
+        ///   Looks up a localized string similar to The UIAutomation Name property for the given element is empty, but the element isn&apos;t focusable. Please consider whether or not the element should have a name..
         /// </summary>
         internal static string NameEmptyButElementNotKeyboardFocusable {
             get {
@@ -831,7 +831,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a Name property for the element that:
+        ///   Looks up a localized string similar to Provide a UIAutomation Name property for the element that:
         /// · Concisely identifies the element, AND
         /// · Does not include the control type..
         /// </summary>
@@ -842,7 +842,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a Name property for the element that:
+        ///   Looks up a localized string similar to Provide a UIAutomation Name property for the element that:
         /// · Concisely identifies the element, AND
         /// · Does not include the same text as the element&apos;s LocalizedControlType property..
         /// </summary>
@@ -853,7 +853,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a Name property for the element that:
+        ///   Looks up a localized string similar to Provide a UIAutomation Name property for the element that:
         /// · Concisely identifies the element, AND
         /// · Does not include any special characters..
         /// </summary>
@@ -864,7 +864,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a Name property for the element that:
+        ///   Looks up a localized string similar to Provide a UIAutomation Name property for the element that:
         /// · Concisely identifies the element, AND
         /// · Does not include the element&apos;s class name (such as Microsoft.*.* or Windows.*.*)..
         /// </summary>
@@ -875,7 +875,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name property of the given element may be null or empty if the element has no siblings of the same type..
+        ///   Looks up a localized string similar to The UIAutomation Name property of the given element may be null or empty if the element has no siblings of the same type..
         /// </summary>
         internal static string NameNoSiblingsOfSameType {
             get {
@@ -884,7 +884,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a Name property that concisely identifies the element..
+        ///   Looks up a localized string similar to Provide a UIAutomation Name property that concisely identifies the element..
         /// </summary>
         internal static string NameNotEmpty {
             get {
@@ -893,7 +893,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a Name property that concisely identifies the element..
+        ///   Looks up a localized string similar to Provide a UIAutomation Name property that concisely identifies the element..
         /// </summary>
         internal static string NameNotNull {
             get {
@@ -902,7 +902,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a Name property that concisely identifies the element..
+        ///   Looks up a localized string similar to Provide a UIAutomation Name property that concisely identifies the element..
         /// </summary>
         internal static string NameNotWhiteSpace {
             get {
@@ -911,7 +911,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Name property for the given element is null, but the element isn&apos;t focusable. Please consider whether or not the element should have a name..
+        ///   Looks up a localized string similar to The UIAutomation Name property for the given element is null, but the element isn&apos;t focusable. Please consider whether or not the element should have a name..
         /// </summary>
         internal static string NameNullButElementNotKeyboardFocusable {
             get {
@@ -920,7 +920,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name property of a custom control may be empty if the parent is a wpf dataitem..
+        ///   Looks up a localized string similar to The UIAutomation Name property of a custom control may be empty if the parent is a wpf dataitem..
         /// </summary>
         internal static string NameOnCustomWithParentWPFDataItem {
             get {
@@ -929,7 +929,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name property for the given element type is optional..
+        ///   Looks up a localized string similar to The UIAutomation Name property for the given element type is optional..
         /// </summary>
         internal static string NameOnOptionalType {
             get {
@@ -938,7 +938,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a Name property for the element that:
+        ///   Looks up a localized string similar to Provide a UIAutomation Name property for the element that:
         /// · Concisely identifies the element, AND
         /// · Contains at most 512 characters..
         /// </summary>
@@ -949,7 +949,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An interactive element with a valid name property is usually expected to have a valid bounding rectangle that is not null and has area..
+        ///   Looks up a localized string similar to An interactive element with a valid UIAutomation Name property is usually expected to have a valid bounding rectangle that is not null and has area..
         /// </summary>
         internal static string NameWithValidBoundingRectangle {
             get {

--- a/src/AccessibilityInsights.Rules/Resources/HowToFix.Designer.cs
+++ b/src/AccessibilityInsights.Rules/Resources/HowToFix.Designer.cs
@@ -831,7 +831,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a UIAutomation Name property for the element that:
+        ///   Looks up a localized string similar to Provide a UI Automation Name property for the element that:
         /// · Concisely identifies the element, AND
         /// · Does not include the control type..
         /// </summary>
@@ -842,7 +842,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a UIAutomation Name property for the element that:
+        ///   Looks up a localized string similar to Provide a UI Automation Name property for the element that:
         /// · Concisely identifies the element, AND
         /// · Does not include the same text as the element&apos;s LocalizedControlType property..
         /// </summary>
@@ -853,7 +853,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a UIAutomation Name property for the element that:
+        ///   Looks up a localized string similar to Provide a UI Automation Name property for the element that:
         /// · Concisely identifies the element, AND
         /// · Does not include any special characters..
         /// </summary>
@@ -864,7 +864,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a UIAutomation Name property for the element that:
+        ///   Looks up a localized string similar to Provide a UI Automation Name property for the element that:
         /// · Concisely identifies the element, AND
         /// · Does not include the element&apos;s class name (such as Microsoft.*.* or Windows.*.*)..
         /// </summary>
@@ -875,7 +875,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The UIAutomation Name property of the given element may be null or empty if the element has no siblings of the same type..
+        ///   Looks up a localized string similar to The UI Automation Name property of the given element may be null or empty if the element has no siblings of the same type..
         /// </summary>
         internal static string NameNoSiblingsOfSameType {
             get {
@@ -884,7 +884,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a UIAutomation Name property that concisely identifies the element..
+        ///   Looks up a localized string similar to Provide a UI Automation Name property that concisely identifies the element..
         /// </summary>
         internal static string NameNotEmpty {
             get {
@@ -893,7 +893,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a UIAutomation Name property that concisely identifies the element..
+        ///   Looks up a localized string similar to Provide a UI Automation Name property that concisely identifies the element..
         /// </summary>
         internal static string NameNotNull {
             get {
@@ -902,7 +902,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a UIAutomation Name property that concisely identifies the element..
+        ///   Looks up a localized string similar to Provide a UI Automation Name property that concisely identifies the element..
         /// </summary>
         internal static string NameNotWhiteSpace {
             get {
@@ -911,7 +911,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The UIAutomation Name property for the given element is null, but the element isn&apos;t focusable. Please consider whether or not the element should have a name..
+        ///   Looks up a localized string similar to The UI Automation Name property for the given element is null, but the element isn&apos;t focusable. Please consider whether or not the element should have a name..
         /// </summary>
         internal static string NameNullButElementNotKeyboardFocusable {
             get {
@@ -920,7 +920,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The UIAutomation Name property of a custom control may be empty if the parent is a wpf dataitem..
+        ///   Looks up a localized string similar to The UI Automation Name property of a custom control may be empty if the parent is a wpf dataitem..
         /// </summary>
         internal static string NameOnCustomWithParentWPFDataItem {
             get {
@@ -929,7 +929,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The UIAutomation Name property for the given element type is optional..
+        ///   Looks up a localized string similar to The UI Automation Name property for the given element type is optional..
         /// </summary>
         internal static string NameOnOptionalType {
             get {
@@ -938,7 +938,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a UIAutomation Name property for the element that:
+        ///   Looks up a localized string similar to Provide a UI Automation Name property for the element that:
         /// · Concisely identifies the element, AND
         /// · Contains at most 512 characters..
         /// </summary>
@@ -949,7 +949,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An interactive element with a valid UIAutomation Name property is usually expected to have a valid bounding rectangle that is not null and has area..
+        ///   Looks up a localized string similar to An interactive element with a valid UI Automation Name property is usually expected to have a valid bounding rectangle that is not null and has area..
         /// </summary>
         internal static string NameWithValidBoundingRectangle {
             get {

--- a/src/AccessibilityInsights.Rules/Resources/HowToFix.resx
+++ b/src/AccessibilityInsights.Rules/Resources/HowToFix.resx
@@ -199,19 +199,19 @@
     <value>The UIAutomation Name property for the given element is empty, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
-    <value>The UIAutomation Name property of the given element may be null or empty if the element has no siblings of the same type.</value>
+    <value>The UI Automation Name property of the given element may be null or empty if the element has no siblings of the same type.</value>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
-    <value>The UIAutomation Name property for the given element is null, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
+    <value>The UI Automation Name property for the given element is null, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
   </data>
   <data name="NameOnCustomWithParentWPFDataItem" xml:space="preserve">
-    <value>The UIAutomation Name property of a custom control may be empty if the parent is a wpf dataitem.</value>
+    <value>The UI Automation Name property of a custom control may be empty if the parent is a wpf dataitem.</value>
   </data>
   <data name="NameOnOptionalType" xml:space="preserve">
-    <value>The UIAutomation Name property for the given element type is optional.</value>
+    <value>The UI Automation Name property for the given element type is optional.</value>
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
-    <value>An interactive element with a valid UIAutomation Name property is usually expected to have a valid bounding rectangle that is not null and has area.</value>
+    <value>An interactive element with a valid UI Automation Name property is usually expected to have a valid bounding rectangle that is not null and has area.</value>
   </data>
   <data name="Structure" xml:space="preserve">
     <value>The given element is expected to have the following structure: {0}.</value>
@@ -504,36 +504,36 @@ If possible, use a predefined (non-custom) control type and the default localize
     <value>Provide an Orientation property for the element.</value>
   </data>
   <data name="NameExcludesControlType" xml:space="preserve">
-    <value>Provide a UIAutomation Name property for the element that:
+    <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the control type.</value>
   </data>
   <data name="NameExcludesLocalizedControlType" xml:space="preserve">
-    <value>Provide a UIAutomation Name property for the element that:
+    <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the same text as the element's LocalizedControlType property.</value>
   </data>
   <data name="NameExcludesSpecialCharacters" xml:space="preserve">
-    <value>Provide a UIAutomation Name property for the element that:
+    <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include any special characters.</value>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
-    <value>Provide a UIAutomation Name property for the element that:
+    <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the element's class name (such as Microsoft.*.* or Windows.*.*).</value>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
-    <value>Provide a UIAutomation Name property that concisely identifies the element.</value>
+    <value>Provide a UI Automation Name property that concisely identifies the element.</value>
   </data>
   <data name="NameNotNull" xml:space="preserve">
-    <value>Provide a UIAutomation Name property that concisely identifies the element.</value>
+    <value>Provide a UI Automation Name property that concisely identifies the element.</value>
   </data>
   <data name="NameNotWhiteSpace" xml:space="preserve">
-    <value>Provide a UIAutomation Name property that concisely identifies the element.</value>
+    <value>Provide a UI Automation Name property that concisely identifies the element.</value>
   </data>
   <data name="NameReasonableLength" xml:space="preserve">
-    <value>Provide a UIAutomation Name property for the element that:
+    <value>Provide a UI Automation Name property for the element that:
  · Concisely identifies the element, AND
  · Contains at most 512 characters.</value>
   </data>

--- a/src/AccessibilityInsights.Rules/Resources/HowToFix.resx
+++ b/src/AccessibilityInsights.Rules/Resources/HowToFix.resx
@@ -196,22 +196,22 @@
     <value>The ItemType property for the given element has no content, and the element has a child image. Please consider including an item type so that assistive technology users can obtain the information provided by the image. If this information is already provided in another way, the item type may not be necessary.</value>
   </data>
   <data name="NameEmptyButElementNotKeyboardFocusable" xml:space="preserve">
-    <value>The Name property for the given element is empty, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
+    <value>The UIAutomation Name property for the given element is empty, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
   </data>
   <data name="NameNoSiblingsOfSameType" xml:space="preserve">
-    <value>The name property of the given element may be null or empty if the element has no siblings of the same type.</value>
+    <value>The UIAutomation Name property of the given element may be null or empty if the element has no siblings of the same type.</value>
   </data>
   <data name="NameNullButElementNotKeyboardFocusable" xml:space="preserve">
-    <value>The Name property for the given element is null, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
+    <value>The UIAutomation Name property for the given element is null, but the element isn't focusable. Please consider whether or not the element should have a name.</value>
   </data>
   <data name="NameOnCustomWithParentWPFDataItem" xml:space="preserve">
-    <value>The name property of a custom control may be empty if the parent is a wpf dataitem.</value>
+    <value>The UIAutomation Name property of a custom control may be empty if the parent is a wpf dataitem.</value>
   </data>
   <data name="NameOnOptionalType" xml:space="preserve">
-    <value>The name property for the given element type is optional.</value>
+    <value>The UIAutomation Name property for the given element type is optional.</value>
   </data>
   <data name="NameWithValidBoundingRectangle" xml:space="preserve">
-    <value>An interactive element with a valid name property is usually expected to have a valid bounding rectangle that is not null and has area.</value>
+    <value>An interactive element with a valid UIAutomation Name property is usually expected to have a valid bounding rectangle that is not null and has area.</value>
   </data>
   <data name="Structure" xml:space="preserve">
     <value>The given element is expected to have the following structure: {0}.</value>
@@ -504,36 +504,36 @@ If possible, use a predefined (non-custom) control type and the default localize
     <value>Provide an Orientation property for the element.</value>
   </data>
   <data name="NameExcludesControlType" xml:space="preserve">
-    <value>Provide a Name property for the element that:
+    <value>Provide a UIAutomation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the control type.</value>
   </data>
   <data name="NameExcludesLocalizedControlType" xml:space="preserve">
-    <value>Provide a Name property for the element that:
+    <value>Provide a UIAutomation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the same text as the element's LocalizedControlType property.</value>
   </data>
   <data name="NameExcludesSpecialCharacters" xml:space="preserve">
-    <value>Provide a Name property for the element that:
+    <value>Provide a UIAutomation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include any special characters.</value>
   </data>
   <data name="NameIsInformative" xml:space="preserve">
-    <value>Provide a Name property for the element that:
+    <value>Provide a UIAutomation Name property for the element that:
  · Concisely identifies the element, AND
  · Does not include the element's class name (such as Microsoft.*.* or Windows.*.*).</value>
   </data>
   <data name="NameNotEmpty" xml:space="preserve">
-    <value>Provide a Name property that concisely identifies the element.</value>
+    <value>Provide a UIAutomation Name property that concisely identifies the element.</value>
   </data>
   <data name="NameNotNull" xml:space="preserve">
-    <value>Provide a Name property that concisely identifies the element.</value>
+    <value>Provide a UIAutomation Name property that concisely identifies the element.</value>
   </data>
   <data name="NameNotWhiteSpace" xml:space="preserve">
-    <value>Provide a Name property that concisely identifies the element.</value>
+    <value>Provide a UIAutomation Name property that concisely identifies the element.</value>
   </data>
   <data name="NameReasonableLength" xml:space="preserve">
-    <value>Provide a Name property for the element that:
+    <value>Provide a UIAutomation Name property for the element that:
  · Concisely identifies the element, AND
  · Contains at most 512 characters.</value>
   </data>


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 1469626
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
(Please provide an overview of the change in this PR)
In How-to-fix resources of Rules project, Add UIAutomation as a prefix in front of Name property to emphasize that the Name property is for UIAutomation, not Name of XAML.

