### PR TITLE
Fixed bug #205  Test reports null BoundingRectangle on ScrollBar button

### DIFF
--- a/src/AccessibilityInsights.Rules/Library/BoundingRectangleNotNull.cs
+++ b/src/AccessibilityInsights.Rules/Library/BoundingRectangleNotNull.cs
@@ -37,10 +37,10 @@ namespace AccessibilityInsights.Rules.Library
             //
             // 2 exceptions related with Menubar "System" and Menu item "System". 
             // These two are excluded since Windows 10 sets the bounding rectangles of these as null by default.
-            // WPF Scrollbar page up and page down buttons may sometimes
-            // legitimately be null or all zeros when the thumb control is at the very top or very bottom.
+            // WPF Scrollbar page buttons may sometimes
+            // legitimately be null or all zeros when the thumb control is at the maximum or minimum value.
             return IsNotOffScreen
-                & ~WPFScrollBarPageUpOrPageDownButtons
+                & ~WPFScrollBarPageButtons
                 & ~sysmenubar
                 & ~sysmenuitem;
         }

--- a/src/AccessibilityInsights.Rules/Library/BoundingRectangleNotNull.cs
+++ b/src/AccessibilityInsights.Rules/Library/BoundingRectangleNotNull.cs
@@ -5,6 +5,7 @@ using AccessibilityInsights.Core.Enums;
 using AccessibilityInsights.Rules.PropertyConditions;
 using AccessibilityInsights.Rules.Resources;
 using static AccessibilityInsights.Rules.PropertyConditions.BoolProperties;
+using static AccessibilityInsights.Rules.PropertyConditions.ElementGroups;
 
 namespace AccessibilityInsights.Rules.Library
 {
@@ -36,7 +37,10 @@ namespace AccessibilityInsights.Rules.Library
             //
             // 2 exceptions related with Menubar "System" and Menu item "System". 
             // These two are excluded since Windows 10 sets the bounding rectangles of these as null by default.
+            // WPF Scrollbar page up and page down  buttons may sometimes
+            // legitimately be null or all zeros when the thumb control is at the very top or very bottom.
             return IsNotOffScreen
+                & ~WPFScrollBarPageUpOrPageDownButtons
                 & ~sysmenubar
                 & ~sysmenuitem;
         }

--- a/src/AccessibilityInsights.Rules/Library/BoundingRectangleNotNull.cs
+++ b/src/AccessibilityInsights.Rules/Library/BoundingRectangleNotNull.cs
@@ -37,7 +37,7 @@ namespace AccessibilityInsights.Rules.Library
             //
             // 2 exceptions related with Menubar "System" and Menu item "System". 
             // These two are excluded since Windows 10 sets the bounding rectangles of these as null by default.
-            // WPF Scrollbar page up and page down  buttons may sometimes
+            // WPF Scrollbar page up and page down buttons may sometimes
             // legitimately be null or all zeros when the thumb control is at the very top or very bottom.
             return IsNotOffScreen
                 & ~WPFScrollBarPageUpOrPageDownButtons

--- a/src/AccessibilityInsights.Rules/PropertyConditions/ElementGroups.cs
+++ b/src/AccessibilityInsights.Rules/PropertyConditions/ElementGroups.cs
@@ -28,6 +28,7 @@ namespace AccessibilityInsights.Rules.PropertyConditions
         public static Condition EmptyContainer = CreateEmptyContainerCondition();
         public static Condition ExpectedToBeFocusable = CreateExpectedToBeFocusableCondition();
         public static Condition ParentWPFDataItem = CreateParentWPFDataItemCondition();
+        public static Condition WPFScrollBarPageUpOrPageDownButtons = CreateWPFScrollBarPageUpOrPageDownButtons();
         public static Condition NameRequired = CreateNameRequiredCondition();
         public static Condition NameOptional = CreateNameOptionalCondition();
         public static Condition IsControlElementTrueRequired = CreateIsControlRequiredCondition();
