### PR TITLE
Update logo when the state of the issue reporter changes

### DIFF
--- a/src/AccessibilityInsights.Extensions/Extensions.csproj
+++ b/src/AccessibilityInsights.Extensions/Extensions.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Interfaces\IssueReporting\IssueConfigurationControl.cs" />
     <Compile Include="Interfaces\IssueReporting\IssueInformation.cs" />
     <Compile Include="Interfaces\IssueReporting\IssueType.cs" />
+    <Compile Include="Interfaces\IssueReporting\ReporterFabricIcon.cs" />
     <Compile Include="Interfaces\Telemetry\Hint.cs" />
     <Compile Include="Interfaces\Telemetry\ITelemetry.cs" />
     <Compile Include="Interfaces\Upgrades\IAutoUpdate.cs" />

--- a/src/AccessibilityInsights.Extensions/Interfaces/IssueReporting/IIssueReporting.cs
+++ b/src/AccessibilityInsights.Extensions/Interfaces/IssueReporting/IIssueReporting.cs
@@ -32,7 +32,7 @@ namespace AccessibilityInsights.Extensions.Interfaces.IssueReporting
         /// <summary>
         /// The logo to display for the extension
         /// </summary>
-        IEnumerable<byte> Logo { get; }
+        ReporterFabricIcon Logo { get; }
 
         /// <summary>
         /// Tooltip/accessible text for logo

