### PR TITLE
Simplify bug URLs with special characters

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
@@ -499,8 +499,8 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
             var sb = new StringBuilder();
             foreach (var c in str)
             {
-                // Extended ascii characters such as the middle dot can 
-                // cause issues during navigation redirects, so we only include
+                // characters such as the middle dot (ascii 183) can 
+                // cause issues during navigation, so we only include
                 // a basic set of characters when building the URL
                 if (c >= 1 && c <= 127)
                 {

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
@@ -489,7 +489,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         }
 
         /// <summary>
-        /// Retains characters within ascii range 1-127 and returns
+        /// Retains characters within ascii range below 127 and returns
         /// an escaped representation of the string
         /// </summary>
         /// <param name="str"></param>
@@ -502,7 +502,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                 // characters such as the middle dot (ascii 183) can 
                 // cause issues during navigation, so we only include
                 // a basic set of characters when building the URL
-                if (c >= 1 && c <= 127)
+                if (c <= 127)
                 {
                     sb.Append(c);
                 }


### PR DESCRIPTION
#### Describe the change

This PR proactively limits the characters allowed in the Azure DevOps bug URLs to a basic (e.g. < 127 ascii) set to limit navigation issues. For example, filing a bug from any rule with how-to-fix text containing the middle dot · character can lead to a redirect loop if the user signs out from the hosted web browser prior to filing the issue. After this PR, filing an issue from any of these rules properly navigates to the page. Any non-basic characters are omitted from the text.


