### PR TITLE
Move Microsoft.Deployment.Windows.Installer.dll up to main app

### DIFF
--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -67,6 +67,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
               <File Source="..\AccessibilityInsights\bin\Release\AccessibilityInsights.SharedUx.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\AccessibilityInsights.SharedUx.dll.config" />
               <File Source="..\AccessibilityInsights\bin\Release\Axe.Windows.Win32.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\Microsoft.Deployment.WindowsInstaller.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\AccessibilityInsights.exe.config" />
               <File Source="..\AccessibilityInsights\bin\Release\Newtonsoft.Json.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\Sarif.dll" />
@@ -100,8 +101,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
                    <!-- AutoUpdate Extension Assemblies -->
                    <File Source="..\AccessibilityInsights.Extensions.GitHubAutoUpdate\bin\Release\AccessibilityInsights.Extensions.GitHubAutoUpdate.dll" Id="autoupdate_extension"/>
-                   <File Source="..\AccessibilityInsights.Extensions.GitHubAutoUpdate\bin\Release\Microsoft.Deployment.WindowsInstaller.dll" Id="windowsinstaller_extension"/>
-                   <File Source="..\AccessibilityInsights.Extensions.GitHubAutoUpdate\bin\Release\Newtonsoft.Json.dll" Id="newtonsoft_json_extension"/>
 
                    <!-- Telemetry Extension Assemblies -->
                    <File Source="..\AccessibilityInsights.Extensions.Telemetry\bin\Release\AccessibilityInsights.Extensions.Telemetry.dll" Id="telemetry_extension"/>


### PR DESCRIPTION
#### Describe the change
Build 1.1.835.1 introduced a change that caused the app to hang when starting on a specific machine. The root cause was that Microsoft.Deployment.WindowsInstaller.dll wasn't being found because it was installed as part of an extension instead of part of the app. Most machines successfully loaded the assembly as part of the AutoUpdate code--it's not clear why this machine behaves differently, but it's 100% reproducible on this machine. This change moves the assembly into the same folder as the main app so it will reliably be found when needed, either by the main app or by the AutoUpdate code.

Tested in 2 stages:
1. On an affected machine, manually moved Microsoft.Deployment.WindowsInstaller.dll to the app folder and successfully launched the app
2. Built a private MSI, installed it on the affected machine, and successfully launched the app

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #317
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