@@ -142,6 +143,15 @@ namespace AccessibilityInsights.Rules.PropertyConditions
         private static Condition CreateParentWPFDataItemCondition()
         {
             return Condition.Create(IsParentWPFDataItem);
+        }
+
+        private static Condition CreateWPFScrollBarPageUpOrPageDownButtons()
+        {
+            return Button
+                & Parent(ScrollBar)
+                & Framework.Is(AccessibilityInsights.Core.Enums.Framework.WPF)
+                & (AutomationID.Is("PageUp")
+                | AutomationID.Is("PageDown"));
         }
 
         private static bool IsParentWPFDataItem(IA11yElement e)

--- a/src/AccessibilityInsights.Rules/PropertyConditions/ElementGroups.cs
+++ b/src/AccessibilityInsights.Rules/PropertyConditions/ElementGroups.cs
@@ -28,7 +28,7 @@ namespace AccessibilityInsights.Rules.PropertyConditions
         public static Condition EmptyContainer = CreateEmptyContainerCondition();
         public static Condition ExpectedToBeFocusable = CreateExpectedToBeFocusableCondition();
         public static Condition ParentWPFDataItem = CreateParentWPFDataItemCondition();
-        public static Condition WPFScrollBarPageUpOrPageDownButtons = CreateWPFScrollBarPageUpOrPageDownButtons();
+        public static Condition WPFScrollBarPageButtons = CreateWPFScrollBarPageButtons();
         public static Condition NameRequired = CreateNameRequiredCondition();
         public static Condition NameOptional = CreateNameOptionalCondition();
         public static Condition IsControlElementTrueRequired = CreateIsControlRequiredCondition();
@@ -145,13 +145,15 @@ namespace AccessibilityInsights.Rules.PropertyConditions
             return Condition.Create(IsParentWPFDataItem);
         }
 
-        private static Condition CreateWPFScrollBarPageUpOrPageDownButtons()
+        private static Condition CreateWPFScrollBarPageButtons()
         {
             return Button
                 & Parent(ScrollBar)
                 & Framework.Is(AccessibilityInsights.Core.Enums.Framework.WPF)
                 & (AutomationID.Is("PageUp")
-                | AutomationID.Is("PageDown"));
+                | AutomationID.Is("PageDown")
+                | AutomationID.Is("PageLeft")
+                | AutomationID.Is("PageRight"));
         }
 
         private static bool IsParentWPFDataItem(IA11yElement e)

--- a/src/AccessibilityInsights.RulesTest/Library/BoundingRectangleNotNullTest.cs
+++ b/src/AccessibilityInsights.RulesTest/Library/BoundingRectangleNotNullTest.cs
@@ -65,5 +65,41 @@ namespace AccessibilityInsights.RulesTest.Library
                 Assert.IsFalse(Rule.Condition.Matches(e));
             } // using
         }
+
+        [TestMethod]
+        public void BoundingRectangleNotNull_WPFScrollbarPageLeftButton_NotApplicable()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = ControlType.ScrollBar;
+                e.IsOffScreen = false;
+                e.ControlTypeId = ControlType.Button;
+                e.Framework = "WPF";
+                e.AutomationId = "PageLeft";
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsFalse(Rule.Condition.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void BoundingRectangleNotNull_WPFScrollbarPageRightButton_NotApplicable()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = ControlType.ScrollBar;
+                e.IsOffScreen = false;
+                e.ControlTypeId = ControlType.Button;
+                e.Framework = "WPF";
+                e.AutomationId = "PageRight";
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsFalse(Rule.Condition.Matches(e));
+            } // using
+        }
     } // class
 } // namespace

--- a/src/AccessibilityInsights.RulesTest/Library/BoundingRectangleNotNullTest.cs
+++ b/src/AccessibilityInsights.RulesTest/Library/BoundingRectangleNotNullTest.cs
@@ -29,5 +29,41 @@ namespace AccessibilityInsights.RulesTest.Library
                 Assert.AreNotEqual(Rule.Evaluate(e), EvaluationCode.Pass);
             } // using
         }
+
+        [TestMethod]
+        public void BoundingRectangleNotNull_WPFScrollbarPageUpButton_NotApplicable()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = ControlType.ScrollBar;
+                e.IsOffScreen = false;
+                e.ControlTypeId = ControlType.Button;
+                e.Framework = "WPF";
+                e.AutomationId = "PageUp";
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsFalse(Rule.Condition.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void BoundingRectangleNotNull_WPFScrollbarPageDownButton_NotApplicable()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = ControlType.ScrollBar;
+                e.IsOffScreen = false;
+                e.ControlTypeId = ControlType.Button;
+                e.Framework = "WPF";
+                e.AutomationId = "PageDown";
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsFalse(Rule.Condition.Matches(e));
+            } // using
+        }
     } // class
 } // namespace

