### PR TITLE
Excluding tests with fakes in azuredevops extension

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOpsTests/AzureDevOpsBugReportingUnitTests.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOpsTests/AzureDevOpsBugReportingUnitTests.cs
@@ -2,13 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Extensions.AzureDevOps;
 using AccessibilityInsights.Extensions.AzureDevOps.Enums;
-using AccessibilityInsights.Extensions.AzureDevOps.Fakes;
 using AccessibilityInsights.Extensions.AzureDevOps.Models;
 using AccessibilityInsights.Extensions.Interfaces.BugReporting;
-using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+#if FAKES_SUPPORTED
+using AccessibilityInsights.Extensions.AzureDevOps.Fakes;
+using Microsoft.QualityTools.Testing.Fakes;
+#endif
 
 namespace AccessibilityInsights.Extensions.AzureDevOpsTests
 {
@@ -184,6 +186,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOpsTests
             Assert.IsNull(bugFieldPairs[BugField.TestMessages]);
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout(1000)]
         public void CreateBugPreviewAsync_TeamNameIsNull_ChainsThroughCorrectly()
@@ -261,5 +264,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOpsTests
                 Assert.AreEqual(expectedTeamName, actualTeamName);
             }
         }
+#endif
     }
 }

--- a/src/AccessibilityInsights.Extensions.AzureDevOpsTests/Extensions.AzureDevOpsTests.csproj
+++ b/src/AccessibilityInsights.Extensions.AzureDevOpsTests/Extensions.AzureDevOpsTests.csproj
@@ -40,6 +40,9 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup Condition="$(FAKES_SUPPORTED) == 1">
+    <DefineConstants>$(DefineConstants);FAKES_SUPPORTED</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AccessibilityInsights.Extensions.AzureDevOps.Fakes">
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\AccessibilityInsights.Extensions.AzureDevOps.Fakes.dll</HintPath>

--- a/src/AccessibilityInsights.Extensions.AzureDevOpsTests/Extensions.AzureDevOpsTests.csproj
+++ b/src/AccessibilityInsights.Extensions.AzureDevOpsTests/Extensions.AzureDevOpsTests.csproj
@@ -62,7 +62,7 @@
     <Compile Include="ConnectionCacheTests.cs" />
     <Compile Include="ConnectionInfoTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="AzureDevOpsBugReportingUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
+    <Compile Include="AzureDevOpsBugReportingUnitTests.cs"/>
     <Compile Include="AzureDevOpsIntegrationTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This project had one file with both fakes & non-fakes tests. Those tests have now been individually excluded based on the FAKES_SUPPORTED env variable.