### PR TITLE
Fixed the event detail view

### DIFF
--- a/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/ActiveTextPositionChangedEventListener.cs
+++ b/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/ActiveTextPositionChangedEventListener.cs
@@ -37,13 +37,10 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
             if (m != null)
             {
                 const int maxTextLengthToInclude = 100;
-                m.Properties = new List<KeyValuePair<string, dynamic>>
-                {
-                    new KeyValuePair<string, dynamic>("Type", range.GetType()),
-                    new KeyValuePair<string, dynamic>("Text", range.GetText(maxTextLengthToInclude))
-                };
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Type", range.GetType()));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Text", range.GetText(maxTextLengthToInclude)));
 
-                this.ListenEventMessage(m);
+               this.ListenEventMessage(m);
             }
         }
 

--- a/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
+++ b/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/EventListenerFactory.cs
@@ -191,14 +191,14 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
                 if (listener != null)
                 {
                     var m = EventMessage.GetInstance(EventType.UIA_EventRecorderNotificationEventId, null);
-                    m.Properties = new List<KeyValuePair<string, dynamic>>() { new KeyValuePair<string, dynamic>("Message", "Succeeded to unregister all event listeners.") };
+                    m.Properties.Add(new KeyValuePair<string, dynamic>("Message", "Succeeded to unregister all event listeners."));
                     listener(m);
                 }
             }
             catch (Exception e)
             {
-                var m  = EventMessage.GetInstance(EventType.UIA_EventRecorderNotificationEventId, null);
-                m.Properties = new List<KeyValuePair<string, dynamic>>() { new KeyValuePair<string, dynamic>("Message", $"Failed to unregister all listeners: {e.Message}") };
+                var m = EventMessage.GetInstance(EventType.UIA_EventRecorderNotificationEventId, null);
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Message", $"Failed to unregister all listeners: {e.Message}"));
                 listener(m);
             }
         }
@@ -284,23 +284,19 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
                 if (listener != null)
                 {
                     var m = EventMessage.GetInstance(EventType.UIA_EventRecorderNotificationEventId, null);
-                    m.Properties = new List<KeyValuePair<string, dynamic>>() {
-                        new KeyValuePair<string, dynamic>("Message", "Succeeded to unregister a event listeners"),
-                        new KeyValuePair<string, dynamic>("Event Id", msgData.EventId),
-                        new KeyValuePair<string, dynamic>("Event Name", EventType.GetInstance().GetNameById(msgData.EventId)),
-                    };
+                    m.Properties.Add(new KeyValuePair<string, dynamic>("Message", "Succeeded to unregister an event listeners"));
+                    m.Properties.Add(new KeyValuePair<string, dynamic>("Event Id", msgData.EventId));
+                    m.Properties.Add(new KeyValuePair<string, dynamic>("Event Name", EventType.GetInstance().GetNameById(msgData.EventId)));
                     listener(m);
                 }
             }
             catch (Exception e)
             {
                 var m = EventMessage.GetInstance(EventType.UIA_EventRecorderNotificationEventId, null);
-                m.Properties = new List<KeyValuePair<string, dynamic>>() {
-                        new KeyValuePair<string, dynamic>("Message", "Failed to unregister a event listeners"),
-                        new KeyValuePair<string, dynamic>("Event Id", msgData.EventId),
-                        new KeyValuePair<string, dynamic>("Event Name", EventType.GetInstance().GetNameById(msgData.EventId)),
-                        new KeyValuePair<string, dynamic>("Error", e.Message)
-                    };
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Message", "Failed to unregister an event listeners"));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Event Id", msgData.EventId));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Event Name", EventType.GetInstance().GetNameById(msgData.EventId)));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Error", e.Message));
 
                 listener(m);
                 /// it is very unexpected situation. 
@@ -361,12 +357,10 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
                         else
                         {
                             m = EventMessage.GetInstance(EventType.UIA_EventRecorderNotificationEventId, null);
-                            m.Properties = new List<KeyValuePair<string, dynamic>>() {
-                                new KeyValuePair<string, dynamic>("Message", "Event listener registration is rejected."),
-                                new KeyValuePair<string, dynamic>("Event Id", msgData.EventId),
-                                new KeyValuePair<string, dynamic>("Event Name", EventType.GetInstance().GetNameById(msgData.EventId)),
-                                new KeyValuePair<string, dynamic>("Reason", "Not supported platform"),
-                            };
+                            m.Properties.Add(new KeyValuePair<string, dynamic>("Message", "Event listener registration is rejected."));
+                            m.Properties.Add(new KeyValuePair<string, dynamic>("Event Id", msgData.EventId));
+                            m.Properties.Add(new KeyValuePair<string, dynamic>("Event Name", EventType.GetInstance().GetNameById(msgData.EventId)));
+                            m.Properties.Add(new KeyValuePair<string, dynamic>("Reason", "Not supported platform"));
                             msgData.Listener(m);
                         }
                         break;