--- a/src/AccessibilityInsights.RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/AccessibilityInsights.RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -63,7 +63,7 @@ namespace AccessibilityInsights.RulesTest.PropertyConditions
         }
 
         [TestMethod]
-        public void WPFScrollbarPageUpButton_True()
+        public void WPFScrollBarPageUpButton_True()
         {
             using (var e = new MockA11yElement())
             using (var parent = new MockA11yElement())
@@ -76,12 +76,12 @@ namespace AccessibilityInsights.RulesTest.PropertyConditions
                 parent.Children.Add(e);
                 e.Parent = parent;
 
-                Assert.IsTrue(ElementGroups.WPFScrollBarPageUpOrPageDownButtons.Matches(e));
+                Assert.IsTrue(ElementGroups.WPFScrollBarPageButtons.Matches(e));
             } // using
         }
 
         [TestMethod]
-        public void WPFScrollbarPageDownButton_True()
+        public void WPFScrollBarPageDownButton_True()
         {
             using (var e = new MockA11yElement())
             using (var parent = new MockA11yElement())
@@ -93,12 +93,46 @@ namespace AccessibilityInsights.RulesTest.PropertyConditions
                 parent.Children.Add(e);
                 e.Parent = parent;
 
-                Assert.IsTrue(ElementGroups.WPFScrollBarPageUpOrPageDownButtons.Matches(e));
+                Assert.IsTrue(ElementGroups.WPFScrollBarPageButtons.Matches(e));
             } // using
         }
 
         [TestMethod]
-        public void WPFScrollbarPageUpOrPageDownButtons_NotWPF_False()
+        public void WPFScrollBarPageLeftButton_True()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = ControlType.ScrollBar;
+                e.ControlTypeId = ControlType.Button;
+                e.Framework = "WPF";
+                e.AutomationId = "PageLeft";
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsTrue(ElementGroups.WPFScrollBarPageButtons.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void WPFScrollBarPageRightButton_True()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = ControlType.ScrollBar;
+                e.ControlTypeId = ControlType.Button;
+                e.Framework = "WPF";
+                e.AutomationId = "PageRight";
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsTrue(ElementGroups.WPFScrollBarPageButtons.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void WPFScrollBarPageButtons_NotWPF_False()
         {
             using (var e = new MockA11yElement())
             using (var parent = new MockA11yElement())
@@ -110,12 +144,12 @@ namespace AccessibilityInsights.RulesTest.PropertyConditions
                 parent.Children.Add(e);
                 e.Parent = parent;
 
-                Assert.IsFalse(ElementGroups.WPFScrollBarPageUpOrPageDownButtons.Matches(e));
+                Assert.IsFalse(ElementGroups.WPFScrollBarPageButtons.Matches(e));
             } // using
         }
 
         [TestMethod]
-        public void WPFScrollbarPageUpOrPageDownButtons_NotButton_False()
+        public void WPFScrollBarPageButtons_NotButton_False()
         {
             using (var e = new MockA11yElement())
             using (var parent = new MockA11yElement())
@@ -127,12 +161,12 @@ namespace AccessibilityInsights.RulesTest.PropertyConditions
                 parent.Children.Add(e);
                 e.Parent = parent;
 
-                Assert.IsFalse(ElementGroups.WPFScrollBarPageUpOrPageDownButtons.Matches(e));
+                Assert.IsFalse(ElementGroups.WPFScrollBarPageButtons.Matches(e));
             } // using
         }
 
         [TestMethod]
-        public void WPFScrollbarPageUpOrPageDownButtons_ParentNotScrollbar_False()
+        public void WPFScrollBarPageButtons_ParentNotScrollBar_False()
         {
             // This test essentially also covers the possibility of no parent.
 
@@ -146,12 +180,12 @@ namespace AccessibilityInsights.RulesTest.PropertyConditions
                 parent.Children.Add(e);
                 e.Parent = parent;
 
-                Assert.IsFalse(ElementGroups.WPFScrollBarPageUpOrPageDownButtons.Matches(e));
+                Assert.IsFalse(ElementGroups.WPFScrollBarPageButtons.Matches(e));
             } // using
         }
 
         [TestMethod]
