### PR TITLE
adding some badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 ## ![Product Logo](./brand/brand-blue-48px.png) Accessibility Insights for Windows
 
 [![Build Status](https://dev.azure.com/accessibility-insights/Accessibility%20Insights/_apis/build/status/Microsoft.accessibility-insights-windows-CI?branchName=master)](https://dev.azure.com/accessibility-insights/Accessibility%20Insights/_build/latest?definitionId=3&branchName=master)
-
-
-
+[![Downloads](https://img.shields.io/github/downloads/microsoft/accessibility-insights-windows/total.svg)](https://github.com/Microsoft/accessibility-insights-windows/releases/latest)
+[![Release](https://img.shields.io/github/release/microsoft/accessibility-insights-windows.svg)](https://github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.0794.01)
 
 Accessibility Insights for Windows is the project for Accessibility tools on Windows platform (Win7/Win8x/Win10).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://dev.azure.com/accessibility-insights/Accessibility%20Insights/_apis/build/status/Microsoft.accessibility-insights-windows-CI?branchName=master)](https://dev.azure.com/accessibility-insights/Accessibility%20Insights/_build/latest?definitionId=3&branchName=master)
 [![Downloads](https://img.shields.io/github/downloads/microsoft/accessibility-insights-windows/total.svg)](https://github.com/Microsoft/accessibility-insights-windows/releases/latest)
-[![Release](https://img.shields.io/github/release/microsoft/accessibility-insights-windows.svg)](https://github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.0794.01)
+[![Release](https://img.shields.io/github/release/microsoft/accessibility-insights-windows.svg)](https://github.com/Microsoft/accessibility-insights-windows/releases/latest)
 
 Accessibility Insights for Windows is the project for Accessibility tools on Windows platform (Win7/Win8x/Win10).
 


### PR DESCRIPTION
This PR adds some badges to the readme. These are small SVGs common to most READMEs that share info about the project.
- The download count is total/all-time. We could also use 'latest' instead or have a specific version. 
- The release badge goes to the release. We could instead link to the direct MSI.

I wanted to add one for the MIT license but GitHub is unable to figure out that our license is MIT. Contrast this with vscode, for example: https://github.com/Microsoft/vscode/blob/master/LICENSE.txt

Please go here to see a rich diff: https://github.com/Microsoft/accessibility-insights-windows/pull/201/files?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8

These badges aren't fully accessible - e.g. we can provide static alt text but the numbers are not available to a screenreader. There is an issue on the shield (badge provider) repo but it has been closed due to inactivity.