### PR TITLE
Adding the releases clean up script 

### DIFF
--- a/tools/scripts/release-cleanup.ps1
+++ b/tools/scripts/release-cleanup.ps1
@@ -90,7 +90,7 @@ foreach($releaseKV in $releaseMap){
         }
         $deleteList += $release
     } elseif ($release.Name -match "Canary"){
-        if($insiderCount -gt 0 -and $canaryCount -ge 2){
+        if(($insiderCount -gt 0 -or $prodCount - gt 0) -and $canaryCount -ge 2){
             $deleteList += $release
             continue
         }

--- a/tools/scripts/release-cleanup.ps1
+++ b/tools/scripts/release-cleanup.ps1
@@ -1,0 +1,108 @@
+﻿# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#This script assumes that the OctoKit Nuget package is a custom install and is in the current folder.
+
+$deleteList = @()
+
+# Extracts a version from the release name.
+function Extract-Version($specificRelease){
+    $versionString = $specificRelease.Name
+    if($versionString -match ".*v(\d+\.\d+\.\d+\.\d+).*"){
+        return $matches[1]
+    } else {
+        $deleteList += $specificRelease
+        return [string]::Empty
+    }
+}
+
+# Sorts the releases based on the version number
+function Sort-Releases($releases){
+    $releaseMap = @{}
+    foreach($release in $releases.Result){
+        $releaseVersion = [System.version](Extract-Version $release)
+        if(-not [string]::IsNullOrEmpty($releaseVersion)){
+            $releaseMap.Add($releaseVersion,$release)
+        }
+    }
+
+    $releaseMap = $releaseMap.GetEnumerator() | Sort-Object -Descending -Property Name
+    return $releaseMap
+}
+
+# Delete a release
+function Delete-Release($release){
+    # Null checks
+    if([string]::IsNullOrEmpty($release.Id)){
+        Write-Host "No Release Id found"
+        return;
+    }
+
+    Write-Host "Deleting release" + $release.Name
+    $response = $instance.Repository.Release.Delete($repoId, $release.Id);
+
+    if(-not ($response.Result -eq "NoContent" -and $response.IsCompleted -eq $True)){
+        Write-Host "Failed to delete release -" $release.Name
+    } 
+}
+
+# Load the octokit dll
+Add-Type -Path ((Get-Location).Path + "\Octokit.0.32.0\lib\net45\Octokit.dll")
+
+# Get a new client with random product header value
+$productHeader = [Octokit.ProductHeaderValue]::new("AIWindows-CleanupScript")
+$instance = [Octokit.GitHubClient]::new($productHeader)
+
+# Add credentials for authentication
+$instance.Credentials = [Octokit.Credentials]::new("$(gitPATX)")
+
+# Get repo id
+$repoId = $instance.Repository.Get("Microsoft", "accessibility-insights-windows").Result.Id;
+
+# Get all releases
+$releases = $instance.Repository.Release.GetAll($repoId)
+
+Write-Host "Releases found" 
+$releases.Result | Select-Object -Property Name, TagName, Id | Format-Table
+
+$releaseMap = Sort-Releases $releases
+Write-Host "==========================================================="
+Write-Host "Sorted Releases" 
+Write-Host ($releaseMap | Out-Default)
+Write-Host "==========================================================="
+
+$prodCount = 0
+$insiderCount = 0
+$canaryCount = 0;
+
+foreach($releaseKV in $releaseMap){
+    $release = $releaseKV.Value
+    if ($release.Name -match "Insider"){
+        if($insiderCount -lt 2){
+            $insiderCount++
+            continue
+        }
+        $deleteList += $release
+    } elseif ($release.Name -match "Production"){
+        if($prodCount -lt 2){
+            $prodCount++
+            continue
+        }
+        $deleteList += $release
+    } elseif ($release.Name -match "Canary"){
+        if($insiderCount -gt 0 -and $canaryCount -ge 2){
+            $deleteList += $release
+            continue
+        }
+        $canaryCount++
+    } else {
+        # Rogues. Delete.
+        $deleteList += $release
+    }
+}
+
+if($deleteList.Count -eq 0){
+    Write-Host "No releases to delete."
+} else {
+    $deleteList | %{ Delete-Release $_ }
+}

--- a/tools/scripts/release-cleanup.ps1
+++ b/tools/scripts/release-cleanup.ps1
@@ -77,20 +77,20 @@ $canaryCount = 0;
 
 foreach($releaseKV in $releaseMap){
     $release = $releaseKV.Value
-    if ($release.Name -match "Insider"){
+    if ($release.Name -like "Insider*"){
         if($insiderCount -lt 2){
             $insiderCount++
             continue
         }
         $deleteList += $release
-    } elseif ($release.Name -match "Production"){
+    } elseif ($release.Name -like "Production*"){
         if($prodCount -lt 2){
             $prodCount++
             continue
         }
         $deleteList += $release
-    } elseif ($release.Name -match "Canary"){
-        if(($insiderCount -gt 0 -or $prodCount - gt 0) -and $canaryCount -ge 2){
+    } elseif ($release.Name -like "Canary*"){
+        if(($insiderCount -gt 0 -or $prodCount -gt 0) -and $canaryCount -ge 2){
             $deleteList += $release
             continue
         }


### PR DESCRIPTION
#### Describe the change
- This script will run in a power shell task to clean up releases.
- It will run after a custom nuget task to install OcktoKit is run.
- Sample run - https://dev.azure.com/mseng/1ES/_releaseProgress?_a=release-environment-logs&releaseId=990&environmentId=1110
#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 