### PR TITLE
Excluding Fakes test methods based on a preprocessor symbol …

### DIFF
--- a/src/AccessibilityInsights.AutomationTests/AutomationSessionUnitTests.cs
+++ b/src/AccessibilityInsights.AutomationTests/AutomationSessionUnitTests.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.Automation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+#if FAKES_SUPPORTED
 using AccessibilityInsights.Actions.Fakes;
-using AccessibilityInsights.Automation;
 using Microsoft.QualityTools.Testing.Fakes;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
 
 namespace AccessibilityInsights.AutomationTests
 {
@@ -19,6 +21,7 @@ namespace AccessibilityInsights.AutomationTests
 
         private readonly CommandParameters TestParameters = new CommandParameters(new Dictionary<string, string>(), string.Empty);
 
+#if FAKES_SUPPORTED
         /// <summary>
         /// Set up all of the shims needed for the unit tests--we make no attempt to
         /// identify a subset of shims to configure
@@ -31,7 +34,9 @@ namespace AccessibilityInsights.AutomationTests
             ShimSelectAction shimSelectAction = new ShimSelectAction();
             ShimSelectAction.GetDefaultInstance = () => shimSelectAction;
         }
+#endif
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(2000)]
         [ExpectedException(typeof(StackOverflowException))]
@@ -57,22 +62,19 @@ namespace AccessibilityInsights.AutomationTests
                 }
             }
         }
+#endif
 
         [TestMethod]
         [Timeout (2000)]
         public void NewInstance_ClearInstance_NotPowerShell_AssemblyResolverIsNull_DoesNotThrow()
         {
-            using (ShimsContext.Create())
+            try
             {
-                InitializeShims();
-                try
-                {
-                    AutomationSession.NewInstance(TestParameters, null);
-                }
-                finally
-                {
-                    AutomationSession.ClearInstance();
-                }
+                AutomationSession.NewInstance(TestParameters, null);
+            }
+            finally
+            {
+                AutomationSession.ClearInstance();
             }
         }
 
