### PR TITLE
#163:  Revise Color Contrast text in WhatsNew dialog

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3277,7 +3277,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Investigate color contrast using Color Contrast..
+        ///   Looks up a localized string similar to Identify accessibility issues caused by low color contrast..
         /// </summary>
         public static string RunTextManualColorTest {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -641,7 +641,7 @@ Accessibility Insights Support Team
     <value>Check color contrast:</value>
   </data>
   <data name="RunTextManualColorTest" xml:space="preserve">
-    <value>Investigate color contrast using Color Contrast.</value>
+    <value>Identify accessibility issues caused by low color contrast.</value>
   </data>
   <data name="CCALink" xml:space="preserve">
     <value>Learn more about checking color contrast.</value>


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
Revise the Color Contrast string to be a little less repetitive (and hopefully more helpful) 

Images (note that the word wrap is simply an effect of my window size, and that this change does not explicitly insert a line break):

![image](https://user-images.githubusercontent.com/45672944/53977687-6d1b9980-40be-11e9-8c62-fa2a6bbb68cc.png)
