### PR TITLE
Update test to ensure any ValuePattern info for Text controls is also exposed via the name property

### DIFF
--- a/src/AccessibilityInsights.Rules/Library/ControlShouldNotSupportValuePattern.cs
+++ b/src/AccessibilityInsights.Rules/Library/ControlShouldNotSupportValuePattern.cs
@@ -3,6 +3,7 @@
 using System;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Enums;
+using Axe.Windows.Core.Types;
 using Axe.Windows.Rules.PropertyConditions;
 using Axe.Windows.Rules.Resources;
 using static Axe.Windows.Rules.PropertyConditions.ControlType;
@@ -22,15 +23,19 @@ namespace Axe.Windows.Rules.Library
         public override EvaluationCode Evaluate(IA11yElement e)
         {
             if (e == null) throw new ArgumentException(nameof(e));
+            
+            var name = e.Name.Trim().ToLower();
+            var value = e.GetPattern(PatternType.UIA_ValuePatternId).GetValue<string>("Value").Trim().ToLower();
 
-            return Patterns.Value.Matches(e) ? EvaluationCode.Warning : EvaluationCode.Pass;
+            bool valuePatternExceedsName = value.Length > e.Name.Length || !name.Contains(value);
+            return valuePatternExceedsName ? EvaluationCode.Error : EvaluationCode.Pass;
         }
 
         protected override Condition CreateCondition()
         {
             // Removed Calendar, even though it is specified in MSDN
             // This seems to be an error in the documentation, or at least it seems to no longer be valid
-            return Text;
+            return Text & Patterns.Value & ValuePattern.ValueProperty.NotNullOrEmpty;
         }
     } // class
 } // namespace

--- a/src/AccessibilityInsights.Rules/PropertyConditions/ValuePattern.cs
+++ b/src/AccessibilityInsights.Rules/PropertyConditions/ValuePattern.cs
@@ -1,0 +1,19 @@
+﻿using Axe.Windows.Core.Bases;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Axe.Windows.Rules.PropertyConditions
+{
+    /// <summary>
+    /// Contains commonly used conditions for testing against the Value pattern of an IA11yElement.
+    /// </summary>
+    static class ValuePattern
+    {
+        public const string ValuePropertyString = "Value";
+        public static StringProperty ValueProperty = new StringProperty(e => 
+            e.GetPattern(Core.Types.PatternType.UIA_ValuePatternId)?.GetValue<string>(ValuePropertyString));
+    }
+}

--- a/src/AccessibilityInsights.Rules/PropertyConditions/ValuePattern.cs
+++ b/src/AccessibilityInsights.Rules/PropertyConditions/ValuePattern.cs
@@ -1,4 +1,6 @@
-﻿using Axe.Windows.Core.Bases;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,7 +10,7 @@ using System.Threading.Tasks;
 namespace Axe.Windows.Rules.PropertyConditions
 {
     /// <summary>
-    /// Contains commonly used conditions for testing against the Value pattern of an IA11yElement.
+    /// Exposes the value property to enable condition matching against the Value pattern of an IA11yElement.
     /// </summary>
     static class ValuePattern
     {

--- a/src/AccessibilityInsights.Rules/Rules.csproj
+++ b/src/AccessibilityInsights.Rules/Rules.csproj
@@ -244,6 +244,7 @@
     <Compile Include="Library\NameWithValidBoundingRectangle.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyConditions\UWP.cs" />
+    <Compile Include="PropertyConditions\ValuePattern.cs" />
     <Compile Include="Resources\ConditionDescriptions.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/AccessibilityInsights.RulesTest/Library/ControlShouldNotSupportValuePatternTests.cs
+++ b/src/AccessibilityInsights.RulesTest/Library/ControlShouldNotSupportValuePatternTests.cs
@@ -1,0 +1,69 @@
+﻿using Axe.Windows.Core.Bases;
+using Axe.Windows.Rules;
+using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Axe.Windows.RulesTest.Library
+{
+    [TestClass]
+    public class ControlShouldNotSupportValuePatternTests
+    {
+        private Rules.IRule Rule = new Rules.Library.ControlShouldNotSupportValuePattern();
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void NoValuePattern_NotApplicable()
+        {
+            var element = new Mock<IA11yElement>();
+            Assert.IsFalse(this.Rule.Condition.Matches(element.Object));
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void EmptyValue_NotApplicable()
+        {
+            var element = GetTextControlWithValueAndName(string.Empty, string.Empty);
+            Assert.IsFalse(this.Rule.Condition.Matches(element.Object));
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void IdenticalValueName_Pass()
+        {
+            var element = GetTextControlWithValueAndName(value: "12 APPLES", name: "12 apples");
+            var res = this.Rule.Condition.Matches(element.Object);
+            Assert.IsTrue(res);
+            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(element.Object));
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ValueContainedInName_Pass()
+        {
+            var element = GetTextControlWithValueAndName(value: "APPLES", name: "12 apples");
+            Assert.IsTrue(this.Rule.Condition.Matches(element.Object));
+            Assert.AreEqual(EvaluationCode.Pass, this.Rule.Evaluate(element.Object));
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void ValueExceedsName_Fail()
+        {
+            var element = GetTextControlWithValueAndName(value: "12 apples", name: "APPLES");
+            Assert.IsTrue(this.Rule.Condition.Matches(element.Object));
+            Assert.AreEqual(EvaluationCode.Error, this.Rule.Evaluate(element.Object));
+        }
+
+        private Mock<IA11yElement> GetTextControlWithValueAndName(string value, string name = null)
+        {
+            var patternMock = new Mock<IA11yPattern>();
+            var element = new Mock<IA11yElement>();
+            patternMock.Setup(m => m.GetValue<string>(ValuePattern.ValuePropertyString)).Returns(value);
+            element.Setup(m => m.GetPattern(Core.Types.PatternType.UIA_ValuePatternId)).Returns(patternMock.Object);
+            element.Setup(m => m.Name).Returns(name);
+            element.Setup(m => m.ControlTypeId).Returns(ControlType.Text);
+            return element;
+        }
+    }
+}

--- a/src/AccessibilityInsights.RulesTest/Library/ControlShouldNotSupportValuePatternTests.cs
+++ b/src/AccessibilityInsights.RulesTest/Library/ControlShouldNotSupportValuePatternTests.cs
@@ -1,4 +1,6 @@
-﻿using Axe.Windows.Core.Bases;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/AccessibilityInsights.RulesTest/MonsterTest.cs
+++ b/src/AccessibilityInsights.RulesTest/MonsterTest.cs
@@ -922,7 +922,7 @@ namespace Axe.Windows.RulesTest
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ControlShouldNotSupportScrollPattern]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ControlShouldNotSupportTablePattern]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ControlShouldNotSupportTogglePattern]);
-            Assert.AreEqual(EvaluationCode.Pass, results[RuleId.ControlShouldNotSupportValuePattern]);
+            Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ControlShouldNotSupportValuePattern]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ControlShouldNotSupportWindowPattern]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ControlShouldSupportExpandCollapsePattern]);
             Assert.AreEqual(EvaluationCode.NotApplicable, results[RuleId.ControlShouldSupportGridItemPattern]);

