### PR TITLE
Changing target application examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ If applicable, add screenshots to help explain your problem.
 **Desktop (please complete the following information):**
  - OS: [e.g. Windows 10 1809] (Get the version by running `winver` from the command line)
  - Accessibility Insights for Windows Version:
- - Target Application: [e.g. chrome, safari]
+ - Target Application: [e.g. Chrome, Wildlife Manager]
  - Target Application Version: [e.g. 22]
 
 


### PR DESCRIPTION
Including non-browsers in the example target application list; I felt a bit confused when filing an issue because I felt I should enter a web browser.