### PR TITLE
fixed the event details view by suppressing the warning

### DIFF
--- a/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/EventMessage.cs
+++ b/src/AccessibilityInsights.Desktop/UIAutomation/EventHandlers/EventMessage.cs
@@ -21,7 +21,9 @@ namespace AccessibilityInsights.Desktop.UIAutomation.EventHandlers
         /// </summary>
         public string TimeStamp { get; set; }
 
-        public List<KeyValuePair<string,dynamic>> Properties { get; internal set; }
+#pragma warning disable CA2227 // Collection properties should be read only
+        public List<KeyValuePair<string,dynamic>> Properties { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         public A11yElement Element { get; set; }
 

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
@@ -260,7 +260,7 @@ namespace AccessibilityInsights.Modes
         /// <param name="e"></param>
         private void UpdateElementInfoUI(A11yElement e)
         {
-            this.ctrlTabs.SetElement(e, e != null && e.PlatformObject != null);           
+            this.ctrlTabs.SetElement(e, e != null && e.PlatformObject != null);
         }
 
         /// <summary>


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ #161 ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

<img width="973" alt="eventdetailfix" src="https://user-images.githubusercontent.com/29690812/55096063-72915180-5076-11e9-85e8-4065c4bd859c.PNG">

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change
Fixed the event details view by suppressing the warning

