### PR TITLE
Adding the issue reporter display name to issue filing telemetry

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -851,6 +851,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 {
                     { TelemetryProperty.By, FileBugRequestSource.Hierarchy.ToString() },
                     { TelemetryProperty.IsAlreadyLoggedIn, IssueReporter.IsConnected.ToString(CultureInfo.InvariantCulture) },
+                    { TelemetryProperty.IssueReporter, IssueReporter.DisplayName.ToString(CultureInfo.InvariantCulture) },
                 });
 
                 if (IssueReporter.IsConnected)

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -847,12 +847,8 @@ namespace AccessibilityInsights.SharedUx.Controls
             else
             {
                 // File a new bug
-                Logger.PublishTelemetryEvent(TelemetryAction.Scan_File_Bug, new Dictionary<TelemetryProperty, string>
-                {
-                    { TelemetryProperty.By, FileBugRequestSource.Hierarchy.ToString() },
-                    { TelemetryProperty.IsAlreadyLoggedIn, IssueReporter.IsConnected.ToString(CultureInfo.InvariantCulture) },
-                    { TelemetryProperty.IssueReporter, IssueReporter.DisplayName.ToString(CultureInfo.InvariantCulture) },
-                });
+                var telemetryEvent = TelemetryEventCreator.ForIssueFilingRequest(FileBugRequestSource.Hierarchy);
+                Logger.PublishTelemetryEvent(TelemetryAction.Scan_File_Bug, telemetryEvent);
 
                 if (IssueReporter.IsConnected)
                 {

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -299,7 +299,8 @@ namespace AccessibilityInsights.SharedUx.Controls
                 // File a new bug
                 Logger.PublishTelemetryEvent(TelemetryAction.Scan_File_Bug, new Dictionary<TelemetryProperty, string>() {
                     { TelemetryProperty.By, FileBugRequestSource.HowtoFix.ToString() },
-                    { TelemetryProperty.IsAlreadyLoggedIn, IssueReporter.IsConnected.ToString(CultureInfo.InvariantCulture) }
+                    { TelemetryProperty.IsAlreadyLoggedIn, IssueReporter.IsConnected.ToString(CultureInfo.InvariantCulture) },
+                    { TelemetryProperty.IssueReporter, IssueReporter.DisplayName.ToString(CultureInfo.InvariantCulture) },
                 });
 
                 if (IssueReporter.IsConnected)

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -297,11 +297,8 @@ namespace AccessibilityInsights.SharedUx.Controls
             else
             {
                 // File a new bug
-                Logger.PublishTelemetryEvent(TelemetryAction.Scan_File_Bug, new Dictionary<TelemetryProperty, string>() {
-                    { TelemetryProperty.By, FileBugRequestSource.HowtoFix.ToString() },
-                    { TelemetryProperty.IsAlreadyLoggedIn, IssueReporter.IsConnected.ToString(CultureInfo.InvariantCulture) },
-                    { TelemetryProperty.IssueReporter, IssueReporter.DisplayName.ToString(CultureInfo.InvariantCulture) },
-                });
+                var telemetryEvent = TelemetryEventCreator.ForIssueFilingRequest(FileBugRequestSource.HowtoFix);
+                Logger.PublishTelemetryEvent(TelemetryAction.Scan_File_Bug, telemetryEvent);
 
                 if (IssueReporter.IsConnected)
                 {

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -988,11 +988,8 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             else
             {
                 // File a new bug
-                Logger.PublishTelemetryEvent(TelemetryAction.Scan_File_Bug, new Dictionary<TelemetryProperty, string>() {
-                    { TelemetryProperty.By, FileBugRequestSource.AutomatedChecks.ToString() },
-                    { TelemetryProperty.IsAlreadyLoggedIn, IssueReporter.IsConnected.ToString(CultureInfo.InvariantCulture) },
-                    { TelemetryProperty.IssueReporter, IssueReporter.DisplayName.ToString(CultureInfo.InvariantCulture) },
-                });
+                var telemetryEvent = TelemetryEventCreator.ForIssueFilingRequest(FileBugRequestSource.AutomatedChecks);
+                Logger.PublishTelemetryEvent(TelemetryAction.Scan_File_Bug, telemetryEvent);
 
                 if (IssueReporter.IsConnected)
                 {

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -990,7 +990,8 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 // File a new bug
                 Logger.PublishTelemetryEvent(TelemetryAction.Scan_File_Bug, new Dictionary<TelemetryProperty, string>() {
                     { TelemetryProperty.By, FileBugRequestSource.AutomatedChecks.ToString() },
-                    { TelemetryProperty.IsAlreadyLoggedIn, IssueReporter.IsConnected.ToString(CultureInfo.InvariantCulture) }
+                    { TelemetryProperty.IsAlreadyLoggedIn, IssueReporter.IsConnected.ToString(CultureInfo.InvariantCulture) },
+                    { TelemetryProperty.IssueReporter, IssueReporter.DisplayName.ToString(CultureInfo.InvariantCulture) },
                 });
 
                 if (IssueReporter.IsConnected)

--- a/src/AccessibilityInsights.SharedUx/FileIssue/FileIssueAction.cs
+++ b/src/AccessibilityInsights.SharedUx/FileIssue/FileIssueAction.cs
@@ -7,6 +7,7 @@ using Axe.Windows.Actions;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
 
 namespace AccessibilityInsights.SharedUx.FileIssue
@@ -38,16 +39,23 @@ namespace AccessibilityInsights.SharedUx.FileIssue
                         {
                             { TelemetryProperty.RuleId, issueInformation.RuleForTelemetry },
                             { TelemetryProperty.UIFramework, issueInformation.UIFramework ?? string.Empty },
+                            { TelemetryProperty.IssueReporter, IssueReporter.DisplayName.ToString(CultureInfo.InvariantCulture) },
                         });
                     }
                     else // if the bug is coming from the hierarchy tree, it will not have ruleID or UIFramework
                     {
-                        Logger.PublishTelemetryEvent(TelemetryAction.Issue_Save);
+                        Logger.PublishTelemetryEvent(TelemetryAction.Issue_Save, new Dictionary<TelemetryProperty, string>
+                        {
+                            { TelemetryProperty.IssueReporter, IssueReporter.DisplayName.ToString(CultureInfo.InvariantCulture) },
+                        });
                     }
                 }
                 else
                 {
-                    Logger.PublishTelemetryEvent(TelemetryAction.Issue_File_Attempt);
+                    Logger.PublishTelemetryEvent(TelemetryAction.Issue_File_Attempt, new Dictionary<TelemetryProperty, string>
+                    {
+                        { TelemetryProperty.IssueReporter, IssueReporter.DisplayName.ToString(CultureInfo.InvariantCulture) },
+                    });
                 }
                 return issueResult;
             }

--- a/src/AccessibilityInsights.SharedUx/FileIssue/FileIssueAction.cs
+++ b/src/AccessibilityInsights.SharedUx/FileIssue/FileIssueAction.cs
@@ -39,14 +39,14 @@ namespace AccessibilityInsights.SharedUx.FileIssue
                         {
                             { TelemetryProperty.RuleId, issueInformation.RuleForTelemetry },
                             { TelemetryProperty.UIFramework, issueInformation.UIFramework ?? string.Empty },
-                            { TelemetryProperty.IssueReporter, IssueReporter.DisplayName.ToString(CultureInfo.InvariantCulture) },
+                            { TelemetryProperty.IssueReporter, IssueReporter.DisplayName?.ToString(CultureInfo.InvariantCulture) },
                         });
                     }
                     else // if the bug is coming from the hierarchy tree, it will not have ruleID or UIFramework
                     {
                         Logger.PublishTelemetryEvent(TelemetryAction.Issue_Save, new Dictionary<TelemetryProperty, string>
                         {
-                            { TelemetryProperty.IssueReporter, IssueReporter.DisplayName.ToString(CultureInfo.InvariantCulture) },
+                            { TelemetryProperty.IssueReporter, IssueReporter.DisplayName?.ToString(CultureInfo.InvariantCulture) },
                         });
                     }
                 }
