### PR TITLE
New rule for scrollbar structure

### DIFF
--- a/src/AccessibilityInsights.Core/Enums/RuleId.cs
+++ b/src/AccessibilityInsights.Core/Enums/RuleId.cs
@@ -91,6 +91,7 @@ namespace Axe.Windows.Core.Enums
         ControlViewMenuStructure,
         ControlViewProgressBarStructure,
         ControlViewRadioButtonStructure,
+        ControlViewScrollbarStructure,
         ControlViewSemanticZoomStructure,
         ControlViewSeparatorStructure,
         ControlViewSliderStructure,

--- a/src/AccessibilityInsights.Rules/Library/Structure/ControlView/Scrollbar.cs
+++ b/src/AccessibilityInsights.Rules/Library/Structure/ControlView/Scrollbar.cs
@@ -1,0 +1,33 @@
+﻿using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
+using Axe.Windows.Rules.PropertyConditions;
+using Axe.Windows.Rules.Resources;
+using System;
+using System.Globalization;
+using static Axe.Windows.Rules.PropertyConditions.ControlType;
+
+namespace Axe.Windows.Rules.Library
+{
+    [RuleInfo(ID = RuleId.ControlViewScrollbarStructure)]
+    class ControlViewScrollbarStructure : Rule
+    {
+        public ControlViewScrollbarStructure()
+        {
+            this.Info.Description = string.Format(CultureInfo.InvariantCulture, Descriptions.Structure, ControlView.ScrollbarStructure);
+            this.Info.HowToFix = string.Format(CultureInfo.InvariantCulture, HowToFix.Structure, ControlView.ScrollbarStructure);
+            this.Info.Standard = A11yCriteriaId.InfoAndRelationships;
+        }
+
+        public override EvaluationCode Evaluate(IA11yElement e)
+        {
+            if (e == null) throw new ArgumentException(nameof(e));
+
+            return ControlView.ScrollbarStructure.Matches(e) ? EvaluationCode.Pass : EvaluationCode.Note;
+        }
+
+        protected override Condition CreateCondition()
+        {
+            return ScrollBar;
+        }
+    } // class
+} // namespace

--- a/src/AccessibilityInsights.Rules/Library/Structure/ControlView/Scrollbar.cs
+++ b/src/AccessibilityInsights.Rules/Library/Structure/ControlView/Scrollbar.cs
@@ -1,4 +1,6 @@
-﻿using Axe.Windows.Core.Bases;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;

--- a/src/AccessibilityInsights.Rules/PropertyConditions/ControlView.cs
+++ b/src/AccessibilityInsights.Rules/PropertyConditions/ControlView.cs
@@ -30,6 +30,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static Condition MenuStructure = Menu & (RequiresChildren & Children(MenuItem));
         public static Condition ProgressBarStructure = ProgressBar & NoChildren;
         public static Condition RadioButtonStructure = RadioButton & NoChildren;
+        public static Condition ScrollbarStructure = CreateScrollbarStructureCondition();
         public static Condition SemanticZoomStructure = SemanticZoom & (NoChildren | Children(List | ListItem))[ConditionDescriptions.Parentheses];
         public static Condition SeparatorStructure = Separator & NoChildren;
         public static Condition SliderStructure = CreateSliderStructureCondition();
@@ -98,6 +99,21 @@ namespace Axe.Windows.Rules.PropertyConditions
             var allChildren = (NoChildren | Children(Header | DataItem))[P];
 
             return DataGrid & headers & allChildren;
+        }
+
+        private static Condition CreateScrollbarStructureCondition()
+        {
+            // from https://docs.microsoft.com/en-us/windows/desktop/winauto/uiauto-supportscrollbarcontroltype
+
+            var P = ConditionDescriptions.Parentheses;
+
+            var buttons = (ChildCount(Button) == 0
+                | ChildCount(Button) == 2
+                | ChildCount(Button) == 4)[P];
+
+            var thumb = ChildCount(Thumb) == 0 | ChildCount(Thumb) == 1;
+
+            return ScrollBar & buttons & thumb;
         }
 
         private static Condition CreateSliderStructureCondition()

