### PR TITLE
excluding tests that require fakes in AutomationTests.csproj

### DIFF
--- a/src/AccessibilityInsights.AutomationTests/AutomationTests.csproj
+++ b/src/AccessibilityInsights.AutomationTests/AutomationTests.csproj
@@ -41,6 +41,9 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup Condition="$(FAKES_SUPPORTED) == 1">
+    <DefineConstants>$(DefineConstants);FAKES_SUPPORTED</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AccessibilityInsights.Actions.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\AccessibilityInsights.Actions.Fakes.dll</HintPath>
@@ -80,10 +83,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutomationSessionUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
-    <Compile Include="CommandParametersUnitTests.cs"  Condition="$(FAKES_SUPPORTED) == 1"/>
+    <Compile Include="CommandParametersUnitTests.cs" />
     <Compile Include="DummyDisposable.cs" />
     <Compile Include="ExecutionWrapperUnitTests.cs" />
-    <Compile Include="LocationHelperUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
+    <Compile Include="LocationHelperUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StartCommandUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>
     <Compile Include="StopCommandUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1"/>

--- a/src/AccessibilityInsights.AutomationTests/CommandParametersUnitTests.cs
+++ b/src/AccessibilityInsights.AutomationTests/CommandParametersUnitTests.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Automation;
-using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Fakes;
 using System.Linq;
+#if FAKES_SUPPORTED
+using Microsoft.QualityTools.Testing.Fakes;
+using System.IO.Fakes;
+#endif
 
 namespace AccessibilityInsights.AutomationTests
 {
@@ -74,6 +76,7 @@ namespace AccessibilityInsights.AutomationTests
             }
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout (1000)]
         [ExpectedException(typeof(A11yAutomationException))]
@@ -154,6 +157,7 @@ namespace AccessibilityInsights.AutomationTests
                 Assert.AreEqual(BoolAsString, value);
             }
         }
+#endif
 
         [TestMethod]
         [Timeout (1000)]

--- a/src/AccessibilityInsights.AutomationTests/LocationHelperUnitTests.cs
+++ b/src/AccessibilityInsights.AutomationTests/LocationHelperUnitTests.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Fakes;
 using AccessibilityInsights.Automation;
-using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if FAKES_SUPPORTED
+using System.IO.Fakes;
+using Microsoft.QualityTools.Testing.Fakes;
+#endif
 
 namespace AccessibilityInsights.AutomationTests
 {
@@ -89,6 +91,7 @@ namespace AccessibilityInsights.AutomationTests
             }
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout (1000)]
         public void Ctor_OutputPathDoesNotExist_CreatesOutputPath()
@@ -161,6 +164,7 @@ namespace AccessibilityInsights.AutomationTests
                 Assert.AreEqual(Core.Enums.FileFilters.TestExtension.Substring(1), helper.OutputFileFormat, true);
             }
         }
+#endif
 
         [TestMethod]
         [Timeout (1000)]
@@ -196,6 +200,7 @@ namespace AccessibilityInsights.AutomationTests
             }
         }
 
+#if FAKES_SUPPORTED
         [TestMethod]
         [Timeout (1000)]
         public void Ctor_NoOutputPathProvidedNullEnvValue_EnsureFetchesFallbackValue()
@@ -268,5 +273,6 @@ namespace AccessibilityInsights.AutomationTests
                 Assert.AreEqual(Core.Enums.FileFilters.TestExtension.Substring(1), helper.OutputFileFormat, true);
             }
         }
+#endif
     }
 }


### PR DESCRIPTION
Any individual test that requires fakes in this project is only included if FAKES_SUPPORTED is enabled