@@ -381,12 +375,10 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
                         else
                         {
                             m = EventMessage.GetInstance(EventType.UIA_EventRecorderNotificationEventId, null);
-                            m.Properties = new List<KeyValuePair<string, dynamic>>() {
-                                new KeyValuePair<string, dynamic>("Message", "Event listener registration is rejected."),
-                                new KeyValuePair<string, dynamic>("Event Id", msgData.EventId),
-                                new KeyValuePair<string, dynamic>("Event Name", EventType.GetInstance().GetNameById(msgData.EventId)),
-                                new KeyValuePair<string, dynamic>("Reason", "Not supported platform"),
-                            };
+                            m.Properties.Add(new KeyValuePair<string, dynamic>("Message", "Event listener registration is rejected."));
+                            m.Properties.Add(new KeyValuePair<string, dynamic>("Event Id", msgData.EventId));
+                            m.Properties.Add(new KeyValuePair<string, dynamic>("Event Name", EventType.GetInstance().GetNameById(msgData.EventId)));
+                            m.Properties.Add(new KeyValuePair<string, dynamic>("Reason", "Not supported platform"));
                             msgData.Listener(m);
                         }
                         break;
@@ -399,11 +391,9 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
                 }
 
                 m = EventMessage.GetInstance(EventType.UIA_EventRecorderNotificationEventId, null);
-                m.Properties = new List<KeyValuePair<string, dynamic>>() {
-                        new KeyValuePair<string, dynamic>("Message", "Succeeded to register an event listener"),
-                        new KeyValuePair<string, dynamic>("Event Id", msgData.EventId),
-                        new KeyValuePair<string, dynamic>("Event Name", EventType.GetInstance().GetNameById(msgData.EventId)),
-                    };
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Message", "Succeeded to register an event listener"));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Event Id", msgData.EventId));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Event Name", EventType.GetInstance().GetNameById(msgData.EventId)));
                 msgData.Listener(m);
                 if(msgData.EventId == EventType.UIA_AutomationFocusChangedEventId)
                 {
@@ -413,12 +403,10 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
             catch (Exception e)
             {
                 var m = EventMessage.GetInstance(EventType.UIA_EventRecorderNotificationEventId, null);
-                m.Properties = new List<KeyValuePair<string, dynamic>>() {
-                        new KeyValuePair<string, dynamic>("Message", "Failed to register an event listener"),
-                        new KeyValuePair<string, dynamic>("Event Id", msgData.EventId),
-                        new KeyValuePair<string, dynamic>("Event Name", EventType.GetInstance().GetNameById(msgData.EventId)),
-                        new KeyValuePair<string, dynamic>("Error", e.Message)
-                };
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Message", "Failed to register an event listener"));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Event Id", msgData.EventId));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Event Name", EventType.GetInstance().GetNameById(msgData.EventId)));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Error", e.Message));
                 msgData.Listener(m);
             }
         }

--- a/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/EventMessage.cs
+++ b/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/EventMessage.cs
@@ -12,7 +12,7 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
     /// <summary>
     /// Event Message Class for passing event information to UI or other handler
     /// </summary>
-    public class EventMessage:IA11yEventMessage, IDisposable
+    public class EventMessage : IA11yEventMessage, IDisposable
     {
         public int EventId { get; set; }
 
@@ -20,8 +20,7 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
         /// Time stamp with millisecond accuracy
         /// </summary>
         public string TimeStamp { get; set; }
-
-        public List<KeyValuePair<string,dynamic>> Properties { get; internal set; }
+        public List<KeyValuePair<string, dynamic>> Properties { get; } = new List<KeyValuePair<string, dynamic>>();
 
         public A11yElement Element { get; set; }
 
@@ -78,7 +77,7 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
         {
             if (sender == null || !DesktopElement.IsFromCurrentProcess(sender))
             {
-                    return new EventMessage(id, sender);
+                return new EventMessage(id, sender);
             }
 
             return null;

--- a/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/NotificationEventListener.cs
+++ b/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/NotificationEventListener.cs
@@ -36,13 +36,10 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
 
             if (m != null)
             {
-                m.Properties = new List<KeyValuePair<string, dynamic>>
-                {
-                    new KeyValuePair<string, dynamic>("NotificationKind", kind.ToString()),
-                    new KeyValuePair<string, dynamic>("NotificationProcessing", process.ToString()),
-                    new KeyValuePair<string, dynamic>("Display", displayString),
-                    new KeyValuePair<string, dynamic>("ActivityId", activityId),
-                };
+                m.Properties.Add(new KeyValuePair<string, dynamic>("NotificationKind", kind.ToString()));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("NotificationProcessing", process.ToString()));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Display", displayString));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("ActivityId", activityId));
                 this.ListenEventMessage(m);
             }
         }