--- a/src/AccessibilityInsights.RulesTest/PropertyConditions/ValuePatternTests.cs
+++ b/src/AccessibilityInsights.RulesTest/PropertyConditions/ValuePatternTests.cs
@@ -1,4 +1,6 @@
-﻿using Axe.Windows.Core.Bases;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Core.Bases;
 using Axe.Windows.Rules.PropertyConditions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;

--- a/src/AccessibilityInsights.RulesTest/PropertyConditions/ValuePatternTests.cs
+++ b/src/AccessibilityInsights.RulesTest/PropertyConditions/ValuePatternTests.cs
@@ -1,0 +1,23 @@
+﻿using Axe.Windows.Core.Bases;
+using Axe.Windows.Rules.PropertyConditions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Axe.Windows.RulesTest.PropertyConditions
+{
+    [TestClass]
+    public class ValuePatternTests
+    {
+        [TestMethod]
+        [Timeout(1000)]
+        public void ValueProperty_ReturnsCorrectStringProperty()
+        {
+            var fakeValue = "hello";
+            var patternMock = new Mock<IA11yPattern>();
+            var element = new Mock<IA11yElement>();
+            patternMock.Setup(m => m.GetValue<string>(ValuePattern.ValuePropertyString)).Returns(fakeValue);
+            element.Setup(m => m.GetPattern(Core.Types.PatternType.UIA_ValuePatternId)).Returns(patternMock.Object);
+            Assert.IsTrue(ValuePattern.ValueProperty.Is(fakeValue).Matches(element.Object));
+        }
+    }
+}

--- a/src/AccessibilityInsights.RulesTest/RulesTests.csproj
+++ b/src/AccessibilityInsights.RulesTest/RulesTests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Library\ComboBoxShouldNotSupportScrollPatternTests.cs" />
     <Compile Include="Library\ControlShouldNotSupportInvokePattern.cs" />
     <Compile Include="Library\ControlShouldNotSupportScrollPatternTests.cs" />
+    <Compile Include="Library\ControlShouldNotSupportValuePatternTests.cs" />
     <Compile Include="Library\ControlShouldSupportSetInfoTest.cs" />
     <Compile Include="Library\ControlShouldSupportTablePattern.cs" />
     <Compile Include="Library\IsKeyboardFocusableTopLevelTextPattern.cs" />
@@ -151,6 +152,7 @@
     <Compile Include="PropertyConditions\EnumPropertyUnitTests.cs" />
     <Compile Include="PropertyConditions\ElementGroupsTests.cs" />
     <Compile Include="PropertyConditions\ValueConditionUnitTests.cs" />
+    <Compile Include="PropertyConditions\ValuePatternTests.cs" />
     <Compile Include="RulesProviderTests.cs" />
     <Compile Include="CCAControlTypesFilterTest.cs" />
   </ItemGroup>


### PR DESCRIPTION
This change updates the rules in response to #270 so that the name property is considered. Specifically, any Text controls that support the ValuePattern should not provide extra information via the value that is not already in the name.