### PR TITLE
Add appropriate feature control registry keys to improve WebBrowser rendering

### DIFF
--- a/src/AccessibilityInsights.SharedUx/FileBug/FileBugAction.cs
+++ b/src/AccessibilityInsights.SharedUx/FileBug/FileBugAction.cs
@@ -292,11 +292,7 @@ namespace AccessibilityInsights.SharedUx.FileBug
         private static int? FileBugWindow(Uri url, bool onTop, int zoomLevel, Action<int> updateZoom)
         {
             System.Diagnostics.Trace.WriteLine(Invariant($"Url is {url.AbsoluteUri.Length} long: {url}"));
-            // To force latest IE to show up
-            var appName = System.Diagnostics.Process.GetCurrentProcess().ProcessName + ".exe";
-            using (var Key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION", true))
-                Key.SetValue(appName, 99999, Microsoft.Win32.RegistryValueKind.DWord);
-
+            IEBrowserEmulation.SetFeatureControls();
             var dlg = new BugFileForm(url, onTop, zoomLevel, updateZoom);
             dlg.ScriptToRun = "window.onerror = function(msg,url,line) { window.external.Log(msg); return true; };";
 

--- a/src/AccessibilityInsights.SharedUx/FileBug/IEBrowserEmulation.cs
+++ b/src/AccessibilityInsights.SharedUx/FileBug/IEBrowserEmulation.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.Desktop.Telemetry;
+using Microsoft.Win32;
+using System;
+using System.Diagnostics;
+
+namespace AccessibilityInsights.SharedUx.FileBug
+{
+    /// <summary>
+    /// This class sets several registry values in order to ensure that the hosted WebBrowser control renders
+    /// documents in standards mode. Without these changes the hosted WebBrowser is unable to properly
+    /// render some pages when filing issues
+    /// https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/general-info/ee330730%28v%3dvs.85%29#browser-emulation
+    /// http://msdn.microsoft.com/en-us/library/ee330720(v=vs.85).aspx
+    /// </summary>
+    public static class IEBrowserEmulation
+    {
+        public static void SetFeatureControls()
+        {
+            try
+            {
+                SetFeatureControlKey("FEATURE_BROWSER_EMULATION", GetBrowserEmulationValue());
+                SetFeatureControlKey("FEATURE_AJAX_CONNECTIONEVENTS", 1);
+                SetFeatureControlKey("FEATURE_GPU_RENDERING", 1);
+            }
+            catch (Exception ex)
+            {
+                ex.ReportException();
+            }
+        }
+
+        private static void SetFeatureControlKey(string feature, uint value)
+        {
+            var currentApp = System.IO.Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName);
+            using (var key = Registry.CurrentUser.CreateSubKey(String.Concat(@"Software\Microsoft\Internet Explorer\Main\FeatureControl\", feature), RegistryKeyPermissionCheck.ReadWriteSubTree))
+            {
+                key.SetValue(currentApp, value, RegistryValueKind.DWord);
+            }
+        }
+
+        /// <summary>
+        /// Get the browser emulation mode most appropriate for the installed version of IE,
+        /// or the default mode for applications hosting the WebBrowser control
+        /// </summary>
+        /// <returns></returns>
+        private static uint GetBrowserEmulationValue()
+        {
+            int browserVersion = 7;
+            using (var Key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Internet Explorer", RegistryKeyPermissionCheck.ReadSubTree, System.Security.AccessControl.RegistryRights.QueryValues))
+            {
+                var version = Key.GetValue("svcVersion") ?? Key.GetValue("Version");
+                if (version == null || int.TryParse(version.ToString().Split('.')[0], out browserVersion) == false)
+                {
+                    return 7000;
+                }
+            }
+
+            switch (browserVersion)
+            {
+                case 7: return 7000; // Webpages containing standards-based !DOCTYPE directives are displayed in IE7 Standards mode. Default value for applications hosting the WebBrowser Control.
+                case 8: return 8000; // Webpages containing standards-based !DOCTYPE directives are displayed in IE8 mode. Default value for Internet Explorer 8
+                case 9: return 9000; // Internet Explorer 9. Webpages containing standards-based !DOCTYPE directives are displayed in IE9 mode. Default value for Internet Explorer 9.
+                case 11: return 11001; // Internet Explorer 11. Webpages containing standards-based !DOCTYPE directives are displayed in IE11 mode. Default value for Internet Explorer 11.
+                case 10:
+                default:
+                    return 10000; // Internet Explorer 10. Webpages containing standards-based !DOCTYPE directives are displayed in IE10 mode. Default value for Internet Explorer 10.
+            }
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -289,6 +289,7 @@
     </Compile>
     <Compile Include="FileBug\BugReporter.cs" />
     <Compile Include="FileBug\FileBugAction.cs" />
+    <Compile Include="FileBug\IEBrowserEmulation.cs" />
     <Compile Include="FileBug\ScriptInterface.cs" />
     <Compile Include="Controls\ColorPicker\ColorPickerControl.xaml.cs">
       <DependentUpon>ColorPickerControl.xaml</DependentUpon>


### PR DESCRIPTION
We have occasionally noticed the WebBrowser used in the AzureDevops extension is unable to render the page and instead shows a white screen (even though viewing the source shows proper HTML). This PR applies a potential fix via feature controls. IE provides several feature controls in order to enhance the way the WebBrowser behaves. Earlier we set the Browser Emulation registry key to a high number [99999] which doesn't seem accurate - according to the docs and suggested fix, this key should be set to the values defined [here](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/general-info/ee330730(v%3dvs.85)#browser-emulation). This affects what 'mode' web pages are rendered in (read more [here](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/general-info/ee330730%28v%3dvs.85%29)). In this PR the value is chosen based on the installed version of IE. This change was tested on a few machines from our team and those with the white screen issue reported successful rendering afterwards. There is one case where the issue still exists - will have to troubleshoot on their box. We are exploring other options to fix or replace the WebBrowser; in the meantime this fix should improve the situation for some users.