### PR TITLE
Fix issue #267

### DIFF
--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/AutoUpdate.cs
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/AutoUpdate.cs
@@ -167,10 +167,10 @@ namespace AccessibilityInsights.Extensions.GitHubAutoUpdate
         }
 
         /// <summary>
-        /// Production ctor
+        /// Production ctor - MUST be a default ctor or extensions will break
         /// </summary>
-        public AutoUpdate(ReleaseChannel? releaseChannel = null) :
-            this(releaseChannel, () => MsiUtilities.GetInstalledProductVersion(ExceptionReporter),
+        public AutoUpdate() :
+            this(SetupLibrary.ReleaseChannel.Production, () => MsiUtilities.GetInstalledProductVersion(ExceptionReporter),
                 new ProductionChannelInfoProvider(new GitHubWrapper(ExceptionReporter), ExceptionReporter))
         {
         }
@@ -181,9 +181,9 @@ namespace AccessibilityInsights.Extensions.GitHubAutoUpdate
         /// <param name="releaseChannel">The client's current release channel</param>
         /// <param name="installedVersionProvider">Method that provides the installed version string</param>
         /// <param name="channelInfoProvider">Method that provides a (potentially invalid) ChannelInfo</param>
-        internal AutoUpdate(ReleaseChannel? releaseChannel, Func<string> installedVersionProvider, IChannelInfoProvider channelInfoProvider)
+        internal AutoUpdate(ReleaseChannel releaseChannel, Func<string> installedVersionProvider, IChannelInfoProvider channelInfoProvider)
         {
-            _strongReleaseChannel = releaseChannel.HasValue ? releaseChannel.Value : SetupLibrary.ReleaseChannel.Production;
+            _strongReleaseChannel = releaseChannel;
             _installedVersionProvider = installedVersionProvider;
             _channelInfoProvider = channelInfoProvider;
             ReleaseChannel = _strongReleaseChannel.ToString();

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/AutoUpdateUnitTests.cs
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/AutoUpdateUnitTests.cs
@@ -69,7 +69,7 @@ namespace Extensions.GitHubAutoUpdateUnitTests
         }
 
         // Wrap the ctor to give us a single place for adding dependency injection parameters
-        private static AutoUpdate BuildAutoUpdate(ReleaseChannel? releaseChannel = null, string testInstalledVersion = null, IChannelInfoProvider channelProvider = null)
+        private static AutoUpdate BuildAutoUpdate(ReleaseChannel releaseChannel = ReleaseChannel.Production, string testInstalledVersion = null, IChannelInfoProvider channelProvider = null)
         {
             return new AutoUpdate(releaseChannel, () => testInstalledVersion ?? TestInstalledVersion, channelProvider ?? InertChannelInfoProvider);
         }


### PR DESCRIPTION
#### Describe the change
Issue #267 was caused by an incorrect production constructor in the AutoUpdate class. MEF requires a default constructor, which is different from a non-default constructor with a default argument. Changed to use a true default constructor.

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #267
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

![image](https://user-images.githubusercontent.com/45672944/55750870-24c30480-59f9-11e9-8f2d-e768f789d277.png)

![image](https://user-images.githubusercontent.com/45672944/55750881-2ab8e580-59f9-11e9-8ffa-d80360141926.png)