@@ -82,17 +84,13 @@ namespace AccessibilityInsights.AutomationTests
         {
             AutomationSession session = null;
 
-            using (ShimsContext.Create())
+            try
             {
-                InitializeShims();
-                try
-                {
-                    session = AutomationSession.NewInstance(TestParameters, null);
-                }
-                finally
-                {
-                    AutomationSession.ClearInstance();
-                }
+                session = AutomationSession.NewInstance(TestParameters, null);
+            }
+            finally
+            {
+                AutomationSession.ClearInstance();
             }
 
             Assert.IsNotNull(session);
@@ -103,26 +101,21 @@ namespace AccessibilityInsights.AutomationTests
         [ExpectedException(typeof(A11yAutomationException))]
         public void NewInstance_InstanceAlreadyExists_ThrowsAutomationException_ErrorAutomation009()
         {
-            using (ShimsContext.Create())
+            AutomationSession session = AutomationSession.NewInstance(TestParameters, null);
+            Assert.IsNotNull(session);
+
+            try
             {
-                InitializeShims();
-
-                AutomationSession session = AutomationSession.NewInstance(TestParameters, null);
-                Assert.IsNotNull(session);
-
-                try
-                {
-                    AutomationSession.NewInstance(TestParameters, null);
-                }
-                catch (A11yAutomationException e)
-                {
-                    Assert.IsTrue(e.Message.Contains(" Automation009:"));
-                    throw;
-                }
-                finally
-                {
-                    AutomationSession.ClearInstance();
-                }
+                AutomationSession.NewInstance(TestParameters, null);
+            }
+            catch (A11yAutomationException e)
+            {
+                Assert.IsTrue(e.Message.Contains(" Automation009:"));
+                throw;
+            }
+            finally
+            {
+                AutomationSession.ClearInstance();
             }
         }
 
@@ -131,19 +124,14 @@ namespace AccessibilityInsights.AutomationTests
         [ExpectedException(typeof(A11yAutomationException))]
         public void Instance_NoInstanceExists_ThrowsAutomationException_Automation010()
         {
-            using (ShimsContext.Create())
+            try
             {
-                InitializeShims();
-
-                try
-                {
-                    AutomationSession.Instance();
-                }
-                catch (A11yAutomationException e)
-                {
-                    Assert.IsTrue(e.Message.Contains(" Automation010:"));
-                    throw;
-                }
+                AutomationSession.Instance();
+            }
+            catch (A11yAutomationException e)
+            {
+                Assert.IsTrue(e.Message.Contains(" Automation010:"));
+                throw;
             }
         }
 
@@ -151,20 +139,15 @@ namespace AccessibilityInsights.AutomationTests
         [Timeout (2000)]
         public void Instance_InstanceExists_ReturnsSameInstance()
         {
-            using (ShimsContext.Create())
+            AutomationSession session = AutomationSession.NewInstance(TestParameters, null);
+            Assert.IsNotNull(session);
+            try
             {
-                InitializeShims();
-
-                AutomationSession session = AutomationSession.NewInstance(TestParameters, null);
-                Assert.IsNotNull(session);
-                try
-                {
-                    Assert.AreSame(session, AutomationSession.Instance());
-                }
-                finally
-                {
-                    AutomationSession.ClearInstance();
-                }
+                Assert.AreSame(session, AutomationSession.Instance());
+            }
+            finally
+            {
+                AutomationSession.ClearInstance();
             }
         }
 
@@ -173,19 +156,14 @@ namespace AccessibilityInsights.AutomationTests
         [ExpectedException(typeof(A11yAutomationException))]
         public void ClearInstance_NoInstanceExists_ThrowsAutomationException_Automation011()
         {
-            using (ShimsContext.Create())
+            try
             {
-                InitializeShims();
-
-                try
-                {
-                    AutomationSession.ClearInstance();
-                }
-                catch (A11yAutomationException e)
-                {
-                    Assert.IsTrue(e.Message.Contains(" Automation011:"));
-                    throw;
-                }
+                AutomationSession.ClearInstance();
+            }
+            catch (A11yAutomationException e)
+            {
+                Assert.IsTrue(e.Message.Contains(" Automation011:"));
+                throw;
             }
         }
 
@@ -193,19 +171,14 @@ namespace AccessibilityInsights.AutomationTests
         [Timeout (2000)]
         public void SessionParameters_MatchesInputParameters()
         {
-            using (ShimsContext.Create())
+            try
             {
-                InitializeShims();
-
-                try
-                {
-                    AutomationSession session = AutomationSession.NewInstance(TestParameters, null);
-                    Assert.AreSame(TestParameters, session.SessionParameters);
-                }
-                finally
-                {
-                    AutomationSession.ClearInstance();
-                }
+                AutomationSession session = AutomationSession.NewInstance(TestParameters, null);
+                Assert.AreSame(TestParameters, session.SessionParameters);
+            }
+            finally
+            {
+                AutomationSession.ClearInstance();
             }
         }
 
@@ -213,10 +186,7 @@ namespace AccessibilityInsights.AutomationTests
         [Timeout (2000)]
         public void NewInstance_ClearInstance_AssemblyResolverIsDisposed()
         {
-            using (ShimsContext.Create())
-            {
                 DummyDisposable assemblyResolver = new DummyDisposable();
-                InitializeShims();
 
                 try
                 {
@@ -228,7 +198,6 @@ namespace AccessibilityInsights.AutomationTests
                     AutomationSession.ClearInstance();
                     Assert.AreEqual(1, assemblyResolver.TimesDisposed);
                 }
-            }
         }
     }
 }

--- a/src/AccessibilityInsights.AutomationTests/AutomationTests.csproj
+++ b/src/AccessibilityInsights.AutomationTests/AutomationTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -41,6 +41,9 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup Condition="$(FAKES_SUPPORTED) == 1">
+    <DefineConstants>$(DefineConstants);FAKES_SUPPORTED</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AccessibilityInsights.Actions.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\AccessibilityInsights.Actions.Fakes.dll</HintPath>
@@ -79,15 +82,15 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AutomationSessionUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
-    <Compile Include="CommandParametersUnitTests.cs"  Condition="$(FAKES_SUPPORTED) == 1"/>
+    <Compile Include="AutomationSessionUnitTests.cs"/>
+    <Compile Include="CommandParametersUnitTests.cs"/>
     <Compile Include="DummyDisposable.cs" />
     <Compile Include="ExecutionWrapperUnitTests.cs" />
-    <Compile Include="LocationHelperUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
+    <Compile Include="LocationHelperUnitTests.cs"/>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="StartCommandUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
-    <Compile Include="StopCommandUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
-    <Compile Include="SnapshotCommandUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
+    <Compile Include="StartCommandUnitTests.cs"/>
+    <Compile Include="StopCommandUnitTests.cs"/>
+    <Compile Include="SnapshotCommandUnitTests.cs"/>
     <Compile Include="TargetElementLocatorUnitTests.cs" />
     <Compile Include="Utilities.cs" />
   </ItemGroup>

