### PR TITLE
Fix Exception being thrown when copying VersionSwitcher

### DIFF
--- a/src/AccessibilityInsights.SetupLibrary/VersionSwitcherWrapper.cs
+++ b/src/AccessibilityInsights.SetupLibrary/VersionSwitcherWrapper.cs
@@ -99,7 +99,7 @@ namespace AccessibilityInsights.SetupLibrary
                 foreach (string file in Directory.GetFiles(source))
                 {
                     FileInfo fileInfo = new FileInfo(file);
-                    fileInfo.CopyTo(Path.Combine(dest, file), true);
+                    fileInfo.CopyTo(Path.Combine(dest, fileInfo.Name), true);
                     fileLocks.Add(File.OpenRead(dest));
                 }
 


### PR DESCRIPTION
#### Describe the change
Upgrade is broken because of an Exception being thrown. This used to work, then apparently I made a bad change without catching it. Tested by confirming that upgrade now works.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



