### PR TITLE
Updates to the docs after axe-windows rename

### DIFF
--- a/docs/AddUnitTests.md
+++ b/docs/AddUnitTests.md
@@ -73,7 +73,7 @@ If you have an edition of Visual Studio which supports Fakes and you would like 
 If you want to add any unit tests which use Fakes into a project, make sure of the following:
 
 1. All Fakes references in the project are conditional on the `FAKES_SUPPORTED` environment variable. For example.<BR/>
-`<Reference Include="AccessibilityInsights.Actions.Fakes" Condition="$(FAKES_SUPPORTED) == 1"/>`
+`<Reference Include="Axe.Windows.Actions.Fakes" Condition="$(FAKES_SUPPORTED) == 1"/>`
 2. The FAKES_SUPPORTED preprocessor symbol is defined for the project based on the environment variable. For example,<BR/>
     ```
     <PropertyGroup Condition="$(FAKES_SUPPORTED) == 1">

--- a/docs/AddingColorContrastTests.md
+++ b/docs/AddingColorContrastTests.md
@@ -8,7 +8,7 @@ to the test images.
 ### Steps
 
 - Convert the image fed to the algorithm at RunTime to a bitmap.
-- Add the bitmap to `AccessibilityInsights.DesktopTests/TestImages`
+- Add the bitmap to `Axe.Windows.DesktopTests/TestImages`
 - Give it a meaningful name.
 - Create a new [TestCase](https://github.com/Microsoft/accessibility-insights-windows/blob/d1fe24c1a763dbbca423fc1d9c4708eb7396a44c/src/AccessibilityInsights.DesktopTests/ColorContrastAnalyzer/ImageTests.cs#L28-L39) 
 
@@ -19,4 +19,4 @@ rules to follow
 
 - If the confidence is not `high` utilize things like Visibly Similar to, rather than precise colors.
 - Always include an assertion about confidence level.
-- If a test case is in a response to a specific issue, link it in comments rather than verbosely describing what your testing.
+- If a test case is in a response to a specific issue, link it in comments rather than verbosely describing what you're testing.

--- a/docs/NewProject.md
+++ b/docs/NewProject.md
@@ -4,7 +4,7 @@ Do the following when adding a new project:
 ### For all projects
 1. Add a project to the AccessibilityInsights Solution (`src\AccessibilityInsights.sln`).
 2. Right-click on the project and select Properties.
-2. In the Application tab, configure "Target Framework" to use the same .NET Framework version used by the `AccessibilityInsights.Core` project.
+2. In the Application tab, configure "Target Framework" to use the same .NET Framework version used by the `AccessibilityInsights` project.
    - Currently .NET Framework 4.7.1 is used as target. 
 3. In the build tab, set the following for both Debug and Release configurations:
    1. "Warning level" to 4.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -18,20 +18,19 @@ These assemblies provide the interaction with UIA, as well as layers that allow 
 
 Assembly | Responsibility
 --- | ---
-AccessibilityInsights.Core | Provide data abstractions which represent accessibility data in a platform-agnostic way.
-AccessibilityInsights.Desktop | Provide platform-specific (Windows) implementations of the platform-agnostic data abstractions. The low-level interactions with UIA occur in this assembly.
-AccessibilityInsights.DesktopUI | Provide platform-specific (Windows) implementations of platform-agnostic UI abstractions. This includes things like element highlighters.
-AccessibilityInsights.Actions | Provide a high-level set of Actions that are the primary interface into the Runtime components.
-AccessibilityInsights.Extensions | Provide extension points that allow certain non-core functionality to be implemented in a loosely coupled way.
-AccessibilityInsights.Win32 | Provide a wrapper around Win32-specific code that is needed by other assemblies.
+Axe.Windows.Actions | Provide a high-level set of Actions that are the primary interface into the Runtime components.
+Axe.Windows.Core | Provide data abstractions which represent accessibility data in a platform-agnostic way.
+Axe.Windows.Desktop | Provide platform-specific (Windows) implementations of the platform-agnostic data abstractions. The low-level interactions with UIA occur in this assembly.
+Axe.Windows.Telemetry | Provides an interface which any caller can provide to capture telemetry from Axe.Windows
+Axe.Windows.Win32 | Provide a wrapper around Win32-specific code that is needed by other assemblies.
 
 #### Accessibility Rules
 These assemblies evaluate the accessibility of an application based upon the data exposed via the platform-agnostic abstractions. Please visit the [Rules Overview](./RulesOverview.md) for a detailed description of the automated accessibility tests.
 
 Assembly | Responsibility
 --- | ---
-AccessibilityInsights.Rules | Provide a library of rules, each of which scans the platform-agnostic information for issues that are likely to be problematic. For example, a button without an accessible label will be flagged as an error.
-AccessibilityInsights.RulesSelection | Select the appropriate set of rules to run on a specific application, then coordinate their execution in a consistent and reproducible way.
+Axe.Windows.Rules | Provide a library of rules, each of which scans the platform-agnostic information for issues that are likely to be problematic. For example, a button without an accessible label will be flagged as an error.
+Axe.Windows.RulesSelection | Coordinate rule execution in a consistent and reproducible way.
 
 #### Application Entry Points
 These assemblies allow user interaction with the Runtime components and the Accessibility Rules.
@@ -40,9 +39,11 @@ Assembly | Responsibility
 --- | ---
 AccessibilityInsights | Provide the UI for most users. This application is built using WPF.
 AccessibilityInsights.CommonUxComponents | Provide non-specialized visual elements used by the main app and extensions. This allows the main app and extensions to share ux components that are unrelated to the runtime.
+AccessibilityInsights.DesktopUI | Provide platform-specific (Windows) implementations of platform-agnostic UI abstractions. This includes things like element highlighters.
+AccessibilityInsights.Extensions | Provide extension points that allow certain non-core functionality to be implemented in a loosely coupled way.
 AccessibilityInsights.SharedUx | Provide visual elements used by the main app. This code is in a separate assembly for historical reasons.
 AccessibilityInsights.WebApiHost | Provide a local service that exposes scanning functionality on locally running applications.
-AccessibilityInsights.Automation | Provide a layer that wraps key actions behind a simplified interface. This layer can then be used either from a .NET application or from PowerShell scripts.
+Axe.Windows.Automation | Provide a layer that wraps key actions behind a simplified interface. This layer can then be used either from a .NET application or from PowerShell scripts.
 
 #### Extensions
 Extensions are intended to allow loose coupling of non-core code. They build upon the [Managed Extensibility Framework](https://docs.microsoft.com/en-us/dotnet/framework/mef/). At the moment, extensions provide the following capabilities:
@@ -72,23 +73,24 @@ The packaging projects exist to gather assemblies into their shipping vehicles:
 Project | Responsibility
 --- | ---
 MSI | Builds the MSI file used by most users.
-ApplicationInsights-CI | Builds the NuGet package that will be used by users who wish to scan via automation.
+AxeWindows-CI | Builds the NuGet package that will be used by users who wish to scan via automation.
 
 #### Tests
 Unit tests are built using a combination of Moq and Microsoft Fakes. The folllowing assemblies exist for testing purposes:
-- AccessibilityInsights.ActionsTests
-- AccessibilityInsights.AutomationTests
-- AccessibilityInsights.CoreTests
-- AccessibilityInsights.DesktopTests
 - AccessibilityInsights.Extensions.AzureDevOpsTests
-- AccessibilityInsights.Extensions.GitHubUnitTests
 - AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests
+- AccessibilityInsights.Extensions.GitHubUnitTests
 - AccessibilityInsights.Extensions.TelemetryTests
 - AccessibilityInsights.ExtensionsTests
 - AccessibilityInsights.Fakes.Prebuild
-- AccessibilityInsights.RuleSelectionTests
-- AccessibilityInsights.RulesTest
 - AccessibilityInsights.SetupLibraryUnitTests
 - AccessibilityInsights.SharedUxTests
 - AccessibilityInsights.WebApiHostTests
-- AccessibilityInsights.Win32Tests 
+- Axe.Windows.ActionsTests
+- Axe.Windows.AutomationTests
+- Axe.Windows.CoreTests
+- Axe.Windows.DesktopTests
+- Axe.Windows.RuleSelectionTests
+- Axe.Windows.RulesTest
+- Axe.Windows.UnitTestSharedLibrary
+- Axe.Windows.Win32Tests 

--- a/docs/RulesOverview.md
+++ b/docs/RulesOverview.md
@@ -19,7 +19,7 @@ Rules have three basic components
 
 ### Inheritence
 
-All rules must inherit from the `AccessibilityInsights.Rules.Rule` base class. Rules are discovered through reflection; when your class inherits from `Rule`,  it is added to the set of rules tested by Accessibility Insights. 
+All rules must inherit from the `Axe.Windows.Rules.Rule` base class. Rules are discovered through reflection; when your class inherits from `Rule`,  it is added to the set of rules tested by Accessibility Insights. 
 
 ### Conventions
 
@@ -49,7 +49,7 @@ Using conditions (described below) makes it possible to represent the evaluation
 
 ### Conditions
 
-Conditions are classses used to represent the properties, patterns, and values of an element in a grammatical form that is reusable, self-describing, and easy to read. All conditions must inherit from the `AccessibilityInsights.Rules.Condition` base class. Conditions have the following features:
+Conditions are classses used to represent the properties, patterns, and values of an element in a grammatical form that is reusable, self-describing, and easy to read. All conditions must inherit from the `Axe.Windows.Rules.Condition` base class. Conditions have the following features:
 
 - A condition evaluates to true or false via its `Matches` method.
 - A condition has an associated text description. Descriptions can be assigned via the index operator, e.g., `Button["Button"]` 
@@ -65,7 +65,7 @@ operator | description | example
 
 When conditions are combined using operators, so too are there associated descriptions, e.g., `(Button & IsKeyboardFocusable)` = "Button and IsKeyboardFocusable". Using this mechanism, all conditions can be written as text strings and used as documentation for the rules.
 
-There are many ready-made conditions you can use from the `AccessibilityInsights.Rules.PropertyConditions` namespace.
+There are many ready-made conditions you can use from the `Axe.Windows.Rules.PropertyConditions` namespace.
 
 ### Future development
 


### PR DESCRIPTION
We want to keep the docs relatively up-to-date, so this reflects the rename to axe-windows for some assemblies. We could probably restructure some of the headings but since this area is still in some flux I don't think it makes sense to do until we have settled fully.