--- a/src/AccessibilityInsights.AutomationTests/CommandParametersUnitTests.cs
+++ b/src/AccessibilityInsights.AutomationTests/CommandParametersUnitTests.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Automation;
-using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Fakes;
 using System.Linq;
+#if FAKES_SUPPORTED
+using Microsoft.QualityTools.Testing.Fakes;
+using System.IO.Fakes;
+#endif
 
 namespace AccessibilityInsights.AutomationTests
 {
@@ -74,6 +76,7 @@ namespace AccessibilityInsights.AutomationTests
             }
         }
 
+        #if FAKES_SUPPORTED
         [TestMethod]
         [Timeout (1000)]
         [ExpectedException(typeof(A11yAutomationException))]
@@ -154,6 +157,7 @@ namespace AccessibilityInsights.AutomationTests
                 Assert.AreEqual(BoolAsString, value);
             }
         }
+#endif
 
         [TestMethod]
         [Timeout (1000)]

--- a/src/AccessibilityInsights.AutomationTests/CommandParametersUnitTests.cs
+++ b/src/AccessibilityInsights.AutomationTests/CommandParametersUnitTests.cs
@@ -76,7 +76,7 @@ namespace AccessibilityInsights.AutomationTests
             }
         }
 
-        #if FAKES_SUPPORTED
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout (1000)]
         [ExpectedException(typeof(A11yAutomationException))]

--- a/src/AccessibilityInsights.AutomationTests/LocationHelperUnitTests.cs
+++ b/src/AccessibilityInsights.AutomationTests/LocationHelperUnitTests.cs
@@ -91,7 +91,7 @@ namespace AccessibilityInsights.AutomationTests
             }
         }
 
-        #if FAKES_SUPPORTED
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout (1000)]
         public void Ctor_OutputPathDoesNotExist_CreatesOutputPath()
@@ -200,7 +200,7 @@ namespace AccessibilityInsights.AutomationTests
             }
         }
 
-        #if FAKES_SUPPORTED
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout (1000)]
         public void Ctor_NoOutputPathProvidedNullEnvValue_EnsureFetchesFallbackValue()

--- a/src/AccessibilityInsights.AutomationTests/LocationHelperUnitTests.cs
+++ b/src/AccessibilityInsights.AutomationTests/LocationHelperUnitTests.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Fakes;
 using AccessibilityInsights.Automation;
-using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if FAKES_SUPPORTED
+using Microsoft.QualityTools.Testing.Fakes;
+using System.IO.Fakes;
+#endif
 
 namespace AccessibilityInsights.AutomationTests
 {
@@ -89,6 +91,7 @@ namespace AccessibilityInsights.AutomationTests
             }
         }
 
+        #if FAKES_SUPPORTED
         [TestMethod]
         [Timeout (1000)]
         public void Ctor_OutputPathDoesNotExist_CreatesOutputPath()
@@ -161,6 +164,7 @@ namespace AccessibilityInsights.AutomationTests
                 Assert.AreEqual(Core.Enums.FileFilters.TestExtension.Substring(1), helper.OutputFileFormat, true);
             }
         }
+#endif
 
         [TestMethod]
         [Timeout (1000)]
@@ -196,6 +200,7 @@ namespace AccessibilityInsights.AutomationTests
             }
         }
 
+        #if FAKES_SUPPORTED
         [TestMethod]
         [Timeout (1000)]
         public void Ctor_NoOutputPathProvidedNullEnvValue_EnsureFetchesFallbackValue()
@@ -268,5 +273,6 @@ namespace AccessibilityInsights.AutomationTests
                 Assert.AreEqual(Core.Enums.FileFilters.TestExtension.Substring(1), helper.OutputFileFormat, true);
             }
         }
+#endif
     }
 }

--- a/src/AccessibilityInsights.AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AccessibilityInsights.AutomationTests/SnapshotCommandUnitTests.cs
@@ -1,17 +1,19 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Actions.Contexts;
-using AccessibilityInsights.Actions.Contexts.Fakes;
-using AccessibilityInsights.Actions.Fakes;
 using AccessibilityInsights.Automation;
-using AccessibilityInsights.Automation.Fakes;
 using AccessibilityInsights.Core.Bases;
 using AccessibilityInsights.Core.Misc;
 using AccessibilityInsights.Core.Results;
