### PR TITLE
fixing a typo in 'to file issues' error message

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1024,7 +1024,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Auto-detect an element’s color contrast ratio by hovering over, or keyboard focusing on an element in your target application..
+        ///   Looks up a localized string similar to Auto-detect an element’s color contrast ratio by hovering over or keyboard focusing on an element in your target application..
         /// </summary>
         public static string ColorContrast_HowToTestAuto {
             get {
@@ -3488,7 +3488,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to o file issues, select where you want to file issues..
+        ///   Looks up a localized string similar to To file issues, select where you want to file issues..
         /// </summary>
         public static string ScannerResultControl_btnFileBug_Click_File_Issue_Configure {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -935,7 +935,7 @@ Accessibility Insights Support Team
     <value>Passed and Uncertain tests</value>
   </data>
   <data name="ScannerResultControl_btnFileBug_Click_File_Issue_Configure" xml:space="preserve">
-    <value>o file issues, select where you want to file issues.</value>
+    <value>To file issues, select where you want to file issues.</value>
   </data>
   <data name="ScannerResultControl_btnFileBug_Click_There_was_an_error_identifying_the_created_bug_This_may_occur_if_the_ID_used_to_create_the_bug_is_removed_from_its_AzureDevOps_description_Attachments_have_not_been_uploaded" xml:space="preserve">
     <value>There was an error identifying the created bug. This may occur if the ID used to create the bug is removed from its Azure DevOps description. Attachments have not been uploaded.</value>


### PR DESCRIPTION
This PR fixes #306 . The PR also includes an updated comment for a different resource string.