--- a/src/AccessibilityInsights.Extensions/Interfaces/IssueReporting/ReporterFabricIcon.cs
+++ b/src/AccessibilityInsights.Extensions/Interfaces/IssueReporting/ReporterFabricIcon.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AccessibilityInsights.Extensions.Interfaces.IssueReporting
+{
+    public enum ReporterFabricIcon
+    {
+        GitHubLogo, // F65E
+        PlugConnected, // F302
+        PlugDisconnected, // F303
+        VSTSLogo, //F381
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
@@ -84,7 +84,7 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
         /// Adds the currently selected connection to the configuration so it is persisted
         /// </summary>
         /// <param name="configuration"></param>
-        public void UpdateConfigFromSelections(ConfigurationModel configuration)
+        public bool UpdateConfigFromSelections(ConfigurationModel configuration)
         {
             if (issueConfigurationControl.CanSave)
             {
@@ -97,7 +97,9 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
                 configuration.IssueReporterSerializedConfigs = JsonConvert.SerializeObject(configs);
                 IssueReporterManager.GetInstance().SetIssueReporter(selectedIssueReporter.StableIdentifier);
                 issueConfigurationControl.OnDismiss();
+                return true;
             }
+            return false;
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/TestIssueProvider.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/TestIssueProvider.cs
@@ -19,7 +19,7 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
 
         public bool CanAttachFiles => true;
 
-        public IEnumerable<byte> Logo => null;
+        public ReporterFabricIcon Logo => ReporterFabricIcon.GitHubLogo;
 
         public string LogoText => null;
 
@@ -30,7 +30,7 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
 
         public Task RestoreConfigurationAsync(string serializedConfig)
         {
-            return new Task<IIssueReporting>(() => { return null; });
+            return Task.Run(() => { return null; });
         }
 
         public IssueConfigurationControl RetrieveConfigurationControl(Action UpdateSaveButton)

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/TestIssueProvider2.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/TestIssueProvider2.cs
@@ -19,7 +19,7 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
 
         public bool CanAttachFiles => true;
 
-        public IEnumerable<byte> Logo => null;
+        public ReporterFabricIcon Logo => ReporterFabricIcon.VSTSLogo;
 
         public string LogoText => null;
 

--- a/src/AccessibilityInsights.SharedUx/FileBug/BugReporter.cs
+++ b/src/AccessibilityInsights.SharedUx/FileBug/BugReporter.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace AccessibilityInsights.SharedUx.FileBug
 {
     /// <summary>
-    /// Adapter between the core app and the bug reporting extension
+    /// Adapter between the core app and the issue reporting extension
     /// </summary>
     static public class BugReporter
     {
@@ -19,9 +19,7 @@ namespace AccessibilityInsights.SharedUx.FileBug
 
         public static bool IsConnected => IsEnabled && (IssueReporting == null ? false : IssueReporting.IsConfigured);
 
-#pragma warning disable CA1819 // Properties should not return arrays
-        public static byte[] Logo => IsEnabled ? IssueReporting.Logo?.ToArray() : null;
-#pragma warning restore CA1819 // Properties should not return arrays
+        public static ReporterFabricIcon Logo => IsEnabled ? IssueReporting.Logo : ReporterFabricIcon.PlugDisconnected;
 
         public static string DisplayName => IsEnabled ? IssueReporting.ServiceName : null;
 

--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -467,7 +467,7 @@
     <Compile Include="Utilities\HelperMethods.cs" />
     <Compile Include="Utilities\InstallationInfo.cs" />
     <Compile Include="ViewModels\BaseActionViewModel.cs" />
-    <Compile Include="ViewModels\ByteArrayViewModel.cs" />
+    <Compile Include="ViewModels\LogoViewModel.cs" />
     <Compile Include="ViewModels\ColorContrastViewModel.cs" />
     <Compile Include="ViewModels\ApplicationSettingsViewModel.cs" />
     <Compile Include="ViewModels\GeneralActionViewModel.cs" />

--- a/src/AccessibilityInsights.SharedUx/ViewModels/LogoViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/LogoViewModel.cs
@@ -3,23 +3,23 @@
 namespace AccessibilityInsights.SharedUx.ViewModels
 {
     /// <summary>
-    /// View model for a byte array, currently used for avatar image
+    /// View model for the issue reporter logo
     /// </summary>
-    public class ByteArrayViewModel : ViewModelBase
+    public class LogoViewModel : ViewModelBase
     {
-        private byte[] array;
+        private string _fabricIconLogoName;
 #pragma warning disable CA1819 // Properties should not return arrays
-        public byte[] ByteData
+        public string FabricIconLogoName
 #pragma warning restore CA1819 // Properties should not return arrays
         {
             get
             {
-                return array;
+                return _fabricIconLogoName;
             }
             set
             {
-                array = value;
-                OnPropertyChanged(nameof(this.ByteData));
+                _fabricIconLogoName = value;
+                OnPropertyChanged(nameof(this.FabricIconLogoName));
             }
         }
     }

--- a/src/AccessibilityInsights.SharedUx/ViewModels/LogoViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/LogoViewModel.cs
@@ -8,9 +8,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     public class LogoViewModel : ViewModelBase
     {
         private string _fabricIconLogoName;
-#pragma warning disable CA1819 // Properties should not return arrays
         public string FabricIconLogoName
-#pragma warning restore CA1819 // Properties should not return arrays
         {
             get
             {

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -182,7 +182,7 @@
                                 <Image x:Name="imgAvatar" Visibility="Collapsed" Source="{Binding Path=vmAvatar.ByteData, TargetNullValue={x:Null}}"/>
                                 <Grid x:Name="newAccountGrid" Visibility="Visible">
                                     <AccessText Text="_i" Opacity="0"/>
-                                    <fabric:FabricIconControl GlyphName="Contact" FontSize="24" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=LightIconBrush}"  HorizontalAlignment="Center"/>
+                                    <fabric:FabricIconControl GlyphName="LadybugSolid" FontSize="24" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=LightIconBrush}"  HorizontalAlignment="Center"/>
                                 </Grid>
                             </Grid>
                         </Button>

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -146,25 +146,7 @@
                             <RowDefinition/>
                             <RowDefinition/>
                         </Grid.RowDefinitions>
-                        <Button Width="40" Height="40"
-                                    x:Name="btnConfig"
-                                    AutomationProperties.Name="{x:Static properties:Resources.btnConfigAutomationPropertiesName}"
-                                    AutomationProperties.HelpText="{x:Static properties:Resources.btnConfigAutomationPropertiesHelpText}"
-                                    Style="{StaticResource btnLeftNav}" Click="onbtnConfigClicked">
-                            <Button.ToolTip>
-                                <ToolTip>
-                                    <Run Text="{x:Static properties:Resources.btnConfigToolTip}" />
-                                </ToolTip>
-                            </Button.ToolTip>
-                            <i:Interaction.Behaviors>
-                                <behaviors:KeyboardToolTipButtonBehavior/>
-                            </i:Interaction.Behaviors>
-                            <Grid>
-                                <AccessText Text="_c" Opacity="0"/>
-                                <fabric:FabricIconControl GlyphName="Settings" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=LightIconBrush}"/>
-                            </Grid>
-                        </Button>
-                        <Button Width="40" Height="40" Grid.Row="1"
+                        <Button Width="40" Height="40" Grid.Row="0"
                             Style="{StaticResource btnLeftNav}"
                             x:Name="btnAccountConfig"
                             Click="btnAccountConfig_Click"
@@ -179,11 +161,28 @@
                                 <behaviors:KeyboardToolTipButtonBehavior/>
                             </i:Interaction.Behaviors>
                             <Grid Width="40" Height="40" x:Name="addAccountGrid">
-                                <Image x:Name="imgAvatar" Visibility="Collapsed" Source="{Binding Path=vmAvatar.ByteData, TargetNullValue={x:Null}}"/>
                                 <Grid x:Name="newAccountGrid" Visibility="Visible">
                                     <AccessText Text="_i" Opacity="0"/>
-                                    <fabric:FabricIconControl GlyphName="LadybugSolid" FontSize="24" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=LightIconBrush}"  HorizontalAlignment="Center"/>
+                                    <fabric:FabricIconControl GlyphName="{Binding Path=vmReporterLogo.FabricIconLogoName, TargetNullValue=PlugDisconnected}" FontSize="24" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=LightIconBrush}"  HorizontalAlignment="Center"/>
                                 </Grid>
+                            </Grid>
+                        </Button>
+                        <Button Width="40" Height="40"
+                                    x:Name="btnConfig" Grid.Row="1"
+                                    AutomationProperties.Name="{x:Static properties:Resources.btnConfigAutomationPropertiesName}"
+                                    AutomationProperties.HelpText="{x:Static properties:Resources.btnConfigAutomationPropertiesHelpText}"
+                                    Style="{StaticResource btnLeftNav}" Click="onbtnConfigClicked">
+                            <Button.ToolTip>
+                                <ToolTip>
+                                    <Run Text="{x:Static properties:Resources.btnConfigToolTip}" />
+                                </ToolTip>
+                            </Button.ToolTip>
+                            <i:Interaction.Behaviors>
+                                <behaviors:KeyboardToolTipButtonBehavior/>
+                            </i:Interaction.Behaviors>
+                            <Grid>
+                                <AccessText Text="_c" Opacity="0"/>
+                                <fabric:FabricIconControl GlyphName="Settings" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=LightIconBrush}"/>
                             </Grid>
                         </Button>
                     </Grid>

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -704,11 +704,9 @@ namespace AccessibilityInsights
                 var serializedConfigsDict = appConfig.IssueReporterSerializedConfigs;
                 Dictionary<Guid, string> configsDictionary = JsonConvert.DeserializeObject<Dictionary<Guid, string>>(serializedConfigsDict);
                 configsDictionary.TryGetValue(selectedIssueReporterGuid, out string serializedConfig);
-                await BugReporter.RestoreConfigurationAsync(serializedConfig).ConfigureAwait(false);
-                Dispatcher.Invoke(() =>
-                {
-                    UpdateMainWindowConnectionFields();
-                });
+                await BugReporter.RestoreConfigurationAsync(serializedConfig).ConfigureAwait(true);
+                UpdateMainWindowConnectionFields();
+
             }
         }
 

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -27,6 +27,7 @@ using static AccessibilityInsights.Misc.FrameworkNavigator;
 using AccessibilityInsights.Properties;
 using System.Web;
 using Newtonsoft.Json;
+using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
 
 namespace AccessibilityInsights
 {
@@ -46,7 +47,7 @@ namespace AccessibilityInsights
         public TwoStateButtonViewModel vmHilighter { get; private set; } = new TwoStateButtonViewModel(ButtonState.On);
         public TwoStateButtonViewModel vmLiveModePauseResume { get; private set; } = new TwoStateButtonViewModel(ButtonState.On);
 
-        public ByteArrayViewModel vmAvatar { get; private set; } = new ByteArrayViewModel();
+        public LogoViewModel vmReporterLogo { get; private set; } = new LogoViewModel();
 
         public bool IsEventRecording { get; private set; }
 
@@ -705,8 +706,9 @@ namespace AccessibilityInsights
                 Dictionary<Guid, string> configsDictionary = JsonConvert.DeserializeObject<Dictionary<Guid, string>>(serializedConfigsDict);
                 configsDictionary.TryGetValue(selectedIssueReporterGuid, out string serializedConfig);
                 await BugReporter.RestoreConfigurationAsync(serializedConfig).ConfigureAwait(true);
-                UpdateMainWindowConnectionFields();
-
+                Dispatcher.Invoke(() => {
+                    UpdateMainWindowConnectionFields();
+                });
             }
         }
 
