### PR TITLE
Fix problems when copying VersionSwitcher

### DIFF
--- a/src/AccessibilityInsights.SetupLibrary/VersionSwitcherWrapper.cs
+++ b/src/AccessibilityInsights.SetupLibrary/VersionSwitcherWrapper.cs
@@ -99,8 +99,9 @@ namespace AccessibilityInsights.SetupLibrary
                 foreach (string file in Directory.GetFiles(source))
                 {
                     FileInfo fileInfo = new FileInfo(file);
-                    fileInfo.CopyTo(Path.Combine(dest, fileInfo.Name), true);
-                    fileLocks.Add(File.OpenRead(dest));
+                    string destFile = Path.Combine(dest, fileInfo.Name);
+                    fileInfo.CopyTo(destFile, true);
+                    fileLocks.Add(File.OpenRead(destFile));
                 }
 
                 // copy folders

--- a/src/AccessibilityInsights.SetupLibrary/VersionSwitcherWrapper.cs
+++ b/src/AccessibilityInsights.SetupLibrary/VersionSwitcherWrapper.cs
@@ -99,7 +99,7 @@ namespace AccessibilityInsights.SetupLibrary
                 foreach (string file in Directory.GetFiles(source))
                 {
                     FileInfo fileInfo = new FileInfo(file);
-                    fileInfo.CopyTo(Path.Combine(dest, file), true);
+                    fileInfo.CopyTo(Path.Combine(dest, fileInfo.Name), true);
                     fileLocks.Add(File.OpenRead(dest));
                 }
 


### PR DESCRIPTION
#### Describe the change
The code to copy VersionSwitcher had 2 bugs:
- It was passing the wrong data to Path.Combine, which threw an Exception
- If wasn't properly locking the file after copy

This code was working, then I did some code shuffling and apparently broke it. Tested by forcing an upgrade situation, ensuring that VersionSwitcher gets copied correctly, then ensuring that the upgrade version gets installed. Without this fix, it's impossible to upgrade or switch channels (change already exists in the branch with the channel selection UI, but I wanted to get it into master to fix potential upgrade cases).

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



