### PR TITLE
Add documentation to public members of A11yElement

### DIFF
--- a/src/AccessibilityInsights.Actions/Actions/LoadAction.cs
+++ b/src/AccessibilityInsights.Actions/Actions/LoadAction.cs
@@ -51,7 +51,7 @@ namespace Axe.Windows.Actions
                 SnapshotMetaInfo meta = SnapshotMetaInfo.DeserializeFromStream(metadataPart);
                 metadataPart.Close();   
 
-                var selectedElement = element.FindDescendent(k => k.UniqueId == meta.ScreenshotElementId);
+                var selectedElement = element.FindDescendant(k => k.UniqueId == meta.ScreenshotElementId);
 
                 return new LoadActionParts(element, bmp, selectedElement.SynthesizeBitmapFromElements(), meta);
             }

--- a/src/AccessibilityInsights.Core/Bases/A11yElement.cs
+++ b/src/AccessibilityInsights.Core/Bases/A11yElement.cs
@@ -497,7 +497,7 @@ namespace Axe.Windows.Core.Bases
         }
 
         /// <summary>
-        /// Finds the first decendent element matching the given condition.
+        /// Finds the first descendant element matching the given condition.
         /// </summary>
         /// <param name="condition">a function that returns true if the given descendant element meets a set of criteria</param>
         /// <returns>an <see cref="IA11yElement"/> object representing the matching descendant if one exists; otherwise, false</returns>

--- a/src/AccessibilityInsights.Core/Bases/A11yElement.cs
+++ b/src/AccessibilityInsights.Core/Bases/A11yElement.cs
@@ -86,7 +86,7 @@ namespace Axe.Windows.Core.Bases
         }
 
         /// <summary>
-        /// a text description of a keystroke which activates the element; usually a single key; only  valid within  a limited scope such as menus
+        /// a text description of a keystroke which activates the element; usually a single key; only valid within a limited scope such as menus
         /// </summary>
         [JsonIgnore]
         public string AccessKey

