### PR TITLE
Adding info about the role of automated checks

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -980,6 +980,11 @@
     <Style TargetType="{x:Type TextBlock}" x:Key="TbHeaderFocusable" BasedOn="{StaticResource TbFocusable}">
         <Setter Property="FontSize" Value="{DynamicResource ResourceKey=LargeTextBlockSize}"/>
     </Style>
+    <Style TargetType="{x:Type TextBlock}" x:Key="TbFocusableCenter" BasedOn="{StaticResource TbFocusable}">
+        <Setter Property="FontSize" Value="{DynamicResource StandardTextSize}"/>
+        <Setter Property="HorizontalAlignment" Value="Center"/>
+        <Setter Property="TextAlignment" Value="Center"/>
+    </Style>
     <Style TargetType="{x:Type Label}" x:Key="LblKey">
         <Setter Property="IsTabStop" Value="True"/>
         <Setter Property="Focusable" Value="True"/>

--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml
@@ -57,20 +57,11 @@
                 <RowDefinition Height="32"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <Grid.Resources>
-                <Style TargetType="TextBlock" BasedOn="{StaticResource TbFocusable}">
-                    <Setter Property="FontSize" Value="{DynamicResource StandardTextSize}"/>
-                    <Setter Property="MinWidth" Value="40"/>
-                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                    <Setter Property="TextAlignment" Value="Center"/>
-                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                </Style>
-            </Grid.Resources>
-            <TextBlock Grid.Row="0" x:Name="tbSelectElement">
+            <TextBlock Grid.Row="0" x:Name="tbSelectElement" Style="{StaticResource TbFocusableCenter}" MinWidth="40">
                 <Run Text="{x:Static properties:Resources.TestModeControl_RunAutomatedChecks}"/>
-                <fabric:FabricIconControl Focusable="False" GlyphName="SearchAndApps" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-3" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal"/>
+                <fabric:FabricIconControl GlyphName="SearchAndApps" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-3" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal"/>
                 <Run Text="{x:Static properties:Resources.TestModeControl_HoverAndTest}"/>
-                <fabric:FabricIconControl Focusable="False" GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal"/>
+                <fabric:FabricIconControl GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal"/>
                 <Run Text="{x:Static properties:Resources.LiveModeControl_FocusOnElement}"/>
                 <Run Name="runHotkey"/><Run Text="."/>
                 <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077027" RequestNavigate="Hyperlink_RequestNavigate"
@@ -79,7 +70,7 @@
                 </Hyperlink>
                 <Run Text="."/>
             </TextBlock>
-            <TextBlock Grid.Row="2" Text="{x:Static properties:Resources.AutomatedChecksRole}"/>
+            <TextBlock Grid.Row="2" Text="{x:Static properties:Resources.AutomatedChecksRole}" Style="{StaticResource TbFocusableCenter}" MinWidth="40"/>
         </Grid>
         
     </Grid>

--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml
@@ -51,20 +51,37 @@
                                    Visibility="Collapsed"
                                    WithSound="True"
                                    Grid.Row="1" Grid.Column="1"/>
