### PR TITLE
Fix empty message box issue

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -972,8 +972,16 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 // Bug already filed, open it in a new window
                 try
                 {
-                    var bugUrl = BugReporter.GetExistingBugUriAsync(vm.BugId.Value).Result.ToString();
-                    Process.Start(bugUrl);
+                    var bugUrl = BugReporter.GetExistingBugUriAsync(vm.BugId.Value).Result?.ToString();
+
+                    if (bugUrl == null)
+                    {
+                        MessageDialog.Show("Please sign into Azure DevOps to view the bug information");
+                    }
+                    else
+                    {
+                        Process.Start(bugUrl);
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
The PR addresses the issue where it shows an empty message box when user is not logged in and trying to view an existing bug. 
