### PR TITLE
Restore mainwindow visibility earlier to fix automated checks IsVisible event timing

### DIFF
--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
@@ -190,6 +190,7 @@ namespace AccessibilityInsights.Modes
                                     {
                                         ScreenShotAction.CaptureScreenShot(ecId);
                                         Application.Current.MainWindow.WindowStyle = WindowStyle.SingleBorderWindow;
+                                        Application.Current.MainWindow.Visibility = Visibility.Visible;
                                     })).Wait();
                                 }
                             }

--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
@@ -190,7 +190,10 @@ namespace AccessibilityInsights.Modes
                                     {
                                         ScreenShotAction.CaptureScreenShot(ecId);
                                         Application.Current.MainWindow.WindowStyle = WindowStyle.SingleBorderWindow;
-                                        Application.Current.MainWindow.Visibility = Visibility.Visible;
+
+                                        // This needs to happen before the call to ctrlAutomatedChecks.SetElement. Otherwise,
+                                        // ctrlAutomatedChecks's checkboxes become out of sync with the highlighter
+                                        Application.Current.MainWindow.Visibility = Visibility.Visible; 
                                     })).Wait();
                                 }
                             }


### PR DESCRIPTION
#### Describe the change
We were encountering this issue: #227. The timing of when MainWindow's visibility is restored affects when UserControl_IsVisibleChanged in AutomatedChecks gets hit. Currently, the timing results in the automated checks listview's checkboxes effectively getting checked twice. This PR fixes the timing such that the boxes are not double-checked. 

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue #227
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



