### PR TITLE
Use IE feature control to change how webpages are rendered in WebBrowser

### DIFF
--- a/src/AccessibilityInsights.SharedUx/FileBug/BrowserEmulation.cs
+++ b/src/AccessibilityInsights.SharedUx/FileBug/BrowserEmulation.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.Win32;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AccessibilityInsights.SharedUx.FileBug
 {

--- a/src/AccessibilityInsights.SharedUx/FileBug/BrowserEmulation.cs
+++ b/src/AccessibilityInsights.SharedUx/FileBug/BrowserEmulation.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AccessibilityInsights.SharedUx.FileBug
+{
+    /// <summary>
+    /// This class is adapted from https://stackoverflow.com/questions/18333459/c-sharp-webbrowser-ajax-call
+    /// and sets several registry values in order to ensure that the hosted WebBrowser control renders
+    /// documents in standards mode. Without these changes the hosted WebBrowser is unable to properly
+    /// render some pages when filing issues
+    /// https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/general-info/ee330730%28v%3dvs.85%29#browser-emulation
+    /// </summary>
+    public static class BrowserEmulation
+    {
+        public static void SetBrowserFeatureControl()
+        {
+            // http://msdn.microsoft.com/en-us/library/ee330720(v=vs.85).aspx
+
+            // FeatureControl settings are per-process
+            dynamic fileName = System.IO.Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName);
+
+            // make the control is not running inside Visual Studio Designer
+            if (String.Compare(fileName, "devenv.exe", true) == 0 || String.Compare(fileName, "XDesProc.exe", true) == 0)
+            {
+                return;
+            }
+
+            SetBrowserFeatureControlKey("FEATURE_BROWSER_EMULATION", fileName, GetBrowserEmulationMode());
+            // Webpages containing standards-based !DOCTYPE directives are displayed in IE10 Standards mode.
+            SetBrowserFeatureControlKey("FEATURE_AJAX_CONNECTIONEVENTS", fileName, 1);
+            SetBrowserFeatureControlKey("FEATURE_GPU_RENDERING", fileName, 1);
+        }
+
+        private static void SetBrowserFeatureControlKey(string feature, string appName, uint value)
+        {
+            using (var key = Registry.CurrentUser.CreateSubKey(String.Concat("Software\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\", feature), RegistryKeyPermissionCheck.ReadWriteSubTree))
+            {
+                key.SetValue(appName, (UInt32)value, RegistryValueKind.DWord);
+            }
+        }
+
+        private static UInt32 GetBrowserEmulationMode()
+        {
+            int browserVersion = 7;
+            using (var Key = Registry.LocalMachine.OpenSubKey("SOFTWARE\\Microsoft\\Internet Explorer", RegistryKeyPermissionCheck.ReadSubTree, System.Security.AccessControl.RegistryRights.QueryValues))
+            {
+                dynamic version = Key.GetValue("svcVersion");
+                if (null == version)
+                {
+                    version = Key.GetValue("Version");
+                    if (null == version)
+                    {
+                        throw new ApplicationException("Microsoft Internet Explorer is required!");
+                    }
+                }
+                int.TryParse(version.ToString().Split('.')[0], out browserVersion);
+            }
+
+            UInt32 mode = 10000;
+            // Internet Explorer 10. Webpages containing standards-based !DOCTYPE directives are displayed in IE10 Standards mode. Default value for Internet Explorer 10.
+            switch (browserVersion)
+            {
+                case 7:
+                    mode = 7000;
+                    // Webpages containing standards-based !DOCTYPE directives are displayed in IE7 Standards mode. Default value for applications hosting the WebBrowser Control.
+                    break;
+                case 8:
+                    mode = 8000;
+                    // Webpages containing standards-based !DOCTYPE directives are displayed in IE8 mode. Default value for Internet Explorer 8
+                    break;
+                case 9:
+                    mode = 9000;
+                    // Internet Explorer 9. Webpages containing standards-based !DOCTYPE directives are displayed in IE9 mode. Default value for Internet Explorer 9.
+                    break;
+                case 10:
+                    mode = 10000;
+                    // Internet Explorer 10. Webpages containing standards-based !DOCTYPE directives are displayed in IE9 mode. Default value for Internet Explorer 9.
+                    break;
+                case 11:
+                    mode = 11001;
+                    // Internet Explorer 11. Webpages containing standards-based !DOCTYPE directives are displayed in IE9 mode. Default value for Internet Explorer 9.
+                    break;
+            }
+
+            return mode;
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/FileBug/BrowserEmulation.cs
+++ b/src/AccessibilityInsights.SharedUx/FileBug/BrowserEmulation.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Win32;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Microsoft.Win32;
 using System;
 using System.Diagnostics;
 

--- a/src/AccessibilityInsights.SharedUx/FileBug/BrowserEmulation.cs
+++ b/src/AccessibilityInsights.SharedUx/FileBug/BrowserEmulation.cs
@@ -22,18 +22,12 @@ namespace AccessibilityInsights.SharedUx.FileBug
             // FeatureControl settings are per-process
             var fileName = System.IO.Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName);
 
-            // make sure the control is not running inside Visual Studio Designer
-            if (string.Compare(fileName, "devenv.exe", true, System.Globalization.CultureInfo.InvariantCulture) == 0 || string.Compare(fileName, "XDesProc.exe", true, System.Globalization.CultureInfo.InvariantCulture) == 0)
-            {
-                return;
-            }
-
             try
             {
                 SetBrowserFeatureControlKey("FEATURE_BROWSER_EMULATION", fileName, GetBrowserEmulationMode());
                 SetBrowserFeatureControlKey("FEATURE_AJAX_CONNECTIONEVENTS", fileName, 1);
                 SetBrowserFeatureControlKey("FEATURE_GPU_RENDERING", fileName, 1);
-            } 
+            }
             catch (Exception)
             {
                 // silently ignore
@@ -64,7 +58,7 @@ namespace AccessibilityInsights.SharedUx.FileBug
                     return 7000;
                 }
             }
-            
+
             switch (browserVersion)
             {
                 case 7: return 7000; // Webpages containing standards-based !DOCTYPE directives are displayed in IE7 Standards mode. Default value for applications hosting the WebBrowser Control.

--- a/src/AccessibilityInsights.SharedUx/FileBug/FileBugAction.cs
+++ b/src/AccessibilityInsights.SharedUx/FileBug/FileBugAction.cs
@@ -292,10 +292,7 @@ namespace AccessibilityInsights.SharedUx.FileBug
         private static int? FileBugWindow(Uri url, bool onTop, int zoomLevel, Action<int> updateZoom)
         {
             System.Diagnostics.Trace.WriteLine(Invariant($"Url is {url.AbsoluteUri.Length} long: {url}"));
-            // To force latest IE to show up
-            var appName = System.Diagnostics.Process.GetCurrentProcess().ProcessName + ".exe";
-            using (var Key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION", true))
-                Key.SetValue(appName, 99999, Microsoft.Win32.RegistryValueKind.DWord);
+            BrowserEmulation.SetBrowserFeatureControl();
 
             var dlg = new BugFileForm(url, onTop, zoomLevel, updateZoom);
             dlg.ScriptToRun = "window.onerror = function(msg,url,line) { window.external.Log(msg); return true; };";

--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -281,6 +281,7 @@
       <DependentUpon>PrivacyLearnMore.xaml</DependentUpon>
     </Compile>
     <Compile Include="Enums\FontSize.cs" />
+    <Compile Include="FileBug\BrowserEmulation.cs" />
     <Compile Include="FileBug\BugFileForm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
(Please provide an overview of the change in this PR)

We have occasionally noticed the WebBrowser used in the AzureDevops extension is unable to render the page and instead shows a white screen (even though viewing the source shows proper HTML). This PR applies a suggested fix via feature controls for a similar problem. IE provides several feature controls in order to enhance the way the WebBrowser behaves. Earlier we set the Browser Emulation registry key to a high number [99999] which doesn't seem accurate - according to the docs and suggested fix, this key should be set to the values defined [here](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/general-info/ee330730%28v%3dvs.85%29). This affects what 'mode' web pages are rendered in (read more [here](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/cc288325(v=vs.85))). In this PR the value is chosen based on the installed version of IE. This change was tested on a few machines from our team and those with the white screen issue reported successful rendering afterwards. There is one case where the issue still exists - will have to troubleshoot on their box. We are exploring other options to fix or replace the WebBrowser; in the meantime this fix should improve the situation for some users.