### PR TITLE
Substituting characters to be more friendly to bug-url generation

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
@@ -491,27 +491,43 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         }
 
         /// <summary>
-        /// Retains characters within ascii range below 127 and returns
-        /// an escaped representation of the string
+        /// Substitutions for characters when creating the bug URL
+        /// </summary>
+        internal static IReadOnlyDictionary<char, char> CharacterSubstitutions = new Dictionary<char, char>()
+        {
+            { '·', '-' }, // middle dot (183) to dash (45)
+        };
+
+        /// <summary>
+        /// replaces characters if substitution defined and
+        /// returns an escaped representation of the string
         /// </summary>
         /// <param name="str"></param>
         /// <returns></returns>
         internal static string EscapeForUrl(string str)
         {
+            // characters such as the middle dot (ascii 183) can 
+            // cause issues during navigation, so we only allow
+            // a basic set of characters when building the URL
             var sb = new StringBuilder();
             foreach (var c in str)
             {
-                // characters such as the middle dot (ascii 183) can 
-                // cause issues during navigation, so we only include
-                // a basic set of characters when building the URL
-                if (c <= 127)
+                if (CharacterSubstitutions.TryGetValue(c, out char replaced))
+                {
+                    sb.Append(replaced);
+                }
+                else if (c <= 127)
                 {
                     sb.Append(c);
+                }
+                else
+                {
+                    sb.Append('?');
                 }
             }
 
             return Uri.EscapeDataString(sb.ToString());
         }
-#endregion // IssueFiling
+        #endregion // IssueFiling
     }
 }

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
@@ -495,7 +495,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         /// </summary>
         internal static IReadOnlyDictionary<char, char> CharacterSubstitutions = new Dictionary<char, char>()
         {
-            { '·', '-' }, // middle dot (183) to dash (45)
+            { '\u00b7', '-' }, // middle dot (183) to dash (45)
         };
 
         /// <summary>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
@@ -506,7 +506,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         /// <returns></returns>
         internal static string EscapeForUrl(string str)
         {
-            // characters such as the middle dot (ascii 183) can 
+            // characters such as the middle dot can 
             // cause issues during navigation, so we only allow
             // a basic set of characters when building the URL
             var sb = new StringBuilder();


### PR DESCRIPTION
This PR follows up on #313 in which we limited the set of allowable characters in our bug URLs to respond to odd behavior when the user is redirected to login - as suggested by @DaveTryon , instead of removing characters outside our allowable range, we now replace them with preconfigured alternatives or a '?'. 