@@ -716,13 +718,12 @@ namespace AccessibilityInsights
         internal void UpdateMainWindowConnectionFields()
         {
             bool isConfigured = BugReporter.IssueReporting != null && BugReporter.IsConnected;
-            
-            // Main window UI changes
-            vmAvatar.ByteData = isConfigured ? BugReporter.Logo : null;
-            imgAvatar.Visibility = isConfigured ? Visibility.Visible : Visibility.Collapsed;
-            newAccountGrid.Visibility = isConfigured ? Visibility.Collapsed : Visibility.Visible;
-            string tooltipResource = isConfigured ? Properties.Resources.UpdateMainWindowLoginFieldsSignedInAs : Properties.Resources.HandleLogoutRequestSignIn;
+            string fabricIconName = BugReporter.Logo.ToString("g");
+            fabricIconName = int.TryParse(fabricIconName, out int invalidLogo) ? ReporterFabricIcon.PlugConnected.ToString("g") : fabricIconName;
 
+            // Main window UI changes
+            vmReporterLogo.FabricIconLogoName = isConfigured ? BugReporter.Logo.ToString("g") : null;
+            string tooltipResource = isConfigured ? Properties.Resources.UpdateMainWindowLoginFieldsSignedInAs : Properties.Resources.HandleLogoutRequestSignIn;
             string tooltipText = string.Format(CultureInfo.InvariantCulture, tooltipResource, BugReporter.DisplayName);
             AutomationProperties.SetName(btnAccountConfig, tooltipText);
             btnAccountConfig.ToolTip = tooltipText;

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
@@ -124,7 +124,7 @@ namespace AccessibilityInsights.Modes
         /// <param name="e"></param>
         private void buttonOk_Click(object sender, RoutedEventArgs e)
         {
-            this.connectionCtrl.UpdateConfigFromSelections(Configuration);
+            bool issueReporterUpdated = this.connectionCtrl.UpdateConfigFromSelections(Configuration);
             this.appSettingsCtrl.UpdateConfigFromSelections(Configuration);
 
             IReadOnlyDictionary<string, object> diff = ConfigurationModel.Diff(this.configSnapshot, Configuration);
@@ -132,6 +132,12 @@ namespace AccessibilityInsights.Modes
             {
                 MainWin.HandleConfigurationChanged(diff);
             }
+
+            if (issueReporterUpdated)
+            {
+                MainWin.UpdateMainWindowConnectionFields();
+            }
+
             MainWin.TransitionToSelectActionMode();
         }
 

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -1541,7 +1541,7 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Signed in as {0}.
+        ///   Looks up a localized string similar to Signed into {0}.
         /// </summary>
         public static string UpdateMainWindowLoginFieldsSignedInAs {
             get {

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -567,7 +567,7 @@ Please ensure that you are opening a valid test file using the most recent relea
     <value>Couldn't save the file: {0}</value>
   </data>
   <data name="UpdateMainWindowLoginFieldsSignedInAs" xml:space="preserve">
-    <value>Signed in as {0}</value>
+    <value>Signed into {0}</value>
   </data>
   <data name="MainWindow_ShowUpgradeDialog_An_update_is_required" xml:space="preserve">
     <value>An update is required.</value>


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
![image](https://user-images.githubusercontent.com/45673569/54719282-b08ff200-4b19-11e9-979b-291964254c40.png)

Provides a way to update the logo and the tooltip after config restore (on login) and when we hit save on the connections page. We do not have the tooltip text and the default logo yet. Added the ladybug tentatively.

Inverts the order of the settings and the connection order.

Please ignore all files with a "TestIssue" prefix in the name (TestIssue*)
