### PR TITLE
Changing the EvaluationCode returned by the LandmarkOneMain rule.

### DIFF
--- a/src/AccessibilityInsights.Rules/Library/LandmarkOneMain.cs
+++ b/src/AccessibilityInsights.Rules/Library/LandmarkOneMain.cs
@@ -25,7 +25,7 @@ namespace AccessibilityInsights.Rules.Library
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var condition = DescendantCount(Landmarks.Main) == 1;
-            return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Error;
+            return condition.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Warning;
         }
 
         protected override Condition CreateCondition()


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
Changing from Error to Warning because the rule is based on Deque's rule for the web, which is labeled "moderate" and "best practice", but is not strictly required for compliance with WCAG.

This was reported as a false positive by a customer.

