### PR TITLE
Attempt to create an MSI-only artifact from the signed build

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -210,6 +210,12 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
 
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: msi'
+    inputs:
+      PathtoPublish: 'src\MSI\bin\Release\msi'
+      ArtifactName: 'msi'
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
     displayName: 'Run BinSkim '
     inputs:


### PR DESCRIPTION
#### Describe the change
The current release script downloads the entire drop artifact. We only need 1 file, so this is to create a smaller artifact to accelerate the Release process (especially when we automate the Canary release)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



