### PR TITLE
Excluding Fakes test methods based on a preprocessor symbol ...

### DIFF
--- a/src/AccessibilityInsights.SharedUxTests/FileBug/FileBugActionTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/FileBug/FileBugActionTests.cs
@@ -1,18 +1,21 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using AccessibilityInsights.Actions.Fakes;
 using AccessibilityInsights.Core.Enums;
 using AccessibilityInsights.Desktop.Telemetry;
-using AccessibilityInsights.Desktop.Telemetry.Fakes;
 using AccessibilityInsights.Extensions.Interfaces.BugReporting;
-using AccessibilityInsights.Extensions.Interfaces.BugReporting.Fakes;
 using AccessibilityInsights.SharedUx.FileBug;
-using AccessibilityInsights.SharedUx.FileBug.Fakes;
-using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+#if FAKES_SUPPORTED
+using AccessibilityInsights.Actions.Fakes;
+using AccessibilityInsights.Desktop.Telemetry.Fakes;
+using AccessibilityInsights.Extensions.Interfaces.BugReporting.Fakes;
+using AccessibilityInsights.SharedUx.FileBug.Fakes;
+using Microsoft.QualityTools.Testing.Fakes;
+#endif
+
 
 namespace AccessibilityInsights.SharedUxTests.FileBug
 {
@@ -21,6 +24,7 @@ namespace AccessibilityInsights.SharedUxTests.FileBug
     {
         static readonly Uri FAKE_SERVER_URL = new Uri("https://myaccount.visualstudio.com/");
 
+#if FAKES_SUPPORTED
         [TestMethod]
         public void FileNewBug_IsNotEnabled_ReturnsPlaceholder()
         {
@@ -97,6 +101,7 @@ namespace AccessibilityInsights.SharedUxTests.FileBug
                 Assert.AreEqual(2, telemetryLog[0].Item2.Count);
             }
         }
+#endif
 
         [TestMethod]
         [Timeout(10000)]
@@ -122,6 +127,7 @@ namespace AccessibilityInsights.SharedUxTests.FileBug
             Assert.AreEqual(expected, FileBugAction.RemoveInternalHTML(original, guid));
         }
 
+#if FAKES_SUPPORTED
         public static void SetUpShims()
         {
             ShimGetDataAction.GetElementDataContextGuid = (_) =>
@@ -139,5 +145,6 @@ namespace AccessibilityInsights.SharedUxTests.FileBug
                 return retBugId;
             };
         }
+#endif
     }
 }

--- a/src/AccessibilityInsights.SharedUxTests/Settings/InstallationInfoTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/InstallationInfoTests.cs
@@ -1,17 +1,20 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+#if FAKES_SUPPORTED
+using Microsoft.QualityTools.Testing.Fakes;
 using System.Fakes;
 using System.IO.Fakes;
-using AccessibilityInsights.SharedUx.Utilities;
-using Microsoft.QualityTools.Testing.Fakes;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
 
 namespace AccessibilityInsights.SharedUxTests.Settings
 {
     [TestClass]
     public class InstallationInfoTests
     {
+#if FAKES_SUPPORTED
         /// <summary>
         /// Checks whether the guid resets when the month changes
         /// </summary>
@@ -51,5 +54,6 @@ namespace AccessibilityInsights.SharedUxTests.Settings
                 Assert.AreEqual(janInfo2.LastReset, januaryYearTwo);
             }
         }
+#endif
     }
 }

--- a/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
+++ b/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
@@ -45,7 +45,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AccessibilityInsights.Actions.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
-      <HintPath>..\AccessibilityInsights.fAKES.Prebuild\FakesAssemblies\AccessibilityInsights.Actions.Fakes.dll</HintPath>
+      <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\AccessibilityInsights.Actions.Fakes.dll</HintPath>
     </Reference>
     <Reference Include="AccessibilityInsights.Desktop.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\AccessibilityInsights.Desktop.Fakes.dll</HintPath>

--- a/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
+++ b/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
@@ -40,20 +40,23 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup Condition="$(FAKES_SUPPORTED) == 1">
+      <DefineConstants>$(DefineConstants);FAKES_SUPPORTED</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AccessibilityInsights.Actions.Fakes">
-      <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\AccessibilityInsights.Actions.Fakes.dll</HintPath>
+    <Reference Include="AccessibilityInsights.Actions.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
+      <HintPath>..\AccessibilityInsights.fAKES.Prebuild\FakesAssemblies\AccessibilityInsights.Actions.Fakes.dll</HintPath>
     </Reference>
-    <Reference Include="AccessibilityInsights.Desktop.Fakes">
+    <Reference Include="AccessibilityInsights.Desktop.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\AccessibilityInsights.Desktop.Fakes.dll</HintPath>
     </Reference>
-    <Reference Include="AccessibilityInsights.Extensions.Fakes">
+    <Reference Include="AccessibilityInsights.Extensions.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\AccessibilityInsights.Extensions.Fakes.dll</HintPath>
     </Reference>
-    <Reference Include="AccessibilityInsights.SharedUx.Fakes">
+    <Reference Include="AccessibilityInsights.SharedUx.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\AccessibilityInsights.SharedUx.Fakes.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.QualityTools.Testing.Fakes, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.QualityTools.Testing.Fakes, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="$(FAKES_SUPPORTED) == 1">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -62,7 +65,7 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib.4.0.0.0.Fakes">
+    <Reference Include="mscorlib.4.0.0.0.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\mscorlib.4.0.0.0.Fakes.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -83,12 +86,12 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Converters\BoolToVisibilityConverterTests.cs" />
-    <Compile Include="FileBug\FileBugActionTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
+    <Compile Include="FileBug\FileBugActionTests.cs"/>
     <Compile Include="Settings\ConfigurationModelTests.cs" />
     <Compile Include="Settings\LayoutTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings\AppLayoutTests.cs" />
-    <Compile Include="Settings\InstallationInfoTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
+    <Compile Include="Settings\InstallationInfoTests.cs"/>
     <Compile Include="Settings\SettingsDictionaryUnitTests.cs" />
     <Compile Include="ViewModels\ColorContrastViewModelTests.cs" />
     <Compile Include="ViewModels\ViewModelTests.cs" />


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change

... instead of by file.
    
        This allows us to exclude only test methods which use Fakes, rather than all methods in a file with a method which uses Fakes. And that makes it possible for developers who use versions of Visual Studio which don't have Fakes support (like Community) to run more unit tests.
