### PR TITLE
Excluding individual fakes-tests in ActionsTests at a test-level granularity

### DIFF
--- a/src/AccessibilityInsights.ActionsTests/Actions/CaptureActionUnitTests.cs
+++ b/src/AccessibilityInsights.ActionsTests/Actions/CaptureActionUnitTests.cs
@@ -5,22 +5,25 @@ using System.Collections.Generic;
 using System.Linq;
 using AccessibilityInsights.Actions;
 using AccessibilityInsights.Actions.Contexts;
-using AccessibilityInsights.Actions.Contexts.Fakes;
 using AccessibilityInsights.Actions.Enums;
-using AccessibilityInsights.Actions.Fakes;
 using AccessibilityInsights.Core.Bases;
-using AccessibilityInsights.Core.Bases.Fakes;
 using AccessibilityInsights.Core.Enums;
 using AccessibilityInsights.Core.Misc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if FAKES_SUPPORTED
+using AccessibilityInsights.Actions.Contexts.Fakes;
+using AccessibilityInsights.Core.Bases.Fakes;
 using AccessibilityInsights.Desktop.UIAutomation.TreeWalkers.Fakes;
 using Microsoft.QualityTools.Testing.Fakes;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AccessibilityInsights.Actions.Fakes;
+#endif
 
 namespace AccessibilityInsights.ActionsTests.Actions
 {
     [TestClass]
     public class CaptureActionUnitTests
     {
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(1000)]
         public void SetTestModeDataContext_OldContextIsNull_CreatesElementDataContext_ChainsToPopulateData_CorrectParameters()
@@ -143,6 +146,7 @@ namespace AccessibilityInsights.ActionsTests.Actions
                 Assert.AreSame(dataContext.Elements, actualDictionary);
             }
         }
+#endif
 
         [TestMethod]
         [Timeout(1000)]
@@ -158,6 +162,7 @@ namespace AccessibilityInsights.ActionsTests.Actions
             Assert.AreEqual(3, counter.Attempts);
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(1000)]
         public void AddElementAndChildrenIntoList_GeneralCase_BuildsCorrectDictionary()
@@ -193,5 +198,6 @@ namespace AccessibilityInsights.ActionsTests.Actions
                 }
             }
         }
+#endif
     }
 }

--- a/src/AccessibilityInsights.ActionsTests/Actions/CaptureActionUnitTests.cs
+++ b/src/AccessibilityInsights.ActionsTests/Actions/CaptureActionUnitTests.cs
@@ -1,21 +1,21 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using AccessibilityInsights.Actions;
 using AccessibilityInsights.Actions.Contexts;
 using AccessibilityInsights.Actions.Enums;
 using AccessibilityInsights.Core.Bases;
 using AccessibilityInsights.Core.Enums;
 using AccessibilityInsights.Core.Misc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 #if FAKES_SUPPORTED
 using AccessibilityInsights.Actions.Contexts.Fakes;
+using AccessibilityInsights.Actions.Fakes;
 using AccessibilityInsights.Core.Bases.Fakes;
 using AccessibilityInsights.Desktop.UIAutomation.TreeWalkers.Fakes;
 using Microsoft.QualityTools.Testing.Fakes;
-using AccessibilityInsights.Actions.Fakes;
 #endif
 
 namespace AccessibilityInsights.ActionsTests.Actions

--- a/src/AccessibilityInsights.ActionsTests/Actions/PrivacyExtensionsUnitTests.cs
+++ b/src/AccessibilityInsights.ActionsTests/Actions/PrivacyExtensionsUnitTests.cs
@@ -4,13 +4,15 @@ using AccessibilityInsights.Actions;
 using AccessibilityInsights.Core.Bases;
 using AccessibilityInsights.Core.Enums;
 using AccessibilityInsights.Core.Results;
-using AccessibilityInsights.Core.Results.Fakes;
 using AccessibilityInsights.Core.Types;
 using AccessibilityInsights.Desktop.UIAutomation;
-using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Linq;
+#if FAKES_SUPPORTED
+using AccessibilityInsights.Core.Results.Fakes;
+using Microsoft.QualityTools.Testing.Fakes;
+#endif
 
 namespace AccessibilityInsights.ActionsTests.Actions
 {
@@ -44,6 +46,7 @@ namespace AccessibilityInsights.ActionsTests.Actions
             Assert.AreEqual(bugId, copy.BugId);
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         public void CreateScrubbedCopyWithoutRelationships_InputHasScanResults_ResultHasSameScanResults()
         {
@@ -58,6 +61,7 @@ namespace AccessibilityInsights.ActionsTests.Actions
                 Assert.AreSame(input.ScanResults, copy.ScanResults);
             }
         }
+#endif
 
         [TestMethod]
         public void CreateScrubbedCopyWithoutRelationships_InputSetsTreeWalkerMode_ResultHasSameTreeWalkerMode()

--- a/src/AccessibilityInsights.ActionsTests/ActionsTests.csproj
+++ b/src/AccessibilityInsights.ActionsTests/ActionsTests.csproj
@@ -40,6 +40,9 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup Condition="$(FAKES_SUPPORTED) == 1">
+    <DefineConstants>$(DefineConstants);FAKES_SUPPORTED</DefineConstants>
+  </PropertyGroup>
   <Import Project="..\..\build\delaysign.targets" />
   <ItemGroup>
     <Reference Include="AccessibilityInsights.Actions.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
