### PR TITLE
Ignore fakes at a per-test level in CoreTests.csproj

### DIFF
--- a/src/AccessibilityInsights.CoreTests/CoreTests.csproj
+++ b/src/AccessibilityInsights.CoreTests/CoreTests.csproj
@@ -40,6 +40,9 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup Condition="$(FAKES_SUPPORTED) == 1">
+    <DefineConstants>$(DefineConstants);FAKES_SUPPORTED</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AccessibilityInsights.Core.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\AccessibilityInsights.Core.Fakes.dll</HintPath>
@@ -82,12 +85,12 @@
     <Compile Include="Bases\A11yPatternPropertyTests.cs" />
     <Compile Include="Bases\A11yPatternTests.cs" />
     <Compile Include="Bases\A11yPropertyTests.cs" />
-    <Compile Include="Fingerprint\ScanResultFingerprintUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
+    <Compile Include="Fingerprint\ScanResultFingerprintUnitTests.cs" />
     <Compile Include="Fingerprint\FingerprintContributionUnitTests.cs" />
-    <Compile Include="Fingerprint\IssueUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
-    <Compile Include="Fingerprint\InMemoryIssueStoreUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
-    <Compile Include="Fingerprint\OutputFileLocationUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
-    <Compile Include="Fingerprint\OutputFileIssueStoreUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
+    <Compile Include="Fingerprint\IssueUnitTests.cs" />
+    <Compile Include="Fingerprint\InMemoryIssueStoreUnitTests.cs" />
+    <Compile Include="Fingerprint\OutputFileLocationUnitTests.cs" />
+    <Compile Include="Fingerprint\OutputFileIssueStoreUnitTests.cs" />
     <Compile Include="Fingerprint\IssueStoreExtensionsUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
     <Compile Include="Misc\MiscTests.cs" />
     <Compile Include="Misc\PreconditionsUnitTests.cs" />

--- a/src/AccessibilityInsights.CoreTests/Fingerprint/InMemoryIssueStoreUnitTests.cs
+++ b/src/AccessibilityInsights.CoreTests/Fingerprint/InMemoryIssueStoreUnitTests.cs
@@ -4,9 +4,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using AccessibilityInsights.Core.Fingerprint;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if FAKES_SUPPORTED
 using AccessibilityInsights.Core.Fingerprint.Fakes;
 using Microsoft.QualityTools.Testing.Fakes;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
 
 namespace AccessibilityInsights.CoreTests.Fingerprint
 {
@@ -62,6 +64,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
             }
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout (2000)]
         public void AddIssue_IssueIsNotInList_AddsIssueAndReturnsCorrectResult()
@@ -120,6 +123,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
                 }
             }
         }
+#endif
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
@@ -140,6 +144,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
             }
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(2000)]
         public void TryFindIssue_FingerprintDoesNotMatch_ReturnsFalse()
@@ -186,5 +191,6 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
                 }
             }
         }
+#endif
     }
 }

--- a/src/AccessibilityInsights.CoreTests/Fingerprint/IssueUnitTests.cs
+++ b/src/AccessibilityInsights.CoreTests/Fingerprint/IssueUnitTests.cs
@@ -4,9 +4,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using AccessibilityInsights.Core.Fingerprint;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if FAKES_SUPPORTED
 using AccessibilityInsights.Core.Fingerprint.Fakes;
 using Microsoft.QualityTools.Testing.Fakes;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
 
 namespace AccessibilityInsights.CoreTests.Fingerprint
 {
@@ -31,6 +33,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
             }
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
         [Timeout(2000)]
@@ -138,5 +141,6 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
                 Assert.AreSame(location, actualLocation);
             }
         }
+#endif
     }
 }

--- a/src/AccessibilityInsights.CoreTests/Fingerprint/OutputFileIssueStoreUnitTests.cs
+++ b/src/AccessibilityInsights.CoreTests/Fingerprint/OutputFileIssueStoreUnitTests.cs
@@ -4,14 +4,16 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using AccessibilityInsights.Core.Bases;
-using AccessibilityInsights.Core.Bases.Fakes;
 using AccessibilityInsights.Core.Enums;
 using AccessibilityInsights.Core.Fingerprint;
-using AccessibilityInsights.Core.Fingerprint.Fakes;
 using AccessibilityInsights.Core.Results;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if FAKES_SUPPORTED
+using AccessibilityInsights.Core.Bases.Fakes;
+using AccessibilityInsights.Core.Fingerprint.Fakes;
 using AccessibilityInsights.Core.Results.Fakes;
 using Microsoft.QualityTools.Testing.Fakes;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
 
 namespace AccessibilityInsights.CoreTests.Fingerprint
 {
@@ -107,6 +109,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
             }
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(2000)]
         public void AddIssue_IssueIsNotNull_ReturnsNotSupported()
@@ -119,6 +122,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
                 }
             }
         }
+#endif
 
         [TestMethod]
         [Timeout(2000)]
@@ -130,6 +134,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
             }
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(2000)]
         public void AddIssue_IssuesExist_ReturnsCorrectSet()
@@ -159,6 +164,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
                 }
             }
         }
+#endif
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
@@ -179,6 +185,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
             }
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(2000)]
         public void TryFindIssue_IssueIsNotInStore_ReturnsFalseWithNullIssue()
@@ -232,6 +239,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
                 }
             }
         }
+#endif
 
         [TestMethod]
         [Timeout(2000)]
@@ -244,6 +252,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
             Assert.IsFalse(store.Any());
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(2000)]
         public void ExtractIssues_ElementsContainNoScanResults_LeavesStoreUnchanged()
