### PR TITLE
Fixed Issue #133: Suggestion: Add a rule to warn if items in a …

### DIFF
--- a/src/AccessibilityInsights.Core/Enums/RuleId.cs
+++ b/src/AccessibilityInsights.Core/Enums/RuleId.cs
@@ -243,5 +243,7 @@ namespace AccessibilityInsights.Core.Enums
         SelectionPatternSelectionRequired,
         SelectionPatternSingleSelection,
         SelectionItemPatternSingleSelection,
+
+        ListItemSiblingsUnique,
     }
 }

--- a/src/AccessibilityInsights.Rules/Library/ListItemSiblingsUnique.cs
+++ b/src/AccessibilityInsights.Rules/Library/ListItemSiblingsUnique.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.Core.Bases;
+using AccessibilityInsights.Core.Enums;
+using AccessibilityInsights.Rules.PropertyConditions;
+using AccessibilityInsights.Rules.Resources;
+using System;
+using static AccessibilityInsights.Rules.PropertyConditions.BoolProperties;
+using static AccessibilityInsights.Rules.PropertyConditions.ControlType;
+using static AccessibilityInsights.Rules.PropertyConditions.Relationships;
+using static AccessibilityInsights.Rules.PropertyConditions.StringProperties;
+
+namespace AccessibilityInsights.Rules.Library
+{
+    [RuleInfo(ID = RuleId.ListItemSiblingsUnique)]
+    class ListItemSiblingsUnique : Rule
+    {
+        public ListItemSiblingsUnique()
+        {
+            this.Info.Description = Descriptions.ListItemSiblingsUnique;
+            this.Info.HowToFix = HowToFix.ListItemSiblingsUnique;
+            this.Info.Standard = A11yCriteriaId.NameRoleValue;
+        }
+
+        public override EvaluationCode Evaluate(IA11yElement e)
+        {
+            if (e == null) throw new ArgumentException(nameof(e));
+            if (e.Parent == null) throw new ArgumentNullException(nameof(e.Parent));
+
+            var siblings = SiblingCount(new ControlTypeCondition(e.ControlTypeId)
+                & (e.IsKeyboardFocusable ? IsKeyboardFocusable : IsNotKeyboardFocusable)
+                & Name.Is(e.Name)
+                & LocalizedControlType.Is(e.LocalizedControlType));
+            var count = siblings.GetValue(e);
+            if (count < 1) return EvaluationCode.RuleExecutionError;
+
+            return count == 1 ? EvaluationCode.Pass : EvaluationCode.Warning;
+        }
+
+        protected override Condition CreateCondition()
+        {
+            return ListItem
+                & IsContentOrControlElement
+                & ParentExists
+                & Name.NotNullOrEmpty
+                & LocalizedControlType.NotNullOrEmpty
+                & BoundingRectangle.Valid;
+        }
+    } // class
+} // namespace