@@ -92,12 +95,12 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
-    <Compile Include="Actions\PrivacyExtensionsUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
+    <Compile Include="Actions\PrivacyExtensionsUnitTests.cs"/>
     <Compile Include="Actions\ScreenShotActionUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
-    <Compile Include="Actions\CaptureActionUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
+    <Compile Include="Actions\CaptureActionUnitTests.cs"/>
     <Compile Include="Misc\ExtensionMethodsTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
     <Compile Include="Misc\OpenSarifTests.cs" />
-    <Compile Include="Misc\ResultsFileSarifMapperUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
+    <Compile Include="Misc\ResultsFileSarifMapperUnitTests.cs"/>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AccessibilityInsights.ActionsTests/Misc/ResultsFileSarifMapperUnitTests.cs
+++ b/src/AccessibilityInsights.ActionsTests/Misc/ResultsFileSarifMapperUnitTests.cs
@@ -1,20 +1,22 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Actions.Contexts;
-using AccessibilityInsights.Actions.Fakes;
 using AccessibilityInsights.Actions.Misc;
-using AccessibilityInsights.Actions.Misc.Fakes;
 using AccessibilityInsights.Core.Bases;
 using AccessibilityInsights.Core.HelpLinks;
 using AccessibilityInsights.Core.Results;
-using AccessibilityInsights.Core.Results.Fakes;
 using AccessibilityInsights.Desktop.Utility;
 using Microsoft.CodeAnalysis.Sarif;
-using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Text;
+#if FAKES_SUPPORTED
+using AccessibilityInsights.Actions.Fakes;
+using AccessibilityInsights.Actions.Misc.Fakes;
+using AccessibilityInsights.Core.Results.Fakes;
+using Microsoft.QualityTools.Testing.Fakes;
+#endif
 
 namespace AccessibilityInsights.ActionsTests.Misc
 {
@@ -41,6 +43,8 @@ namespace AccessibilityInsights.ActionsTests.Misc
         private const string Source = "[4.1.2]";
         private const string TestHelpURL = "https://www.bing.com/";
         private const string TestGlimpse = "Testing";
+
+#if FAKES_SUPPORTED        
         static string ScreenshotTemplateValue = @"file:///C:/ScanOutput/{fileGUID}.png";
         static string ToolOutputTemplateValue = @"file:///C:/ScanOutput/{fileGUID}.a11ytest";
 
@@ -189,6 +193,7 @@ namespace AccessibilityInsights.ActionsTests.Misc
                 Assert.AreEqual(ResultLevel.Open, elementResult.Item2.Level);
             }
         }
+#endif
 
         [TestMethod]
         [Timeout(1000)]
@@ -256,6 +261,7 @@ namespace AccessibilityInsights.ActionsTests.Misc
             Assert.AreEqual(0, elementResults.Count);
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(1000)]
         public void GetScanResults_NoRuleResults_EmptyResult()
@@ -433,6 +439,7 @@ namespace AccessibilityInsights.ActionsTests.Misc
                 Assert.AreEqual(Standard, standards[0]);
             }
         }
+#endif
 
         [TestMethod]
         [Timeout(1000)]
@@ -468,6 +475,7 @@ namespace AccessibilityInsights.ActionsTests.Misc
             Assert.AreEqual(ToolOutputKey, attachments[1].Description.Text);
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(1000)]
         public void GenerateInvocationInfo_ReceivesValidParameters_GeneratesInvocationInfo()
@@ -482,6 +490,7 @@ namespace AccessibilityInsights.ActionsTests.Misc
                 Assert.AreEqual(invocationOfInterest.StartTimeUtc.Ticks, expectedDate.Ticks);
             }
         }
+#endif
 
         [TestMethod]
         [Timeout(1000)]
@@ -493,6 +502,7 @@ namespace AccessibilityInsights.ActionsTests.Misc
             Assert.IsNotNull(toolInfo.Version);
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(1000)]
         public void GenerateAndPersistSarifFile_ReceivesNormalParameters_WritesToFile()
@@ -561,6 +571,7 @@ namespace AccessibilityInsights.ActionsTests.Misc
                 Assert.IsTrue(fileWriteInvoked);
             }
         }
+#endif
 
         [TestMethod]
         [Timeout(1000)]

--- a/src/AccessibilityInsights.ActionsTests/Misc/ResultsFileSarifMapperUnitTests.cs
+++ b/src/AccessibilityInsights.ActionsTests/Misc/ResultsFileSarifMapperUnitTests.cs
@@ -44,7 +44,7 @@ namespace AccessibilityInsights.ActionsTests.Misc
         private const string TestHelpURL = "https://www.bing.com/";
         private const string TestGlimpse = "Testing";
 
-#if FAKES_SUPPORTED        
+#if FAKES_SUPPORTED 
         static string ScreenshotTemplateValue = @"file:///C:/ScanOutput/{fileGUID}.png";
         static string ToolOutputTemplateValue = @"file:///C:/ScanOutput/{fileGUID}.a11ytest";
 


### PR DESCRIPTION
This omits individual unit tests in ActionsTests if they have fakes. The original behavior omits entire files. With this PR we can still preserve the unit tests that don't require fakes, and we get 27 tests back in this project.

Some open questions:
- if all the tests in a file require fakes, should we still if/endif methods, or should we leave it the way it is?
- if consecutive tests require fakes, should we if/endif the whole block & rearrange methods, or should each method have its own if/endif?
- does each fakes import require its own if/endif or are we OK breaking sorting order to block them together?
