### PR TITLE
Enable ReleaseChannel in AutoUpdate

### DIFF
--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/AutoUpdate.cs
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/AutoUpdate.cs
@@ -167,10 +167,10 @@ namespace AccessibilityInsights.Extensions.GitHubAutoUpdate
         }
 
         /// <summary>
-        /// Production ctor
+        /// Production ctor - MUST be a default ctor or extensions will break
         /// </summary>
-        public AutoUpdate(ReleaseChannel? releaseChannel = null) :
-            this(releaseChannel, () => MsiUtilities.GetInstalledProductVersion(ExceptionReporter),
+        public AutoUpdate() :
+            this(SetupLibrary.ReleaseChannel.Production, () => MsiUtilities.GetInstalledProductVersion(ExceptionReporter),
                 new ProductionChannelInfoProvider(new GitHubWrapper(ExceptionReporter), ExceptionReporter))
         {
         }
@@ -181,9 +181,9 @@ namespace AccessibilityInsights.Extensions.GitHubAutoUpdate
         /// <param name="releaseChannel">The client's current release channel</param>
         /// <param name="installedVersionProvider">Method that provides the installed version string</param>
         /// <param name="channelInfoProvider">Method that provides a (potentially invalid) ChannelInfo</param>
-        internal AutoUpdate(ReleaseChannel? releaseChannel, Func<string> installedVersionProvider, IChannelInfoProvider channelInfoProvider)
+        internal AutoUpdate(ReleaseChannel releaseChannel, Func<string> installedVersionProvider, IChannelInfoProvider channelInfoProvider)
         {
-            _strongReleaseChannel = releaseChannel.HasValue ? releaseChannel.Value : SetupLibrary.ReleaseChannel.Production;
+            _strongReleaseChannel = releaseChannel;
             _installedVersionProvider = installedVersionProvider;
             _channelInfoProvider = channelInfoProvider;
             ReleaseChannel = _strongReleaseChannel.ToString();

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/AutoUpdate.cs
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/AutoUpdate.cs
@@ -170,7 +170,7 @@ namespace AccessibilityInsights.Extensions.GitHubAutoUpdate
         /// Production ctor - MUST be a default ctor or extensions will break
         /// </summary>
         public AutoUpdate() :
-            this(ProductionReleaseChannelProvider, () => MsiUtilities.GetInstalledProductVersion(ExceptionReporter),
+            this(ConfiguredReleaseChannelProvider, () => MsiUtilities.GetInstalledProductVersion(ExceptionReporter),
                 new ProductionChannelInfoProvider(new GitHubWrapper(ExceptionReporter), ExceptionReporter))
         {
         }
@@ -190,7 +190,7 @@ namespace AccessibilityInsights.Extensions.GitHubAutoUpdate
             _initTask = Task.Run(() => InitializeWithTimer());
         }
 
-        private static ReleaseChannel ProductionReleaseChannelProvider()
+        private static ReleaseChannel ConfiguredReleaseChannelProvider()
         {
             if (Enum.TryParse<ReleaseChannel>(ReleaseChannelProvider.ReleaseChannel, out ReleaseChannel releaseChannel))
             {

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/ProductionChannelInfoProvider.cs
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/ProductionChannelInfoProvider.cs
@@ -28,7 +28,7 @@ namespace AccessibilityInsights.Extensions.GitHubAutoUpdate
         /// </summary>
         public bool TryGetChannelInfo(ReleaseChannel releaseChannel, out ChannelInfo channelInfo)
         {
-            return ChannelInfoUtilities.TryGetChannelInfo(releaseChannel, out channelInfo, _gitHubWrapper, null, _exceptionReporter);
+            return ChannelInfoUtilities.TryGetChannelInfo(releaseChannel, out channelInfo, _gitHubWrapper, exceptionReporter: _exceptionReporter);
         }
     }
 }

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/AutoUpdateUnitTests.cs
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/AutoUpdateUnitTests.cs
@@ -71,7 +71,7 @@ namespace Extensions.GitHubAutoUpdateUnitTests
         // Wrap the ctor to give us a single place for adding dependency injection parameters
         private static AutoUpdate BuildAutoUpdate(ReleaseChannel releaseChannel = ReleaseChannel.Production, string testInstalledVersion = null, IChannelInfoProvider channelProvider = null)
         {
-            return new AutoUpdate(releaseChannel, () => testInstalledVersion ?? TestInstalledVersion, channelProvider ?? InertChannelInfoProvider);
+            return new AutoUpdate(() => releaseChannel, () => testInstalledVersion ?? TestInstalledVersion, channelProvider ?? InertChannelInfoProvider);
         }
 
         [TestMethod]

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/AutoUpdateUnitTests.cs
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/AutoUpdateUnitTests.cs
@@ -69,7 +69,7 @@ namespace Extensions.GitHubAutoUpdateUnitTests
         }
 
         // Wrap the ctor to give us a single place for adding dependency injection parameters
-        private static AutoUpdate BuildAutoUpdate(ReleaseChannel? releaseChannel = null, string testInstalledVersion = null, IChannelInfoProvider channelProvider = null)
+        private static AutoUpdate BuildAutoUpdate(ReleaseChannel releaseChannel = ReleaseChannel.Production, string testInstalledVersion = null, IChannelInfoProvider channelProvider = null)
         {
             return new AutoUpdate(releaseChannel, () => testInstalledVersion ?? TestInstalledVersion, channelProvider ?? InertChannelInfoProvider);
         }

--- a/src/AccessibilityInsights.Extensions/Container.cs
+++ b/src/AccessibilityInsights.Extensions/Container.cs
@@ -145,6 +145,16 @@ namespace AccessibilityInsights.Extensions
 
             return _defaultInstance;
         }
