### PR TITLE
Issue [#298] - direct link from What's new page to release-specific page

### DIFF
--- a/src/AccessibilityInsights.SetupLibrary/MsiUtilities.cs
+++ b/src/AccessibilityInsights.SetupLibrary/MsiUtilities.cs
@@ -4,6 +4,7 @@ using Microsoft.Deployment.WindowsInstaller;
 using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace AccessibilityInsights.SetupLibrary
@@ -88,11 +89,29 @@ namespace AccessibilityInsights.SetupLibrary
         }
 
         /// <summary>
+        /// Get the Uri to the release notes, based on the installed version
+        /// </summary>
+        /// <param name="exceptionReporter">Allows exceptions to get tracked</param>
+        /// <returns>The Uri if available, null if not</returns>
+        public static Uri GetReleaseNotesUri(IExceptionReporter exceptionReporter)
+        {
+            string version = GetInstalledProductVersion(exceptionReporter);
+            if (!string.IsNullOrEmpty(version))
+            {
+                return new Uri(string.Format(CultureInfo.InvariantCulture,
+                    "https://github.com/Microsoft/accessibility-insights-windows/releases/tag/v{0}",
+                    version));
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Returns the product version of the file at the given path
         /// </summary>
         /// <param name="pathToMSI">The path to the MSI being queried</param>
         /// <returns>The product version in string format</returns>
-            internal static string GetMSIProductVersion(string pathToMSI)
+        internal static string GetMSIProductVersion(string pathToMSI)
         {
             using (Database db = new Database(pathToMSI, DatabaseOpenMode.ReadOnly))
             {

--- a/src/AccessibilityInsights.SharedUx/Misc/SetupExceptionReporter.cs
+++ b/src/AccessibilityInsights.SharedUx/Misc/SetupExceptionReporter.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SetupLibrary;
+using AccessibilityInsights.SharedUx.Telemetry;
+using System;
+
+namespace AccessibilityInsights.SharedUx.Misc
+{
+    /// <summary>
+    /// Class to pass as an IExceptionReporter when calling into SetupLibrary
+    /// </summary>
+    public class SetupExceptionReporter : IExceptionReporter
+    {
+        /// <summary>
+        /// Implements <see cref="IExceptionReporter.ReportException(Exception)"/>
+        /// </summary>
+        /// <param name="exception">The Exception being reported</param>
+        public void ReportException(Exception exception)
+        {
+            exception.ReportException();
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -380,6 +380,7 @@
     <Compile Include="Enums\EventConfigNodeType.cs" />
     <Compile Include="Interfaces\ICCAMode.cs" />
     <Compile Include="Misc\ListViewSelectionLock.cs" />
+    <Compile Include="Misc\SetupExceptionReporter.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/AccessibilityInsights/Modes/StartUpModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/StartUpModeControl.xaml.cs
@@ -11,10 +11,10 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Navigation;
-using System.Windows.Automation.Peers;
 
 namespace AccessibilityInsights.Modes
 {

--- a/src/AccessibilityInsights/Modes/StartUpModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/StartUpModeControl.xaml.cs
@@ -1,19 +1,20 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.CommonUxComponents.Dialogs;
+using AccessibilityInsights.SetupLibrary;
+using AccessibilityInsights.SharedUx.Controls.CustomControls;
 using AccessibilityInsights.SharedUx.Interfaces;
+using AccessibilityInsights.SharedUx.Misc;
+using AccessibilityInsights.SharedUx.Settings;
 using System;
+using System.Diagnostics;
+using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Navigation;
-using AccessibilityInsights.SharedUx.Settings;
 using System.Windows.Automation.Peers;
-using System.Diagnostics;
-using AccessibilityInsights.SharedUx.Dialogs;
-using AccessibilityInsights.SharedUx.Controls.CustomControls;
-using System.Globalization;
-using AccessibilityInsights.CommonUxComponents.Dialogs;
 
 namespace AccessibilityInsights.Modes
 {
@@ -78,6 +79,12 @@ namespace AccessibilityInsights.Modes
         {
             this.VersionString = Axe.Windows.Core.Misc.Utility.GetAppVersion();
             InitializeComponent();
+            // If possible, point to build-specific release notes
+            Uri releaseNotesUri = MsiUtilities.GetReleaseNotesUri(new SetupExceptionReporter());
+            if (releaseNotesUri != null)
+            {
+                hlLink.NavigateUri = releaseNotesUri;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
#### Describe the change
Make the release notes page in the What's New dialog point to a release-specific page, instead of a generic page in the docs. This makes it work for all channels, and eventually lets us reduce the amount of duplicated content that we need to maintain

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - [#298]
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Uri before change was a fwlink that pointed to https://accessibilityinsights.io/docs/en/windows/reference/releases. 
Uri after the change is build-specific. With build 1.1.0831.02 installed, it points to https://github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.0831.02.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