--- a/src/AccessibilityInsights.Core/Bases/A11yElement.cs
+++ b/src/AccessibilityInsights.Core/Bases/A11yElement.cs
@@ -24,6 +24,9 @@ namespace Axe.Windows.Core.Bases
     {
         private string _ProcessName = null;
 
+        /// <summary>
+        /// The label or primary text identifier for the element
+        /// </summary>
         [JsonIgnore]
         public string Name
         {
@@ -33,6 +36,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// The control type identifier for the element; see <see cref="Axe.Windows.Core.Types.ControlType"/>
+        /// </summary>
         [JsonIgnore]
         public int ControlTypeId
         {
@@ -43,6 +49,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// a localized text representation of <see cref="ControlTypeId"/>
+        /// </summary>
         [JsonIgnore]
         public string LocalizedControlType
         {
@@ -52,6 +61,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// a unique identifier for the element, valid only for the element's lifetime
+        /// </summary>
         [JsonIgnore]
         public string RuntimeId
         {
@@ -61,6 +73,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// a text description of a keystroke which activates the element; valid within a dialog, pane, or app
+        /// </summary>
         [JsonIgnore]
         public string AcceleratorKey
         {
@@ -70,6 +85,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// a text description of a keystroke which activates the element; usually a single key; only  valid within  a limited scope such as menus
+        /// </summary>
         [JsonIgnore]
         public string AccessKey
         {
@@ -79,6 +97,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// the culture/language of the text properties of the element
+        /// </summary>
         [JsonIgnore]
         public string Culture
         {
@@ -88,6 +109,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// a permanent unique identifier for the specific element, or sometimes the type of element
+        /// </summary>
         [JsonIgnore]
         public string AutomationId
         {
@@ -97,6 +121,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// the process ID of the process which owns the element
+        /// </summary>
         [JsonIgnore]
         public int ProcessId
         {
@@ -107,6 +134,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// the screen rectangle encompassing the element; typically corresponds to the visible bounds of the element
+        /// </summary>
         [JsonIgnore]
         public Rectangle BoundingRectangle
         {
@@ -116,6 +146,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// a name identifying the underlying class type of the element; common for types such as windows
+        /// </summary>
         [JsonIgnore]
         public string ClassName
         {
@@ -127,6 +160,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// information on how to interact with a control, useful contextual information, or other special instructions
+        /// </summary>
         [JsonIgnore]
         public string HelpText
         {
@@ -136,6 +172,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// whether the user may interact with the element
+        /// </summary>
         [JsonIgnore]
         public bool IsEnabled
         {
@@ -147,6 +186,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// whether the element may receive keyboard focus
+        /// </summary>
         [JsonIgnore]
         public bool IsKeyboardFocusable
         {
@@ -158,6 +200,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// whether the element is part of the UI Automation content view
+        /// </summary>
         [JsonIgnore]
         public bool IsContentElement
         {
@@ -174,6 +219,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// whether the element is part of the UI Automation control view
+        /// </summary>
         [JsonIgnore]
         public bool IsControlElement
         {
@@ -190,6 +238,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// whether the element is visible on the screen
+        /// </summary>
         [JsonIgnore]
         public bool IsOffScreen
         {
@@ -201,6 +252,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// a text description of the element's status
+        /// </summary>
         [JsonIgnore]
         public string ItemStatus
         {
@@ -215,6 +269,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// whether the element is oriented horizontally or vertically
+        /// </summary>
         public OrientationType Orientation
         {
             get
@@ -224,6 +281,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// the type of landmark if it exists; otherwise, 0; related to aria-landmarks
+        /// </summary>
         [JsonIgnore]
         public int LandmarkType
         {
@@ -235,6 +295,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// a localized text representation of <see cref="LandmarkType"/> if it exists; otherwise, null
+        /// </summary>
         [JsonIgnore]
         public string LocalizedLandmarkType
         {
@@ -246,6 +309,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// the heading level if it exists; otherwise, 0
+        /// </summary>
         [JsonIgnore]
         public int HeadingLevel
         {
@@ -257,6 +323,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// the framework on which the application is based: WPF, UWP, etc
+        /// </summary>
         [JsonIgnore]
         public string Framework
         {
@@ -268,6 +337,13 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// Safely gets a specified property's value. Throws no exceptions.
+        /// </summary>
+        /// <typeparam name="T">the expected type of the value parameter; The function will return false if the given type does not match the actual type of the property.</typeparam>
+        /// <param name="propertyId">the ID of the property to retrieve; see <see cref="Axe.Windows.Core.Types.PropertyType"/></param>
+        /// <param name="value">If the method returns true, this parameter contains the property value. If the function returns false, the value is undefined.</param>
+        /// <returns>true if the property was retrieved successfully and types match; otherwise, false</returns>
         public bool TryGetPropertyValue<T>(int propertyId, out T value)
         {
             // assignment required
@@ -319,6 +395,11 @@ namespace Axe.Windows.Core.Bases
             return enumerable.ToArray();
         }
 
+        /// <summary>
+        /// Retrieves an <see cref="IA11yPattern"/> representing the specified pattern.
+        /// </summary>
+        /// <param name="patternId">the ID of the pattern to retrieve; see <see cref="PatternType"/></param>
+        /// <returns>an <see cref="IA11yPattern"/> object for the specified pattern if it exists; otherwise, null.</returns>
         public IA11yPattern GetPattern(int patternId)
         {
             var pattern = this.Patterns?.FirstOrDefault(p => p.Id == patternId);
@@ -327,6 +408,12 @@ namespace Axe.Windows.Core.Bases
             return pattern;
         }
 
+        /// <summary>
+        /// Gets a specified property value for the current platform, e.g., Windows.
+        /// </summary>
+        /// <typeparam name="T">the expected type of the property value</typeparam>
+        /// <param name="propertyId">the ID of the platform property to retrieve; see <see cref="PlatformPropertyType"/></param>
+        /// <returns>the value of the specified property if it exists; otherwise, the default value for the given type</returns>
         public T GetPlatformPropertyValue<T>(int propertyId)
         {
             var property = this.PlatformProperties?.ById(propertyId);
@@ -336,6 +423,9 @@ namespace Axe.Windows.Core.Bases
             return property.Value;
         }
 
+        /// <summary>
+        /// the index of an item within a set
+        /// </summary>
         [JsonIgnore]
         public int PositionInSet
         {
@@ -347,6 +437,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// the total number of items in a set
+        /// </summary>
         [JsonIgnore]
         public int SizeOfSet
         {
@@ -358,6 +451,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// whether the element is resizeable
+        /// </summary>
         [JsonIgnore]
         public bool TransformPatternCanResize
         {
@@ -369,6 +465,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// the name of the process that owns the element
+        /// </summary>
         [JsonIgnore]
         public string ProcessName
         {
@@ -385,6 +484,10 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// Gets the element's first child element if it exists.
+        /// </summary>
+        /// <returns>an <see cref="IA11yElement"/> object for the child if it exists</returns>
         public IA11yElement GetFirstChild()
         {
             if (this.Children == null) return null;
@@ -393,6 +496,11 @@ namespace Axe.Windows.Core.Bases
             return Children[0];
         }
 
+        /// <summary>
+        /// Finds the first decendent element matching the given condition.
+        /// </summary>
+        /// <param name="condition">a function that returns true if the given descendant element meets a set of criteria</param>
+        /// <returns>an <see cref="IA11yElement"/> object representing the matching descendant if one exists; otherwise, false</returns>
         public A11yElement FindDescendent(Func<A11yElement, Boolean> condition)
         {
             Queue<A11yElement> children = new Queue<A11yElement>(this.Children);
@@ -457,6 +565,9 @@ namespace Axe.Windows.Core.Bases
         /// </summary>
         public Dictionary<int, A11yProperty> PlatformProperties { get; set; }
 
+        /// <summary>
+        /// a collection of patterns supported by the element
+        /// </summary>
         public List<A11yPattern> Patterns { get; set; }
 
         /// <summary>
@@ -481,6 +592,9 @@ namespace Axe.Windows.Core.Bases
             }
         }
 
+        /// <summary>
+        /// the <see cref="TreeViewMode"/> in which the element was found, or which should be used to walk to related elements
+        /// </summary>
         public TreeViewMode TreeWalkerMode { get; set; }
 
         /// <summary>

--- a/src/AccessibilityInsights.Core/Bases/A11yElement.cs
+++ b/src/AccessibilityInsights.Core/Bases/A11yElement.cs
@@ -501,7 +501,7 @@ namespace Axe.Windows.Core.Bases
         /// </summary>
         /// <param name="condition">a function that returns true if the given descendant element meets a set of criteria</param>
         /// <returns>an <see cref="IA11yElement"/> object representing the matching descendant if one exists; otherwise, false</returns>
-        public A11yElement FindDescendent(Func<A11yElement, Boolean> condition)
+        public A11yElement FindDescendant(Func<A11yElement, Boolean> condition)
         {
             Queue<A11yElement> children = new Queue<A11yElement>(this.Children);
             while (children.Count > 0)

--- a/src/AccessibilityInsights.Core/Bases/A11yElement.cs
+++ b/src/AccessibilityInsights.Core/Bases/A11yElement.cs
@@ -452,7 +452,7 @@ namespace Axe.Windows.Core.Bases
         }
 
         /// <summary>
-        /// whether the element is resizeable
+        /// whether the element is resizable
         /// </summary>
         [JsonIgnore]
         public bool TransformPatternCanResize

--- a/src/AccessibilityInsights.Core/Bases/A11yElement.cs
+++ b/src/AccessibilityInsights.Core/Bases/A11yElement.cs
@@ -110,7 +110,7 @@ namespace Axe.Windows.Core.Bases
         }
 
         /// <summary>
-        /// a permanent unique identifier for the specific element, or sometimes the type of element
+        /// a permanent unique identifier among siblings for the specific element, or sometimes the type of element
         /// </summary>
         [JsonIgnore]
         public string AutomationId

--- a/src/AccessibilityInsights.CoreTests/Bases/A11yElementTests.cs
+++ b/src/AccessibilityInsights.CoreTests/Bases/A11yElementTests.cs
@@ -27,7 +27,7 @@ namespace Axe.Windows.CoreTests.Bases
             {
                 Children = new List<A11yElement>() { child }
             };
-            var result = parent.FindDescendent(ke => ke.UniqueId == 0);
+            var result = parent.FindDescendant(ke => ke.UniqueId == 0);
             Assert.AreEqual(result, child);
         }
 
@@ -43,7 +43,7 @@ namespace Axe.Windows.CoreTests.Bases
             {
                 Children = new List<A11yElement>() { child },
             };
-            var result = parent.FindDescendent(ke => ke.UniqueId == 0);
+            var result = parent.FindDescendant(ke => ke.UniqueId == 0);
             Assert.IsNull(result);
         }
 
@@ -66,7 +66,7 @@ namespace Axe.Windows.CoreTests.Bases
                     }
                 }
             };
-            var result = parent.FindDescendent(ke => ke.UniqueId == 0);
+            var result = parent.FindDescendant(ke => ke.UniqueId == 0);
             Assert.AreEqual(result, grandChild);
         }
 
@@ -89,7 +89,7 @@ namespace Axe.Windows.CoreTests.Bases
             {
                 Children = new List<A11yElement>() { child }
             };
-            var result = parent.FindDescendent(ke => ke.UniqueId == 0);
+            var result = parent.FindDescendant(ke => ke.UniqueId == 0);
             Assert.IsNull(result);
         }
 


### PR DESCRIPTION
#### Describe the change

This content needs to be created so we can generate xml documentation files to accompany the axe-windows NuGet package. This is only part of the work needed to get Axe.Windows.Core ready, but it's a start.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