--- a/src/AccessibilityInsights.Rules/Rules.csproj
+++ b/src/AccessibilityInsights.Rules/Rules.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Library\ParentChildShouldNotHaveSameNameAndLocalizedControlType.cs" />
     <Compile Include="Library\SelectionItemPatternSingleSelection.cs" />
     <Compile Include="Library\ListItemSiblingsUnique.cs" />
+    <Compile Include="Library\Structure\ControlView\Scrollbar.cs" />
     <Compile Include="Misc\ControlTypeStrings.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/AccessibilityInsights.RulesTest/Library/Structure/ControlView/ScrollbarTest.cs
+++ b/src/AccessibilityInsights.RulesTest/Library/Structure/ControlView/ScrollbarTest.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using EvaluationCode = Axe.Windows.Rules.EvaluationCode;
+
+namespace Axe.Windows.RulesTest.Library
+{
+    [TestClass]
+    public class ControlViewScrollbarStructureTest
+    {
+        private static Rules.IRule Rule = new Rules.Library.ControlViewScrollbarStructure();
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ScrollbarNoChildren_Pass()
+        {
+            var m = new Mock<IA11yElement>();
+            m.Setup(e => e.ControlTypeId).Returns(Core.Types.ControlType.UIA_ScrollBarControlTypeId);
+            
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(m.Object));
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ScrollbarOneButton_Note()
+        {
+            var m = new Mock<IA11yElement>();
+            m.Setup(e => e.ControlTypeId).Returns(Core.Types.ControlType.UIA_ScrollBarControlTypeId);
+            m.Setup(e => e.Children).Returns(() => GenerateElementsWithControlTypes(new Dictionary<int, int>() {
+                { Core.Types.ControlType.UIA_ButtonControlTypeId, 1 },
+            }));
+
+            Assert.AreEqual(EvaluationCode.Note, Rule.Evaluate(m.Object));
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ScrollbarTwoButtons_Pass()
+        {
+            var m = new Mock<IA11yElement>();
+            m.Setup(e => e.ControlTypeId).Returns(Core.Types.ControlType.UIA_ScrollBarControlTypeId);
+            m.Setup(e => e.Children).Returns(() => GenerateElementsWithControlTypes(new Dictionary<int, int>() {
+                { Core.Types.ControlType.UIA_ButtonControlTypeId, 2 },
+            }));
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(m.Object));
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ScrollbarFourButtons_Pass()
+        {
+            var m = new Mock<IA11yElement>();
+            m.Setup(e => e.ControlTypeId).Returns(Core.Types.ControlType.UIA_ScrollBarControlTypeId);
+            m.Setup(e => e.Children).Returns(() => GenerateElementsWithControlTypes(new Dictionary<int, int>() {
+                { Core.Types.ControlType.UIA_ButtonControlTypeId, 4 },
+            }));
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(m.Object));
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ScrollbarFourButtonsOneThumb_Pass()
+        {
+            var m = new Mock<IA11yElement>();
+            m.Setup(e => e.ControlTypeId).Returns(Core.Types.ControlType.UIA_ScrollBarControlTypeId);
+            m.Setup(e => e.Children).Returns(() => GenerateElementsWithControlTypes(new Dictionary<int, int>() {
+                { Core.Types.ControlType.UIA_ButtonControlTypeId, 4 },
+                { Core.Types.ControlType.UIA_ThumbControlTypeId, 1 },
+            }));
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(m.Object));
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ScrollbarFourButtonsTwoThumbs_Note()
+        {
+            var m = new Mock<IA11yElement>();
+            m.Setup(e => e.ControlTypeId).Returns(Core.Types.ControlType.UIA_ScrollBarControlTypeId);
+            m.Setup(e => e.Children).Returns(() => GenerateElementsWithControlTypes(new Dictionary<int, int>() {
+                { Core.Types.ControlType.UIA_ButtonControlTypeId, 4 },
+                { Core.Types.ControlType.UIA_ThumbControlTypeId, 2 },
+            }));
+
+            Assert.AreEqual(EvaluationCode.Note, Rule.Evaluate(m.Object));
+        }
+
+        /// <summary>
+        /// Returns a sequence of elements with the given distribution of control types,
+        /// </summary>
+        /// <param name="controlTypeCounts">mapping from control type to number of elements for that type</param>
+        /// <returns>sequence of elements with given control type counts</returns>
+        private IEnumerable<IA11yElement> GenerateElementsWithControlTypes(Dictionary<int, int> controlTypeCounts)
+        {
+            return controlTypeCounts.Keys.SelectMany(controlType =>
+            {
+                return Enumerable.Range(0, controlTypeCounts[controlType]).Select(_ =>
+                {
+                    var m = new Mock<IA11yElement>();
+                    m.Setup(e => e.ControlTypeId).Returns(controlType);
+                    return m.Object;
+                });
+            });
+        }
+    } // class
+} // namespace

--- a/src/AccessibilityInsights.RulesTest/Library/Structure/ControlView/ScrollbarTest.cs
+++ b/src/AccessibilityInsights.RulesTest/Library/Structure/ControlView/ScrollbarTest.cs
@@ -19,7 +19,7 @@ namespace Axe.Windows.RulesTest.Library
         public void ScrollbarNoChildren_Pass()
         {
             var m = new Mock<IA11yElement>();
-            m.Setup(e => e.ControlTypeId).Returns(Core.Types.ControlType.UIA_ScrollBarControlTypeId);
+            m.Setup(e => e.ControlTypeId).Returns(ControlType.ScrollBar);
             
             Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(m.Object));
         }

