### PR TITLE
Fixed two spinner Content/Control view issues.

### DIFF
--- a/src/AccessibilityInsights.Rules/PropertyConditions/ContentView.cs
+++ b/src/AccessibilityInsights.Rules/PropertyConditions/ContentView.cs
@@ -28,7 +28,7 @@ namespace Axe.Windows.Rules.PropertyConditions
         public static Condition ProgressBarStructure = ProgressBar & NoChildren;
         public static Condition RadioButtonStructure = RadioButton & NoChildren;
         public static Condition SliderStructure = Slider & (NoChildren | Children(ListItem))[ConditionDescriptions.Parentheses];
-        public static Condition SpinnerStructure = Spinner & NoChildren;
+        public static Condition SpinnerStructure = Spinner & (NoChildren | Children(ListItem))[ConditionDescriptions.Parentheses];
         public static Condition SplitButtonStructure = CreateSplitButtonStructureCondition();
         public static Condition StatusBarStructure = StatusBar & (NoChildren | Children(Button | Edit | Image | ProgressBar))[ConditionDescriptions.Parentheses];
         public static Condition TabStructure = Tab & (RequiresChildren & Children(Group | TabItem));

--- a/src/AccessibilityInsights.Rules/PropertyConditions/ControlView.cs
+++ b/src/AccessibilityInsights.Rules/PropertyConditions/ControlView.cs
@@ -123,7 +123,7 @@ namespace Axe.Windows.Rules.PropertyConditions
             var buttons = ChildCount(Button) == 2;
             var edit = ChildCount(Edit) <= 1;
 
-            var allChildren = Children(Button | Edit);
+            var allChildren = Children(Button | Edit | ListItem);
 
             return Spinner & buttons & edit & allChildren;
         }

--- a/src/AccessibilityInsights.RulesTest/Library/Structure/ContentView/SpinnerTests.cs
+++ b/src/AccessibilityInsights.RulesTest/Library/Structure/ContentView/SpinnerTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Rules;
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Axe.Windows.RulesTest.Library.Structure.ContentView
+{
+    [TestClass]
+    public class SpinnerTests
+    {
+        private readonly static IRule Rule = new Axe.Windows.Rules.Library.ContentViewSpinnerStructure();
+
+        [TestMethod]
+        public void Spinner_ZeroListItemChildren_Pass()
+        {
+            var spinner = new MockA11yElement();
+            spinner.ControlTypeId = ControlType.Spinner;
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(spinner));
+        }
+
+        [TestMethod]
+        public void Spinner_ListItemChildren_Pass()
+        {
+            var spinner = new MockA11yElement();
+            spinner.ControlTypeId = ControlType.Spinner;
+
+            var listItem = new MockA11yElement();
+            listItem.ControlTypeId = ControlType.ListItem;
+
+            spinner.Children.Add(listItem);
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(spinner));
+        }
+    } // class
+} // namespace

--- a/src/AccessibilityInsights.RulesTest/Library/Structure/ControlView/SpinnerTests.cs
+++ b/src/AccessibilityInsights.RulesTest/Library/Structure/ControlView/SpinnerTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Rules;
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Axe.Windows.RulesTest.Library.Structure.ControlView
+{
+    [TestClass]
+    public class SpinnerTests
+    {
+        private readonly static IRule Rule = new Axe.Windows.Rules.Library.ControlViewSpinnerStructure();
+
+        [TestMethod]
+        public void Spinner_ZeroListItemChildren_Pass()
+        {
+            var spinner = new MockA11yElement();
+            spinner.ControlTypeId = ControlType.Spinner;
+
+            var button1 = new MockA11yElement();
+            button1.ControlTypeId = ControlType.Button;
+
+            var button2 = new MockA11yElement();
+            button2.ControlTypeId = ControlType.Button;
+
+            spinner.Children.Add(button1);
+            spinner.Children.Add(button2);
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(spinner));
+        }
+
+        [TestMethod]
+        public void Spinner_ListItemChildren_Pass()
+        {
+            var spinner = new MockA11yElement();
+            spinner.ControlTypeId = ControlType.Spinner;
+
+            var button1 = new MockA11yElement();
+            button1.ControlTypeId = ControlType.Button;
+
+            var button2 = new MockA11yElement();
+            button2.ControlTypeId = ControlType.Button;
+
+            var listItem = new MockA11yElement();
+            listItem.ControlTypeId = ControlType.ListItem;
+
+            spinner.Children.Add(button1);
+            spinner.Children.Add(button2);
+            spinner.Children.Add(listItem);
+
+            Assert.AreEqual(EvaluationCode.Pass, Rule.Evaluate(spinner));
+        }
+    } // class
+} // namespace

--- a/src/AccessibilityInsights.RulesTest/RulesTests.csproj
+++ b/src/AccessibilityInsights.RulesTest/RulesTests.csproj
@@ -114,6 +114,8 @@
     <Compile Include="Library\SiblingUniqueAndNotFocusableTest.cs" />
     <Compile Include="Library\HeadingLevelDescendsWhenNestedTest.cs" />
     <Compile Include="Library\LocalizedLandmarkTypeNotCustomTests.cs" />
+    <Compile Include="Library\Structure\ContentView\SpinnerTests.cs" />
+    <Compile Include="Library\Structure\ControlView\SpinnerTests.cs" />
     <Compile Include="Library\UWPTest.cs" />
     <Compile Include="PatternIDs.cs" />
     <Compile Include="PropertyConditions\BoolPropertiesTest.cs" />


### PR DESCRIPTION
- Issue #272 ControlViewSpinnerStructure should allow ListItem
- Issue #268 ContentViewSpinnerStructure should allow ListItem

In both cases, the code now allows for 0 or more ListItem children of the spinner control.

Note: Keen observers of the documentation may notice that list items are permitted only when the Selection control pattern is present, and such a check is not done in this code. This is a shortcoming of several of the content/control view rules. However, since no rules currently check for such patterns, it is not the intent to remedy that as part of this change.

Another such failing is that the children are not actually checked to make sure they have the IsContentElement or IsControlElement properties set to true. This failing is common throughout these rules. And again, there is no intent to remedy that as part of this change.

#### Describe the change
(Please provide an overview of the change in this PR)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