@@ -801,5 +810,6 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
                 Assert.AreEqual(expectedRuleId, actualRuleIds[1]);
             }
         }
+#endif
     }
 }

--- a/src/AccessibilityInsights.CoreTests/Fingerprint/OutputFileLocationUnitTests.cs
+++ b/src/AccessibilityInsights.CoreTests/Fingerprint/OutputFileLocationUnitTests.cs
@@ -5,13 +5,15 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
-using System.IO.Fakes;
 using AccessibilityInsights.Core.Bases;
-using AccessibilityInsights.Core.Bases.Fakes;
 using AccessibilityInsights.Core.Fingerprint;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if FAKES_SUPPORTED
+using System.IO.Fakes;
+using AccessibilityInsights.Core.Bases.Fakes;
 using AccessibilityInsights.Core.Fingerprint.Fakes;
 using Microsoft.QualityTools.Testing.Fakes;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
 
 namespace AccessibilityInsights.CoreTests.Fingerprint
 {
@@ -69,6 +71,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
             }
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
         [Timeout(2000)]
@@ -453,5 +456,6 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
                 Assert.AreEqual("open", actualStartInfo.Verb);
             }
         }
+#endif
     }
 }

--- a/src/AccessibilityInsights.CoreTests/Fingerprint/ScanResultFingerprintUnitTests.cs
+++ b/src/AccessibilityInsights.CoreTests/Fingerprint/ScanResultFingerprintUnitTests.cs
@@ -6,23 +6,26 @@ using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using AccessibilityInsights.Core.Bases;
-using AccessibilityInsights.Core.Bases.Fakes;
 using AccessibilityInsights.Core.Enums;
 using AccessibilityInsights.Core.Fingerprint;
-using AccessibilityInsights.Core.Fingerprint.Fakes;
 using AccessibilityInsights.Core.Results;
 using AccessibilityInsights.Core.Types;
-using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if FAKES_SUPPORTED
+using AccessibilityInsights.Core.Bases.Fakes;
+using AccessibilityInsights.Core.Fingerprint.Fakes;
+using Microsoft.QualityTools.Testing.Fakes;
+#endif
 
 namespace AccessibilityInsights.CoreTests.Fingerprint
 {
     [TestClass]
     public class ScanResultFingerprintUnitTests
     {
+#pragma warning disable CS0414
         private readonly string _specialNameValue1;
         private readonly string _specialNameValue2;
-
+#pragma warning restore 414
         private const RuleId DefaultRule = RuleId.ItemTypeCorrect;
         private const ScanStatus DefaultScanStatus = ScanStatus.Fail;
         private const string DefaultRuleIdValue = "ItemTypeCorrect";
@@ -265,6 +268,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
             }
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(2000)]
         public void Ctor_ElementHasName_FingerprintIncludesName()
@@ -547,6 +551,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
                 ValidateFingerprint(fingerprint, ruleIdValue: "IsKeyboardFocusableBasedOnPatterns", isKeyboardFocusableValue: "False");
             }
         }
+#endif
 
         [TestMethod]
         [Timeout(2000)]
@@ -570,6 +575,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
             Assert.AreEqual(fingerprint1.GetHashCode(), fingerprint2.GetHashCode());
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(2000)]
         public void GetHashCode_EquivalentComplexContributions_ReturnsSameHashCode()
@@ -595,6 +601,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
                 Assert.AreEqual(fingerprint1.GetHashCode(), fingerprint2.GetHashCode());
             }
         }
+#endif
 
         [TestMethod]
         [Timeout(2000)]
@@ -614,6 +621,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
             Assert.AreNotEqual(fingerprint1.GetHashCode(), fingerprint2.GetHashCode());
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(2000)]
         public void GetHashCode_DifferentComplexContributions_ReturnsSameHashCode()
@@ -639,6 +647,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
                 Assert.AreNotEqual(fingerprint1.GetHashCode(), fingerprint2.GetHashCode());
             }
         }
+#endif
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
@@ -658,6 +667,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
             }
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
         [Timeout(2000)]
@@ -729,6 +739,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
                 }
             }
         }
+#endif
 
         [TestMethod]
         [Timeout (2000)]
@@ -738,6 +749,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
             Assert.IsFalse(fingerprint.Equals(null));
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout (2000)]
         public void Equals_OtherIsDifferentImplementation_ReturnsFalse()
@@ -869,6 +881,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
                 Assert.AreEqual(2, value);
             }
         }
+#endif
 
         [TestMethod]
         [Timeout(2000)]

--- a/src/AccessibilityInsights.CoreTests/Fingerprint/ScanResultFingerprintUnitTests.cs
+++ b/src/AccessibilityInsights.CoreTests/Fingerprint/ScanResultFingerprintUnitTests.cs
@@ -25,7 +25,7 @@ namespace AccessibilityInsights.CoreTests.Fingerprint
 #pragma warning disable CS0414
         private readonly string _specialNameValue1;
         private readonly string _specialNameValue2;
-#pragma warning restore 414
+#pragma warning restore CS0414
         private const RuleId DefaultRule = RuleId.ItemTypeCorrect;
         private const ScanStatus DefaultScanStatus = ScanStatus.Fail;
         private const string DefaultRuleIdValue = "ItemTypeCorrect";


### PR DESCRIPTION
This PR ignores individual tests in CoreTests.csproj that require fakes if the FAKES_SUPPORTED environment variable is disabled. This improves upon the old approach that ignored entire files.