--- a/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/PropertyChangedEventListener.cs
+++ b/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/PropertyChangedEventListener.cs
@@ -36,11 +36,9 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
 
             if (m != null)
             {
-                m.Properties = new List<KeyValuePair<string, dynamic>>
-                {
-                   new KeyValuePair<string, dynamic>("Property Id", propertyId),
-                   new KeyValuePair<string, dynamic>("Property Name", PropertyType.GetInstance().GetNameById(propertyId)),
-                };
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Property Id", propertyId));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Property Name", PropertyType.GetInstance().GetNameById(propertyId)));
+
                 if (newValue != null)
                 {
                     m.Properties.Add(new KeyValuePair<string, dynamic>(newValue.GetType().Name, newValue));

--- a/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
+++ b/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/StructureChangedEventListener.cs
@@ -33,11 +33,8 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
             var m = EventMessage.GetInstance(EventType.UIA_StructureChangedEventId, sender);
             if (m != null)
             {
-                m.Properties = new List<KeyValuePair<string, dynamic>>
-                {
-                    new KeyValuePair<string, dynamic>("StructureChangeType", changeType),
-                    new KeyValuePair<string, dynamic>("Runtime Id", runtimeId.ConvertInt32ArrayToString()),
-                };
+                m.Properties.Add(new KeyValuePair<string, dynamic>("StructureChangeType", changeType));
+                m.Properties.Add(new KeyValuePair<string, dynamic>("Runtime Id", runtimeId.ConvertInt32ArrayToString()));
                 this.ListenEventMessage(m);
             }
         }

--- a/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/TextEditTextChangedEventListener.cs
+++ b/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/TextEditTextChangedEventListener.cs
@@ -41,10 +41,8 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
 
             if (m != null)
             {
-                m.Properties = new List<KeyValuePair<string, dynamic>>
-                {
-                    new KeyValuePair<string, dynamic>("TextEditChangeType", type.ToString()),
-                };
+                m.Properties.Add(new KeyValuePair<string, dynamic>("TextEditChangeType", type.ToString()));
+
                 for (int i = 0; i < array.Length; i++)
                 {
                     m.Properties.Add(new KeyValuePair<string, dynamic>(Invariant($"[{i}]"), array.GetValue(i)));

--- a/src/AccessibilityInsights.SharedUx/Controls/EventDetailControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventDetailControl.xaml.cs
@@ -60,7 +60,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 {
                     dg.CurrentCell = new DataGridCellInfo(dg.Items[dg.SelectedIndex], dg.Columns[0]);
                 }
-            }            
+            }
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml.cs
@@ -1,20 +1,20 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.Core.Bases;
 using AccessibilityInsights.Core.Types;
+using AccessibilityInsights.SharedUx.Controls.CustomControls;
+using AccessibilityInsights.SharedUx.Dialogs;
+using AccessibilityInsights.SharedUx.Interfaces;
+using AccessibilityInsights.SharedUx.Settings;
+using AccessibilityInsights.SharedUx.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
-using AccessibilityInsights.Core.Bases;
-using AccessibilityInsights.SharedUx.ViewModels;
-using AccessibilityInsights.SharedUx.Dialogs;
-using System.Windows.Automation.Peers;
-using AccessibilityInsights.SharedUx.Settings;
-using AccessibilityInsights.SharedUx.Interfaces;
-using AccessibilityInsights.SharedUx.Controls.CustomControls;
 
 namespace AccessibilityInsights.SharedUx.Controls
 {
@@ -71,9 +71,9 @@ namespace AccessibilityInsights.SharedUx.Controls
 
             foreach (var col in this.dgProperties.Columns)
             {
-                col.Width = 0;                
+                col.Width = 0;
                 col.Width = new DataGridLength(0, DataGridLengthUnitType.Auto);
-            }          
+            }
         }
 
         /// <summary>
@@ -145,7 +145,6 @@ namespace AccessibilityInsights.SharedUx.Controls
                 return true;
             else
             {
-
                 string name = (string)((PropertyListViewItemModel)item).Name;
                 return (name.IndexOf(textboxSearch.Text, StringComparison.OrdinalIgnoreCase) >= 0);
             }
@@ -166,7 +165,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         {
             Configuration.ShowAllProperties = true;
             UpdateProperties();
-            dpFilter.Visibility = Visibility.Visible;            
+            dpFilter.Visibility = Visibility.Visible;
         }
 
         /// <summary>


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ #161 ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

<img width="973" alt="eventdetailfix" src="https://user-images.githubusercontent.com/29690812/55039511-9f475980-4fe1-11e9-91d1-296814a6b5b5.PNG">

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
Fixed the event detail view by modifying the Properties variable and the way it gets initialized.

