### PR TITLE
Removing unneeded references to eventual axe-windows

### DIFF
--- a/src/AccessibilityInsights.Automation/Automation.csproj
+++ b/src/AccessibilityInsights.Automation/Automation.csproj
@@ -50,10 +50,6 @@
       <Project>{2da36fa6-4ff8-4db4-aa7e-2f1cacae6e35}</Project>
       <Name>Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\AccessibilityInsights.DesktopUI\DesktopUI.csproj">
-      <Project>{31c471c1-2ef1-4fe1-90dc-16d007b87648}</Project>
-      <Name>DesktopUI</Name>
-    </ProjectReference>
     <ProjectReference Include="..\AccessibilityInsights.Desktop\Desktop.csproj">
       <Project>{0b9855fd-7b04-415c-a813-da9697693fda}</Project>
       <Name>Desktop</Name>

--- a/src/AccessibilityInsights.WebApiHost/WebApiHost.csproj
+++ b/src/AccessibilityInsights.WebApiHost/WebApiHost.csproj
@@ -117,10 +117,6 @@
       <Project>{0b9855fd-7b04-415c-a813-da9697693fda}</Project>
       <Name>Desktop</Name>
     </ProjectReference>
-    <ProjectReference Include="..\AccessibilityInsights.Extensions.Telemetry\Extensions.Telemetry.csproj">
-      <Project>{d17e1749-28fe-44b9-a9f6-af8985124fe4}</Project>
-      <Name>Extensions.Telemetry</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\BrandIconDesktop.ico" />


### PR DESCRIPTION
Removing two references from ai-win projects to axe-windows projects. These references are not being used and will need to be severed if we plan to separate axe-windows