### PR TITLE
Include ContextProperties in reported exceptions

### DIFF
--- a/src/AccessibilityInsights.Extensions.Telemetry/AITelemetry.cs
+++ b/src/AccessibilityInsights.Extensions.Telemetry/AITelemetry.cs
@@ -111,7 +111,7 @@ namespace AccessibilityInsights.Extensions.Telemetry
             {
                 try
                 {
-                    TClient.TrackException(e);
+                    TClient.TrackException(e, ContextProperties);
                 }
                 catch { } // Don't try to report this Exception
             }


### PR DESCRIPTION
#### Describe the change
ContextProperties are intended to be included on all client telemetry, and are properly being sent on all published actions, but they are not included on Exceptions. As a result, it's much more difficult to use Exception telemetry in a meaningful way. This change adds the ContextProperties into the Exception data stream

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

I've forced an Exception on my local build, and confirmed that the following customDimension field is included in the Exception telemetry, with the following values:

AppSessionID = 5aa1b757-ec2e-4c52-8f4b-42ae7c8db0ce
InstallationID = f30ece9b-90a3-4e51-8d14-5ef47b54c1d7
ModeName  = Inspect
ModeSessionId = 4e38fd7c-1b11-43b1-8072-d7f62846ce12
ReleaseChannel = Insider
SessionType = Desktop
Version = 1.1.836.1
View = Live


> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