-        <TextBlock Grid.Row="1" x:Name="tbSelectElement" Visibility="Visible"  FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}"  MinWidth="40" HorizontalAlignment="Center" TextAlignment="Center" Margin="230,50,40,0" VerticalAlignment="Top">
-            <Run Text="{x:Static properties:Resources.TestModeControl_RunAutomatedChecks}"/>
-            <fabric:FabricIconControl GlyphName="SearchAndApps" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-3" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal"/>
-            <Run Text="{x:Static properties:Resources.TestModeControl_HoverAndTest}"/>
-            <fabric:FabricIconControl GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal"/>
-            <Run Text="{x:Static properties:Resources.LiveModeControl_FocusOnElement}"/>
-            <Run Name="runHotkey"/><Run Text="."/>
-            <TextBlock>
+        <Grid Grid.Row="1" x:Name="instructionsAutomatedChecks" Margin="230,50,40,0" Visibility="Visible">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="32"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.Resources>
+                <Style TargetType="TextBlock" BasedOn="{StaticResource TbFocusable}">
+                    <Setter Property="FontSize" Value="{DynamicResource StandardTextSize}"/>
+                    <Setter Property="MinWidth" Value="40"/>
+                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                    <Setter Property="TextAlignment" Value="Center"/>
+                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                </Style>
+            </Grid.Resources>
+            <TextBlock Grid.Row="0" x:Name="tbSelectElement">
+                <Run Text="{x:Static properties:Resources.TestModeControl_RunAutomatedChecks}"/>
+                <fabric:FabricIconControl Focusable="False" GlyphName="SearchAndApps" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-3" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal"/>
+                <Run Text="{x:Static properties:Resources.TestModeControl_HoverAndTest}"/>
+                <fabric:FabricIconControl Focusable="False" GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal"/>
+                <Run Text="{x:Static properties:Resources.LiveModeControl_FocusOnElement}"/>
+                <Run Name="runHotkey"/><Run Text="."/>
                 <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077027" RequestNavigate="Hyperlink_RequestNavigate"
-                           FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">
+                            FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">
                     <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreAutomated}"/>
                 </Hyperlink>
-            </TextBlock><Run Text="."/>
-        </TextBlock>
+                <Run Text="."/>
+            </TextBlock>
+            <TextBlock Grid.Row="2" Text="{x:Static properties:Resources.AutomatedChecksRole}"/>
+        </Grid>
+        
     </Grid>
 </UserControl>
 

--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
@@ -133,7 +133,7 @@ namespace AccessibilityInsights.Modes
             {
                 EnableMenuButtons(this.DataContextMode != DataContextMode.Load);
                 this.ctrlAutomatedChecks.Visibility = Visibility.Visible;
-                this.tbSelectElement.Visibility = Visibility.Collapsed;
+                this.instructionsAutomatedChecks.Visibility = Visibility.Collapsed;
                 this.tabControl.IsEnabled = true;
 
                 try
@@ -277,7 +277,7 @@ namespace AccessibilityInsights.Modes
             this.tbiTabStop.Visibility = Visibility.Visible;
             this.tabControl.IsEnabled = false;
             this.ctrlAutomatedChecks.Visibility = Visibility.Collapsed;
-            this.tbSelectElement.Visibility = Visibility.Visible;
+            this.instructionsAutomatedChecks.Visibility = Visibility.Visible;
             HollowHighlightDriver.GetDefaultInstance().Clear();
         }
 

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Did you know? Automated checks can detect some common accessibility problems, such as missing or invalid properties. However, most accessibility problems can be identified only through manual testing..
+        /// </summary>
+        public static string AutomatedChecksRole {
+            get {
+                return ResourceManager.GetString("AutomatedChecksRole", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Navigation Bar.
         /// </summary>
         public static string bdLeftNavAutomationPropertiesName {

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -611,4 +611,7 @@ Please ensure that you are opening a valid test file using the most recent relea
   <data name="LocalizedControlType_Page" xml:space="preserve">
     <value>page</value>
   </data>
+  <data name="AutomatedChecksRole" xml:space="preserve">
+    <value>Did you know? Automated checks can detect some common accessibility problems, such as missing or invalid properties. However, most accessibility problems can be identified only through manual testing.</value>
+  </data>
 </root>


### PR DESCRIPTION
#### Describe the change
This is for issue #186 - we are adding text so that users are aware of the role of automated vs manual testing in accessibility. 

#### PR checklist

- [x] validated tab stops for this page
- [x] Does this address an existing issue? If yes, Issue# - #186 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

![image](https://user-images.githubusercontent.com/7775527/56446708-0db5c980-62b9-11e9-9904-0e997118ec80.png)