-using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+#if FAKES_SUPPORTED
+using AccessibilityInsights.Actions.Contexts.Fakes;
+using AccessibilityInsights.Actions.Fakes;
+using AccessibilityInsights.Automation.Fakes;
+using Microsoft.QualityTools.Testing.Fakes;
+#endif
 
 namespace AccessibilityInsights.AutomationTests
 {
@@ -92,6 +94,7 @@ namespace AccessibilityInsights.AutomationTests
             return element;
         }
 
+        #if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(2000)]
         public void Execute_AutomationSessionInstanceThrowsAutomationException_ReturnsIncomplete_MessageMatchesException()
@@ -587,5 +590,6 @@ namespace AccessibilityInsights.AutomationTests
 
             ShimGetDataAction.GetElementDataContextGuid = (_) => dc;
         }
+#endif
     }
 }

--- a/src/AccessibilityInsights.AutomationTests/SnapshotCommandUnitTests.cs
+++ b/src/AccessibilityInsights.AutomationTests/SnapshotCommandUnitTests.cs
@@ -94,7 +94,7 @@ namespace AccessibilityInsights.AutomationTests
             return element;
         }
 
-        #if FAKES_SUPPORTED
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(2000)]
         public void Execute_AutomationSessionInstanceThrowsAutomationException_ReturnsIncomplete_MessageMatchesException()

--- a/src/AccessibilityInsights.AutomationTests/StartCommandUnitTests.cs
+++ b/src/AccessibilityInsights.AutomationTests/StartCommandUnitTests.cs
@@ -13,7 +13,7 @@ namespace AccessibilityInsights.AutomationTests
     [TestClass]
     public class StartCommandUnitTests
     {
-        #if FAKES_SUPPORTED
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(1000)]
         public void Execute_NewInstanceSucceeds_ReturnsSuccessfulResult()

--- a/src/AccessibilityInsights.AutomationTests/StartCommandUnitTests.cs
+++ b/src/AccessibilityInsights.AutomationTests/StartCommandUnitTests.cs
@@ -1,16 +1,19 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Automation;
-using AccessibilityInsights.Automation.Fakes;
-using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+#if FAKES_SUPPORTED
+using AccessibilityInsights.Automation.Fakes;
+using Microsoft.QualityTools.Testing.Fakes;
+#endif
 
 namespace AccessibilityInsights.AutomationTests
 {
     [TestClass]
     public class StartCommandUnitTests
     {
+        #if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(1000)]
         public void Execute_NewInstanceSucceeds_ReturnsSuccessfulResult()
@@ -57,5 +60,6 @@ namespace AccessibilityInsights.AutomationTests
                 Assert.AreEqual(exceptionMessage, result.SummaryMessage);
             }
         }
+#endif
     }
 }

--- a/src/AccessibilityInsights.AutomationTests/StopCommandUnitTests.cs
+++ b/src/AccessibilityInsights.AutomationTests/StopCommandUnitTests.cs
@@ -1,15 +1,18 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Automation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if FAKES_SUPPORTED
 using AccessibilityInsights.Automation.Fakes;
 using Microsoft.QualityTools.Testing.Fakes;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
 
 namespace AccessibilityInsights.AutomationTests
 {
     [TestClass]
     public class StopCommandUnitTests
     {
+        #if FAKES_SUPPORTED
         [TestMethod]
         [Timeout (1000)]
         public void Execute_ClearInstanceSucceeds_ReturnsSuccessfulResult()
@@ -56,5 +59,6 @@ namespace AccessibilityInsights.AutomationTests
                 Assert.AreEqual(exceptionMessage, result.SummaryMessage);
             }
         }
+#endif
     }
 }

--- a/src/AccessibilityInsights.AutomationTests/StopCommandUnitTests.cs
+++ b/src/AccessibilityInsights.AutomationTests/StopCommandUnitTests.cs
@@ -12,7 +12,7 @@ namespace AccessibilityInsights.AutomationTests
     [TestClass]
     public class StopCommandUnitTests
     {
-        #if FAKES_SUPPORTED
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout (1000)]
         public void Execute_ClearInstanceSucceeds_ReturnsSuccessfulResult()


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
This allows us to exclude only test methods which use Fakes, rather than all methods in a file with a method which uses Fakes. And that makes it possible for developers who use versions of Visual Studio which don't have Fakes support (like Community) to run more unit tests.


