### PR TITLE
Code was dropping telemetry if conflicting properties were being set

### DIFF
--- a/src/AccessibilityInsights.Extensions.Telemetry/AITelemetry.cs
+++ b/src/AccessibilityInsights.Extensions.Telemetry/AITelemetry.cs
@@ -76,7 +76,7 @@ namespace AccessibilityInsights.Extensions.Telemetry
 
             foreach (var pair in props)
             {
-                aiEvent.Properties.Add(pair);
+                aiEvent.Properties[pair.Key] = pair.Value;
             }
         }
 


### PR DESCRIPTION
#### Describe the change
Telemetry has 2 sets of properties--context properties and event-specific properties. The intent is that event-specific properties will take precedence over context properties if the same key exists in both sets of properties.

The code to merge was using the Dictionary.Add method, which throws an ArgumentException if the key being added already exists. To merge properly, we need to use the syntax that overrides an existing key.

(Found this while running bug filing inside the debugger, with the telemetry extension enabled)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



