### PR TITLE
Stop main window from being topmost while UAC prompt is displayed

### DIFF
--- a/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
@@ -125,7 +125,7 @@ namespace AccessibilityInsights
             UpdateResult result = UpdateResult.Unknown;
 
             // The UAC prompt from the version switcher will appear behind the main window
-            // if it is topmost, so we store, change, and restore the value in this method.
+            // if it is topmost, we store, change, and restore the value in this method.
             bool oldTopMost = Topmost;
 
             try

--- a/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
@@ -124,8 +124,9 @@ namespace AccessibilityInsights
         {
             UpdateResult result = UpdateResult.Unknown;
 
-            // The UAC prompt from the version switcher will appear behind the main window.
-            // If the window is topmost, we store, change, and restore the value in this method.
+            // If the window is topmost, the UAC prompt from the version switcher will appear behind the main window.
+            // To prevent this, save the previous topmost state, ensure that the main window is not topmost when the
+            // UAC prompt will display, then restore the previous topmost state.
             bool previousTopmostSetting = Topmost;
 
             try

--- a/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
@@ -124,9 +124,9 @@ namespace AccessibilityInsights
         {
             UpdateResult result = UpdateResult.Unknown;
 
-            // The UAC prompt from the version switcher will appear behind the main window
-            // if it is topmost, we store, change, and restore the value in this method.
-            bool oldTopMost = Topmost;
+            // The UAC prompt from the version switcher will appear behind the main window.
+            // If the window is topmost, we store, change, and restore the value in this method.
+            bool previousTopmostSetting = Topmost;
 
             try
             {
@@ -150,7 +150,7 @@ namespace AccessibilityInsights
                 e.ReportException();
             };
 
-            Topmost = oldTopMost;
+            Topmost = previousTopmostSetting;
             ctrlProgressRing.Deactivate();
             Logger.PublishTelemetryEvent(TelemetryAction.Upgrade_InstallationError, TelemetryProperty.Error, result.ToString());
 

--- a/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using AccessibilityInsights.SharedUx.Telemetry;
+using AccessibilityInsights.CommonUxComponents.Dialogs;
 using AccessibilityInsights.Dialogs;
 using AccessibilityInsights.Extensions;
 using AccessibilityInsights.Extensions.Interfaces.Upgrades;
 using AccessibilityInsights.Resources;
+using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.SharedUx.Utilities;
 using System;
 using System.Collections.Generic;
@@ -122,9 +123,15 @@ namespace AccessibilityInsights
         private async void DownLoadInstaller(IAutoUpdate autoUpdate, AutoUpdateOption updateOption)
         {
             UpdateResult result = UpdateResult.Unknown;
+
+            // The UAC prompt from the version switcher will appear behind the main window
+            // if it is topmost, so we store, change, and restore the value in this method.
+            bool oldTopMost = Topmost;
+
             try
             {
                 ctrlProgressRing.Activate();
+                Topmost = false;
                 result = await autoUpdate.UpdateAsync().ConfigureAwait(true);
 
                 Logger.PublishTelemetryEvent(TelemetryAction.Upgrade_DoInstallation, new Dictionary<TelemetryProperty, string>
@@ -143,13 +150,14 @@ namespace AccessibilityInsights
                 e.ReportException();
             };
 
+            Topmost = oldTopMost;
             ctrlProgressRing.Deactivate();
             Logger.PublishTelemetryEvent(TelemetryAction.Upgrade_InstallationError, TelemetryProperty.Error, result.ToString());
 
             string message = updateOption == AutoUpdateOption.RequiredUpgrade
                 ? GetMessageForRequiredUpdateFailure() : GetMessageForOptionalUpdateFailure();
 
-            MessageBox.Show(message);
+            MessageDialog.Show(message);
 
             if (updateOption == AutoUpdateOption.RequiredUpgrade)
             {

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
@@ -160,7 +160,7 @@ namespace AccessibilityInsights.Modes
             }
 
             // The UAC prompt from the version switcher will appear behind the main window
-            // if it is topmost, so we store, change, and restore the value in this method.
+            // if it is topmost, we store, change, and restore the value in this method.
             bool oldTopMost = Configuration.AlwaysOnTop;
 
             try

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
@@ -183,9 +183,9 @@ namespace AccessibilityInsights.Modes
                     MainWin.Topmost = oldTopMost;
                     MessageDialog.Show(string.Format(CultureInfo.InvariantCulture, Properties.Resources.ConfigurationModeControl_VersionSwitcherException));
                 });
-            }
 
-            return false;
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
@@ -159,8 +159,17 @@ namespace AccessibilityInsights.Modes
                 return false;
             }
 