--- a/src/AccessibilityInsights.RulesTest/Library/Structure/ControlView/ScrollbarTest.cs
+++ b/src/AccessibilityInsights.RulesTest/Library/Structure/ControlView/ScrollbarTest.cs
@@ -98,15 +98,24 @@ namespace Axe.Windows.RulesTest.Library
         /// <returns>sequence of elements with given control type counts</returns>
         private IEnumerable<IA11yElement> GenerateElementsWithControlTypes(Dictionary<int, int> controlTypeCounts)
         {
-            return controlTypeCounts.Keys.SelectMany(controlType =>
+            return controlTypeCounts.SelectMany(controlTypeToCount => 
+                GenerateElementsWithControlType(controlTypeToCount.Key, controlTypeToCount.Value));
+        }
+
+        /// <summary>
+        /// Returns a sequence of {count} elements with the {controlType} control type
+        /// </summary>
+        /// <param name="controlType"></param>
+        /// <param name="count"></param>
+        /// <returns></returns>
+        private IEnumerable<IA11yElement> GenerateElementsWithControlType(int controlType, int count)
+        {
+            for (int i = 0; i < count; i++)
             {
-                return Enumerable.Range(0, controlTypeCounts[controlType]).Select(_ =>
-                {
-                    var m = new Mock<IA11yElement>();
-                    m.Setup(e => e.ControlTypeId).Returns(controlType);
-                    return m.Object;
-                });
-            });
+                var m = new Mock<IA11yElement>();
+                m.Setup(e => e.ControlTypeId).Returns(controlType);
+                yield return m.Object;
+            }
         }
     } // class
 } // namespace

--- a/src/AccessibilityInsights.RulesTest/RulesTests.csproj
+++ b/src/AccessibilityInsights.RulesTest/RulesTests.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Library\SiblingUniqueAndNotFocusableTest.cs" />
     <Compile Include="Library\HeadingLevelDescendsWhenNestedTest.cs" />
     <Compile Include="Library\LocalizedLandmarkTypeNotCustomTests.cs" />
+    <Compile Include="Library\Structure\ControlView\ScrollbarTest.cs" />
     <Compile Include="Library\UWPTest.cs" />
     <Compile Include="PatternIDs.cs" />
     <Compile Include="PropertyConditions\BoolPropertiesTest.cs" />


### PR DESCRIPTION
#### Describe the change
(Please provide an overview of the change in this PR)

This PR adds a rule that checks whether Control View scrollbars adhere to the structure given here: https://docs.microsoft.com/en-us/windows/desktop/WinAuto/uiauto-supportscrollbarcontroltype

It is partly in response to issue #274 - when a complex structure like a tab has children controls like a scrollbar, the scrollbar's children can be checked using this rule instead of checking the full tree at the tab-level.