@@ -54,7 +54,7 @@ namespace AccessibilityInsights.SharedUx.FileIssue
                 {
                     Logger.PublishTelemetryEvent(TelemetryAction.Issue_File_Attempt, new Dictionary<TelemetryProperty, string>
                     {
-                        { TelemetryProperty.IssueReporter, IssueReporter.DisplayName.ToString(CultureInfo.InvariantCulture) },
+                        { TelemetryProperty.IssueReporter, IssueReporter.DisplayName?.ToString(CultureInfo.InvariantCulture) },
                     });
                 }
                 return issueResult;

--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -469,6 +469,7 @@
     <Compile Include="Telemetry\ReportExceptionBuffer.cs" />
     <Compile Include="Telemetry\TelemetryAction.cs" />
     <Compile Include="Telemetry\TelemetryController.cs" />
+    <Compile Include="Telemetry\TelemetryEventCreator.cs" />
     <Compile Include="Telemetry\TelemetryProperty.cs" />
     <Compile Include="Telemetry\TelemetrySink.cs" />
     <Compile Include="Telemetry\WindowsEventLogger.cs" />

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryEventCreator.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryEventCreator.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.FileIssue;
+using Axe.Windows.Actions.Enums;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AccessibilityInsights.SharedUx.Telemetry
+{
+    /// <summary>
+    /// Responsible for creating payloads for telemetry from user actions in the application
+    /// </summary>
+    public static class TelemetryEventCreator
+    {
+        public static IReadOnlyDictionary<TelemetryProperty, string> ForIssueFilingRequest(FileBugRequestSource source)
+        {
+            return new Dictionary<TelemetryProperty, string>()
+            {
+                    { TelemetryProperty.By, source.ToString() },
+                    { TelemetryProperty.IsAlreadyLoggedIn, IssueReporter.IsConnected.ToString(CultureInfo.InvariantCulture) },
+                    { TelemetryProperty.IssueReporter, IssueReporter.DisplayName?.ToString(CultureInfo.InvariantCulture) },
+            };
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
@@ -57,5 +57,6 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         ReleaseChannel,
         ReleaseChannelConsidered,
         ReleaseChannelChangeResult,  // Value from the ReleaseChannelChangeResult enum
+        IssueReporter,
     }
 }


### PR DESCRIPTION
#### Describe the change
This PR adds the issue reporter name to the telemetry sent when an issue is filed. For example, it might distinguish between GitHub or Azure Boards.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #296 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