--- a/src/AccessibilityInsights.Rules/Resources/Descriptions.Designer.cs
+++ b/src/AccessibilityInsights.Rules/Resources/Descriptions.Designer.cs
@@ -646,6 +646,15 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Name property of sibbling list items should be unique..
+        /// </summary>
+        internal static string ListItemSiblingsUnique {
+            get {
+                return ResourceManager.GetString("ListItemSiblingsUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The ControlType and LocalizedControlType must not both be set to &quot;custom.&quot;.
         /// </summary>
         internal static string LocalizedControlTypeNotCustom {

--- a/src/AccessibilityInsights.Rules/Resources/Descriptions.Designer.cs
+++ b/src/AccessibilityInsights.Rules/Resources/Descriptions.Designer.cs
@@ -646,7 +646,7 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Name property of sibbling list items should be unique..
+        ///   Looks up a localized string similar to The Name property of sibling list items should be unique..
         /// </summary>
         internal static string ListItemSiblingsUnique {
             get {

--- a/src/AccessibilityInsights.Rules/Resources/Descriptions.resx
+++ b/src/AccessibilityInsights.Rules/Resources/Descriptions.resx
@@ -418,6 +418,6 @@
     <value>The Name property must not be longer than 512 characters.</value>
   </data>
   <data name="ListItemSiblingsUnique" xml:space="preserve">
-    <value>The Name property of sibbling list items should be unique.</value>
+    <value>The Name property of sibling list items should be unique.</value>
   </data>
 </root>

--- a/src/AccessibilityInsights.Rules/Resources/Descriptions.resx
+++ b/src/AccessibilityInsights.Rules/Resources/Descriptions.resx
@@ -417,4 +417,7 @@
   <data name="NameReasonableLength" xml:space="preserve">
     <value>The Name property must not be longer than 512 characters.</value>
   </data>
+  <data name="ListItemSiblingsUnique" xml:space="preserve">
+    <value>The Name property of sibbling list items should be unique.</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.Rules/Resources/HowToFix.Designer.cs
+++ b/src/AccessibilityInsights.Rules/Resources/HowToFix.Designer.cs
@@ -689,6 +689,15 @@ namespace AccessibilityInsights.Rules.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Provide unique names for sibling list items..
+        /// </summary>
+        internal static string ListItemSiblingsUnique {
+            get {
+                return ResourceManager.GetString("ListItemSiblingsUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Sufficient:
         ///Provide a string for the LocalizedControlType property that concisely describes the control&apos;s function or purpose.
         ///

--- a/src/AccessibilityInsights.Rules/Resources/HowToFix.resx
+++ b/src/AccessibilityInsights.Rules/Resources/HowToFix.resx
@@ -537,4 +537,7 @@ If possible, use a predefined (non-custom) control type and the default localize
  · Concisely identifies the element, AND
  · Contains at most 512 characters.</value>
   </data>
+  <data name="ListItemSiblingsUnique" xml:space="preserve">
+    <value>Provide unique names for sibling list items.</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.Rules/Rules.csproj
+++ b/src/AccessibilityInsights.Rules/Rules.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Library\ComboBoxShouldNotSupportScrollPattern.cs" />
     <Compile Include="Library\ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs" />
     <Compile Include="Library\SelectionItemPatternSingleSelection.cs" />
+    <Compile Include="Library\ListItemSiblingsUnique.cs" />
     <Compile Include="Misc\ControlTypeStrings.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/AccessibilityInsights.RulesTest/Library/ListItemSiblingUniqueTests.cs
+++ b/src/AccessibilityInsights.RulesTest/Library/ListItemSiblingUniqueTests.cs
@@ -1,0 +1,241 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Drawing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using EvaluationCode = AccessibilityInsights.Rules.EvaluationCode;
+
+namespace AccessibilityInsights.RulesTest.Library
+{
+    [TestClass]
+    public class ListItemSiblingUniqueTests
+    {
+        private static AccessibilityInsights.Rules.IRule Rule = new AccessibilityInsights.Rules.Library.ListItemSiblingsUnique();
+
+        [TestMethod]
+        public void ElementsMatch_Warning()
+        {
+            var parent = new MockA11yElement();
+            var child1 = new MockA11yElement();
+            var child2 = new MockA11yElement();
+            child1.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child2.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child1.ControlTypeId = ControlType.ListItem;
+            child2.ControlTypeId = ControlType.ListItem;
+            child1.LocalizedControlType = "ListItem";
+            child2.LocalizedControlType = "ListItem";
+            child1.Name = "Alice";
+            child2.Name = "Alice";
+            child1.IsKeyboardFocusable = true;
+            child2.IsKeyboardFocusable = true;
+            child1.Parent = parent;
+            child2.Parent = parent;
+            parent.Children.Add(child1);
+            parent.Children.Add(child2);
+
+            Assert.AreEqual(EvaluationCode.Warning, Rule.Evaluate(child2));
+        }
+
+        [TestMethod]
+        public void ControlTypeMismatch_Pass()
+        {
+            var parent = new MockA11yElement();
+            var child1 = new MockA11yElement();
+            var child2 = new MockA11yElement();
+            child1.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child2.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child1.ControlTypeId = ControlType.ListItem;
+            child2.ControlTypeId = ControlType.Button;
+            child1.LocalizedControlType = "ListItem";
+            child2.LocalizedControlType = "ListItem";
+            child1.Name = "Alice";
+            child2.Name = "Alice";
+            child1.IsKeyboardFocusable = true;
+            child2.IsKeyboardFocusable = true;
+            child1.Parent = parent;
+            child2.Parent = parent;
+            parent.Children.Add(child1);
+            parent.Children.Add(child2);
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+        }
+
+        [TestMethod]
+        public void NameMismatchPass()
+        {
+            var parent = new MockA11yElement();
+            var child1 = new MockA11yElement();
+            var child2 = new MockA11yElement();
+            child1.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child2.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child1.ControlTypeId = ControlType.ListItem;
+            child2.ControlTypeId = ControlType.ListItem;
+            child1.LocalizedControlType = "ListItem";
+            child2.LocalizedControlType = "ListItem";
+            child1.Name = "Alice";
+            child2.Name = "Bob";
+            child1.IsKeyboardFocusable = true;
+            child2.IsKeyboardFocusable = true;
+            child1.Parent = parent;
+            child2.Parent = parent;
+            parent.Children.Add(child1);
+            parent.Children.Add(child2);
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+        }
+
+        [TestMethod]
+        public void IsKeyboardFocusableMismatch_Pass()
+        {
+            var parent = new MockA11yElement();
+            var child1 = new MockA11yElement();
+            var child2 = new MockA11yElement();
+            child1.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child2.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child1.ControlTypeId = ControlType.ListItem;
+            child2.ControlTypeId = ControlType.ListItem;
+            child1.LocalizedControlType = "ListItem";
+            child2.LocalizedControlType = "ListItem";
+            child1.Name = "Alice";
+            child2.Name = "Alice";
+            child1.IsKeyboardFocusable = true;
+            child2.IsKeyboardFocusable = false;
+            child1.Parent = parent;
+            child2.Parent = parent;
+            parent.Children.Add(child1);
+            parent.Children.Add(child2);
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+        }
+
+        [TestMethod]
+        public void LocalizedControlTypeMismatch_Pass()
+        {
+            var parent = new MockA11yElement();
+            var child1 = new MockA11yElement();
+            var child2 = new MockA11yElement();
+            child1.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child2.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child1.ControlTypeId = ControlType.ListItem;
+            child2.ControlTypeId = ControlType.ListItem;
+            child1.LocalizedControlType = "ListItem";
+            child2.LocalizedControlType = "Button";
+            child1.Name = "Alice";
+            child2.Name = "Alice";
+            child1.IsKeyboardFocusable = true;
+            child2.IsKeyboardFocusable = true;
+            child1.Parent = parent;
+            child2.Parent = parent;
+            parent.Children.Add(child1);
+            parent.Children.Add(child2);
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(child2));
+        }
+
+        [TestMethod]
+        public void ConditionMatch_True()
+        {
+            var parent = new MockA11yElement();
+            var child = new MockA11yElement();
+            child.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child.IsContentElement = true;
+            child.ControlTypeId = ControlType.ListItem;
+            child.LocalizedControlType = "ListItem";
+            child.Name = "Alice";
+            child.IsKeyboardFocusable = true;
+            child.Parent = parent;
+            parent.Children.Add(child);
+
+            Assert.IsTrue(Rule.Condition.Matches(child));
+        }
+
+        [TestMethod]
+        public void ConditionMatch_InvalidBoundingRect_False()
+        {
+            var parent = new MockA11yElement();
+            var child = new MockA11yElement();
+            child.BoundingRectangle = new Rectangle(0, 0, 0, 0);
+            child.IsContentElement = true;
+            child.ControlTypeId = ControlType.ListItem;
+            child.LocalizedControlType = "ListItem";
+            child.Name = "Alice";
+            child.Parent = parent;
+            parent.Children.Add(child);
+
+            Assert.IsFalse(Rule.Condition.Matches(child));
+        }
+
+        [TestMethod]
+        public void ConditionMatch_NotListItem_False()
+        {
+            var parent = new MockA11yElement();
+            var child = new MockA11yElement();
+            child.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child.IsContentElement = true;
+            child.ControlTypeId = ControlType.Button;
+            child.LocalizedControlType = "ListItem";
+            child.Name = "Alice";
+            child.Parent = parent;
+            parent.Children.Add(child);
+
+            Assert.IsFalse(Rule.Condition.Matches(child));
+        }
+
+        [TestMethod]
+        public void ConditionMatch_NotContentOrControl_False()
+        {
+            var parent = new MockA11yElement();
+            var child = new MockA11yElement();
+            child.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child.ControlTypeId = ControlType.ListItem;
+            child.LocalizedControlType = "ListItem";
+            child.Name = "Alice";
+            child.Parent = parent;
+            parent.Children.Add(child);
+
+            Assert.IsFalse(Rule.Condition.Matches(child));
+        }
+
+        [TestMethod]
+        public void ConditionMatch_NoName_False()
+        {
+            var parent = new MockA11yElement();
+            var child = new MockA11yElement();
+            child.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child.IsContentElement = true;
+            child.ControlTypeId = ControlType.ListItem;
+            child.LocalizedControlType = "ListItem";
+            child.Parent = parent;
+            parent.Children.Add(child);
+
+            Assert.IsFalse(Rule.Condition.Matches(child));
+        }
+
+        [TestMethod]
+        public void ConditionMatch_NoLocalizedControlType_False()
+        {
+            var parent = new MockA11yElement();
+            var child = new MockA11yElement();
+            child.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child.IsContentElement = true;
+            child.ControlTypeId = ControlType.ListItem;
+            child.Name = "Alice";
+            child.Parent = parent;
+            parent.Children.Add(child);
+
+            Assert.IsFalse(Rule.Condition.Matches(child));
+        }
+
+        [TestMethod]
+        public void ConditionMatch_NoParent_False()
+        {
+            var child = new MockA11yElement();
+            child.BoundingRectangle = new Rectangle(0, 0, 25, 25);
+            child.IsContentElement = true;
+            child.ControlTypeId = ControlType.ListItem;
+            child.LocalizedControlType = "ListItem";
+            child.Name = "Alice";
+
+            Assert.IsFalse(Rule.Condition.Matches(child));
+        }
+    } // class
+} // namespace

--- a/src/AccessibilityInsights.RulesTest/RulesTests.csproj
+++ b/src/AccessibilityInsights.RulesTest/RulesTests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Library\SelectionItemPatternSingleSelection.cs" />
     <Compile Include="Library\SelectionPatternSelectionRequired.cs" />
     <Compile Include="Library\ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs" />
+    <Compile Include="Library\ListItemSiblingUniqueTests.cs" />
     <Compile Include="Library\SplitButtonInvokeAndTogglePatterns.cs" />
     <Compile Include="Library\ControlShouldSupportExpandCollapsePattern.cs" />
     <Compile Include="Library\LocalizedControlTypeIsReasonable.cs" />


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
Adding the ListItemSiblingUnique rule which returns a warning. List items are not included in either of the related rules: SiblingUniqueNameAndFocusable and SiblingUniqueNameAndNotFocusable.


