### PR TITLE
Remove reference from SharedUxTests to UnitTestSharedLibrary

### DIFF
--- a/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
+++ b/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
@@ -119,6 +119,9 @@
     <None Include="packages.config" />
     <None Include="Resources\ConfigSettings.json" />
     <None Include="Resources\LegacyConfigSettings.json" />
+    <EmbeddedResource Include="Snapshots\Taskbar.snapshot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="..\..\build\delaysign.targets" />
   <ItemGroup>
@@ -149,10 +152,6 @@
     <ProjectReference Include="..\AccessibilityInsights.Desktop\Desktop.csproj">
       <Project>{0b9855fd-7b04-415c-a813-da9697693fda}</Project>
       <Name>Desktop</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\AccessibilityInsights.UnitTestSharedLibrary\UnitTestSharedLibrary.csproj">
-      <Project>{01dc8363-73bc-47fa-bd23-12ac45618e1d}</Project>
-      <Name>UnitTestSharedLibrary</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup />

--- a/src/AccessibilityInsights.SharedUxTests/Snapshots/Taskbar.snapshot
+++ b/src/AccessibilityInsights.SharedUxTests/Snapshots/Taskbar.snapshot
@@ -1,0 +1,13658 @@
+﻿{
+  "Name": null,
+  "ControlTypeId": 50033,
+  "LocalizedControlType": "pane",
+  "RuntimeId": "[2A,1009E]",
+  "ProcessId": 7064,
+  "BoundingRectangle": "0, 2100, 3840, 60",
+  "IsKeyboardFocusable": true,
+  "IsContent": true,
+  "IsControl": true,
+  "TestStatus": 1,
+  "Glimpse": "pane \"\"",
+  "Properties": {
+    "30000": {
+      "Value": [
+        42,
+        65694
+      ],
+      "Id": 30000,
+      "Name": "RuntimeId",
+      "TextValue": "[2A,1009E]"
+    },
+    "30001": {
+      "Value": [
+        0.0,
+        2100.0,
+        3840.0,
+        60.0
+      ],
+      "Id": 30001,
+      "Name": "BoundingRectangle",
+      "TextValue": "[l=0,t=2100,r=3840,b=2160]"
+    },
+    "30002": {
+      "Value": 7064,
+      "Id": 30002,
+      "Name": "ProcessId",
+      "TextValue": "7064"
+    },
+    "30003": {
+      "Value": 50033,
+      "Id": 30003,
+      "Name": "ControlType",
+      "TextValue": "Pane(50033)"
+    },
+    "30004": {
+      "Value": "pane",
+      "Id": 30004,
+      "Name": "LocalizedControlType",
+      "TextValue": "pane"
+    },
+    "30008": {
+      "Value": false,
+      "Id": 30008,
+      "Name": "HasKeyboardFocus",
+      "TextValue": "False"
+    },
+    "30009": {
+      "Value": true,
+      "Id": 30009,
+      "Name": "IsKeyboardFocusable",
+      "TextValue": "True"
+    },
+    "30010": {
+      "Value": true,
+      "Id": 30010,
+      "Name": "IsEnabled",
+      "TextValue": "True"
+    },
+    "30012": {
+      "Value": "Shell_TrayWnd",
+      "Id": 30012,
+      "Name": "ClassName",
+      "TextValue": "Shell_TrayWnd"
+    },
+    "30015": {
+      "Value": 0,
+      "Id": 30015,
+      "Name": "Culture",
+      "TextValue": "0"
+    },
+    "30016": {
+      "Value": true,
+      "Id": 30016,
+      "Name": "IsControlElement",
+      "TextValue": "True"
+    },
+    "30017": {
+      "Value": true,
+      "Id": 30017,
+      "Name": "IsContentElement",
+      "TextValue": "True"
+    },
+    "30019": {
+      "Value": false,
+      "Id": 30019,
+      "Name": "IsPassword",
+      "TextValue": "False"
+    },
+    "30020": {
+      "Value": 65694,
+      "Id": 30020,
+      "Name": "NativeWindowHandle",
+      "TextValue": "65694"
+    },
+    "30022": {
+      "Value": false,
+      "Id": 30022,
+      "Name": "IsOffscreen",
+      "TextValue": "False"
+    },
+    "30023": {
+      "Value": 0,
+      "Id": 30023,
+      "Name": "Orientation",
+      "TextValue": "None(0)"
+    },
+    "30024": {
+      "Value": "Win32",
+      "Id": 30024,
+      "Name": "FrameworkId",
+      "TextValue": "Win32"
+    },
+    "30025": {
+      "Value": false,
+      "Id": 30025,
+      "Name": "IsRequiredForForm",
+      "TextValue": "False"
+    },
+    "30103": {
+      "Value": false,
+      "Id": 30103,
+      "Name": "IsDataValidForForm",
+      "TextValue": "False"
+    },
+    "30107": {
+      "Value": "[pid:29536,providerId:0x1009E Main:Nested [pid:7064,providerId:0x1009E Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+      "Id": 30107,
+      "Name": "ProviderDescription",
+      "TextValue": "[pid:29536,providerId:0x1009E Main:Nested [pid:7064,providerId:0x1009E Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+    },
+    "30111": {
+      "Value": false,
+      "Id": 30111,
+      "Name": "OptimizeForVisualContent",
+      "TextValue": "False"
+    },
+    "30135": {
+      "Value": 0,
+      "Id": 30135,
+      "Name": "LiveSetting",
+      "TextValue": "0"
+    },
+    "30150": {
+      "Value": false,
+      "Id": 30150,
+      "Name": "IsPeripheral",
+      "TextValue": "False"
+    },
+    "30152": {
+      "Value": 0,
+      "Id": 30152,
+      "Name": "PositionInSet",
+      "TextValue": "0"
+    },
+    "30153": {
+      "Value": 0,
+      "Id": 30153,
+      "Name": "SizeOfSet",
+      "TextValue": "0"
+    },
+    "30154": {
+      "Value": 0,
+      "Id": 30154,
+      "Name": "Level",
+      "TextValue": "0"
+    },
+    "30157": {
+      "Value": 0,
+      "Id": 30157,
+      "Name": "LandmarkType",
+      "TextValue": "0"
+    },
+    "30162": {
+      "Value": 0,
+      "Id": 30162,
+      "Name": "FillType",
+      "TextValue": "0"
+    },
+    "30163": {
+      "Value": 0,
+      "Id": 30163,
+      "Name": "VisualEffects",
+      "TextValue": "0"
+    }
+  },
+  "PlatformProperties": {
+    "2": {
+      "Value": 136,
+      "Id": 2,
+      "Name": "Unknown(2)",
+      "TextValue": "136"
+    },
+    "1": {
+      "Value": 2516582400,
+      "Id": 1,
+      "Name": "Unknown(1)",
+      "TextValue": "2516582400"
+    }
+  },
+  "Patterns": [
+    {
+      "Name": "LegacyIAccessiblePattern",
+      "Id": 10018,
+      "Properties": [
+        {
+          "Name": "ChildId",
+          "Value": 0,
+          "NodeValue": "ChildId = 0"
+        },
+        {
+          "Name": "DefaultAction",
+          "Value": "",
+          "NodeValue": "DefaultAction = \"\""
+        },
+        {
+          "Name": "Description",
+          "Value": "",
+          "NodeValue": "Description = \"\""
+        },
+        {
+          "Name": "Help",
+          "Value": "",
+          "NodeValue": "Help = \"\""
+        },
+        {
+          "Name": "KeyboardShorcut",
+          "Value": "",
+          "NodeValue": "KeyboardShorcut = \"\""
+        },
+        {
+          "Name": "Name",
+          "Value": "",
+          "NodeValue": "Name = \"\""
+        },
+        {
+          "Name": "Role",
+          "Value": 10,
+          "NodeValue": "Role = 10"
+        },
+        {
+          "Name": "State",
+          "Value": 1048576,
+          "NodeValue": "State = 1048576"
+        },
+        {
+          "Name": "Value",
+          "Value": "",
+          "NodeValue": "Value = \"\""
+        }
+      ],
+      "IsUIActionable": false
+    }
+  ],
+  "Children": [
+    {
+      "Name": "Start",
+      "ControlTypeId": 50000,
+      "LocalizedControlType": "button",
+      "RuntimeId": "[2A,100A2]",
+      "ProcessId": 7064,
+      "BoundingRectangle": "0, 2100, 72, 60",
+      "IsKeyboardFocusable": true,
+      "IsContent": true,
+      "IsControl": true,
+      "TestStatus": 1,
+      "Glimpse": "button \"Start\"",
+      "Properties": {
+        "30000": {
+          "Value": [
+            42,
+            65698
+          ],
+          "Id": 30000,
+          "Name": "RuntimeId",
+          "TextValue": "[2A,100A2]"
+        },
+        "30001": {
+          "Value": [
+            0.0,
+            2100.0,
+            72.0,
+            60.0
+          ],
+          "Id": 30001,
+          "Name": "BoundingRectangle",
+          "TextValue": "[l=0,t=2100,r=72,b=2160]"
+        },
+        "30002": {
+          "Value": 7064,
+          "Id": 30002,
+          "Name": "ProcessId",
+          "TextValue": "7064"
+        },
+        "30003": {
+          "Value": 50000,
+          "Id": 30003,
+          "Name": "ControlType",
+          "TextValue": "Button(50000)"
+        },
+        "30004": {
+          "Value": "button",
+          "Id": 30004,
+          "Name": "LocalizedControlType",
+          "TextValue": "button"
+        },
+        "30005": {
+          "Value": "Start",
+          "Id": 30005,
+          "Name": "Name",
+          "TextValue": "Start"
+        },
+        "30008": {
+          "Value": false,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus",
+          "TextValue": "False"
+        },
+        "30009": {
+          "Value": true,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable",
+          "TextValue": "True"
+        },
+        "30010": {
+          "Value": true,
+          "Id": 30010,
+          "Name": "IsEnabled",
+          "TextValue": "True"
+        },
+        "30012": {
+          "Value": "Start",
+          "Id": 30012,
+          "Name": "ClassName",
+          "TextValue": "Start"
+        },
+        "30015": {
+          "Value": 0,
+          "Id": 30015,
+          "Name": "Culture",
+          "TextValue": "0"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement",
+          "TextValue": "True"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement",
+          "TextValue": "True"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword",
+          "TextValue": "False"
+        },
+        "30020": {
+          "Value": 65698,
+          "Id": 30020,
+          "Name": "NativeWindowHandle",
+          "TextValue": "65698"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen",
+          "TextValue": "False"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation",
+          "TextValue": "None(0)"
+        },
+        "30024": {
+          "Value": "Win32",
+          "Id": 30024,
+          "Name": "FrameworkId",
+          "TextValue": "Win32"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm",
+          "TextValue": "False"
+        },
+        "30103": {
+          "Value": false,
+          "Id": 30103,
+          "Name": "IsDataValidForForm",
+          "TextValue": "False"
+        },
+        "30107": {
+          "Value": "[pid:29536,providerId:0x100A2 Main:Nested [pid:7064,providerId:0x100A2 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+          "Id": 30107,
+          "Name": "ProviderDescription",
+          "TextValue": "[pid:29536,providerId:0x100A2 Main:Nested [pid:7064,providerId:0x100A2 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent",
+          "TextValue": "False"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting",
+          "TextValue": "0"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral",
+          "TextValue": "False"
+        },
+        "30152": {
+          "Value": 0,
+          "Id": 30152,
+          "Name": "PositionInSet",
+          "TextValue": "0"
+        },
+        "30153": {
+          "Value": 0,
+          "Id": 30153,
+          "Name": "SizeOfSet",
+          "TextValue": "0"
+        },
+        "30154": {
+          "Value": 0,
+          "Id": 30154,
+          "Name": "Level",
+          "TextValue": "0"
+        },
+        "30157": {
+          "Value": 0,
+          "Id": 30157,
+          "Name": "LandmarkType",
+          "TextValue": "0"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType",
+          "TextValue": "0"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects",
+          "TextValue": "0"
+        }
+      },
+      "PlatformProperties": {
+        "1": {
+          "Value": 1409286144,
+          "Id": 1,
+          "Name": "Unknown(1)",
+          "TextValue": "1409286144"
+        }
+      },
+      "Patterns": [
+        {
+          "Name": "InvokePattern",
+          "Id": 10000,
+          "Properties": [],
+          "IsUIActionable": true
+        },
+        {
+          "Name": "LegacyIAccessiblePattern",
+          "Id": 10018,
+          "Properties": [
+            {
+              "Name": "ChildId",
+              "Value": 0,
+              "NodeValue": "ChildId = 0"
+            },
+            {
+              "Name": "DefaultAction",
+              "Value": "Press",
+              "NodeValue": "DefaultAction = \"Press\""
+            },
+            {
+              "Name": "Description",
+              "Value": "",
+              "NodeValue": "Description = \"\""
+            },
+            {
+              "Name": "Help",
+              "Value": "",
+              "NodeValue": "Help = \"\""
+            },
+            {
+              "Name": "KeyboardShorcut",
+              "Value": "",
+              "NodeValue": "KeyboardShorcut = \"\""
+            },
+            {
+              "Name": "Name",
+              "Value": "Start",
+              "NodeValue": "Name = \"Start\""
+            },
+            {
+              "Name": "Role",
+              "Value": 43,
+              "NodeValue": "Role = 43"
+            },
+            {
+              "Name": "State",
+              "Value": 1048576,
+              "NodeValue": "State = 1048576"
+            },
+            {
+              "Name": "Value",
+              "Value": "",
+              "NodeValue": "Value = \"\""
+            }
+          ],
+          "IsUIActionable": false
+        }
+      ],
+      "Children": [],
+      "TreeWalkerMode": 1,
+      "ScanResults": {
+        "Items": [
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[4.1.2] Name",
+            "MetaInfo": {
+              "PropertyId": 30005,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [
+              "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+              "The BoundingRectagle of the current element is [l=0,t=2100,r=72,b=2160]."
+            ],
+            "Status": 1,
+            "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+            "MetaInfo": {
+              "PropertyId": 30001,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[4.2.1] IsKeyboardFocusable",
+            "MetaInfo": {
+              "PropertyId": 30009,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [
+              "The property value may be one of [button]."
+            ],
+            "Status": 1,
+            "Description": "[4.2.1] LocalizedControlType",
+            "MetaInfo": {
+              "PropertyId": 30004,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [
+              "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] Typical SubTree structure in Control mode",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[MSDN] Typical SubTree structure in Content mode",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [
+              "'IsControlElement' property value should be \"True\"."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] IsControlElement Property",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 30016,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[4.1.2] Name: Child element should have unique name.",
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [
+              "Only one of Invoke/Toggle patterns expected.",
+              "Invoke pattern exists."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] Control Pattern",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [
+              "Check IsContentElement property value."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] Properties",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 30017,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          }
+        ],
+        "Status": 1
+      }
+    },
+    {
+      "Name": null,
+      "ControlTypeId": 50033,
+      "LocalizedControlType": "pane",
+      "RuntimeId": "[2A,100A8]",
+      "ProcessId": 7064,
+      "BoundingRectangle": "72, 2100, 516, 60",
+      "IsKeyboardFocusable": true,
+      "IsContent": true,
+      "IsControl": true,
+      "TestStatus": 1,
+      "Glimpse": "pane \"\"",
+      "Properties": {
+        "30000": {
+          "Value": [
+            42,
+            65704
+          ],
+          "Id": 30000,
+          "Name": "RuntimeId",
+          "TextValue": "[2A,100A8]"
+        },
+        "30001": {
+          "Value": [
+            72.0,
+            2100.0,
+            516.0,
+            60.0
+          ],
+          "Id": 30001,
+          "Name": "BoundingRectangle",
+          "TextValue": "[l=72,t=2100,r=588,b=2160]"
+        },
+        "30002": {
+          "Value": 7064,
+          "Id": 30002,
+          "Name": "ProcessId",
+          "TextValue": "7064"
+        },
+        "30003": {
+          "Value": 50033,
+          "Id": 30003,
+          "Name": "ControlType",
+          "TextValue": "Pane(50033)"
+        },
+        "30004": {
+          "Value": "pane",
+          "Id": 30004,
+          "Name": "LocalizedControlType",
+          "TextValue": "pane"
+        },
+        "30008": {
+          "Value": false,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus",
+          "TextValue": "False"
+        },
+        "30009": {
+          "Value": true,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable",
+          "TextValue": "True"
+        },
+        "30010": {
+          "Value": true,
+          "Id": 30010,
+          "Name": "IsEnabled",
+          "TextValue": "True"
+        },
+        "30011": {
+          "Value": "4100",
+          "Id": 30011,
+          "Name": "AutomationId",
+          "TextValue": "4100"
+        },
+        "30012": {
+          "Value": "TrayDummySearchControl",
+          "Id": 30012,
+          "Name": "ClassName",
+          "TextValue": "TrayDummySearchControl"
+        },
+        "30015": {
+          "Value": 0,
+          "Id": 30015,
+          "Name": "Culture",
+          "TextValue": "0"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement",
+          "TextValue": "True"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement",
+          "TextValue": "True"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword",
+          "TextValue": "False"
+        },
+        "30020": {
+          "Value": 65704,
+          "Id": 30020,
+          "Name": "NativeWindowHandle",
+          "TextValue": "65704"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen",
+          "TextValue": "False"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation",
+          "TextValue": "None(0)"
+        },
+        "30024": {
+          "Value": "Win32",
+          "Id": 30024,
+          "Name": "FrameworkId",
+          "TextValue": "Win32"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm",
+          "TextValue": "False"
+        },
+        "30103": {
+          "Value": false,
+          "Id": 30103,
+          "Name": "IsDataValidForForm",
+          "TextValue": "False"
+        },
+        "30107": {
+          "Value": "[pid:29536,providerId:0x100A8 Main:Nested [pid:7064,providerId:0x100A8 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+          "Id": 30107,
+          "Name": "ProviderDescription",
+          "TextValue": "[pid:29536,providerId:0x100A8 Main:Nested [pid:7064,providerId:0x100A8 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent",
+          "TextValue": "False"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting",
+          "TextValue": "0"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral",
+          "TextValue": "False"
+        },
+        "30152": {
+          "Value": 0,
+          "Id": 30152,
+          "Name": "PositionInSet",
+          "TextValue": "0"
+        },
+        "30153": {
+          "Value": 0,
+          "Id": 30153,
+          "Name": "SizeOfSet",
+          "TextValue": "0"
+        },
+        "30154": {
+          "Value": 0,
+          "Id": 30154,
+          "Name": "Level",
+          "TextValue": "0"
+        },
+        "30157": {
+          "Value": 0,
+          "Id": 30157,
+          "Name": "LandmarkType",
+          "TextValue": "0"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType",
+          "TextValue": "0"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects",
+          "TextValue": "0"
+        }
+      },
+      "PlatformProperties": {
+        "1": {
+          "Value": 1342242816,
+          "Id": 1,
+          "Name": "Unknown(1)",
+          "TextValue": "1342242816"
+        }
+      },
+      "Patterns": [
+        {
+          "Name": "LegacyIAccessiblePattern",
+          "Id": 10018,
+          "Properties": [
+            {
+              "Name": "ChildId",
+              "Value": 0,
+              "NodeValue": "ChildId = 0"
+            },
+            {
+              "Name": "DefaultAction",
+              "Value": "",
+              "NodeValue": "DefaultAction = \"\""
+            },
+            {
+              "Name": "Description",
+              "Value": "",
+              "NodeValue": "Description = \"\""
+            },
+            {
+              "Name": "Help",
+              "Value": "",
+              "NodeValue": "Help = \"\""
+            },
+            {
+              "Name": "KeyboardShorcut",
+              "Value": "",
+              "NodeValue": "KeyboardShorcut = \"\""
+            },
+            {
+              "Name": "Name",
+              "Value": "",
+              "NodeValue": "Name = \"\""
+            },
+            {
+              "Name": "Role",
+              "Value": 10,
+              "NodeValue": "Role = 10"
+            },
+            {
+              "Name": "State",
+              "Value": 1048576,
+              "NodeValue": "State = 1048576"
+            },
+            {
+              "Name": "Value",
+              "Value": "",
+              "NodeValue": "Value = \"\""
+            }
+          ],
+          "IsUIActionable": false
+        }
+      ],
+      "Children": [
+        {
+          "Name": "Type here to search",
+          "ControlTypeId": 50000,
+          "LocalizedControlType": "button",
+          "RuntimeId": "[2A,100B6]",
+          "ProcessId": 7064,
+          "BoundingRectangle": "72, 2100, 456, 60",
+          "IsKeyboardFocusable": true,
+          "IsContent": true,
+          "IsControl": true,
+          "TestStatus": 1,
+          "Glimpse": "button \"Type here to search\"",
+          "Properties": {
+            "30000": {
+              "Value": [
+                42,
+                65718
+              ],
+              "Id": 30000,
+              "Name": "RuntimeId",
+              "TextValue": "[2A,100B6]"
+            },
+            "30001": {
+              "Value": [
+                72.0,
+                2100.0,
+                456.0,
+                60.0
+              ],
+              "Id": 30001,
+              "Name": "BoundingRectangle",
+              "TextValue": "[l=72,t=2100,r=528,b=2160]"
+            },
+            "30002": {
+              "Value": 7064,
+              "Id": 30002,
+              "Name": "ProcessId",
+              "TextValue": "7064"
+            },
+            "30003": {
+              "Value": 50000,
+              "Id": 30003,
+              "Name": "ControlType",
+              "TextValue": "Button(50000)"
+            },
+            "30004": {
+              "Value": "button",
+              "Id": 30004,
+              "Name": "LocalizedControlType",
+              "TextValue": "button"
+            },
+            "30005": {
+              "Value": "Type here to search",
+              "Id": 30005,
+              "Name": "Name",
+              "TextValue": "Type here to search"
+            },
+            "30008": {
+              "Value": false,
+              "Id": 30008,
+              "Name": "HasKeyboardFocus",
+              "TextValue": "False"
+            },
+            "30009": {
+              "Value": true,
+              "Id": 30009,
+              "Name": "IsKeyboardFocusable",
+              "TextValue": "True"
+            },
+            "30010": {
+              "Value": true,
+              "Id": 30010,
+              "Name": "IsEnabled",
+              "TextValue": "True"
+            },
+            "30011": {
+              "Value": "4101",
+              "Id": 30011,
+              "Name": "AutomationId",
+              "TextValue": "4101"
+            },
+            "30012": {
+              "Value": "Button",
+              "Id": 30012,
+              "Name": "ClassName",
+              "TextValue": "Button"
+            },
+            "30015": {
+              "Value": 0,
+              "Id": 30015,
+              "Name": "Culture",
+              "TextValue": "0"
+            },
+            "30016": {
+              "Value": true,
+              "Id": 30016,
+              "Name": "IsControlElement",
+              "TextValue": "True"
+            },
+            "30017": {
+              "Value": true,
+              "Id": 30017,
+              "Name": "IsContentElement",
+              "TextValue": "True"
+            },
+            "30019": {
+              "Value": false,
+              "Id": 30019,
+              "Name": "IsPassword",
+              "TextValue": "False"
+            },
+            "30020": {
+              "Value": 65718,
+              "Id": 30020,
+              "Name": "NativeWindowHandle",
+              "TextValue": "65718"
+            },
+            "30022": {
+              "Value": false,
+              "Id": 30022,
+              "Name": "IsOffscreen",
+              "TextValue": "False"
+            },
+            "30023": {
+              "Value": 0,
+              "Id": 30023,
+              "Name": "Orientation",
+              "TextValue": "None(0)"
+            },
+            "30024": {
+              "Value": "Win32",
+              "Id": 30024,
+              "Name": "FrameworkId",
+              "TextValue": "Win32"
+            },
+            "30025": {
+              "Value": false,
+              "Id": 30025,
+              "Name": "IsRequiredForForm",
+              "TextValue": "False"
+            },
+            "30103": {
+              "Value": false,
+              "Id": 30103,
+              "Name": "IsDataValidForForm",
+              "TextValue": "False"
+            },
+            "30107": {
+              "Value": "[pid:29536,providerId:0x100B6 Main:Nested [pid:7064,providerId:0x100B6 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+              "Id": 30107,
+              "Name": "ProviderDescription",
+              "TextValue": "[pid:29536,providerId:0x100B6 Main:Nested [pid:7064,providerId:0x100B6 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+            },
+            "30111": {
+              "Value": false,
+              "Id": 30111,
+              "Name": "OptimizeForVisualContent",
+              "TextValue": "False"
+            },
+            "30135": {
+              "Value": 0,
+              "Id": 30135,
+              "Name": "LiveSetting",
+              "TextValue": "0"
+            },
+            "30150": {
+              "Value": false,
+              "Id": 30150,
+              "Name": "IsPeripheral",
+              "TextValue": "False"
+            },
+            "30152": {
+              "Value": 0,
+              "Id": 30152,
+              "Name": "PositionInSet",
+              "TextValue": "0"
+            },
+            "30153": {
+              "Value": 0,
+              "Id": 30153,
+              "Name": "SizeOfSet",
+              "TextValue": "0"
+            },
+            "30154": {
+              "Value": 0,
+              "Id": 30154,
+              "Name": "Level",
+              "TextValue": "0"
+            },
+            "30157": {
+              "Value": 0,
+              "Id": 30157,
+              "Name": "LandmarkType",
+              "TextValue": "0"
+            },
+            "30162": {
+              "Value": 0,
+              "Id": 30162,
+              "Name": "FillType",
+              "TextValue": "0"
+            },
+            "30163": {
+              "Value": 0,
+              "Id": 30163,
+              "Name": "VisualEffects",
+              "TextValue": "0"
+            }
+          },
+          "PlatformProperties": {
+            "2": {
+              "Value": 2097152,
+              "Id": 2,
+              "Name": "Unknown(2)",
+              "TextValue": "2097152"
+            },
+            "1": {
+              "Value": 1342177280,
+              "Id": 1,
+              "Name": "Unknown(1)",
+              "TextValue": "1342177280"
+            }
+          },
+          "Patterns": [
+            {
+              "Name": "InvokePattern",
+              "Id": 10000,
+              "Properties": [],
+              "IsUIActionable": true
+            },
+            {
+              "Name": "LegacyIAccessiblePattern",
+              "Id": 10018,
+              "Properties": [
+                {
+                  "Name": "ChildId",
+                  "Value": 0,
+                  "NodeValue": "ChildId = 0"
+                },
+                {
+                  "Name": "DefaultAction",
+                  "Value": "Press",
+                  "NodeValue": "DefaultAction = \"Press\""
+                },
+                {
+                  "Name": "Description",
+                  "Value": "",
+                  "NodeValue": "Description = \"\""
+                },
+                {
+                  "Name": "Help",
+                  "Value": "",
+                  "NodeValue": "Help = \"\""
+                },
+                {
+                  "Name": "KeyboardShorcut",
+                  "Value": "",
+                  "NodeValue": "KeyboardShorcut = \"\""
+                },
+                {
+                  "Name": "Name",
+                  "Value": "Type here to search",
+                  "NodeValue": "Name = \"Type here to search\""
+                },
+                {
+                  "Name": "Role",
+                  "Value": 43,
+                  "NodeValue": "Role = 43"
+                },
+                {
+                  "Name": "State",
+                  "Value": 1048704,
+                  "NodeValue": "State = 1048704"
+                },
+                {
+                  "Name": "Value",
+                  "Value": "",
+                  "NodeValue": "Value = \"\""
+                }
+              ],
+              "IsUIActionable": false
+            }
+          ],
+          "Children": [],
+          "TreeWalkerMode": 1,
+          "ScanResults": {
+            "Items": [
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name",
+                "MetaInfo": {
+                  "PropertyId": 30005,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                  "The BoundingRectagle of the current element is [l=72,t=2100,r=528,b=2160]."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                "MetaInfo": {
+                  "PropertyId": 30001,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.2.1] IsKeyboardFocusable",
+                "MetaInfo": {
+                  "PropertyId": 30009,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "The property value may be one of [button]."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] LocalizedControlType",
+                "MetaInfo": {
+                  "PropertyId": 30004,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Typical SubTree structure in Control mode",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[MSDN] Typical SubTree structure in Content mode",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "'IsControlElement' property value should be \"True\"."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] IsControlElement Property",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30016,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name: Child element should have unique name.",
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Only one of Invoke/Toggle patterns expected.",
+                  "Invoke pattern exists."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Control Pattern",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Check IsContentElement property value."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Properties",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30017,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              }
+            ],
+            "Status": 1
+          }
+        },
+        {
+          "Name": null,
+          "ControlTypeId": 50021,
+          "LocalizedControlType": "tool bar",
+          "RuntimeId": "[2A,100B8]",
+          "ProcessId": 7064,
+          "BoundingRectangle": "528, 2100, 60, 60",
+          "IsKeyboardFocusable": true,
+          "IsContent": false,
+          "IsControl": true,
+          "TestStatus": 3,
+          "Glimpse": "tool bar \"\"",
+          "Properties": {
+            "30000": {
+              "Value": [
+                42,
+                65720
+              ],
+              "Id": 30000,
+              "Name": "RuntimeId",
+              "TextValue": "[2A,100B8]"
+            },
+            "30001": {
+              "Value": [
+                528.0,
+                2100.0,
+                60.0,
+                60.0
+              ],
+              "Id": 30001,
+              "Name": "BoundingRectangle",
+              "TextValue": "[l=528,t=2100,r=588,b=2160]"
+            },
+            "30002": {
+              "Value": 7064,
+              "Id": 30002,
+              "Name": "ProcessId",
+              "TextValue": "7064"
+            },
+            "30003": {
+              "Value": 50021,
+              "Id": 30003,
+              "Name": "ControlType",
+              "TextValue": "ToolBar(50021)"
+            },
+            "30004": {
+              "Value": "tool bar",
+              "Id": 30004,
+              "Name": "LocalizedControlType",
+              "TextValue": "tool bar"
+            },
+            "30008": {
+              "Value": false,
+              "Id": 30008,
+              "Name": "HasKeyboardFocus",
+              "TextValue": "False"
+            },
+            "30009": {
+              "Value": true,
+              "Id": 30009,
+              "Name": "IsKeyboardFocusable",
+              "TextValue": "True"
+            },
+            "30010": {
+              "Value": true,
+              "Id": 30010,
+              "Name": "IsEnabled",
+              "TextValue": "True"
+            },
+            "30011": {
+              "Value": "4102",
+              "Id": 30011,
+              "Name": "AutomationId",
+              "TextValue": "4102"
+            },
+            "30012": {
+              "Value": "ToolbarWindow32",
+              "Id": 30012,
+              "Name": "ClassName",
+              "TextValue": "ToolbarWindow32"
+            },
+            "30015": {
+              "Value": 0,
+              "Id": 30015,
+              "Name": "Culture",
+              "TextValue": "0"
+            },
+            "30016": {
+              "Value": true,
+              "Id": 30016,
+              "Name": "IsControlElement",
+              "TextValue": "True"
+            },
+            "30017": {
+              "Value": false,
+              "Id": 30017,
+              "Name": "IsContentElement",
+              "TextValue": "False"
+            },
+            "30019": {
+              "Value": false,
+              "Id": 30019,
+              "Name": "IsPassword",
+              "TextValue": "False"
+            },
+            "30020": {
+              "Value": 65720,
+              "Id": 30020,
+              "Name": "NativeWindowHandle",
+              "TextValue": "65720"
+            },
+            "30022": {
+              "Value": false,
+              "Id": 30022,
+              "Name": "IsOffscreen",
+              "TextValue": "False"
+            },
+            "30023": {
+              "Value": 0,
+              "Id": 30023,
+              "Name": "Orientation",
+              "TextValue": "None(0)"
+            },
+            "30024": {
+              "Value": "Win32",
+              "Id": 30024,
+              "Name": "FrameworkId",
+              "TextValue": "Win32"
+            },
+            "30025": {
+              "Value": false,
+              "Id": 30025,
+              "Name": "IsRequiredForForm",
+              "TextValue": "False"
+            },
+            "30103": {
+              "Value": false,
+              "Id": 30103,
+              "Name": "IsDataValidForForm",
+              "TextValue": "False"
+            },
+            "30107": {
+              "Value": "[pid:29536,providerId:0x100B8 Main:Nested [pid:7064,providerId:0x100B8 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+              "Id": 30107,
+              "Name": "ProviderDescription",
+              "TextValue": "[pid:29536,providerId:0x100B8 Main:Nested [pid:7064,providerId:0x100B8 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+            },
+            "30111": {
+              "Value": false,
+              "Id": 30111,
+              "Name": "OptimizeForVisualContent",
+              "TextValue": "False"
+            },
+            "30135": {
+              "Value": 0,
+              "Id": 30135,
+              "Name": "LiveSetting",
+              "TextValue": "0"
+            },
+            "30150": {
+              "Value": false,
+              "Id": 30150,
+              "Name": "IsPeripheral",
+              "TextValue": "False"
+            },
+            "30152": {
+              "Value": 0,
+              "Id": 30152,
+              "Name": "PositionInSet",
+              "TextValue": "0"
+            },
+            "30153": {
+              "Value": 0,
+              "Id": 30153,
+              "Name": "SizeOfSet",
+              "TextValue": "0"
+            },
+            "30154": {
+              "Value": 0,
+              "Id": 30154,
+              "Name": "Level",
+              "TextValue": "0"
+            },
+            "30157": {
+              "Value": 0,
+              "Id": 30157,
+              "Name": "LandmarkType",
+              "TextValue": "0"
+            },
+            "30162": {
+              "Value": 0,
+              "Id": 30162,
+              "Name": "FillType",
+              "TextValue": "0"
+            },
+            "30163": {
+              "Value": 0,
+              "Id": 30163,
+              "Name": "VisualEffects",
+              "TextValue": "0"
+            }
+          },
+          "PlatformProperties": {
+            "1": {
+              "Value": 1342282061,
+              "Id": 1,
+              "Name": "Unknown(1)",
+              "TextValue": "1342282061"
+            }
+          },
+          "Patterns": [
+            {
+              "Name": "LegacyIAccessiblePattern",
+              "Id": 10018,
+              "Properties": [
+                {
+                  "Name": "ChildId",
+                  "Value": 0,
+                  "NodeValue": "ChildId = 0"
+                },
+                {
+                  "Name": "DefaultAction",
+                  "Value": "",
+                  "NodeValue": "DefaultAction = \"\""
+                },
+                {
+                  "Name": "Description",
+                  "Value": "",
+                  "NodeValue": "Description = \"\""
+                },
+                {
+                  "Name": "Help",
+                  "Value": "",
+                  "NodeValue": "Help = \"\""
+                },
+                {
+                  "Name": "KeyboardShorcut",
+                  "Value": "",
+                  "NodeValue": "KeyboardShorcut = \"\""
+                },
+                {
+                  "Name": "Name",
+                  "Value": "",
+                  "NodeValue": "Name = \"\""
+                },
+                {
+                  "Name": "Role",
+                  "Value": 22,
+                  "NodeValue": "Role = 22"
+                },
+                {
+                  "Name": "State",
+                  "Value": 1048576,
+                  "NodeValue": "State = 1048576"
+                },
+                {
+                  "Name": "Value",
+                  "Value": "",
+                  "NodeValue": "Value = \"\""
+                }
+              ],
+              "IsUIActionable": false
+            }
+          ],
+          "Children": [
+            {
+              "Name": "Start Listening",
+              "ControlTypeId": 50000,
+              "LocalizedControlType": "button",
+              "RuntimeId": "[2A,100B8,3,80000001,100B8,FFFFFFFC,1]",
+              "ProcessId": 7064,
+              "BoundingRectangle": "528, 2100, 60, 60",
+              "IsKeyboardFocusable": false,
+              "IsContent": true,
+              "IsControl": true,
+              "TestStatus": 3,
+              "Glimpse": "button \"Start Listening\"",
+              "Properties": {
+                "30000": {
+                  "Value": [
+                    42,
+                    65720,
+                    3,
+                    -2147483647,
+                    65720,
+                    -4,
+                    1
+                  ],
+                  "Id": 30000,
+                  "Name": "RuntimeId",
+                  "TextValue": "[2A,100B8,3,80000001,100B8,FFFFFFFC,1]"
+                },
+                "30001": {
+                  "Value": [
+                    528.0,
+                    2100.0,
+                    60.0,
+                    60.0
+                  ],
+                  "Id": 30001,
+                  "Name": "BoundingRectangle",
+                  "TextValue": "[l=528,t=2100,r=588,b=2160]"
+                },
+                "30002": {
+                  "Value": 7064,
+                  "Id": 30002,
+                  "Name": "ProcessId",
+                  "TextValue": "7064"
+                },
+                "30003": {
+                  "Value": 50000,
+                  "Id": 30003,
+                  "Name": "ControlType",
+                  "TextValue": "Button(50000)"
+                },
+                "30004": {
+                  "Value": "button",
+                  "Id": 30004,
+                  "Name": "LocalizedControlType",
+                  "TextValue": "button"
+                },
+                "30005": {
+                  "Value": "Start Listening",
+                  "Id": 30005,
+                  "Name": "Name",
+                  "TextValue": "Start Listening"
+                },
+                "30008": {
+                  "Value": false,
+                  "Id": 30008,
+                  "Name": "HasKeyboardFocus",
+                  "TextValue": "False"
+                },
+                "30009": {
+                  "Value": false,
+                  "Id": 30009,
+                  "Name": "IsKeyboardFocusable",
+                  "TextValue": "False"
+                },
+                "30010": {
+                  "Value": true,
+                  "Id": 30010,
+                  "Name": "IsEnabled",
+                  "TextValue": "True"
+                },
+                "30015": {
+                  "Value": 0,
+                  "Id": 30015,
+                  "Name": "Culture",
+                  "TextValue": "0"
+                },
+                "30016": {
+                  "Value": true,
+                  "Id": 30016,
+                  "Name": "IsControlElement",
+                  "TextValue": "True"
+                },
+                "30017": {
+                  "Value": true,
+                  "Id": 30017,
+                  "Name": "IsContentElement",
+                  "TextValue": "True"
+                },
+                "30019": {
+                  "Value": false,
+                  "Id": 30019,
+                  "Name": "IsPassword",
+                  "TextValue": "False"
+                },
+                "30020": {
+                  "Value": 0,
+                  "Id": 30020,
+                  "Name": "NativeWindowHandle",
+                  "TextValue": "0"
+                },
+                "30022": {
+                  "Value": false,
+                  "Id": 30022,
+                  "Name": "IsOffscreen",
+                  "TextValue": "False"
+                },
+                "30023": {
+                  "Value": 0,
+                  "Id": 30023,
+                  "Name": "Orientation",
+                  "TextValue": "None(0)"
+                },
+                "30025": {
+                  "Value": false,
+                  "Id": 30025,
+                  "Name": "IsRequiredForForm",
+                  "TextValue": "False"
+                },
+                "30103": {
+                  "Value": false,
+                  "Id": 30103,
+                  "Name": "IsDataValidForForm",
+                  "TextValue": "False"
+                },
+                "30107": {
+                  "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                  "Id": 30107,
+                  "Name": "ProviderDescription",
+                  "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                },
+                "30111": {
+                  "Value": false,
+                  "Id": 30111,
+                  "Name": "OptimizeForVisualContent",
+                  "TextValue": "False"
+                },
+                "30135": {
+                  "Value": 0,
+                  "Id": 30135,
+                  "Name": "LiveSetting",
+                  "TextValue": "0"
+                },
+                "30150": {
+                  "Value": false,
+                  "Id": 30150,
+                  "Name": "IsPeripheral",
+                  "TextValue": "False"
+                },
+                "30152": {
+                  "Value": 0,
+                  "Id": 30152,
+                  "Name": "PositionInSet",
+                  "TextValue": "0"
+                },
+                "30153": {
+                  "Value": 0,
+                  "Id": 30153,
+                  "Name": "SizeOfSet",
+                  "TextValue": "0"
+                },
+                "30154": {
+                  "Value": 0,
+                  "Id": 30154,
+                  "Name": "Level",
+                  "TextValue": "0"
+                },
+                "30157": {
+                  "Value": 0,
+                  "Id": 30157,
+                  "Name": "LandmarkType",
+                  "TextValue": "0"
+                },
+                "30162": {
+                  "Value": 0,
+                  "Id": 30162,
+                  "Name": "FillType",
+                  "TextValue": "0"
+                },
+                "30163": {
+                  "Value": 0,
+                  "Id": 30163,
+                  "Name": "VisualEffects",
+                  "TextValue": "0"
+                }
+              },
+              "PlatformProperties": {},
+              "Patterns": [
+                {
+                  "Name": "InvokePattern",
+                  "Id": 10000,
+                  "Properties": [],
+                  "IsUIActionable": true
+                },
+                {
+                  "Name": "LegacyIAccessiblePattern",
+                  "Id": 10018,
+                  "Properties": [
+                    {
+                      "Name": "ChildId",
+                      "Value": 1,
+                      "NodeValue": "ChildId = 1"
+                    },
+                    {
+                      "Name": "DefaultAction",
+                      "Value": "Press",
+                      "NodeValue": "DefaultAction = \"Press\""
+                    },
+                    {
+                      "Name": "Description",
+                      "Value": "",
+                      "NodeValue": "Description = \"\""
+                    },
+                    {
+                      "Name": "Help",
+                      "Value": "",
+                      "NodeValue": "Help = \"\""
+                    },
+                    {
+                      "Name": "KeyboardShorcut",
+                      "Value": "",
+                      "NodeValue": "KeyboardShorcut = \"\""
+                    },
+                    {
+                      "Name": "Name",
+                      "Value": "Start Listening",
+                      "NodeValue": "Name = \"Start Listening\""
+                    },
+                    {
+                      "Name": "Role",
+                      "Value": 43,
+                      "NodeValue": "Role = 43"
+                    },
+                    {
+                      "Name": "State",
+                      "Value": 0,
+                      "NodeValue": "State = 0"
+                    },
+                    {
+                      "Name": "Value",
+                      "Value": "",
+                      "NodeValue": "Value = \"\""
+                    }
+                  ],
+                  "IsUIActionable": false
+                }
+              ],
+              "Children": [],
+              "TreeWalkerMode": 1,
+              "ScanResults": {
+                "Items": [
+                  {
+                    "Messages": [],
+                    "Status": 1,
+                    "Description": "[4.1.2] Name",
+                    "MetaInfo": {
+                      "PropertyId": 30005,
+                      "UIFramework": "Win32",
+                      "ControlType": "Button"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                      "The BoundingRectagle of the current element is [l=528,t=2100,r=588,b=2160]."
+                    ],
+                    "Status": 1,
+                    "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                    "MetaInfo": {
+                      "PropertyId": 30001,
+                      "UIFramework": "Win32",
+                      "ControlType": "Button"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "UI element is not keyboard focusible though it has some actionable control patterns.",
+                      "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                      "UI interactable Pattern: InvokePattern"
+                    ],
+                    "Status": 3,
+                    "Description": "[4.2.1] IsKeyboardFocusable",
+                    "MetaInfo": {
+                      "PropertyId": 30009,
+                      "UIFramework": "Win32",
+                      "ControlType": "Button"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "The property value may be one of [button]."
+                    ],
+                    "Status": 1,
+                    "Description": "[4.2.1] LocalizedControlType",
+                    "MetaInfo": {
+                      "PropertyId": 30004,
+                      "UIFramework": "Win32",
+                      "ControlType": "Button"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                    ],
+                    "Status": 1,
+                    "Description": "[MSDN] Typical SubTree structure in Control mode",
+                    "HelpUrl": {
+                      "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                      "Type": 0
+                    },
+                    "MetaInfo": {
+                      "PropertyId": 0,
+                      "UIFramework": "Win32",
+                      "ControlType": "Button"
+                    }
+                  },
+                  {
+                    "Messages": [],
+                    "Status": 1,
+                    "Description": "[MSDN] Typical SubTree structure in Content mode",
+                    "HelpUrl": {
+                      "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                      "Type": 0
+                    },
+                    "MetaInfo": {
+                      "PropertyId": 0,
+                      "UIFramework": "Win32",
+                      "ControlType": "Button"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "'IsControlElement' property value should be \"True\"."
+                    ],
+                    "Status": 1,
+                    "Description": "[MSDN] IsControlElement Property",
+                    "HelpUrl": {
+                      "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                      "Type": 0
+                    },
+                    "MetaInfo": {
+                      "PropertyId": 30016,
+                      "UIFramework": "Win32",
+                      "ControlType": "Button"
+                    }
+                  },
+                  {
+                    "Messages": [],
+                    "Status": 1,
+                    "Description": "[4.1.2] Name: Child element should have unique name.",
+                    "MetaInfo": {
+                      "PropertyId": 0,
+                      "UIFramework": "Win32",
+                      "ControlType": "Button"
+                    }
+                  },
+                  {
+                    "Messages": [],
+                    "Status": 1,
+                    "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                    "HelpUrl": {
+                      "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                      "Type": 0
+                    },
+                    "MetaInfo": {
+                      "PropertyId": 0,
+                      "UIFramework": "Win32",
+                      "ControlType": "Button"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "Only one of Invoke/Toggle patterns expected.",
+                      "Invoke pattern exists."
+                    ],
+                    "Status": 1,
+                    "Description": "[MSDN] Control Pattern",
+                    "HelpUrl": {
+                      "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                      "Type": 0
+                    },
+                    "MetaInfo": {
+                      "PropertyId": 0,
+                      "UIFramework": "Win32",
+                      "ControlType": "Button"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "Check IsContentElement property value."
+                    ],
+                    "Status": 1,
+                    "Description": "[MSDN] Properties",
+                    "HelpUrl": {
+                      "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                      "Type": 0
+                    },
+                    "MetaInfo": {
+                      "PropertyId": 30017,
+                      "UIFramework": "Win32",
+                      "ControlType": "Button"
+                    }
+                  }
+                ],
+                "Status": 3
+              }
+            }
+          ],
+          "TreeWalkerMode": 1,
+          "ScanResults": {
+            "Items": [
+              {
+                "Messages": [
+                  "Name property is required. but it doesn't exist or it has no value."
+                ],
+                "Status": 3,
+                "Description": "[4.1.2] Name",
+                "MetaInfo": {
+                  "PropertyId": 30005,
+                  "UIFramework": "Win32",
+                  "ControlType": "ToolBar"
+                }
+              },
+              {
+                "Messages": [
+                  "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                  "The BoundingRectagle of the current element is [l=528,t=2100,r=588,b=2160].",
+                  "The BoundingRectangle of button \"Start Listening\" child is [l=528,t=2100,r=588,b=2160]"
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                "MetaInfo": {
+                  "PropertyId": 30001,
+                  "UIFramework": "Win32",
+                  "ControlType": "ToolBar"
+                }
+              },
+              {
+                "Messages": [
+                  "The property value may be one of [toolbar].",
+                  "Localized control type property is not matched with expected values."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] LocalizedControlType",
+                "MetaInfo": {
+                  "PropertyId": 30004,
+                  "UIFramework": "Win32",
+                  "ControlType": "ToolBar"
+                }
+              },
+              {
+                "Messages": [
+                  "'IsContentElement' property value should be \"True\".",
+                  "the property value is \"False\"."
+                ],
+                "Status": 2,
+                "Description": "[MSDN] IsContentElement Property",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671654(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30017,
+                  "UIFramework": "Win32",
+                  "ControlType": "ToolBar"
+                }
+              },
+              {
+                "Messages": [
+                  "'IsControlElement' property value should be \"True\"."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] IsControlElement Property",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671654(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30016,
+                  "UIFramework": "Win32",
+                  "ControlType": "ToolBar"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name: Child element should have unique name.",
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "ToolBar"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "ToolBar"
+                }
+              }
+            ],
+            "Status": 3
+          }
+        }
+      ],
+      "TreeWalkerMode": 1,
+      "ScanResults": {
+        "Items": [
+          {
+            "Messages": [
+              "Name doesn't exit or empty. but it is ok for this control type.(Pane(50033))"
+            ],
+            "Status": 1,
+            "Description": "[4.1.2] Name",
+            "MetaInfo": {
+              "PropertyId": 30005,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+              "The BoundingRectagle of the current element is [l=72,t=2100,r=588,b=2160].",
+              "The BoundingRectangle of button \"Type here to search\" child is [l=72,t=2100,r=528,b=2160]",
+              "The BoundingRectangle of tool bar \"\" child is [l=528,t=2100,r=588,b=2160]"
+            ],
+            "Status": 1,
+            "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+            "MetaInfo": {
+              "PropertyId": 30001,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "There is no pattern with UI action related Method(s), but the element is KeyboardFocusible."
+            ],
+            "Status": 1,
+            "Description": "[4.2.1] IsKeyboardFocusable",
+            "MetaInfo": {
+              "PropertyId": 30009,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "The property value may be one of [pane]."
+            ],
+            "Status": 1,
+            "Description": "[4.2.1] LocalizedControlType",
+            "MetaInfo": {
+              "PropertyId": 30004,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "'IsContentElement' property value should be \"True\"."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] IsContentElement Property",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671639(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 30017,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "'IsControlElement' property value should be \"True\"."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] IsControlElement Property",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671639(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 30016,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[4.1.2] Name: Child element should have unique name.",
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "The DoNotSupport pattern(s): WindowPattern"
+            ],
+            "Status": 1,
+            "Description": "[MSDN]: Based on control type, some patterns should not be supported.",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          }
+        ],
+        "Status": 1
+      }
+    },
+    {
+      "Name": "Task View",
+      "ControlTypeId": 50000,
+      "LocalizedControlType": "button",
+      "RuntimeId": "[2A,200BA]",
+      "ProcessId": 7064,
+      "BoundingRectangle": "588, 2100, 72, 60",
+      "IsKeyboardFocusable": true,
+      "IsContent": true,
+      "IsControl": true,
+      "TestStatus": 1,
+      "Glimpse": "button \"Task View\"",
+      "Properties": {
+        "30000": {
+          "Value": [
+            42,
+            131258
+          ],
+          "Id": 30000,
+          "Name": "RuntimeId",
+          "TextValue": "[2A,200BA]"
+        },
+        "30001": {
+          "Value": [
+            588.0,
+            2100.0,
+            72.0,
+            60.0
+          ],
+          "Id": 30001,
+          "Name": "BoundingRectangle",
+          "TextValue": "[l=588,t=2100,r=660,b=2160]"
+        },
+        "30002": {
+          "Value": 7064,
+          "Id": 30002,
+          "Name": "ProcessId",
+          "TextValue": "7064"
+        },
+        "30003": {
+          "Value": 50000,
+          "Id": 30003,
+          "Name": "ControlType",
+          "TextValue": "Button(50000)"
+        },
+        "30004": {
+          "Value": "button",
+          "Id": 30004,
+          "Name": "LocalizedControlType",
+          "TextValue": "button"
+        },
+        "30005": {
+          "Value": "Task View",
+          "Id": 30005,
+          "Name": "Name",
+          "TextValue": "Task View"
+        },
+        "30008": {
+          "Value": false,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus",
+          "TextValue": "False"
+        },
+        "30009": {
+          "Value": true,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable",
+          "TextValue": "True"
+        },
+        "30010": {
+          "Value": true,
+          "Id": 30010,
+          "Name": "IsEnabled",
+          "TextValue": "True"
+        },
+        "30011": {
+          "Value": "4113",
+          "Id": 30011,
+          "Name": "AutomationId",
+          "TextValue": "4113"
+        },
+        "30012": {
+          "Value": "TrayButton",
+          "Id": 30012,
+          "Name": "ClassName",
+          "TextValue": "TrayButton"
+        },
+        "30015": {
+          "Value": 0,
+          "Id": 30015,
+          "Name": "Culture",
+          "TextValue": "0"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement",
+          "TextValue": "True"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement",
+          "TextValue": "True"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword",
+          "TextValue": "False"
+        },
+        "30020": {
+          "Value": 131258,
+          "Id": 30020,
+          "Name": "NativeWindowHandle",
+          "TextValue": "131258"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen",
+          "TextValue": "False"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation",
+          "TextValue": "None(0)"
+        },
+        "30024": {
+          "Value": "Win32",
+          "Id": 30024,
+          "Name": "FrameworkId",
+          "TextValue": "Win32"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm",
+          "TextValue": "False"
+        },
+        "30103": {
+          "Value": false,
+          "Id": 30103,
+          "Name": "IsDataValidForForm",
+          "TextValue": "False"
+        },
+        "30107": {
+          "Value": "[pid:29536,providerId:0x200BA Main:Nested [pid:7064,providerId:0x200BA Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+          "Id": 30107,
+          "Name": "ProviderDescription",
+          "TextValue": "[pid:29536,providerId:0x200BA Main:Nested [pid:7064,providerId:0x200BA Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent",
+          "TextValue": "False"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting",
+          "TextValue": "0"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral",
+          "TextValue": "False"
+        },
+        "30152": {
+          "Value": 0,
+          "Id": 30152,
+          "Name": "PositionInSet",
+          "TextValue": "0"
+        },
+        "30153": {
+          "Value": 0,
+          "Id": 30153,
+          "Name": "SizeOfSet",
+          "TextValue": "0"
+        },
+        "30154": {
+          "Value": 0,
+          "Id": 30154,
+          "Name": "Level",
+          "TextValue": "0"
+        },
+        "30157": {
+          "Value": 0,
+          "Id": 30157,
+          "Name": "LandmarkType",
+          "TextValue": "0"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType",
+          "TextValue": "0"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects",
+          "TextValue": "0"
+        }
+      },
+      "PlatformProperties": {
+        "1": {
+          "Value": 1409286144,
+          "Id": 1,
+          "Name": "Unknown(1)",
+          "TextValue": "1409286144"
+        }
+      },
+      "Patterns": [
+        {
+          "Name": "InvokePattern",
+          "Id": 10000,
+          "Properties": [],
+          "IsUIActionable": true
+        },
+        {
+          "Name": "LegacyIAccessiblePattern",
+          "Id": 10018,
+          "Properties": [
+            {
+              "Name": "ChildId",
+              "Value": 0,
+              "NodeValue": "ChildId = 0"
+            },
+            {
+              "Name": "DefaultAction",
+              "Value": "Press",
+              "NodeValue": "DefaultAction = \"Press\""
+            },
+            {
+              "Name": "Description",
+              "Value": "",
+              "NodeValue": "Description = \"\""
+            },
+            {
+              "Name": "Help",
+              "Value": "",
+              "NodeValue": "Help = \"\""
+            },
+            {
+              "Name": "KeyboardShorcut",
+              "Value": "",
+              "NodeValue": "KeyboardShorcut = \"\""
+            },
+            {
+              "Name": "Name",
+              "Value": "Task View",
+              "NodeValue": "Name = \"Task View\""
+            },
+            {
+              "Name": "Role",
+              "Value": 43,
+              "NodeValue": "Role = 43"
+            },
+            {
+              "Name": "State",
+              "Value": 1048576,
+              "NodeValue": "State = 1048576"
+            },
+            {
+              "Name": "Value",
+              "Value": "",
+              "NodeValue": "Value = \"\""
+            }
+          ],
+          "IsUIActionable": false
+        }
+      ],
+      "Children": [],
+      "TreeWalkerMode": 1,
+      "ScanResults": {
+        "Items": [
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[4.1.2] Name",
+            "MetaInfo": {
+              "PropertyId": 30005,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [
+              "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+              "The BoundingRectagle of the current element is [l=588,t=2100,r=660,b=2160]."
+            ],
+            "Status": 1,
+            "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+            "MetaInfo": {
+              "PropertyId": 30001,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[4.2.1] IsKeyboardFocusable",
+            "MetaInfo": {
+              "PropertyId": 30009,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [
+              "The property value may be one of [button]."
+            ],
+            "Status": 1,
+            "Description": "[4.2.1] LocalizedControlType",
+            "MetaInfo": {
+              "PropertyId": 30004,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [
+              "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] Typical SubTree structure in Control mode",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[MSDN] Typical SubTree structure in Content mode",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [
+              "'IsControlElement' property value should be \"True\"."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] IsControlElement Property",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 30016,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[4.1.2] Name: Child element should have unique name.",
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [
+              "Only one of Invoke/Toggle patterns expected.",
+              "Invoke pattern exists."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] Control Pattern",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          },
+          {
+            "Messages": [
+              "Check IsContentElement property value."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] Properties",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 30017,
+              "UIFramework": "Win32",
+              "ControlType": "Button"
+            }
+          }
+        ],
+        "Status": 1
+      }
+    },
+    {
+      "Name": null,
+      "ControlTypeId": 50033,
+      "LocalizedControlType": "pane",
+      "RuntimeId": "[2A,200F6]",
+      "ProcessId": 7064,
+      "BoundingRectangle": "658, 2100, 2890, 60",
+      "IsKeyboardFocusable": true,
+      "IsContent": true,
+      "IsControl": true,
+      "TestStatus": 1,
+      "Glimpse": "pane \"\"",
+      "Properties": {
+        "30000": {
+          "Value": [
+            42,
+            131318
+          ],
+          "Id": 30000,
+          "Name": "RuntimeId",
+          "TextValue": "[2A,200F6]"
+        },
+        "30001": {
+          "Value": [
+            658.0,
+            2100.0,
+            2890.0,
+            60.0
+          ],
+          "Id": 30001,
+          "Name": "BoundingRectangle",
+          "TextValue": "[l=658,t=2100,r=3548,b=2160]"
+        },
+        "30002": {
+          "Value": 7064,
+          "Id": 30002,
+          "Name": "ProcessId",
+          "TextValue": "7064"
+        },
+        "30003": {
+          "Value": 50033,
+          "Id": 30003,
+          "Name": "ControlType",
+          "TextValue": "Pane(50033)"
+        },
+        "30004": {
+          "Value": "pane",
+          "Id": 30004,
+          "Name": "LocalizedControlType",
+          "TextValue": "pane"
+        },
+        "30008": {
+          "Value": false,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus",
+          "TextValue": "False"
+        },
+        "30009": {
+          "Value": true,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable",
+          "TextValue": "True"
+        },
+        "30010": {
+          "Value": true,
+          "Id": 30010,
+          "Name": "IsEnabled",
+          "TextValue": "True"
+        },
+        "30011": {
+          "Value": "40965",
+          "Id": 30011,
+          "Name": "AutomationId",
+          "TextValue": "40965"
+        },
+        "30012": {
+          "Value": "ReBarWindow32",
+          "Id": 30012,
+          "Name": "ClassName",
+          "TextValue": "ReBarWindow32"
+        },
+        "30015": {
+          "Value": 0,
+          "Id": 30015,
+          "Name": "Culture",
+          "TextValue": "0"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement",
+          "TextValue": "True"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement",
+          "TextValue": "True"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword",
+          "TextValue": "False"
+        },
+        "30020": {
+          "Value": 131318,
+          "Id": 30020,
+          "Name": "NativeWindowHandle",
+          "TextValue": "131318"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen",
+          "TextValue": "False"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation",
+          "TextValue": "None(0)"
+        },
+        "30024": {
+          "Value": "Win32",
+          "Id": 30024,
+          "Name": "FrameworkId",
+          "TextValue": "Win32"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm",
+          "TextValue": "False"
+        },
+        "30103": {
+          "Value": false,
+          "Id": 30103,
+          "Name": "IsDataValidForForm",
+          "TextValue": "False"
+        },
+        "30107": {
+          "Value": "[pid:29536,providerId:0x200F6 Main:Nested [pid:7064,providerId:0x200F6 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+          "Id": 30107,
+          "Name": "ProviderDescription",
+          "TextValue": "[pid:29536,providerId:0x200F6 Main:Nested [pid:7064,providerId:0x200F6 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent",
+          "TextValue": "False"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting",
+          "TextValue": "0"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral",
+          "TextValue": "False"
+        },
+        "30152": {
+          "Value": 0,
+          "Id": 30152,
+          "Name": "PositionInSet",
+          "TextValue": "0"
+        },
+        "30153": {
+          "Value": 0,
+          "Id": 30153,
+          "Name": "SizeOfSet",
+          "TextValue": "0"
+        },
+        "30154": {
+          "Value": 0,
+          "Id": 30154,
+          "Name": "Level",
+          "TextValue": "0"
+        },
+        "30157": {
+          "Value": 0,
+          "Id": 30157,
+          "Name": "LandmarkType",
+          "TextValue": "0"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType",
+          "TextValue": "0"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects",
+          "TextValue": "0"
+        }
+      },
+      "PlatformProperties": {
+        "2": {
+          "Value": 128,
+          "Id": 2,
+          "Name": "Unknown(2)",
+          "TextValue": "128"
+        },
+        "1": {
+          "Value": 1442886237,
+          "Id": 1,
+          "Name": "Unknown(1)",
+          "TextValue": "1442886237"
+        }
+      },
+      "Patterns": [
+        {
+          "Name": "LegacyIAccessiblePattern",
+          "Id": 10018,
+          "Properties": [
+            {
+              "Name": "ChildId",
+              "Value": 0,
+              "NodeValue": "ChildId = 0"
+            },
+            {
+              "Name": "DefaultAction",
+              "Value": "",
+              "NodeValue": "DefaultAction = \"\""
+            },
+            {
+              "Name": "Description",
+              "Value": "",
+              "NodeValue": "Description = \"\""
+            },
+            {
+              "Name": "Help",
+              "Value": "",
+              "NodeValue": "Help = \"\""
+            },
+            {
+              "Name": "KeyboardShorcut",
+              "Value": "",
+              "NodeValue": "KeyboardShorcut = \"\""
+            },
+            {
+              "Name": "Name",
+              "Value": "",
+              "NodeValue": "Name = \"\""
+            },
+            {
+              "Name": "Role",
+              "Value": 10,
+              "NodeValue": "Role = 10"
+            },
+            {
+              "Name": "State",
+              "Value": 1048832,
+              "NodeValue": "State = 1048832"
+            },
+            {
+              "Name": "Value",
+              "Value": "",
+              "NodeValue": "Value = \"\""
+            }
+          ],
+          "IsUIActionable": false
+        }
+      ],
+      "Children": [
+        {
+          "Name": "Running applications",
+          "ControlTypeId": 50033,
+          "LocalizedControlType": "pane",
+          "RuntimeId": "[2A,200FC]",
+          "ProcessId": 7064,
+          "BoundingRectangle": "660, 2100, 2888, 60",
+          "IsKeyboardFocusable": true,
+          "IsContent": true,
+          "IsControl": true,
+          "TestStatus": 1,
+          "Glimpse": "pane \"Running applications\"",
+          "Properties": {
+            "30000": {
+              "Value": [
+                42,
+                131324
+              ],
+              "Id": 30000,
+              "Name": "RuntimeId",
+              "TextValue": "[2A,200FC]"
+            },
+            "30001": {
+              "Value": [
+                660.0,
+                2100.0,
+                2888.0,
+                60.0
+              ],
+              "Id": 30001,
+              "Name": "BoundingRectangle",
+              "TextValue": "[l=660,t=2100,r=3548,b=2160]"
+            },
+            "30002": {
+              "Value": 7064,
+              "Id": 30002,
+              "Name": "ProcessId",
+              "TextValue": "7064"
+            },
+            "30003": {
+              "Value": 50033,
+              "Id": 30003,
+              "Name": "ControlType",
+              "TextValue": "Pane(50033)"
+            },
+            "30004": {
+              "Value": "pane",
+              "Id": 30004,
+              "Name": "LocalizedControlType",
+              "TextValue": "pane"
+            },
+            "30005": {
+              "Value": "Running applications",
+              "Id": 30005,
+              "Name": "Name",
+              "TextValue": "Running applications"
+            },
+            "30008": {
+              "Value": false,
+              "Id": 30008,
+              "Name": "HasKeyboardFocus",
+              "TextValue": "False"
+            },
+            "30009": {
+              "Value": true,
+              "Id": 30009,
+              "Name": "IsKeyboardFocusable",
+              "TextValue": "True"
+            },
+            "30010": {
+              "Value": true,
+              "Id": 30010,
+              "Name": "IsEnabled",
+              "TextValue": "True"
+            },
+            "30012": {
+              "Value": "MSTaskSwWClass",
+              "Id": 30012,
+              "Name": "ClassName",
+              "TextValue": "MSTaskSwWClass"
+            },
+            "30015": {
+              "Value": 0,
+              "Id": 30015,
+              "Name": "Culture",
+              "TextValue": "0"
+            },
+            "30016": {
+              "Value": true,
+              "Id": 30016,
+              "Name": "IsControlElement",
+              "TextValue": "True"
+            },
+            "30017": {
+              "Value": true,
+              "Id": 30017,
+              "Name": "IsContentElement",
+              "TextValue": "True"
+            },
+            "30019": {
+              "Value": false,
+              "Id": 30019,
+              "Name": "IsPassword",
+              "TextValue": "False"
+            },
+            "30020": {
+              "Value": 131324,
+              "Id": 30020,
+              "Name": "NativeWindowHandle",
+              "TextValue": "131324"
+            },
+            "30022": {
+              "Value": false,
+              "Id": 30022,
+              "Name": "IsOffscreen",
+              "TextValue": "False"
+            },
+            "30023": {
+              "Value": 0,
+              "Id": 30023,
+              "Name": "Orientation",
+              "TextValue": "None(0)"
+            },
+            "30024": {
+              "Value": "Win32",
+              "Id": 30024,
+              "Name": "FrameworkId",
+              "TextValue": "Win32"
+            },
+            "30025": {
+              "Value": false,
+              "Id": 30025,
+              "Name": "IsRequiredForForm",
+              "TextValue": "False"
+            },
+            "30103": {
+              "Value": false,
+              "Id": 30103,
+              "Name": "IsDataValidForForm",
+              "TextValue": "False"
+            },
+            "30107": {
+              "Value": "[pid:29536,providerId:0x200FC Main:Nested [pid:7064,providerId:0x200FC Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+              "Id": 30107,
+              "Name": "ProviderDescription",
+              "TextValue": "[pid:29536,providerId:0x200FC Main:Nested [pid:7064,providerId:0x200FC Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+            },
+            "30111": {
+              "Value": false,
+              "Id": 30111,
+              "Name": "OptimizeForVisualContent",
+              "TextValue": "False"
+            },
+            "30135": {
+              "Value": 0,
+              "Id": 30135,
+              "Name": "LiveSetting",
+              "TextValue": "0"
+            },
+            "30150": {
+              "Value": false,
+              "Id": 30150,
+              "Name": "IsPeripheral",
+              "TextValue": "False"
+            },
+            "30152": {
+              "Value": 0,
+              "Id": 30152,
+              "Name": "PositionInSet",
+              "TextValue": "0"
+            },
+            "30153": {
+              "Value": 0,
+              "Id": 30153,
+              "Name": "SizeOfSet",
+              "TextValue": "0"
+            },
+            "30154": {
+              "Value": 0,
+              "Id": 30154,
+              "Name": "Level",
+              "TextValue": "0"
+            },
+            "30157": {
+              "Value": 0,
+              "Id": 30157,
+              "Name": "LandmarkType",
+              "TextValue": "0"
+            },
+            "30162": {
+              "Value": 0,
+              "Id": 30162,
+              "Name": "FillType",
+              "TextValue": "0"
+            },
+            "30163": {
+              "Value": 0,
+              "Id": 30163,
+              "Name": "VisualEffects",
+              "TextValue": "0"
+            }
+          },
+          "PlatformProperties": {
+            "1": {
+              "Value": 1442906112,
+              "Id": 1,
+              "Name": "Unknown(1)",
+              "TextValue": "1442906112"
+            }
+          },
+          "Patterns": [
+            {
+              "Name": "LegacyIAccessiblePattern",
+              "Id": 10018,
+              "Properties": [
+                {
+                  "Name": "ChildId",
+                  "Value": 0,
+                  "NodeValue": "ChildId = 0"
+                },
+                {
+                  "Name": "DefaultAction",
+                  "Value": "",
+                  "NodeValue": "DefaultAction = \"\""
+                },
+                {
+                  "Name": "Description",
+                  "Value": "",
+                  "NodeValue": "Description = \"\""
+                },
+                {
+                  "Name": "Help",
+                  "Value": "",
+                  "NodeValue": "Help = \"\""
+                },
+                {
+                  "Name": "KeyboardShorcut",
+                  "Value": "",
+                  "NodeValue": "KeyboardShorcut = \"\""
+                },
+                {
+                  "Name": "Name",
+                  "Value": "Running applications",
+                  "NodeValue": "Name = \"Running applications\""
+                },
+                {
+                  "Name": "Role",
+                  "Value": 10,
+                  "NodeValue": "Role = 10"
+                },
+                {
+                  "Name": "State",
+                  "Value": 1048576,
+                  "NodeValue": "State = 1048576"
+                },
+                {
+                  "Name": "Value",
+                  "Value": "",
+                  "NodeValue": "Value = \"\""
+                }
+              ],
+              "IsUIActionable": false
+            }
+          ],
+          "Children": [
+            {
+              "Name": "Running applications",
+              "ControlTypeId": 50021,
+              "LocalizedControlType": "tool bar",
+              "RuntimeId": "[2A,100FE]",
+              "ProcessId": 7064,
+              "BoundingRectangle": "660, 2100, 2888, 60",
+              "IsKeyboardFocusable": true,
+              "IsContent": true,
+              "IsControl": true,
+              "TestStatus": 1,
+              "Glimpse": "tool bar \"Running applications\"",
+              "Properties": {
+                "30000": {
+                  "Value": [
+                    42,
+                    65790
+                  ],
+                  "Id": 30000,
+                  "Name": "RuntimeId",
+                  "TextValue": "[2A,100FE]"
+                },
+                "30001": {
+                  "Value": [
+                    660.0,
+                    2100.0,
+                    2888.0,
+                    60.0
+                  ],
+                  "Id": 30001,
+                  "Name": "BoundingRectangle",
+                  "TextValue": "[l=660,t=2100,r=3548,b=2160]"
+                },
+                "30002": {
+                  "Value": 7064,
+                  "Id": 30002,
+                  "Name": "ProcessId",
+                  "TextValue": "7064"
+                },
+                "30003": {
+                  "Value": 50021,
+                  "Id": 30003,
+                  "Name": "ControlType",
+                  "TextValue": "ToolBar(50021)"
+                },
+                "30004": {
+                  "Value": "tool bar",
+                  "Id": 30004,
+                  "Name": "LocalizedControlType",
+                  "TextValue": "tool bar"
+                },
+                "30005": {
+                  "Value": "Running applications",
+                  "Id": 30005,
+                  "Name": "Name",
+                  "TextValue": "Running applications"
+                },
+                "30008": {
+                  "Value": false,
+                  "Id": 30008,
+                  "Name": "HasKeyboardFocus",
+                  "TextValue": "False"
+                },
+                "30009": {
+                  "Value": true,
+                  "Id": 30009,
+                  "Name": "IsKeyboardFocusable",
+                  "TextValue": "True"
+                },
+                "30010": {
+                  "Value": true,
+                  "Id": 30010,
+                  "Name": "IsEnabled",
+                  "TextValue": "True"
+                },
+                "30012": {
+                  "Value": "MSTaskListWClass",
+                  "Id": 30012,
+                  "Name": "ClassName",
+                  "TextValue": "MSTaskListWClass"
+                },
+                "30015": {
+                  "Value": 0,
+                  "Id": 30015,
+                  "Name": "Culture",
+                  "TextValue": "0"
+                },
+                "30016": {
+                  "Value": true,
+                  "Id": 30016,
+                  "Name": "IsControlElement",
+                  "TextValue": "True"
+                },
+                "30017": {
+                  "Value": true,
+                  "Id": 30017,
+                  "Name": "IsContentElement",
+                  "TextValue": "True"
+                },
+                "30019": {
+                  "Value": false,
+                  "Id": 30019,
+                  "Name": "IsPassword",
+                  "TextValue": "False"
+                },
+                "30020": {
+                  "Value": 65790,
+                  "Id": 30020,
+                  "Name": "NativeWindowHandle",
+                  "TextValue": "65790"
+                },
+                "30022": {
+                  "Value": false,
+                  "Id": 30022,
+                  "Name": "IsOffscreen",
+                  "TextValue": "False"
+                },
+                "30023": {
+                  "Value": 0,
+                  "Id": 30023,
+                  "Name": "Orientation",
+                  "TextValue": "None(0)"
+                },
+                "30024": {
+                  "Value": "Win32",
+                  "Id": 30024,
+                  "Name": "FrameworkId",
+                  "TextValue": "Win32"
+                },
+                "30025": {
+                  "Value": false,
+                  "Id": 30025,
+                  "Name": "IsRequiredForForm",
+                  "TextValue": "False"
+                },
+                "30103": {
+                  "Value": false,
+                  "Id": 30103,
+                  "Name": "IsDataValidForForm",
+                  "TextValue": "False"
+                },
+                "30107": {
+                  "Value": "[pid:29536,providerId:0x100FE Main:Nested [pid:7064,providerId:0x100FE Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+                  "Id": 30107,
+                  "Name": "ProviderDescription",
+                  "TextValue": "[pid:29536,providerId:0x100FE Main:Nested [pid:7064,providerId:0x100FE Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+                },
+                "30111": {
+                  "Value": false,
+                  "Id": 30111,
+                  "Name": "OptimizeForVisualContent",
+                  "TextValue": "False"
+                },
+                "30135": {
+                  "Value": 0,
+                  "Id": 30135,
+                  "Name": "LiveSetting",
+                  "TextValue": "0"
+                },
+                "30150": {
+                  "Value": false,
+                  "Id": 30150,
+                  "Name": "IsPeripheral",
+                  "TextValue": "False"
+                },
+                "30152": {
+                  "Value": 0,
+                  "Id": 30152,
+                  "Name": "PositionInSet",
+                  "TextValue": "0"
+                },
+                "30153": {
+                  "Value": 0,
+                  "Id": 30153,
+                  "Name": "SizeOfSet",
+                  "TextValue": "0"
+                },
+                "30154": {
+                  "Value": 0,
+                  "Id": 30154,
+                  "Name": "Level",
+                  "TextValue": "0"
+                },
+                "30157": {
+                  "Value": 0,
+                  "Id": 30157,
+                  "Name": "LandmarkType",
+                  "TextValue": "0"
+                },
+                "30162": {
+                  "Value": 0,
+                  "Id": 30162,
+                  "Name": "FillType",
+                  "TextValue": "0"
+                },
+                "30163": {
+                  "Value": 0,
+                  "Id": 30163,
+                  "Name": "VisualEffects",
+                  "TextValue": "0"
+                }
+              },
+              "PlatformProperties": {
+                "1": {
+                  "Value": 1442840576,
+                  "Id": 1,
+                  "Name": "Unknown(1)",
+                  "TextValue": "1442840576"
+                }
+              },
+              "Patterns": [
+                {
+                  "Name": "LegacyIAccessiblePattern",
+                  "Id": 10018,
+                  "Properties": [
+                    {
+                      "Name": "ChildId",
+                      "Value": 0,
+                      "NodeValue": "ChildId = 0"
+                    },
+                    {
+                      "Name": "DefaultAction",
+                      "Value": "",
+                      "NodeValue": "DefaultAction = \"\""
+                    },
+                    {
+                      "Name": "Description",
+                      "Value": "",
+                      "NodeValue": "Description = \"\""
+                    },
+                    {
+                      "Name": "Help",
+                      "Value": "",
+                      "NodeValue": "Help = \"\""
+                    },
+                    {
+                      "Name": "KeyboardShorcut",
+                      "Value": "",
+                      "NodeValue": "KeyboardShorcut = \"\""
+                    },
+                    {
+                      "Name": "Name",
+                      "Value": "Running applications",
+                      "NodeValue": "Name = \"Running applications\""
+                    },
+                    {
+                      "Name": "Role",
+                      "Value": 22,
+                      "NodeValue": "Role = 22"
+                    },
+                    {
+                      "Name": "State",
+                      "Value": 1048576,
+                      "NodeValue": "State = 1048576"
+                    },
+                    {
+                      "Name": "Value",
+                      "Value": "",
+                      "NodeValue": "Value = \"\""
+                    }
+                  ],
+                  "IsUIActionable": false
+                }
+              ],
+              "Children": [
+                {
+                  "Name": "Microsoft Edge - 1 running window",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,2]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "664, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"Microsoft Edge - 1 running window\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        2
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,2]"
+                    },
+                    "30001": {
+                      "Value": [
+                        664.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=664,t=2100,r=739,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "Microsoft Edge - 1 running window",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "Microsoft Edge - 1 running window"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 2,
+                          "NodeValue": "ChildId = 2"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "Microsoft Edge - 1 running window",
+                          "NodeValue": "Name = \"Microsoft Edge - 1 running window\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 1073741824,
+                          "NodeValue": "State = 1073741824"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=664,t=2100,r=739,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "File Explorer - 1 running window",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,4]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "739, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"File Explorer - 1 running window\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        4
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,4]"
+                    },
+                    "30001": {
+                      "Value": [
+                        739.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=739,t=2100,r=814,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "File Explorer - 1 running window",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "File Explorer - 1 running window"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "Microsoft.Windows.Explorer",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "Microsoft.Windows.Explorer"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 4,
+                          "NodeValue": "ChildId = 4"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "File Explorer - 1 running window",
+                          "NodeValue": "Name = \"File Explorer - 1 running window\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 1073741824,
+                          "NodeValue": "State = 1073741824"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=739,t=2100,r=814,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "Visual Studio 2017 - 1 running window",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,6]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "814, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"Visual Studio 2017 - 1 running window\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        6
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,6]"
+                    },
+                    "30001": {
+                      "Value": [
+                        814.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=814,t=2100,r=889,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "Visual Studio 2017 - 1 running window",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "Visual Studio 2017 - 1 running window"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "VisualStudio.fb1edefe",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "VisualStudio.fb1edefe"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 6,
+                          "NodeValue": "ChildId = 6"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "Visual Studio 2017 - 1 running window",
+                          "NodeValue": "Name = \"Visual Studio 2017 - 1 running window\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 1073741824,
+                          "NodeValue": "State = 1073741824"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=814,t=2100,r=889,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "Outlook 2016 - 1 running window",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,8]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "889, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"Outlook 2016 - 1 running window\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        8
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,8]"
+                    },
+                    "30001": {
+                      "Value": [
+                        889.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=889,t=2100,r=964,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "Outlook 2016 - 1 running window",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "Outlook 2016 - 1 running window"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "Microsoft.Office.OUTLOOK.EXE.15",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "Microsoft.Office.OUTLOOK.EXE.15"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 8,
+                          "NodeValue": "ChildId = 8"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "Outlook 2016 - 1 running window",
+                          "NodeValue": "Name = \"Outlook 2016 - 1 running window\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 1073741824,
+                          "NodeValue": "State = 1073741824"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=889,t=2100,r=964,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "Sublime Text 3 - 1 running window",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,A]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "964, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"Sublime Text 3 - 1 running window\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        10
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,A]"
+                    },
+                    "30001": {
+                      "Value": [
+                        964.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=964,t=2100,r=1039,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "Sublime Text 3 - 1 running window",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "Sublime Text 3 - 1 running window"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "{6D809377-6AF0-444B-8957-A3773F02200E}\\Sublime Text 3\\sublime_text.exe",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "{6D809377-6AF0-444B-8957-A3773F02200E}\\Sublime Text 3\\sublime_text.exe"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 10,
+                          "NodeValue": "ChildId = 10"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "Sublime Text 3 - 1 running window",
+                          "NodeValue": "Name = \"Sublime Text 3 - 1 running window\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 1073741824,
+                          "NodeValue": "State = 1073741824"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=964,t=2100,r=1039,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "Skype for Business 2016 - 1 running window",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,C]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "1039, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"Skype for Business 2016 - 1 running window\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        12
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,C]"
+                    },
+                    "30001": {
+                      "Value": [
+                        1039.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=1039,t=2100,r=1114,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "Skype for Business 2016 - 1 running window",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "Skype for Business 2016 - 1 running window"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "Microsoft.Office.lync.exe.15",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "Microsoft.Office.lync.exe.15"
+                    },
+                    "30013": {
+                      "Value": "Available",
+                      "Id": 30013,
+                      "Name": "HelpText",
+                      "TextValue": "Available"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 12,
+                          "NodeValue": "ChildId = 12"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "Available",
+                          "NodeValue": "Help = \"Available\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "Skype for Business 2016 - 1 running window",
+                          "NodeValue": "Name = \"Skype for Business 2016 - 1 running window\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 1073741824,
+                          "NodeValue": "State = 1073741824"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=1039,t=2100,r=1114,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "Spotify",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,D]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "1114, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"Spotify\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        13
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,D]"
+                    },
+                    "30001": {
+                      "Value": [
+                        1114.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=1114,t=2100,r=1189,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "Spotify",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "Spotify"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "C:\\Users\\administrator\\AppData\\Roaming\\Spotify\\Spotify.exe",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "C:\\Users\\administrator\\AppData\\Roaming\\Spotify\\Spotify.exe"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 13,
+                          "NodeValue": "ChildId = 13"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "Spotify",
+                          "NodeValue": "Name = \"Spotify\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 0,
+                          "NodeValue": "State = 0"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=1114,t=2100,r=1189,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "Figma",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,E]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "1189, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"Figma\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        14
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,E]"
+                    },
+                    "30001": {
+                      "Value": [
+                        1189.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=1189,t=2100,r=1264,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "Figma",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "Figma"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "com.squirrel.Figma.Figma",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "com.squirrel.Figma.Figma"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 14,
+                          "NodeValue": "ChildId = 14"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "Figma",
+                          "NodeValue": "Name = \"Figma\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 0,
+                          "NodeValue": "State = 0"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=1189,t=2100,r=1264,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "MonsterElement_WPF",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,F]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "1264, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"MonsterElement_WPF\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        15
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,F]"
+                    },
+                    "30001": {
+                      "Value": [
+                        1264.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=1264,t=2100,r=1339,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "MonsterElement_WPF",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "MonsterElement_WPF"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "MonsterElement_WPF.exe",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "MonsterElement_WPF.exe"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 15,
+                          "NodeValue": "ChildId = 15"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "MonsterElement_WPF",
+                          "NodeValue": "Name = \"MonsterElement_WPF\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 0,
+                          "NodeValue": "State = 0"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=1264,t=2100,r=1339,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "Word 2016 - 1 running window",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,11]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "1339, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"Word 2016 - 1 running window\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        17
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,11]"
+                    },
+                    "30001": {
+                      "Value": [
+                        1339.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=1339,t=2100,r=1414,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "Word 2016 - 1 running window",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "Word 2016 - 1 running window"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "Microsoft.Office.WINWORD.EXE.15",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "Microsoft.Office.WINWORD.EXE.15"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 17,
+                          "NodeValue": "ChildId = 17"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "Word 2016 - 1 running window",
+                          "NodeValue": "Name = \"Word 2016 - 1 running window\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 1073741824,
+                          "NodeValue": "State = 1073741824"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=1339,t=2100,r=1414,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "Settings - 1 running window",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,13]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "1414, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"Settings - 1 running window\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        19
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,13]"
+                    },
+                    "30001": {
+                      "Value": [
+                        1414.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=1414,t=2100,r=1489,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "Settings - 1 running window",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "Settings - 1 running window"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "windows.immersivecontrolpanel_cw5n1h2txyewy!microsoft.windows.immersivecontrolpanel",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "windows.immersivecontrolpanel_cw5n1h2txyewy!microsoft.windows.immersivecontrolpanel"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 19,
+                          "NodeValue": "ChildId = 19"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "Settings - 1 running window",
+                          "NodeValue": "Name = \"Settings - 1 running window\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 1073741824,
+                          "NodeValue": "State = 1073741824"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=1414,t=2100,r=1489,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "Windows Command Processor - 3 running windows",
+                  "ControlTypeId": 50011,
+                  "LocalizedControlType": "menu item",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,14]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "1489, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "menu item \"Windows Command Processor - 3 running windows\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        20
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,14]"
+                    },
+                    "30001": {
+                      "Value": [
+                        1489.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=1489,t=2100,r=1564,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50011,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "MenuItem(50011)"
+                    },
+                    "30004": {
+                      "Value": "menu item",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "menu item"
+                    },
+                    "30005": {
+                      "Value": "Windows Command Processor - 3 running windows",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "Windows Command Processor - 3 running windows"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "{D65231B0-B2F1-4857-A4CE-A8E7C6EA7D27}\\cmd.exe",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "{D65231B0-B2F1-4857-A4CE-A8E7C6EA7D27}\\cmd.exe"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "ExpandCollapsePattern",
+                      "Id": 10005,
+                      "Properties": [
+                        {
+                          "Name": "ExpandCollapseState",
+                          "Value": 3,
+                          "NodeValue": "ExpandCollapseState = ExpandCollapseState_LeafNode"
+                        }
+                      ],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 20,
+                          "NodeValue": "ChildId = 20"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Open",
+                          "NodeValue": "DefaultAction = \"Open\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "Windows Command Processor - 3 running windows",
+                          "NodeValue": "Name = \"Windows Command Processor - 3 running windows\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 57,
+                          "NodeValue": "Role = 57"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 1073741824,
+                          "NodeValue": "State = 1073741824"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "MenuItem"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=1489,t=2100,r=1564,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "MenuItem"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern, ExpandCollapsePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "MenuItem"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [menu item]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "MenuItem"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsContentElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsContentElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671638(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "MenuItem"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671638(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "MenuItem"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "MenuItem"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "MenuItem"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "OneNote 2016 - 1 running window",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,19]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "1564, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"OneNote 2016 - 1 running window\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        25
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,19]"
+                    },
+                    "30001": {
+                      "Value": [
+                        1564.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=1564,t=2100,r=1639,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "OneNote 2016 - 1 running window",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "OneNote 2016 - 1 running window"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "Microsoft.Office.ONENOTE.EXE.15",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "Microsoft.Office.ONENOTE.EXE.15"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 25,
+                          "NodeValue": "ChildId = 25"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "OneNote 2016 - 1 running window",
+                          "NodeValue": "Name = \"OneNote 2016 - 1 running window\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 1073741824,
+                          "NodeValue": "State = 1073741824"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=1564,t=2100,r=1639,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "AccessibilityInsights - 1 running window",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100FE,3,80000001,100FE,FFFFFFFC,1B]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "1639, 2100, 75, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"AccessibilityInsights - 1 running window\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65790,
+                        3,
+                        -2147483647,
+                        65790,
+                        -4,
+                        27
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100FE,3,80000001,100FE,FFFFFFFC,1B]"
+                    },
+                    "30001": {
+                      "Value": [
+                        1639.0,
+                        2100.0,
+                        75.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=1639,t=2100,r=1714,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "AccessibilityInsights - 1 running window",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "AccessibilityInsights - 1 running window"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "AccessibilityInsights.exe",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "AccessibilityInsights.exe"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 27,
+                          "NodeValue": "ChildId = 27"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "AccessibilityInsights - 1 running window",
+                          "NodeValue": "Name = \"AccessibilityInsights - 1 running window\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 1073741832,
+                          "NodeValue": "State = 1073741832"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=1639,t=2100,r=1714,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                }
+              ],
+              "TreeWalkerMode": 1,
+              "ScanResults": {
+                "Items": [
+                  {
+                    "Messages": [],
+                    "Status": 1,
+                    "Description": "[4.1.2] Name",
+                    "MetaInfo": {
+                      "PropertyId": 30005,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                      "The BoundingRectagle of the current element is [l=660,t=2100,r=3548,b=2160].",
+                      "The BoundingRectangle of button \"Microsoft Edge - 1 running window\" child is [l=664,t=2100,r=739,b=2160]",
+                      "The BoundingRectangle of button \"File Explorer - 1 running window\" child is [l=739,t=2100,r=814,b=2160]",
+                      "The BoundingRectangle of button \"Visual Studio 2017 - 1 running window\" child is [l=814,t=2100,r=889,b=2160]",
+                      "The BoundingRectangle of button \"Outlook 2016 - 1 running window\" child is [l=889,t=2100,r=964,b=2160]",
+                      "The BoundingRectangle of button \"Sublime Text 3 - 1 running window\" child is [l=964,t=2100,r=1039,b=2160]",
+                      "The BoundingRectangle of button \"Skype for Business 2016 - 1 running window\" child is [l=1039,t=2100,r=1114,b=2160]",
+                      "The BoundingRectangle of button \"Spotify\" child is [l=1114,t=2100,r=1189,b=2160]",
+                      "The BoundingRectangle of button \"Figma\" child is [l=1189,t=2100,r=1264,b=2160]",
+                      "The BoundingRectangle of button \"MonsterElement_WPF\" child is [l=1264,t=2100,r=1339,b=2160]",
+                      "The BoundingRectangle of button \"Word 2016 - 1 running window\" child is [l=1339,t=2100,r=1414,b=2160]",
+                      "The BoundingRectangle of button \"Settings - 1 running window\" child is [l=1414,t=2100,r=1489,b=2160]",
+                      "The BoundingRectangle of menu item \"Windows Command Processor - 3 running windows\" child is [l=1489,t=2100,r=1564,b=2160]",
+                      "The BoundingRectangle of button \"OneNote 2016 - 1 running window\" child is [l=1564,t=2100,r=1639,b=2160]",
+                      "The BoundingRectangle of button \"AccessibilityInsights - 1 running window\" child is [l=1639,t=2100,r=1714,b=2160]"
+                    ],
+                    "Status": 1,
+                    "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                    "MetaInfo": {
+                      "PropertyId": 30001,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "The property value may be one of [toolbar].",
+                      "Localized control type property is not matched with expected values."
+                    ],
+                    "Status": 1,
+                    "Description": "[4.2.1] LocalizedControlType",
+                    "MetaInfo": {
+                      "PropertyId": 30004,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "'IsContentElement' property value should be \"True\"."
+                    ],
+                    "Status": 1,
+                    "Description": "[MSDN] IsContentElement Property",
+                    "HelpUrl": {
+                      "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671654(v=vs.85).aspx",
+                      "Type": 0
+                    },
+                    "MetaInfo": {
+                      "PropertyId": 30017,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "'IsControlElement' property value should be \"True\"."
+                    ],
+                    "Status": 1,
+                    "Description": "[MSDN] IsControlElement Property",
+                    "HelpUrl": {
+                      "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671654(v=vs.85).aspx",
+                      "Type": 0
+                    },
+                    "MetaInfo": {
+                      "PropertyId": 30016,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  },
+                  {
+                    "Messages": [],
+                    "Status": 1,
+                    "Description": "[4.1.2] Name: Child element should have unique name.",
+                    "MetaInfo": {
+                      "PropertyId": 0,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  },
+                  {
+                    "Messages": [],
+                    "Status": 1,
+                    "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                    "HelpUrl": {
+                      "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                      "Type": 0
+                    },
+                    "MetaInfo": {
+                      "PropertyId": 0,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  }
+                ],
+                "Status": 1
+              }
+            }
+          ],
+          "TreeWalkerMode": 1,
+          "ScanResults": {
+            "Items": [
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name",
+                "MetaInfo": {
+                  "PropertyId": 30005,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [
+                  "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                  "The BoundingRectagle of the current element is [l=660,t=2100,r=3548,b=2160].",
+                  "The BoundingRectangle of tool bar \"Running applications\" child is [l=660,t=2100,r=3548,b=2160]"
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                "MetaInfo": {
+                  "PropertyId": 30001,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [
+                  "There is no pattern with UI action related Method(s), but the element is KeyboardFocusible."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] IsKeyboardFocusable",
+                "MetaInfo": {
+                  "PropertyId": 30009,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [
+                  "The property value may be one of [pane]."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] LocalizedControlType",
+                "MetaInfo": {
+                  "PropertyId": 30004,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [
+                  "'IsContentElement' property value should be \"True\"."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] IsContentElement Property",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671639(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30017,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [
+                  "'IsControlElement' property value should be \"True\"."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] IsControlElement Property",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671639(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30016,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name: Child element should have unique name.",
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [
+                  "The DoNotSupport pattern(s): WindowPattern"
+                ],
+                "Status": 1,
+                "Description": "[MSDN]: Based on control type, some patterns should not be supported.",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              }
+            ],
+            "Status": 1
+          }
+        }
+      ],
+      "TreeWalkerMode": 1,
+      "ScanResults": {
+        "Items": [
+          {
+            "Messages": [
+              "Name doesn't exit or empty. but it is ok for this control type.(Pane(50033))"
+            ],
+            "Status": 1,
+            "Description": "[4.1.2] Name",
+            "MetaInfo": {
+              "PropertyId": 30005,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+              "The BoundingRectagle of the current element is [l=658,t=2100,r=3548,b=2160].",
+              "The BoundingRectangle of pane \"Running applications\" child is [l=660,t=2100,r=3548,b=2160]"
+            ],
+            "Status": 1,
+            "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+            "MetaInfo": {
+              "PropertyId": 30001,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "There is no pattern with UI action related Method(s), but the element is KeyboardFocusible."
+            ],
+            "Status": 1,
+            "Description": "[4.2.1] IsKeyboardFocusable",
+            "MetaInfo": {
+              "PropertyId": 30009,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "The property value may be one of [pane]."
+            ],
+            "Status": 1,
+            "Description": "[4.2.1] LocalizedControlType",
+            "MetaInfo": {
+              "PropertyId": 30004,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "'IsContentElement' property value should be \"True\"."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] IsContentElement Property",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671639(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 30017,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "'IsControlElement' property value should be \"True\"."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] IsControlElement Property",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671639(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 30016,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[4.1.2] Name: Child element should have unique name.",
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "The DoNotSupport pattern(s): WindowPattern"
+            ],
+            "Status": 1,
+            "Description": "[MSDN]: Based on control type, some patterns should not be supported.",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          }
+        ],
+        "Status": 1
+      }
+    },
+    {
+      "Name": null,
+      "ControlTypeId": 50033,
+      "LocalizedControlType": "pane",
+      "RuntimeId": "[2A,100BE]",
+      "ProcessId": 7064,
+      "BoundingRectangle": "3548, 2100, 292, 60",
+      "IsKeyboardFocusable": true,
+      "IsContent": true,
+      "IsControl": true,
+      "TestStatus": 1,
+      "Glimpse": "pane \"\"",
+      "Properties": {
+        "30000": {
+          "Value": [
+            42,
+            65726
+          ],
+          "Id": 30000,
+          "Name": "RuntimeId",
+          "TextValue": "[2A,100BE]"
+        },
+        "30001": {
+          "Value": [
+            3548.0,
+            2100.0,
+            292.0,
+            60.0
+          ],
+          "Id": 30001,
+          "Name": "BoundingRectangle",
+          "TextValue": "[l=3548,t=2100,r=3840,b=2160]"
+        },
+        "30002": {
+          "Value": 7064,
+          "Id": 30002,
+          "Name": "ProcessId",
+          "TextValue": "7064"
+        },
+        "30003": {
+          "Value": 50033,
+          "Id": 30003,
+          "Name": "ControlType",
+          "TextValue": "Pane(50033)"
+        },
+        "30004": {
+          "Value": "pane",
+          "Id": 30004,
+          "Name": "LocalizedControlType",
+          "TextValue": "pane"
+        },
+        "30008": {
+          "Value": false,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus",
+          "TextValue": "False"
+        },
+        "30009": {
+          "Value": true,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable",
+          "TextValue": "True"
+        },
+        "30010": {
+          "Value": true,
+          "Id": 30010,
+          "Name": "IsEnabled",
+          "TextValue": "True"
+        },
+        "30011": {
+          "Value": "303",
+          "Id": 30011,
+          "Name": "AutomationId",
+          "TextValue": "303"
+        },
+        "30012": {
+          "Value": "TrayNotifyWnd",
+          "Id": 30012,
+          "Name": "ClassName",
+          "TextValue": "TrayNotifyWnd"
+        },
+        "30015": {
+          "Value": 0,
+          "Id": 30015,
+          "Name": "Culture",
+          "TextValue": "0"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement",
+          "TextValue": "True"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement",
+          "TextValue": "True"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword",
+          "TextValue": "False"
+        },
+        "30020": {
+          "Value": 65726,
+          "Id": 30020,
+          "Name": "NativeWindowHandle",
+          "TextValue": "65726"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen",
+          "TextValue": "False"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation",
+          "TextValue": "None(0)"
+        },
+        "30024": {
+          "Value": "Win32",
+          "Id": 30024,
+          "Name": "FrameworkId",
+          "TextValue": "Win32"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm",
+          "TextValue": "False"
+        },
+        "30103": {
+          "Value": false,
+          "Id": 30103,
+          "Name": "IsDataValidForForm",
+          "TextValue": "False"
+        },
+        "30107": {
+          "Value": "[pid:29536,providerId:0x100BE Main:Nested [pid:7064,providerId:0x100BE Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+          "Id": 30107,
+          "Name": "ProviderDescription",
+          "TextValue": "[pid:29536,providerId:0x100BE Main:Nested [pid:7064,providerId:0x100BE Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent",
+          "TextValue": "False"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting",
+          "TextValue": "0"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral",
+          "TextValue": "False"
+        },
+        "30152": {
+          "Value": 0,
+          "Id": 30152,
+          "Name": "PositionInSet",
+          "TextValue": "0"
+        },
+        "30153": {
+          "Value": 0,
+          "Id": 30153,
+          "Name": "SizeOfSet",
+          "TextValue": "0"
+        },
+        "30154": {
+          "Value": 0,
+          "Id": 30154,
+          "Name": "Level",
+          "TextValue": "0"
+        },
+        "30157": {
+          "Value": 0,
+          "Id": 30157,
+          "Name": "LandmarkType",
+          "TextValue": "0"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType",
+          "TextValue": "0"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects",
+          "TextValue": "0"
+        }
+      },
+      "PlatformProperties": {
+        "1": {
+          "Value": 1442840576,
+          "Id": 1,
+          "Name": "Unknown(1)",
+          "TextValue": "1442840576"
+        }
+      },
+      "Patterns": [
+        {
+          "Name": "LegacyIAccessiblePattern",
+          "Id": 10018,
+          "Properties": [
+            {
+              "Name": "ChildId",
+              "Value": 0,
+              "NodeValue": "ChildId = 0"
+            },
+            {
+              "Name": "DefaultAction",
+              "Value": "",
+              "NodeValue": "DefaultAction = \"\""
+            },
+            {
+              "Name": "Description",
+              "Value": "",
+              "NodeValue": "Description = \"\""
+            },
+            {
+              "Name": "Help",
+              "Value": "",
+              "NodeValue": "Help = \"\""
+            },
+            {
+              "Name": "KeyboardShorcut",
+              "Value": "",
+              "NodeValue": "KeyboardShorcut = \"\""
+            },
+            {
+              "Name": "Name",
+              "Value": "",
+              "NodeValue": "Name = \"\""
+            },
+            {
+              "Name": "Role",
+              "Value": 10,
+              "NodeValue": "Role = 10"
+            },
+            {
+              "Name": "State",
+              "Value": 1048576,
+              "NodeValue": "State = 1048576"
+            },
+            {
+              "Name": "Value",
+              "Value": "",
+              "NodeValue": "Value = \"\""
+            }
+          ],
+          "IsUIActionable": false
+        }
+      ],
+      "Children": [
+        {
+          "Name": "Notification Chevron",
+          "ControlTypeId": 50000,
+          "LocalizedControlType": "button",
+          "RuntimeId": "[2A,100C0]",
+          "ProcessId": 7064,
+          "BoundingRectangle": "3548, 2100, 36, 60",
+          "IsKeyboardFocusable": true,
+          "IsContent": true,
+          "IsControl": true,
+          "TestStatus": 1,
+          "Glimpse": "button \"Notification Chevron\"",
+          "Properties": {
+            "30000": {
+              "Value": [
+                42,
+                65728
+              ],
+              "Id": 30000,
+              "Name": "RuntimeId",
+              "TextValue": "[2A,100C0]"
+            },
+            "30001": {
+              "Value": [
+                3548.0,
+                2100.0,
+                36.0,
+                60.0
+              ],
+              "Id": 30001,
+              "Name": "BoundingRectangle",
+              "TextValue": "[l=3548,t=2100,r=3584,b=2160]"
+            },
+            "30002": {
+              "Value": 7064,
+              "Id": 30002,
+              "Name": "ProcessId",
+              "TextValue": "7064"
+            },
+            "30003": {
+              "Value": 50000,
+              "Id": 30003,
+              "Name": "ControlType",
+              "TextValue": "Button(50000)"
+            },
+            "30004": {
+              "Value": "button",
+              "Id": 30004,
+              "Name": "LocalizedControlType",
+              "TextValue": "button"
+            },
+            "30005": {
+              "Value": "Notification Chevron",
+              "Id": 30005,
+              "Name": "Name",
+              "TextValue": "Notification Chevron"
+            },
+            "30008": {
+              "Value": false,
+              "Id": 30008,
+              "Name": "HasKeyboardFocus",
+              "TextValue": "False"
+            },
+            "30009": {
+              "Value": true,
+              "Id": 30009,
+              "Name": "IsKeyboardFocusable",
+              "TextValue": "True"
+            },
+            "30010": {
+              "Value": true,
+              "Id": 30010,
+              "Name": "IsEnabled",
+              "TextValue": "True"
+            },
+            "30011": {
+              "Value": "1502",
+              "Id": 30011,
+              "Name": "AutomationId",
+              "TextValue": "1502"
+            },
+            "30012": {
+              "Value": "Button",
+              "Id": 30012,
+              "Name": "ClassName",
+              "TextValue": "Button"
+            },
+            "30015": {
+              "Value": 0,
+              "Id": 30015,
+              "Name": "Culture",
+              "TextValue": "0"
+            },
+            "30016": {
+              "Value": true,
+              "Id": 30016,
+              "Name": "IsControlElement",
+              "TextValue": "True"
+            },
+            "30017": {
+              "Value": true,
+              "Id": 30017,
+              "Name": "IsContentElement",
+              "TextValue": "True"
+            },
+            "30019": {
+              "Value": false,
+              "Id": 30019,
+              "Name": "IsPassword",
+              "TextValue": "False"
+            },
+            "30020": {
+              "Value": 65728,
+              "Id": 30020,
+              "Name": "NativeWindowHandle",
+              "TextValue": "65728"
+            },
+            "30022": {
+              "Value": false,
+              "Id": 30022,
+              "Name": "IsOffscreen",
+              "TextValue": "False"
+            },
+            "30023": {
+              "Value": 0,
+              "Id": 30023,
+              "Name": "Orientation",
+              "TextValue": "None(0)"
+            },
+            "30024": {
+              "Value": "Win32",
+              "Id": 30024,
+              "Name": "FrameworkId",
+              "TextValue": "Win32"
+            },
+            "30025": {
+              "Value": false,
+              "Id": 30025,
+              "Name": "IsRequiredForForm",
+              "TextValue": "False"
+            },
+            "30103": {
+              "Value": false,
+              "Id": 30103,
+              "Name": "IsDataValidForForm",
+              "TextValue": "False"
+            },
+            "30107": {
+              "Value": "[pid:29536,providerId:0x100C0 Main:Nested [pid:7064,providerId:0x100C0 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+              "Id": 30107,
+              "Name": "ProviderDescription",
+              "TextValue": "[pid:29536,providerId:0x100C0 Main:Nested [pid:7064,providerId:0x100C0 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+            },
+            "30111": {
+              "Value": false,
+              "Id": 30111,
+              "Name": "OptimizeForVisualContent",
+              "TextValue": "False"
+            },
+            "30135": {
+              "Value": 0,
+              "Id": 30135,
+              "Name": "LiveSetting",
+              "TextValue": "0"
+            },
+            "30150": {
+              "Value": false,
+              "Id": 30150,
+              "Name": "IsPeripheral",
+              "TextValue": "False"
+            },
+            "30152": {
+              "Value": 0,
+              "Id": 30152,
+              "Name": "PositionInSet",
+              "TextValue": "0"
+            },
+            "30153": {
+              "Value": 0,
+              "Id": 30153,
+              "Name": "SizeOfSet",
+              "TextValue": "0"
+            },
+            "30154": {
+              "Value": 0,
+              "Id": 30154,
+              "Name": "Level",
+              "TextValue": "0"
+            },
+            "30157": {
+              "Value": 0,
+              "Id": 30157,
+              "Name": "LandmarkType",
+              "TextValue": "0"
+            },
+            "30162": {
+              "Value": 0,
+              "Id": 30162,
+              "Name": "FillType",
+              "TextValue": "0"
+            },
+            "30163": {
+              "Value": 0,
+              "Id": 30163,
+              "Name": "VisualEffects",
+              "TextValue": "0"
+            }
+          },
+          "PlatformProperties": {
+            "1": {
+              "Value": 1375731712,
+              "Id": 1,
+              "Name": "Unknown(1)",
+              "TextValue": "1375731712"
+            }
+          },
+          "Patterns": [
+            {
+              "Name": "InvokePattern",
+              "Id": 10000,
+              "Properties": [],
+              "IsUIActionable": true
+            },
+            {
+              "Name": "LegacyIAccessiblePattern",
+              "Id": 10018,
+              "Properties": [
+                {
+                  "Name": "ChildId",
+                  "Value": 0,
+                  "NodeValue": "ChildId = 0"
+                },
+                {
+                  "Name": "DefaultAction",
+                  "Value": "Press",
+                  "NodeValue": "DefaultAction = \"Press\""
+                },
+                {
+                  "Name": "Description",
+                  "Value": "",
+                  "NodeValue": "Description = \"\""
+                },
+                {
+                  "Name": "Help",
+                  "Value": "",
+                  "NodeValue": "Help = \"\""
+                },
+                {
+                  "Name": "KeyboardShorcut",
+                  "Value": "",
+                  "NodeValue": "KeyboardShorcut = \"\""
+                },
+                {
+                  "Name": "Name",
+                  "Value": "Notification Chevron",
+                  "NodeValue": "Name = \"Notification Chevron\""
+                },
+                {
+                  "Name": "Role",
+                  "Value": 43,
+                  "NodeValue": "Role = 43"
+                },
+                {
+                  "Name": "State",
+                  "Value": 1048576,
+                  "NodeValue": "State = 1048576"
+                },
+                {
+                  "Name": "Value",
+                  "Value": "",
+                  "NodeValue": "Value = \"\""
+                }
+              ],
+              "IsUIActionable": false
+            }
+          ],
+          "Children": [],
+          "TreeWalkerMode": 1,
+          "ScanResults": {
+            "Items": [
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name",
+                "MetaInfo": {
+                  "PropertyId": 30005,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                  "The BoundingRectagle of the current element is [l=3548,t=2100,r=3584,b=2160]."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                "MetaInfo": {
+                  "PropertyId": 30001,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.2.1] IsKeyboardFocusable",
+                "MetaInfo": {
+                  "PropertyId": 30009,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "The property value may be one of [button]."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] LocalizedControlType",
+                "MetaInfo": {
+                  "PropertyId": 30004,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Typical SubTree structure in Control mode",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[MSDN] Typical SubTree structure in Content mode",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "'IsControlElement' property value should be \"True\"."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] IsControlElement Property",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30016,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name: Child element should have unique name.",
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Only one of Invoke/Toggle patterns expected.",
+                  "Invoke pattern exists."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Control Pattern",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Check IsContentElement property value."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Properties",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30017,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              }
+            ],
+            "Status": 1
+          }
+        },
+        {
+          "Name": null,
+          "ControlTypeId": 50033,
+          "LocalizedControlType": "pane",
+          "RuntimeId": "[2A,100CE]",
+          "ProcessId": 7064,
+          "BoundingRectangle": "3584, 2100, 72, 60",
+          "IsKeyboardFocusable": true,
+          "IsContent": true,
+          "IsControl": true,
+          "TestStatus": 1,
+          "Glimpse": "pane \"\"",
+          "Properties": {
+            "30000": {
+              "Value": [
+                42,
+                65742
+              ],
+              "Id": 30000,
+              "Name": "RuntimeId",
+              "TextValue": "[2A,100CE]"
+            },
+            "30001": {
+              "Value": [
+                3584.0,
+                2100.0,
+                72.0,
+                60.0
+              ],
+              "Id": 30001,
+              "Name": "BoundingRectangle",
+              "TextValue": "[l=3584,t=2100,r=3656,b=2160]"
+            },
+            "30002": {
+              "Value": 7064,
+              "Id": 30002,
+              "Name": "ProcessId",
+              "TextValue": "7064"
+            },
+            "30003": {
+              "Value": 50033,
+              "Id": 30003,
+              "Name": "ControlType",
+              "TextValue": "Pane(50033)"
+            },
+            "30004": {
+              "Value": "pane",
+              "Id": 30004,
+              "Name": "LocalizedControlType",
+              "TextValue": "pane"
+            },
+            "30008": {
+              "Value": false,
+              "Id": 30008,
+              "Name": "HasKeyboardFocus",
+              "TextValue": "False"
+            },
+            "30009": {
+              "Value": true,
+              "Id": 30009,
+              "Name": "IsKeyboardFocusable",
+              "TextValue": "True"
+            },
+            "30010": {
+              "Value": true,
+              "Id": 30010,
+              "Name": "IsEnabled",
+              "TextValue": "True"
+            },
+            "30012": {
+              "Value": "SysPager",
+              "Id": 30012,
+              "Name": "ClassName",
+              "TextValue": "SysPager"
+            },
+            "30015": {
+              "Value": 0,
+              "Id": 30015,
+              "Name": "Culture",
+              "TextValue": "0"
+            },
+            "30016": {
+              "Value": true,
+              "Id": 30016,
+              "Name": "IsControlElement",
+              "TextValue": "True"
+            },
+            "30017": {
+              "Value": true,
+              "Id": 30017,
+              "Name": "IsContentElement",
+              "TextValue": "True"
+            },
+            "30019": {
+              "Value": false,
+              "Id": 30019,
+              "Name": "IsPassword",
+              "TextValue": "False"
+            },
+            "30020": {
+              "Value": 65742,
+              "Id": 30020,
+              "Name": "NativeWindowHandle",
+              "TextValue": "65742"
+            },
+            "30022": {
+              "Value": false,
+              "Id": 30022,
+              "Name": "IsOffscreen",
+              "TextValue": "False"
+            },
+            "30023": {
+              "Value": 0,
+              "Id": 30023,
+              "Name": "Orientation",
+              "TextValue": "None(0)"
+            },
+            "30024": {
+              "Value": "Win32",
+              "Id": 30024,
+              "Name": "FrameworkId",
+              "TextValue": "Win32"
+            },
+            "30025": {
+              "Value": false,
+              "Id": 30025,
+              "Name": "IsRequiredForForm",
+              "TextValue": "False"
+            },
+            "30103": {
+              "Value": false,
+              "Id": 30103,
+              "Name": "IsDataValidForForm",
+              "TextValue": "False"
+            },
+            "30107": {
+              "Value": "[pid:29536,providerId:0x100CE Main:Nested [pid:7064,providerId:0x100CE Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+              "Id": 30107,
+              "Name": "ProviderDescription",
+              "TextValue": "[pid:29536,providerId:0x100CE Main:Nested [pid:7064,providerId:0x100CE Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+            },
+            "30111": {
+              "Value": false,
+              "Id": 30111,
+              "Name": "OptimizeForVisualContent",
+              "TextValue": "False"
+            },
+            "30135": {
+              "Value": 0,
+              "Id": 30135,
+              "Name": "LiveSetting",
+              "TextValue": "0"
+            },
+            "30150": {
+              "Value": false,
+              "Id": 30150,
+              "Name": "IsPeripheral",
+              "TextValue": "False"
+            },
+            "30152": {
+              "Value": 0,
+              "Id": 30152,
+              "Name": "PositionInSet",
+              "TextValue": "0"
+            },
+            "30153": {
+              "Value": 0,
+              "Id": 30153,
+              "Name": "SizeOfSet",
+              "TextValue": "0"
+            },
+            "30154": {
+              "Value": 0,
+              "Id": 30154,
+              "Name": "Level",
+              "TextValue": "0"
+            },
+            "30157": {
+              "Value": 0,
+              "Id": 30157,
+              "Name": "LandmarkType",
+              "TextValue": "0"
+            },
+            "30162": {
+              "Value": 0,
+              "Id": 30162,
+              "Name": "FillType",
+              "TextValue": "0"
+            },
+            "30163": {
+              "Value": 0,
+              "Id": 30163,
+              "Name": "VisualEffects",
+              "TextValue": "0"
+            }
+          },
+          "PlatformProperties": {
+            "1": {
+              "Value": 1442906113,
+              "Id": 1,
+              "Name": "Unknown(1)",
+              "TextValue": "1442906113"
+            }
+          },
+          "Patterns": [
+            {
+              "Name": "LegacyIAccessiblePattern",
+              "Id": 10018,
+              "Properties": [
+                {
+                  "Name": "ChildId",
+                  "Value": 0,
+                  "NodeValue": "ChildId = 0"
+                },
+                {
+                  "Name": "DefaultAction",
+                  "Value": "",
+                  "NodeValue": "DefaultAction = \"\""
+                },
+                {
+                  "Name": "Description",
+                  "Value": "",
+                  "NodeValue": "Description = \"\""
+                },
+                {
+                  "Name": "Help",
+                  "Value": "",
+                  "NodeValue": "Help = \"\""
+                },
+                {
+                  "Name": "KeyboardShorcut",
+                  "Value": "",
+                  "NodeValue": "KeyboardShorcut = \"\""
+                },
+                {
+                  "Name": "Name",
+                  "Value": "",
+                  "NodeValue": "Name = \"\""
+                },
+                {
+                  "Name": "Role",
+                  "Value": 10,
+                  "NodeValue": "Role = 10"
+                },
+                {
+                  "Name": "State",
+                  "Value": 1048576,
+                  "NodeValue": "State = 1048576"
+                },
+                {
+                  "Name": "Value",
+                  "Value": "",
+                  "NodeValue": "Value = \"\""
+                }
+              ],
+              "IsUIActionable": false
+            }
+          ],
+          "Children": [
+            {
+              "Name": "User Promoted Notification Area",
+              "ControlTypeId": 50021,
+              "LocalizedControlType": "tool bar",
+              "RuntimeId": "[2A,100D0]",
+              "ProcessId": 7064,
+              "BoundingRectangle": "3584, 2100, 72, 60",
+              "IsKeyboardFocusable": true,
+              "IsContent": false,
+              "IsControl": true,
+              "TestStatus": 2,
+              "Glimpse": "tool bar \"User Promoted Notification Area\"",
+              "Properties": {
+                "30000": {
+                  "Value": [
+                    42,
+                    65744
+                  ],
+                  "Id": 30000,
+                  "Name": "RuntimeId",
+                  "TextValue": "[2A,100D0]"
+                },
+                "30001": {
+                  "Value": [
+                    3584.0,
+                    2100.0,
+                    72.0,
+                    60.0
+                  ],
+                  "Id": 30001,
+                  "Name": "BoundingRectangle",
+                  "TextValue": "[l=3584,t=2100,r=3656,b=2160]"
+                },
+                "30002": {
+                  "Value": 7064,
+                  "Id": 30002,
+                  "Name": "ProcessId",
+                  "TextValue": "7064"
+                },
+                "30003": {
+                  "Value": 50021,
+                  "Id": 30003,
+                  "Name": "ControlType",
+                  "TextValue": "ToolBar(50021)"
+                },
+                "30004": {
+                  "Value": "tool bar",
+                  "Id": 30004,
+                  "Name": "LocalizedControlType",
+                  "TextValue": "tool bar"
+                },
+                "30005": {
+                  "Value": "User Promoted Notification Area",
+                  "Id": 30005,
+                  "Name": "Name",
+                  "TextValue": "User Promoted Notification Area"
+                },
+                "30008": {
+                  "Value": false,
+                  "Id": 30008,
+                  "Name": "HasKeyboardFocus",
+                  "TextValue": "False"
+                },
+                "30009": {
+                  "Value": true,
+                  "Id": 30009,
+                  "Name": "IsKeyboardFocusable",
+                  "TextValue": "True"
+                },
+                "30010": {
+                  "Value": true,
+                  "Id": 30010,
+                  "Name": "IsEnabled",
+                  "TextValue": "True"
+                },
+                "30011": {
+                  "Value": "1504",
+                  "Id": 30011,
+                  "Name": "AutomationId",
+                  "TextValue": "1504"
+                },
+                "30012": {
+                  "Value": "ToolbarWindow32",
+                  "Id": 30012,
+                  "Name": "ClassName",
+                  "TextValue": "ToolbarWindow32"
+                },
+                "30015": {
+                  "Value": 0,
+                  "Id": 30015,
+                  "Name": "Culture",
+                  "TextValue": "0"
+                },
+                "30016": {
+                  "Value": true,
+                  "Id": 30016,
+                  "Name": "IsControlElement",
+                  "TextValue": "True"
+                },
+                "30017": {
+                  "Value": false,
+                  "Id": 30017,
+                  "Name": "IsContentElement",
+                  "TextValue": "False"
+                },
+                "30019": {
+                  "Value": false,
+                  "Id": 30019,
+                  "Name": "IsPassword",
+                  "TextValue": "False"
+                },
+                "30020": {
+                  "Value": 65744,
+                  "Id": 30020,
+                  "Name": "NativeWindowHandle",
+                  "TextValue": "65744"
+                },
+                "30022": {
+                  "Value": false,
+                  "Id": 30022,
+                  "Name": "IsOffscreen",
+                  "TextValue": "False"
+                },
+                "30023": {
+                  "Value": 0,
+                  "Id": 30023,
+                  "Name": "Orientation",
+                  "TextValue": "None(0)"
+                },
+                "30024": {
+                  "Value": "Win32",
+                  "Id": 30024,
+                  "Name": "FrameworkId",
+                  "TextValue": "Win32"
+                },
+                "30025": {
+                  "Value": false,
+                  "Id": 30025,
+                  "Name": "IsRequiredForForm",
+                  "TextValue": "False"
+                },
+                "30103": {
+                  "Value": false,
+                  "Id": 30103,
+                  "Name": "IsDataValidForForm",
+                  "TextValue": "False"
+                },
+                "30107": {
+                  "Value": "[pid:29536,providerId:0x100D0 Main:Nested [pid:7064,providerId:0x100D0 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+                  "Id": 30107,
+                  "Name": "ProviderDescription",
+                  "TextValue": "[pid:29536,providerId:0x100D0 Main:Nested [pid:7064,providerId:0x100D0 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+                },
+                "30111": {
+                  "Value": false,
+                  "Id": 30111,
+                  "Name": "OptimizeForVisualContent",
+                  "TextValue": "False"
+                },
+                "30135": {
+                  "Value": 0,
+                  "Id": 30135,
+                  "Name": "LiveSetting",
+                  "TextValue": "0"
+                },
+                "30150": {
+                  "Value": false,
+                  "Id": 30150,
+                  "Name": "IsPeripheral",
+                  "TextValue": "False"
+                },
+                "30152": {
+                  "Value": 0,
+                  "Id": 30152,
+                  "Name": "PositionInSet",
+                  "TextValue": "0"
+                },
+                "30153": {
+                  "Value": 0,
+                  "Id": 30153,
+                  "Name": "SizeOfSet",
+                  "TextValue": "0"
+                },
+                "30154": {
+                  "Value": 0,
+                  "Id": 30154,
+                  "Name": "Level",
+                  "TextValue": "0"
+                },
+                "30157": {
+                  "Value": 0,
+                  "Id": 30157,
+                  "Name": "LandmarkType",
+                  "TextValue": "0"
+                },
+                "30162": {
+                  "Value": 0,
+                  "Id": 30162,
+                  "Name": "FillType",
+                  "TextValue": "0"
+                },
+                "30163": {
+                  "Value": 0,
+                  "Id": 30163,
+                  "Name": "VisualEffects",
+                  "TextValue": "0"
+                }
+              },
+              "PlatformProperties": {
+                "2": {
+                  "Value": 128,
+                  "Id": 2,
+                  "Name": "Unknown(2)",
+                  "TextValue": "128"
+                },
+                "1": {
+                  "Value": 1442876237,
+                  "Id": 1,
+                  "Name": "Unknown(1)",
+                  "TextValue": "1442876237"
+                }
+              },
+              "Patterns": [
+                {
+                  "Name": "LegacyIAccessiblePattern",
+                  "Id": 10018,
+                  "Properties": [
+                    {
+                      "Name": "ChildId",
+                      "Value": 0,
+                      "NodeValue": "ChildId = 0"
+                    },
+                    {
+                      "Name": "DefaultAction",
+                      "Value": "",
+                      "NodeValue": "DefaultAction = \"\""
+                    },
+                    {
+                      "Name": "Description",
+                      "Value": "",
+                      "NodeValue": "Description = \"\""
+                    },
+                    {
+                      "Name": "Help",
+                      "Value": "",
+                      "NodeValue": "Help = \"\""
+                    },
+                    {
+                      "Name": "KeyboardShorcut",
+                      "Value": "",
+                      "NodeValue": "KeyboardShorcut = \"\""
+                    },
+                    {
+                      "Name": "Name",
+                      "Value": "User Promoted Notification Area",
+                      "NodeValue": "Name = \"User Promoted Notification Area\""
+                    },
+                    {
+                      "Name": "Role",
+                      "Value": 22,
+                      "NodeValue": "Role = 22"
+                    },
+                    {
+                      "Name": "State",
+                      "Value": 1048576,
+                      "NodeValue": "State = 1048576"
+                    },
+                    {
+                      "Name": "Value",
+                      "Value": "",
+                      "NodeValue": "Value = \"\""
+                    }
+                  ],
+                  "IsUIActionable": false
+                }
+              ],
+              "Children": [
+                {
+                  "Name": "corp.microsoft.com\nInternet access",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100D0,3,80000001,100D0,FFFFFFFC,1]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "3584, 2100, 36, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"corp.microsoft.com\nInternet access\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65744,
+                        3,
+                        -2147483647,
+                        65744,
+                        -4,
+                        1
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100D0,3,80000001,100D0,FFFFFFFC,1]"
+                    },
+                    "30001": {
+                      "Value": [
+                        3584.0,
+                        2100.0,
+                        36.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=3584,t=2100,r=3620,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "corp.microsoft.com\nInternet access",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "corp.microsoft.com\nInternet access"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "{7820AE74-23E3-4229-82C1-E41CB67D5B9C}",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "{7820AE74-23E3-4229-82C1-E41CB67D5B9C}"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 1,
+                          "NodeValue": "ChildId = 1"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "corp.microsoft.com\nInternet access",
+                          "NodeValue": "Name = \"corp.microsoft.com\nInternet access\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 0,
+                          "NodeValue": "State = 0"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=3584,t=2100,r=3620,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                },
+                {
+                  "Name": "Speakers (USB): 25%",
+                  "ControlTypeId": 50000,
+                  "LocalizedControlType": "button",
+                  "RuntimeId": "[2A,100D0,3,80000001,100D0,FFFFFFFC,2]",
+                  "ProcessId": 7064,
+                  "BoundingRectangle": "3620, 2100, 36, 60",
+                  "IsKeyboardFocusable": false,
+                  "IsContent": true,
+                  "IsControl": true,
+                  "TestStatus": 3,
+                  "Glimpse": "button \"Speakers (USB): 25%\"",
+                  "Properties": {
+                    "30000": {
+                      "Value": [
+                        42,
+                        65744,
+                        3,
+                        -2147483647,
+                        65744,
+                        -4,
+                        2
+                      ],
+                      "Id": 30000,
+                      "Name": "RuntimeId",
+                      "TextValue": "[2A,100D0,3,80000001,100D0,FFFFFFFC,2]"
+                    },
+                    "30001": {
+                      "Value": [
+                        3620.0,
+                        2100.0,
+                        36.0,
+                        60.0
+                      ],
+                      "Id": 30001,
+                      "Name": "BoundingRectangle",
+                      "TextValue": "[l=3620,t=2100,r=3656,b=2160]"
+                    },
+                    "30002": {
+                      "Value": 7064,
+                      "Id": 30002,
+                      "Name": "ProcessId",
+                      "TextValue": "7064"
+                    },
+                    "30003": {
+                      "Value": 50000,
+                      "Id": 30003,
+                      "Name": "ControlType",
+                      "TextValue": "Button(50000)"
+                    },
+                    "30004": {
+                      "Value": "button",
+                      "Id": 30004,
+                      "Name": "LocalizedControlType",
+                      "TextValue": "button"
+                    },
+                    "30005": {
+                      "Value": "Speakers (USB): 25%",
+                      "Id": 30005,
+                      "Name": "Name",
+                      "TextValue": "Speakers (USB): 25%"
+                    },
+                    "30008": {
+                      "Value": false,
+                      "Id": 30008,
+                      "Name": "HasKeyboardFocus",
+                      "TextValue": "False"
+                    },
+                    "30009": {
+                      "Value": false,
+                      "Id": 30009,
+                      "Name": "IsKeyboardFocusable",
+                      "TextValue": "False"
+                    },
+                    "30010": {
+                      "Value": true,
+                      "Id": 30010,
+                      "Name": "IsEnabled",
+                      "TextValue": "True"
+                    },
+                    "30011": {
+                      "Value": "{7820AE73-23E3-4229-82C1-E41CB67D5B9C}",
+                      "Id": 30011,
+                      "Name": "AutomationId",
+                      "TextValue": "{7820AE73-23E3-4229-82C1-E41CB67D5B9C}"
+                    },
+                    "30015": {
+                      "Value": 0,
+                      "Id": 30015,
+                      "Name": "Culture",
+                      "TextValue": "0"
+                    },
+                    "30016": {
+                      "Value": true,
+                      "Id": 30016,
+                      "Name": "IsControlElement",
+                      "TextValue": "True"
+                    },
+                    "30017": {
+                      "Value": true,
+                      "Id": 30017,
+                      "Name": "IsContentElement",
+                      "TextValue": "True"
+                    },
+                    "30019": {
+                      "Value": false,
+                      "Id": 30019,
+                      "Name": "IsPassword",
+                      "TextValue": "False"
+                    },
+                    "30020": {
+                      "Value": 0,
+                      "Id": 30020,
+                      "Name": "NativeWindowHandle",
+                      "TextValue": "0"
+                    },
+                    "30022": {
+                      "Value": false,
+                      "Id": 30022,
+                      "Name": "IsOffscreen",
+                      "TextValue": "False"
+                    },
+                    "30023": {
+                      "Value": 0,
+                      "Id": 30023,
+                      "Name": "Orientation",
+                      "TextValue": "None(0)"
+                    },
+                    "30025": {
+                      "Value": false,
+                      "Id": 30025,
+                      "Name": "IsRequiredForForm",
+                      "TextValue": "False"
+                    },
+                    "30103": {
+                      "Value": false,
+                      "Id": 30103,
+                      "Name": "IsDataValidForForm",
+                      "TextValue": "False"
+                    },
+                    "30107": {
+                      "Value": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]",
+                      "Id": 30107,
+                      "Name": "ProviderDescription",
+                      "TextValue": "[pid:7064,providerId:0x0 Annotation:Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]"
+                    },
+                    "30111": {
+                      "Value": false,
+                      "Id": 30111,
+                      "Name": "OptimizeForVisualContent",
+                      "TextValue": "False"
+                    },
+                    "30135": {
+                      "Value": 0,
+                      "Id": 30135,
+                      "Name": "LiveSetting",
+                      "TextValue": "0"
+                    },
+                    "30150": {
+                      "Value": false,
+                      "Id": 30150,
+                      "Name": "IsPeripheral",
+                      "TextValue": "False"
+                    },
+                    "30152": {
+                      "Value": 0,
+                      "Id": 30152,
+                      "Name": "PositionInSet",
+                      "TextValue": "0"
+                    },
+                    "30153": {
+                      "Value": 0,
+                      "Id": 30153,
+                      "Name": "SizeOfSet",
+                      "TextValue": "0"
+                    },
+                    "30154": {
+                      "Value": 0,
+                      "Id": 30154,
+                      "Name": "Level",
+                      "TextValue": "0"
+                    },
+                    "30157": {
+                      "Value": 0,
+                      "Id": 30157,
+                      "Name": "LandmarkType",
+                      "TextValue": "0"
+                    },
+                    "30162": {
+                      "Value": 0,
+                      "Id": 30162,
+                      "Name": "FillType",
+                      "TextValue": "0"
+                    },
+                    "30163": {
+                      "Value": 0,
+                      "Id": 30163,
+                      "Name": "VisualEffects",
+                      "TextValue": "0"
+                    }
+                  },
+                  "PlatformProperties": {},
+                  "Patterns": [
+                    {
+                      "Name": "InvokePattern",
+                      "Id": 10000,
+                      "Properties": [],
+                      "IsUIActionable": true
+                    },
+                    {
+                      "Name": "LegacyIAccessiblePattern",
+                      "Id": 10018,
+                      "Properties": [
+                        {
+                          "Name": "ChildId",
+                          "Value": 2,
+                          "NodeValue": "ChildId = 2"
+                        },
+                        {
+                          "Name": "DefaultAction",
+                          "Value": "Press",
+                          "NodeValue": "DefaultAction = \"Press\""
+                        },
+                        {
+                          "Name": "Description",
+                          "Value": "",
+                          "NodeValue": "Description = \"\""
+                        },
+                        {
+                          "Name": "Help",
+                          "Value": "",
+                          "NodeValue": "Help = \"\""
+                        },
+                        {
+                          "Name": "KeyboardShorcut",
+                          "Value": "",
+                          "NodeValue": "KeyboardShorcut = \"\""
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": "Speakers (USB): 25%",
+                          "NodeValue": "Name = \"Speakers (USB): 25%\""
+                        },
+                        {
+                          "Name": "Role",
+                          "Value": 43,
+                          "NodeValue": "Role = 43"
+                        },
+                        {
+                          "Name": "State",
+                          "Value": 0,
+                          "NodeValue": "State = 0"
+                        },
+                        {
+                          "Name": "Value",
+                          "Value": "",
+                          "NodeValue": "Value = \"\""
+                        }
+                      ],
+                      "IsUIActionable": false
+                    }
+                  ],
+                  "Children": [],
+                  "TreeWalkerMode": 1,
+                  "ScanResults": {
+                    "Items": [
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name",
+                        "MetaInfo": {
+                          "PropertyId": 30005,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                          "The BoundingRectagle of the current element is [l=3620,t=2100,r=3656,b=2160]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                        "MetaInfo": {
+                          "PropertyId": 30001,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "UI element is not keyboard focusible though it has some actionable control patterns.",
+                          "The element should have IsKeyboardFocusable True since it has UI interactive control pattern.",
+                          "UI interactable Pattern: InvokePattern"
+                        ],
+                        "Status": 3,
+                        "Description": "[4.2.1] IsKeyboardFocusable",
+                        "MetaInfo": {
+                          "PropertyId": 30009,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "The property value may be one of [button]."
+                        ],
+                        "Status": 1,
+                        "Description": "[4.2.1] LocalizedControlType",
+                        "MetaInfo": {
+                          "PropertyId": 30004,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Control mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN] Typical SubTree structure in Content mode",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "'IsControlElement' property value should be \"True\"."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] IsControlElement Property",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30016,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[4.1.2] Name: Child element should have unique name.",
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [],
+                        "Status": 1,
+                        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Only one of Invoke/Toggle patterns expected.",
+                          "Invoke pattern exists."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Control Pattern",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 0,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      },
+                      {
+                        "Messages": [
+                          "Check IsContentElement property value."
+                        ],
+                        "Status": 1,
+                        "Description": "[MSDN] Properties",
+                        "HelpUrl": {
+                          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                          "Type": 0
+                        },
+                        "MetaInfo": {
+                          "PropertyId": 30017,
+                          "UIFramework": "Win32",
+                          "ControlType": "Button"
+                        }
+                      }
+                    ],
+                    "Status": 3
+                  }
+                }
+              ],
+              "TreeWalkerMode": 1,
+              "ScanResults": {
+                "Items": [
+                  {
+                    "Messages": [],
+                    "Status": 1,
+                    "Description": "[4.1.2] Name",
+                    "MetaInfo": {
+                      "PropertyId": 30005,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                      "The BoundingRectagle of the current element is [l=3584,t=2100,r=3656,b=2160].",
+                      "The BoundingRectangle of button \"corp.microsoft.com\nInternet access\" child is [l=3584,t=2100,r=3620,b=2160]",
+                      "The BoundingRectangle of button \"Speakers (USB): 25%\" child is [l=3620,t=2100,r=3656,b=2160]"
+                    ],
+                    "Status": 1,
+                    "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                    "MetaInfo": {
+                      "PropertyId": 30001,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "The property value may be one of [toolbar].",
+                      "Localized control type property is not matched with expected values."
+                    ],
+                    "Status": 1,
+                    "Description": "[4.2.1] LocalizedControlType",
+                    "MetaInfo": {
+                      "PropertyId": 30004,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "'IsContentElement' property value should be \"True\".",
+                      "the property value is \"False\"."
+                    ],
+                    "Status": 2,
+                    "Description": "[MSDN] IsContentElement Property",
+                    "HelpUrl": {
+                      "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671654(v=vs.85).aspx",
+                      "Type": 0
+                    },
+                    "MetaInfo": {
+                      "PropertyId": 30017,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  },
+                  {
+                    "Messages": [
+                      "'IsControlElement' property value should be \"True\"."
+                    ],
+                    "Status": 1,
+                    "Description": "[MSDN] IsControlElement Property",
+                    "HelpUrl": {
+                      "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671654(v=vs.85).aspx",
+                      "Type": 0
+                    },
+                    "MetaInfo": {
+                      "PropertyId": 30016,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  },
+                  {
+                    "Messages": [],
+                    "Status": 1,
+                    "Description": "[4.1.2] Name: Child element should have unique name.",
+                    "MetaInfo": {
+                      "PropertyId": 0,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  },
+                  {
+                    "Messages": [],
+                    "Status": 1,
+                    "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                    "HelpUrl": {
+                      "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                      "Type": 0
+                    },
+                    "MetaInfo": {
+                      "PropertyId": 0,
+                      "UIFramework": "Win32",
+                      "ControlType": "ToolBar"
+                    }
+                  }
+                ],
+                "Status": 2
+              }
+            }
+          ],
+          "TreeWalkerMode": 1,
+          "ScanResults": {
+            "Items": [
+              {
+                "Messages": [
+                  "Name doesn't exit or empty. but it is ok for this control type.(Pane(50033))"
+                ],
+                "Status": 1,
+                "Description": "[4.1.2] Name",
+                "MetaInfo": {
+                  "PropertyId": 30005,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [
+                  "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                  "The BoundingRectagle of the current element is [l=3584,t=2100,r=3656,b=2160].",
+                  "The BoundingRectangle of tool bar \"User Promoted Notification Area\" child is [l=3584,t=2100,r=3656,b=2160]"
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                "MetaInfo": {
+                  "PropertyId": 30001,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [
+                  "There is no pattern with UI action related Method(s), but the element is KeyboardFocusible."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] IsKeyboardFocusable",
+                "MetaInfo": {
+                  "PropertyId": 30009,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [
+                  "The property value may be one of [pane]."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] LocalizedControlType",
+                "MetaInfo": {
+                  "PropertyId": 30004,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [
+                  "'IsContentElement' property value should be \"True\"."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] IsContentElement Property",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671639(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30017,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [
+                  "'IsControlElement' property value should be \"True\"."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] IsControlElement Property",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671639(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30016,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name: Child element should have unique name.",
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [
+                  "The DoNotSupport pattern(s): WindowPattern"
+                ],
+                "Status": 1,
+                "Description": "[MSDN]: Based on control type, some patterns should not be supported.",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Pane"
+                }
+              }
+            ],
+            "Status": 1
+          }
+        },
+        {
+          "Name": "System Clock, 12:04 PM, ‎10/‎13/‎2017",
+          "ControlTypeId": 50000,
+          "LocalizedControlType": "button",
+          "RuntimeId": "[2A,200DE]",
+          "ProcessId": 7064,
+          "BoundingRectangle": "3656, 2100, 104, 60",
+          "IsKeyboardFocusable": true,
+          "IsContent": true,
+          "IsControl": true,
+          "TestStatus": 1,
+          "Glimpse": "button \"System Clock, 12:04 PM, ‎10/‎13/‎2017\"",
+          "Properties": {
+            "30000": {
+              "Value": [
+                42,
+                131294
+              ],
+              "Id": 30000,
+              "Name": "RuntimeId",
+              "TextValue": "[2A,200DE]"
+            },
+            "30001": {
+              "Value": [
+                3656.0,
+                2100.0,
+                104.0,
+                60.0
+              ],
+              "Id": 30001,
+              "Name": "BoundingRectangle",
+              "TextValue": "[l=3656,t=2100,r=3760,b=2160]"
+            },
+            "30002": {
+              "Value": 7064,
+              "Id": 30002,
+              "Name": "ProcessId",
+              "TextValue": "7064"
+            },
+            "30003": {
+              "Value": 50000,
+              "Id": 30003,
+              "Name": "ControlType",
+              "TextValue": "Button(50000)"
+            },
+            "30004": {
+              "Value": "button",
+              "Id": 30004,
+              "Name": "LocalizedControlType",
+              "TextValue": "button"
+            },
+            "30005": {
+              "Value": "System Clock, 12:04 PM, ‎10/‎13/‎2017",
+              "Id": 30005,
+              "Name": "Name",
+              "TextValue": "System Clock, 12:04 PM, ‎10/‎13/‎2017"
+            },
+            "30008": {
+              "Value": false,
+              "Id": 30008,
+              "Name": "HasKeyboardFocus",
+              "TextValue": "False"
+            },
+            "30009": {
+              "Value": true,
+              "Id": 30009,
+              "Name": "IsKeyboardFocusable",
+              "TextValue": "True"
+            },
+            "30010": {
+              "Value": true,
+              "Id": 30010,
+              "Name": "IsEnabled",
+              "TextValue": "True"
+            },
+            "30012": {
+              "Value": "TrayClockWClass",
+              "Id": 30012,
+              "Name": "ClassName",
+              "TextValue": "TrayClockWClass"
+            },
+            "30015": {
+              "Value": 0,
+              "Id": 30015,
+              "Name": "Culture",
+              "TextValue": "0"
+            },
+            "30016": {
+              "Value": true,
+              "Id": 30016,
+              "Name": "IsControlElement",
+              "TextValue": "True"
+            },
+            "30017": {
+              "Value": true,
+              "Id": 30017,
+              "Name": "IsContentElement",
+              "TextValue": "True"
+            },
+            "30019": {
+              "Value": false,
+              "Id": 30019,
+              "Name": "IsPassword",
+              "TextValue": "False"
+            },
+            "30020": {
+              "Value": 131294,
+              "Id": 30020,
+              "Name": "NativeWindowHandle",
+              "TextValue": "131294"
+            },
+            "30022": {
+              "Value": false,
+              "Id": 30022,
+              "Name": "IsOffscreen",
+              "TextValue": "False"
+            },
+            "30023": {
+              "Value": 0,
+              "Id": 30023,
+              "Name": "Orientation",
+              "TextValue": "None(0)"
+            },
+            "30024": {
+              "Value": "Win32",
+              "Id": 30024,
+              "Name": "FrameworkId",
+              "TextValue": "Win32"
+            },
+            "30025": {
+              "Value": false,
+              "Id": 30025,
+              "Name": "IsRequiredForForm",
+              "TextValue": "False"
+            },
+            "30103": {
+              "Value": false,
+              "Id": 30103,
+              "Name": "IsDataValidForForm",
+              "TextValue": "False"
+            },
+            "30107": {
+              "Value": "[pid:29536,providerId:0x200DE Main:Nested [pid:7064,providerId:0x200DE Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+              "Id": 30107,
+              "Name": "ProviderDescription",
+              "TextValue": "[pid:29536,providerId:0x200DE Main:Nested [pid:7064,providerId:0x200DE Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+            },
+            "30111": {
+              "Value": false,
+              "Id": 30111,
+              "Name": "OptimizeForVisualContent",
+              "TextValue": "False"
+            },
+            "30135": {
+              "Value": 0,
+              "Id": 30135,
+              "Name": "LiveSetting",
+              "TextValue": "0"
+            },
+            "30150": {
+              "Value": false,
+              "Id": 30150,
+              "Name": "IsPeripheral",
+              "TextValue": "False"
+            },
+            "30152": {
+              "Value": 0,
+              "Id": 30152,
+              "Name": "PositionInSet",
+              "TextValue": "0"
+            },
+            "30153": {
+              "Value": 0,
+              "Id": 30153,
+              "Name": "SizeOfSet",
+              "TextValue": "0"
+            },
+            "30154": {
+              "Value": 0,
+              "Id": 30154,
+              "Name": "Level",
+              "TextValue": "0"
+            },
+            "30157": {
+              "Value": 0,
+              "Id": 30157,
+              "Name": "LandmarkType",
+              "TextValue": "0"
+            },
+            "30162": {
+              "Value": 0,
+              "Id": 30162,
+              "Name": "FillType",
+              "TextValue": "0"
+            },
+            "30163": {
+              "Value": 0,
+              "Id": 30163,
+              "Name": "VisualEffects",
+              "TextValue": "0"
+            }
+          },
+          "PlatformProperties": {
+            "1": {
+              "Value": 1409286144,
+              "Id": 1,
+              "Name": "Unknown(1)",
+              "TextValue": "1409286144"
+            }
+          },
+          "Patterns": [
+            {
+              "Name": "InvokePattern",
+              "Id": 10000,
+              "Properties": [],
+              "IsUIActionable": true
+            },
+            {
+              "Name": "LegacyIAccessiblePattern",
+              "Id": 10018,
+              "Properties": [
+                {
+                  "Name": "ChildId",
+                  "Value": 0,
+                  "NodeValue": "ChildId = 0"
+                },
+                {
+                  "Name": "DefaultAction",
+                  "Value": "Press",
+                  "NodeValue": "DefaultAction = \"Press\""
+                },
+                {
+                  "Name": "Description",
+                  "Value": "",
+                  "NodeValue": "Description = \"\""
+                },
+                {
+                  "Name": "Help",
+                  "Value": "",
+                  "NodeValue": "Help = \"\""
+                },
+                {
+                  "Name": "KeyboardShorcut",
+                  "Value": "",
+                  "NodeValue": "KeyboardShorcut = \"\""
+                },
+                {
+                  "Name": "Name",
+                  "Value": "System Clock, 12:04 PM, ‎10/‎13/‎2017",
+                  "NodeValue": "Name = \"System Clock, 12:04 PM, ‎10/‎13/‎2017\""
+                },
+                {
+                  "Name": "Role",
+                  "Value": 43,
+                  "NodeValue": "Role = 43"
+                },
+                {
+                  "Name": "State",
+                  "Value": 1048576,
+                  "NodeValue": "State = 1048576"
+                },
+                {
+                  "Name": "Value",
+                  "Value": "",
+                  "NodeValue": "Value = \"\""
+                }
+              ],
+              "IsUIActionable": false
+            }
+          ],
+          "Children": [],
+          "TreeWalkerMode": 1,
+          "ScanResults": {
+            "Items": [
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name",
+                "MetaInfo": {
+                  "PropertyId": 30005,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                  "The BoundingRectagle of the current element is [l=3656,t=2100,r=3760,b=2160]."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                "MetaInfo": {
+                  "PropertyId": 30001,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.2.1] IsKeyboardFocusable",
+                "MetaInfo": {
+                  "PropertyId": 30009,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "The property value may be one of [button]."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] LocalizedControlType",
+                "MetaInfo": {
+                  "PropertyId": 30004,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Typical SubTree structure in Control mode",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[MSDN] Typical SubTree structure in Content mode",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "'IsControlElement' property value should be \"True\"."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] IsControlElement Property",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30016,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name: Child element should have unique name.",
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Only one of Invoke/Toggle patterns expected.",
+                  "Invoke pattern exists."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Control Pattern",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Check IsContentElement property value."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Properties",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30017,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              }
+            ],
+            "Status": 1
+          }
+        },
+        {
+          "Name": "Action Center",
+          "ControlTypeId": 50000,
+          "LocalizedControlType": "button",
+          "RuntimeId": "[2A,100E2]",
+          "ProcessId": 7064,
+          "BoundingRectangle": "3760, 2100, 72, 60",
+          "IsKeyboardFocusable": true,
+          "IsContent": true,
+          "IsControl": true,
+          "TestStatus": 1,
+          "Glimpse": "button \"Action Center\"",
+          "Properties": {
+            "30000": {
+              "Value": [
+                42,
+                65762
+              ],
+              "Id": 30000,
+              "Name": "RuntimeId",
+              "TextValue": "[2A,100E2]"
+            },
+            "30001": {
+              "Value": [
+                3760.0,
+                2100.0,
+                72.0,
+                60.0
+              ],
+              "Id": 30001,
+              "Name": "BoundingRectangle",
+              "TextValue": "[l=3760,t=2100,r=3832,b=2160]"
+            },
+            "30002": {
+              "Value": 7064,
+              "Id": 30002,
+              "Name": "ProcessId",
+              "TextValue": "7064"
+            },
+            "30003": {
+              "Value": 50000,
+              "Id": 30003,
+              "Name": "ControlType",
+              "TextValue": "Button(50000)"
+            },
+            "30004": {
+              "Value": "button",
+              "Id": 30004,
+              "Name": "LocalizedControlType",
+              "TextValue": "button"
+            },
+            "30005": {
+              "Value": "Action Center",
+              "Id": 30005,
+              "Name": "Name",
+              "TextValue": "Action Center"
+            },
+            "30008": {
+              "Value": false,
+              "Id": 30008,
+              "Name": "HasKeyboardFocus",
+              "TextValue": "False"
+            },
+            "30009": {
+              "Value": true,
+              "Id": 30009,
+              "Name": "IsKeyboardFocusable",
+              "TextValue": "True"
+            },
+            "30010": {
+              "Value": true,
+              "Id": 30010,
+              "Name": "IsEnabled",
+              "TextValue": "True"
+            },
+            "30012": {
+              "Value": "TrayButton",
+              "Id": 30012,
+              "Name": "ClassName",
+              "TextValue": "TrayButton"
+            },
+            "30015": {
+              "Value": 0,
+              "Id": 30015,
+              "Name": "Culture",
+              "TextValue": "0"
+            },
+            "30016": {
+              "Value": true,
+              "Id": 30016,
+              "Name": "IsControlElement",
+              "TextValue": "True"
+            },
+            "30017": {
+              "Value": true,
+              "Id": 30017,
+              "Name": "IsContentElement",
+              "TextValue": "True"
+            },
+            "30019": {
+              "Value": false,
+              "Id": 30019,
+              "Name": "IsPassword",
+              "TextValue": "False"
+            },
+            "30020": {
+              "Value": 65762,
+              "Id": 30020,
+              "Name": "NativeWindowHandle",
+              "TextValue": "65762"
+            },
+            "30022": {
+              "Value": false,
+              "Id": 30022,
+              "Name": "IsOffscreen",
+              "TextValue": "False"
+            },
+            "30023": {
+              "Value": 0,
+              "Id": 30023,
+              "Name": "Orientation",
+              "TextValue": "None(0)"
+            },
+            "30024": {
+              "Value": "Win32",
+              "Id": 30024,
+              "Name": "FrameworkId",
+              "TextValue": "Win32"
+            },
+            "30025": {
+              "Value": false,
+              "Id": 30025,
+              "Name": "IsRequiredForForm",
+              "TextValue": "False"
+            },
+            "30103": {
+              "Value": false,
+              "Id": 30103,
+              "Name": "IsDataValidForForm",
+              "TextValue": "False"
+            },
+            "30107": {
+              "Value": "[pid:29536,providerId:0x100E2 Main:Nested [pid:7064,providerId:0x100E2 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+              "Id": 30107,
+              "Name": "ProviderDescription",
+              "TextValue": "[pid:29536,providerId:0x100E2 Main:Nested [pid:7064,providerId:0x100E2 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+            },
+            "30111": {
+              "Value": false,
+              "Id": 30111,
+              "Name": "OptimizeForVisualContent",
+              "TextValue": "False"
+            },
+            "30135": {
+              "Value": 0,
+              "Id": 30135,
+              "Name": "LiveSetting",
+              "TextValue": "0"
+            },
+            "30150": {
+              "Value": false,
+              "Id": 30150,
+              "Name": "IsPeripheral",
+              "TextValue": "False"
+            },
+            "30152": {
+              "Value": 0,
+              "Id": 30152,
+              "Name": "PositionInSet",
+              "TextValue": "0"
+            },
+            "30153": {
+              "Value": 0,
+              "Id": 30153,
+              "Name": "SizeOfSet",
+              "TextValue": "0"
+            },
+            "30154": {
+              "Value": 0,
+              "Id": 30154,
+              "Name": "Level",
+              "TextValue": "0"
+            },
+            "30157": {
+              "Value": 0,
+              "Id": 30157,
+              "Name": "LandmarkType",
+              "TextValue": "0"
+            },
+            "30162": {
+              "Value": 0,
+              "Id": 30162,
+              "Name": "FillType",
+              "TextValue": "0"
+            },
+            "30163": {
+              "Value": 0,
+              "Id": 30163,
+              "Name": "VisualEffects",
+              "TextValue": "0"
+            }
+          },
+          "PlatformProperties": {
+            "1": {
+              "Value": 1409286144,
+              "Id": 1,
+              "Name": "Unknown(1)",
+              "TextValue": "1409286144"
+            }
+          },
+          "Patterns": [
+            {
+              "Name": "InvokePattern",
+              "Id": 10000,
+              "Properties": [],
+              "IsUIActionable": true
+            },
+            {
+              "Name": "LegacyIAccessiblePattern",
+              "Id": 10018,
+              "Properties": [
+                {
+                  "Name": "ChildId",
+                  "Value": 0,
+                  "NodeValue": "ChildId = 0"
+                },
+                {
+                  "Name": "DefaultAction",
+                  "Value": "Press",
+                  "NodeValue": "DefaultAction = \"Press\""
+                },
+                {
+                  "Name": "Description",
+                  "Value": "",
+                  "NodeValue": "Description = \"\""
+                },
+                {
+                  "Name": "Help",
+                  "Value": "",
+                  "NodeValue": "Help = \"\""
+                },
+                {
+                  "Name": "KeyboardShorcut",
+                  "Value": "",
+                  "NodeValue": "KeyboardShorcut = \"\""
+                },
+                {
+                  "Name": "Name",
+                  "Value": "Action Center",
+                  "NodeValue": "Name = \"Action Center\""
+                },
+                {
+                  "Name": "Role",
+                  "Value": 43,
+                  "NodeValue": "Role = 43"
+                },
+                {
+                  "Name": "State",
+                  "Value": 1048576,
+                  "NodeValue": "State = 1048576"
+                },
+                {
+                  "Name": "Value",
+                  "Value": "",
+                  "NodeValue": "Value = \"\""
+                }
+              ],
+              "IsUIActionable": false
+            }
+          ],
+          "Children": [],
+          "TreeWalkerMode": 1,
+          "ScanResults": {
+            "Items": [
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name",
+                "MetaInfo": {
+                  "PropertyId": 30005,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                  "The BoundingRectagle of the current element is [l=3760,t=2100,r=3832,b=2160]."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                "MetaInfo": {
+                  "PropertyId": 30001,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.2.1] IsKeyboardFocusable",
+                "MetaInfo": {
+                  "PropertyId": 30009,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "The property value may be one of [button]."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] LocalizedControlType",
+                "MetaInfo": {
+                  "PropertyId": 30004,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Typical SubTree structure in Control mode",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[MSDN] Typical SubTree structure in Content mode",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "'IsControlElement' property value should be \"True\"."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] IsControlElement Property",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30016,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name: Child element should have unique name.",
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Only one of Invoke/Toggle patterns expected.",
+                  "Invoke pattern exists."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Control Pattern",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Check IsContentElement property value."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Properties",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30017,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              }
+            ],
+            "Status": 1
+          }
+        },
+        {
+          "Name": "Show desktop",
+          "ControlTypeId": 50000,
+          "LocalizedControlType": "button",
+          "RuntimeId": "[2A,100E6]",
+          "ProcessId": 7064,
+          "BoundingRectangle": "3832, 2100, 8, 60",
+          "IsKeyboardFocusable": true,
+          "IsContent": true,
+          "IsControl": true,
+          "TestStatus": 1,
+          "Glimpse": "button \"Show desktop\"",
+          "Properties": {
+            "30000": {
+              "Value": [
+                42,
+                65766
+              ],
+              "Id": 30000,
+              "Name": "RuntimeId",
+              "TextValue": "[2A,100E6]"
+            },
+            "30001": {
+              "Value": [
+                3832.0,
+                2100.0,
+                8.0,
+                60.0
+              ],
+              "Id": 30001,
+              "Name": "BoundingRectangle",
+              "TextValue": "[l=3832,t=2100,r=3840,b=2160]"
+            },
+            "30002": {
+              "Value": 7064,
+              "Id": 30002,
+              "Name": "ProcessId",
+              "TextValue": "7064"
+            },
+            "30003": {
+              "Value": 50000,
+              "Id": 30003,
+              "Name": "ControlType",
+              "TextValue": "Button(50000)"
+            },
+            "30004": {
+              "Value": "button",
+              "Id": 30004,
+              "Name": "LocalizedControlType",
+              "TextValue": "button"
+            },
+            "30005": {
+              "Value": "Show desktop",
+              "Id": 30005,
+              "Name": "Name",
+              "TextValue": "Show desktop"
+            },
+            "30008": {
+              "Value": false,
+              "Id": 30008,
+              "Name": "HasKeyboardFocus",
+              "TextValue": "False"
+            },
+            "30009": {
+              "Value": true,
+              "Id": 30009,
+              "Name": "IsKeyboardFocusable",
+              "TextValue": "True"
+            },
+            "30010": {
+              "Value": true,
+              "Id": 30010,
+              "Name": "IsEnabled",
+              "TextValue": "True"
+            },
+            "30011": {
+              "Value": "307",
+              "Id": 30011,
+              "Name": "AutomationId",
+              "TextValue": "307"
+            },
+            "30012": {
+              "Value": "TrayShowDesktopButtonWClass",
+              "Id": 30012,
+              "Name": "ClassName",
+              "TextValue": "TrayShowDesktopButtonWClass"
+            },
+            "30015": {
+              "Value": 0,
+              "Id": 30015,
+              "Name": "Culture",
+              "TextValue": "0"
+            },
+            "30016": {
+              "Value": true,
+              "Id": 30016,
+              "Name": "IsControlElement",
+              "TextValue": "True"
+            },
+            "30017": {
+              "Value": true,
+              "Id": 30017,
+              "Name": "IsContentElement",
+              "TextValue": "True"
+            },
+            "30019": {
+              "Value": false,
+              "Id": 30019,
+              "Name": "IsPassword",
+              "TextValue": "False"
+            },
+            "30020": {
+              "Value": 65766,
+              "Id": 30020,
+              "Name": "NativeWindowHandle",
+              "TextValue": "65766"
+            },
+            "30022": {
+              "Value": false,
+              "Id": 30022,
+              "Name": "IsOffscreen",
+              "TextValue": "False"
+            },
+            "30023": {
+              "Value": 0,
+              "Id": 30023,
+              "Name": "Orientation",
+              "TextValue": "None(0)"
+            },
+            "30024": {
+              "Value": "Win32",
+              "Id": 30024,
+              "Name": "FrameworkId",
+              "TextValue": "Win32"
+            },
+            "30025": {
+              "Value": false,
+              "Id": 30025,
+              "Name": "IsRequiredForForm",
+              "TextValue": "False"
+            },
+            "30103": {
+              "Value": false,
+              "Id": 30103,
+              "Name": "IsDataValidForForm",
+              "TextValue": "False"
+            },
+            "30107": {
+              "Value": "[pid:29536,providerId:0x100E6 Main:Nested [pid:7064,providerId:0x100E6 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]",
+              "Id": 30107,
+              "Name": "ProviderDescription",
+              "TextValue": "[pid:29536,providerId:0x100E6 Main:Nested [pid:7064,providerId:0x100E6 Annotation(parent link):Microsoft: Annotation Proxy (unmanaged:UIAutomationCore.DLL); Main:Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.DLL)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:UIAutomationCore.dll)]"
+            },
+            "30111": {
+              "Value": false,
+              "Id": 30111,
+              "Name": "OptimizeForVisualContent",
+              "TextValue": "False"
+            },
+            "30135": {
+              "Value": 0,
+              "Id": 30135,
+              "Name": "LiveSetting",
+              "TextValue": "0"
+            },
+            "30150": {
+              "Value": false,
+              "Id": 30150,
+              "Name": "IsPeripheral",
+              "TextValue": "False"
+            },
+            "30152": {
+              "Value": 0,
+              "Id": 30152,
+              "Name": "PositionInSet",
+              "TextValue": "0"
+            },
+            "30153": {
+              "Value": 0,
+              "Id": 30153,
+              "Name": "SizeOfSet",
+              "TextValue": "0"
+            },
+            "30154": {
+              "Value": 0,
+              "Id": 30154,
+              "Name": "Level",
+              "TextValue": "0"
+            },
+            "30157": {
+              "Value": 0,
+              "Id": 30157,
+              "Name": "LandmarkType",
+              "TextValue": "0"
+            },
+            "30162": {
+              "Value": 0,
+              "Id": 30162,
+              "Name": "FillType",
+              "TextValue": "0"
+            },
+            "30163": {
+              "Value": 0,
+              "Id": 30163,
+              "Name": "VisualEffects",
+              "TextValue": "0"
+            }
+          },
+          "PlatformProperties": {
+            "1": {
+              "Value": 1409286144,
+              "Id": 1,
+              "Name": "Unknown(1)",
+              "TextValue": "1409286144"
+            }
+          },
+          "Patterns": [
+            {
+              "Name": "InvokePattern",
+              "Id": 10000,
+              "Properties": [],
+              "IsUIActionable": true
+            },
+            {
+              "Name": "LegacyIAccessiblePattern",
+              "Id": 10018,
+              "Properties": [
+                {
+                  "Name": "ChildId",
+                  "Value": 0,
+                  "NodeValue": "ChildId = 0"
+                },
+                {
+                  "Name": "DefaultAction",
+                  "Value": "Press",
+                  "NodeValue": "DefaultAction = \"Press\""
+                },
+                {
+                  "Name": "Description",
+                  "Value": "",
+                  "NodeValue": "Description = \"\""
+                },
+                {
+                  "Name": "Help",
+                  "Value": "",
+                  "NodeValue": "Help = \"\""
+                },
+                {
+                  "Name": "KeyboardShorcut",
+                  "Value": "",
+                  "NodeValue": "KeyboardShorcut = \"\""
+                },
+                {
+                  "Name": "Name",
+                  "Value": "Show desktop",
+                  "NodeValue": "Name = \"Show desktop\""
+                },
+                {
+                  "Name": "Role",
+                  "Value": 43,
+                  "NodeValue": "Role = 43"
+                },
+                {
+                  "Name": "State",
+                  "Value": 1048576,
+                  "NodeValue": "State = 1048576"
+                },
+                {
+                  "Name": "Value",
+                  "Value": "",
+                  "NodeValue": "Value = \"\""
+                }
+              ],
+              "IsUIActionable": false
+            }
+          ],
+          "Children": [],
+          "TreeWalkerMode": 1,
+          "ScanResults": {
+            "Items": [
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name",
+                "MetaInfo": {
+                  "PropertyId": 30005,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+                  "The BoundingRectagle of the current element is [l=3832,t=2100,r=3840,b=2160]."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+                "MetaInfo": {
+                  "PropertyId": 30001,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.2.1] IsKeyboardFocusable",
+                "MetaInfo": {
+                  "PropertyId": 30009,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "The property value may be one of [button]."
+                ],
+                "Status": 1,
+                "Description": "[4.2.1] LocalizedControlType",
+                "MetaInfo": {
+                  "PropertyId": 30004,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Expect to have [Image(50006), Text(50020)] child type(s) in 'Control' mode."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Typical SubTree structure in Control mode",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[MSDN] Typical SubTree structure in Content mode",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "'IsControlElement' property value should be \"True\"."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] IsControlElement Property",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30016,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[4.1.2] Name: Child element should have unique name.",
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [],
+                "Status": 1,
+                "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Only one of Invoke/Toggle patterns expected.",
+                  "Invoke pattern exists."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Control Pattern",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 0,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              },
+              {
+                "Messages": [
+                  "Check IsContentElement property value."
+                ],
+                "Status": 1,
+                "Description": "[MSDN] Properties",
+                "HelpUrl": {
+                  "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671619(v=vs.85).aspx",
+                  "Type": 0
+                },
+                "MetaInfo": {
+                  "PropertyId": 30017,
+                  "UIFramework": "Win32",
+                  "ControlType": "Button"
+                }
+              }
+            ],
+            "Status": 1
+          }
+        }
+      ],
+      "TreeWalkerMode": 1,
+      "ScanResults": {
+        "Items": [
+          {
+            "Messages": [
+              "Name doesn't exit or empty. but it is ok for this control type.(Pane(50033))"
+            ],
+            "Status": 1,
+            "Description": "[4.1.2] Name",
+            "MetaInfo": {
+              "PropertyId": 30005,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+              "The BoundingRectagle of the current element is [l=3548,t=2100,r=3840,b=2160].",
+              "The BoundingRectangle of button \"Notification Chevron\" child is [l=3548,t=2100,r=3584,b=2160]",
+              "The BoundingRectangle of pane \"\" child is [l=3584,t=2100,r=3656,b=2160]",
+              "The BoundingRectangle of button \"System Clock, 12:04 PM, ‎10/‎13/‎2017\" child is [l=3656,t=2100,r=3760,b=2160]",
+              "The BoundingRectangle of button \"Action Center\" child is [l=3760,t=2100,r=3832,b=2160]",
+              "The BoundingRectangle of button \"Show desktop\" child is [l=3832,t=2100,r=3840,b=2160]"
+            ],
+            "Status": 1,
+            "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+            "MetaInfo": {
+              "PropertyId": 30001,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "There is no pattern with UI action related Method(s), but the element is KeyboardFocusible."
+            ],
+            "Status": 1,
+            "Description": "[4.2.1] IsKeyboardFocusable",
+            "MetaInfo": {
+              "PropertyId": 30009,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "The property value may be one of [pane]."
+            ],
+            "Status": 1,
+            "Description": "[4.2.1] LocalizedControlType",
+            "MetaInfo": {
+              "PropertyId": 30004,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "'IsContentElement' property value should be \"True\"."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] IsContentElement Property",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671639(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 30017,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "'IsControlElement' property value should be \"True\"."
+            ],
+            "Status": 1,
+            "Description": "[MSDN] IsControlElement Property",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671639(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 30016,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[4.1.2] Name: Child element should have unique name.",
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [
+              "The DoNotSupport pattern(s): WindowPattern"
+            ],
+            "Status": 1,
+            "Description": "[MSDN]: Based on control type, some patterns should not be supported.",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          },
+          {
+            "Messages": [],
+            "Status": 1,
+            "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+            "HelpUrl": {
+              "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+              "Type": 0
+            },
+            "MetaInfo": {
+              "PropertyId": 0,
+              "UIFramework": "Win32",
+              "ControlType": "Pane"
+            }
+          }
+        ],
+        "Status": 1
+      }
+    }
+  ],
+  "TreeWalkerMode": 1,
+  "ScanResults": {
+    "Items": [
+      {
+        "Messages": [
+          "Name doesn't exit or empty. but it is ok for this control type.(Pane(50033))"
+        ],
+        "Status": 1,
+        "Description": "[4.1.2] Name",
+        "MetaInfo": {
+          "PropertyId": 30005,
+          "UIFramework": "Win32",
+          "ControlType": "Pane"
+        }
+      },
+      {
+        "Messages": [
+          "Check whether the bounding rectangle of the element contains the bounding rectangles of all children.",
+          "The BoundingRectagle of the current element is [l=0,t=2100,r=3840,b=2160].",
+          "The BoundingRectangle of button \"Start\" child is [l=0,t=2100,r=72,b=2160]",
+          "The BoundingRectangle of pane \"\" child is [l=72,t=2100,r=588,b=2160]",
+          "The BoundingRectangle of button \"Task View\" child is [l=588,t=2100,r=660,b=2160]",
+          "The BoundingRectangle of pane \"\" child is [l=658,t=2100,r=3548,b=2160]",
+          "The BoundingRectangle of pane \"\" child is [l=3548,t=2100,r=3840,b=2160]"
+        ],
+        "Status": 1,
+        "Description": "[4.2.1] BoundingRectangle: All child elements must be contained within BoundingRectangle.",
+        "MetaInfo": {
+          "PropertyId": 30001,
+          "UIFramework": "Win32",
+          "ControlType": "Pane"
+        }
+      },
+      {
+        "Messages": [
+          "There is no pattern with UI action related Method(s), but the element is KeyboardFocusible."
+        ],
+        "Status": 1,
+        "Description": "[4.2.1] IsKeyboardFocusable",
+        "MetaInfo": {
+          "PropertyId": 30009,
+          "UIFramework": "Win32",
+          "ControlType": "Pane"
+        }
+      },
+      {
+        "Messages": [
+          "The property value may be one of [pane]."
+        ],
+        "Status": 1,
+        "Description": "[4.2.1] LocalizedControlType",
+        "MetaInfo": {
+          "PropertyId": 30004,
+          "UIFramework": "Win32",
+          "ControlType": "Pane"
+        }
+      },
+      {
+        "Messages": [
+          "'IsContentElement' property value should be \"True\"."
+        ],
+        "Status": 1,
+        "Description": "[MSDN] IsContentElement Property",
+        "HelpUrl": {
+          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671639(v=vs.85).aspx",
+          "Type": 0
+        },
+        "MetaInfo": {
+          "PropertyId": 30017,
+          "UIFramework": "Win32",
+          "ControlType": "Pane"
+        }
+      },
+      {
+        "Messages": [
+          "'IsControlElement' property value should be \"True\"."
+        ],
+        "Status": 1,
+        "Description": "[MSDN] IsControlElement Property",
+        "HelpUrl": {
+          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671639(v=vs.85).aspx",
+          "Type": 0
+        },
+        "MetaInfo": {
+          "PropertyId": 30016,
+          "UIFramework": "Win32",
+          "ControlType": "Pane"
+        }
+      },
+      {
+        "Messages": [
+          "pane is excluded, since it would be ok to have childrens with same name and localized control type."
+        ],
+        "Status": 1,
+        "Description": "[4.1.2] Name: Child element should have unique name.",
+        "MetaInfo": {
+          "PropertyId": 0,
+          "UIFramework": "Win32",
+          "ControlType": "Pane"
+        }
+      },
+      {
+        "Messages": [
+          "The DoNotSupport pattern(s): WindowPattern"
+        ],
+        "Status": 1,
+        "Description": "[MSDN]: Based on control type, some patterns should not be supported.",
+        "HelpUrl": {
+          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+          "Type": 0
+        },
+        "MetaInfo": {
+          "PropertyId": 0,
+          "UIFramework": "Win32",
+          "ControlType": "Pane"
+        }
+      },
+      {
+        "Messages": [],
+        "Status": 1,
+        "Description": "[MSDN]: Based on available pattern(s) of parent element, some patterns are expected.",
+        "HelpUrl": {
+          "Url": "https://msdn.microsoft.com/en-us/library/windows/desktop/ee671193(v=vs.85).aspx",
+          "Type": 0
+        },
+        "MetaInfo": {
+          "PropertyId": 0,
+          "UIFramework": "Win32",
+          "ControlType": "Pane"
+        }
+      }
+    ],
+    "Status": 1
+  }
+}


### PR DESCRIPTION
This PR removes the reference from SharedUxTests to UnitTestSharedLibrary so that UnitTestSharedLibrary does not need to be exposed from axe-windows. There is more to do here - it would be better to remove the utility entirely and mock out the tests loading an A11yElement. Doing this requires adding several fields to the IA11yElement interface so I'd like to chat about it offline first. This PR should decouple the projects for now so we can proceed with splitting the repos - will work on introducing mocking asyncronously.