-        public void WPFScrollbarPageUpOrPageDownButtons_NotPageUpOrPageDown_False()
+        public void WPFScrollBarPageButtons_NotPageUpOrPageDown_False()
         {
             using (var e = new MockA11yElement())
             using (var parent = new MockA11yElement())
@@ -163,7 +197,7 @@ namespace AccessibilityInsights.RulesTest.PropertyConditions
                 parent.Children.Add(e);
                 e.Parent = parent;
 
-                Assert.IsFalse(ElementGroups.WPFScrollBarPageUpOrPageDownButtons.Matches(e));
+                Assert.IsFalse(ElementGroups.WPFScrollBarPageButtons.Matches(e));
             } // using
         }
     } // class

--- a/src/AccessibilityInsights.RulesTest/PropertyConditions/ElementGroupsTests.cs
+++ b/src/AccessibilityInsights.RulesTest/PropertyConditions/ElementGroupsTests.cs
@@ -61,5 +61,110 @@ namespace AccessibilityInsights.RulesTest.PropertyConditions
 
             Assert.IsTrue(ElementGroups.AllowSameNameAndControlType.Matches(e));
         }
+
+        [TestMethod]
+        public void WPFScrollbarPageUpButton_True()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = ControlType.ScrollBar;
+                e.IsOffScreen = false;
+                e.ControlTypeId = ControlType.Button;
+                e.Framework = "WPF";
+                e.AutomationId = "PageUp";
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsTrue(ElementGroups.WPFScrollBarPageUpOrPageDownButtons.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void WPFScrollbarPageDownButton_True()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = ControlType.ScrollBar;
+                e.ControlTypeId = ControlType.Button;
+                e.Framework = "WPF";
+                e.AutomationId = "PageDown";
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsTrue(ElementGroups.WPFScrollBarPageUpOrPageDownButtons.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void WPFScrollbarPageUpOrPageDownButtons_NotWPF_False()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = ControlType.ScrollBar;
+                e.ControlTypeId = ControlType.Button;
+                // e.Framework = "WPF";
+                e.AutomationId = "PageUp";
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsFalse(ElementGroups.WPFScrollBarPageUpOrPageDownButtons.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void WPFScrollbarPageUpOrPageDownButtons_NotButton_False()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = ControlType.ScrollBar;
+                // e.ControlTypeId = ControlType.Button;
+                e.Framework = "WPF";
+                e.AutomationId = "PageUp";
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsFalse(ElementGroups.WPFScrollBarPageUpOrPageDownButtons.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void WPFScrollbarPageUpOrPageDownButtons_ParentNotScrollbar_False()
+        {
+            // This test essentially also covers the possibility of no parent.
+
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                // parent.ControlTypeId = ControlType.ScrollBar;
+                e.ControlTypeId = ControlType.Button;
+                e.Framework = "WPF";
+                e.AutomationId = "PageUp";
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsFalse(ElementGroups.WPFScrollBarPageUpOrPageDownButtons.Matches(e));
+            } // using
+        }
+
+        [TestMethod]
+        public void WPFScrollbarPageUpOrPageDownButtons_NotPageUpOrPageDown_False()
+        {
+            using (var e = new MockA11yElement())
+            using (var parent = new MockA11yElement())
+            {
+                parent.ControlTypeId = ControlType.ScrollBar;
+                e.ControlTypeId = ControlType.Button;
+                e.Framework = "WPF";
+                // e.AutomationId = "PageUp";
+                parent.Children.Add(e);
+                e.Parent = parent;
+
+                Assert.IsFalse(ElementGroups.WPFScrollBarPageUpOrPageDownButtons.Matches(e));
+            } // using
+        }
     } // class
 } // namespace


### PR DESCRIPTION
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Note - After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

#### Describe the change

When the thumb control of a WPF scrollbar is all the way down or up, the rectangle of the PageDown or PageUp buttons may be null.

It is possible this fix could be even more specific, testing to actually see if the vertical or horizontal scroll percent of the parent scrollbar is 0 or 100%. Such a test might be overkill, but thoughts are welcome.