+            // The UAC prompt from the version switcher will appear behind the main window
+            // if it is topmost, so we store, change, and restore the value in this method.
+            bool oldTopMost = Configuration.AlwaysOnTop;
+
             try
             {
+                Dispatcher.Invoke(() =>
+                {
+                    oldTopMost = MainWin.Topmost;
+                    MainWin.Topmost = false;
+                });
                 VersionSwitcherWrapper.ChangeChannel(appSettingsCtrl.SelectedReleaseChannel);
                 Dispatcher.Invoke(() => MainWin.Close());
                 return true;
@@ -170,8 +179,10 @@ namespace AccessibilityInsights.Modes
                 ex.ReportException();
 
                 Dispatcher.Invoke(() =>
-                    MessageDialog.Show(string.Format(CultureInfo.InvariantCulture, Properties.Resources.ConfigurationModeControl_VersionSwitcherException))
-                );
+                {
+                    MainWin.Topmost = oldTopMost;
+                    MessageDialog.Show(string.Format(CultureInfo.InvariantCulture, Properties.Resources.ConfigurationModeControl_VersionSwitcherException));
+                });
             }
 
             return false;

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
@@ -159,15 +159,15 @@ namespace AccessibilityInsights.Modes
                 return false;
             }
 
-            // The UAC prompt from the version switcher will appear behind the main window
-            // if it is topmost, we store, change, and restore the value in this method.
-            bool oldTopMost = Configuration.AlwaysOnTop;
+            // The UAC prompt from the version switcher will appear behind the main window.
+            // If the window is topmost, we store, change, and restore the value in this method.
+            bool previousTopmostSetting = Configuration.AlwaysOnTop;
 
             try
             {
                 Dispatcher.Invoke(() =>
                 {
-                    oldTopMost = MainWin.Topmost;
+                    previousTopmostSetting = MainWin.Topmost;
                     MainWin.Topmost = false;
                 });
                 VersionSwitcherWrapper.ChangeChannel(appSettingsCtrl.SelectedReleaseChannel);
@@ -180,8 +180,8 @@ namespace AccessibilityInsights.Modes
 
                 Dispatcher.Invoke(() =>
                 {
-                    MainWin.Topmost = oldTopMost;
-                    MessageDialog.Show(string.Format(CultureInfo.InvariantCulture, Properties.Resources.ConfigurationModeControl_VersionSwitcherException));
+                    MainWin.Topmost = previousTopmostSetting;
+                    MessageDialog.Show(Properties.Resources.ConfigurationModeControl_VersionSwitcherException);
                 });
 
                 return false;

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
@@ -9,7 +9,6 @@ using AccessibilityInsights.SharedUx.Settings;
 using AccessibilityInsights.SharedUx.Utilities;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Automation.Peers;
@@ -159,8 +158,9 @@ namespace AccessibilityInsights.Modes
                 return false;
             }
 
-            // The UAC prompt from the version switcher will appear behind the main window.
-            // If the window is topmost, we store, change, and restore the value in this method.
+            // If the window is topmost, the UAC prompt from the version switcher will appear behind the main window.
+            // To prevent this, save the previous topmost state, ensure that the main window is not topmost when the
+            // UAC prompt will display, then restore the previous topmost state.
             bool previousTopmostSetting = Configuration.AlwaysOnTop;
 
             try


### PR DESCRIPTION
#### Describe the change
Addressing #336: If AI-Win attempts to install a new version of itself, whether from auto-update or from channel change, the UAC dialog is obscurred.
This change causes AI-Win to backup its current topmost state, set topmost to false, run the update/channel switch, and then restore its topmost state (if AI-Win is still open). This is similar to what we do for the ADO sign in dialog scenario.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue #336
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

See bug for before screenshots. 

UAC dialog is on top of AI-Win:
![image](https://user-images.githubusercontent.com/4615491/56677612-bbd4c100-6675-11e9-907e-15bbc5ad6886.png)
![image](https://user-images.githubusercontent.com/4615491/56677689-e3c42480-6675-11e9-9d9c-a10a5fc7b6a3.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