+
+        /// <summary>
+        /// Set the ReleaseChannel for update
+        /// </summary>
+        /// <param name="releaseChannel">The value to use in the AutoUpdate code</param>
+        public static void SetAutoUpdateReleaseChannel(string releaseChannel)
+        {
+            ReleaseChannelProvider.ReleaseChannel = releaseChannel;
+        }
+
         #endregion
 
         #region IDisposable Support

--- a/src/AccessibilityInsights.Extensions/Extensions.csproj
+++ b/src/AccessibilityInsights.Extensions/Extensions.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Interfaces\Telemetry\Hint.cs" />
     <Compile Include="Interfaces\Telemetry\ITelemetry.cs" />
     <Compile Include="Interfaces\Upgrades\IAutoUpdate.cs" />
+    <Compile Include="Interfaces\Upgrades\ReleaseChannelProvider.cs" />
     <Compile Include="Interfaces\Upgrades\UpdateResult.cs" />
     <Compile Include="Interfaces\Upgrades\UpgradeOption.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/AccessibilityInsights.Extensions/Interfaces/Upgrades/ReleaseChannelProvider.cs
+++ b/src/AccessibilityInsights.Extensions/Interfaces/Upgrades/ReleaseChannelProvider.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace AccessibilityInsights.Extensions.Interfaces.Upgrades
+{
+    /// <summary>
+    /// Class to provide the ReleaseChannel to implementations
+    /// </summary>
+    public static class ReleaseChannelProvider
+    {
+        /// <summary>
+        /// The ReleaseChannel to be used by AutoUpdate
+        /// </summary>
+        public static string ReleaseChannel { get; internal set; }
+    }
+}

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Actions;
 using AccessibilityInsights.CommonUxComponents.Dialogs;
-using Axe.Windows.Desktop.Keyboard;
 using AccessibilityInsights.Enums;
+using AccessibilityInsights.Extensions;
 using AccessibilityInsights.Misc;
 using AccessibilityInsights.SetupLibrary;
 using AccessibilityInsights.SharedUx.Highlighting;
 using AccessibilityInsights.SharedUx.Settings;
 using AccessibilityInsights.SharedUx.Telemetry;
+using Axe.Windows.Actions;
+using Axe.Windows.Desktop.Keyboard;
 using Axe.Windows.Win32;
 using System;
 using System.Globalization;
@@ -113,6 +114,9 @@ namespace AccessibilityInsights
             // based on customer feedback, we will set default selection mode to Element
             // when AccessibilityInsights starts up. 
             ConfigurationManager.GetDefaultInstance().AppConfig.IsUnderElementScope = true;
+
+            // Configure the correct ReleaseChannel for autoupdate
+            Container.SetAutoUpdateReleaseChannel(ConfigurationManager.GetDefaultInstance().AppConfig.ReleaseChannel.ToString());
 
             // enable/disable telemetry
             if (ConfigurationManager.GetDefaultInstance().AppConfig.EnableTelemetry)


### PR DESCRIPTION
#### Describe the change
AutoUpdate needs to be responsive to ReleaseChannel settings (it currently only supports Production)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



