### PR TITLE
Remove remaining references to check-automation.ps1

### DIFF
--- a/build/compliance-build.yml
+++ b/build/compliance-build.yml
@@ -47,14 +47,6 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
 
-  - task: PowerShell@2
-    displayName: 'Check Automation'
-    inputs:
-      targetType: 'filePath'
-      filePath: '$(Build.Repository.LocalPath)\tools\scripts\check-automation.ps1'
-      arguments: 'release'
-      workingDirectory: '$(Build.Repository.LocalPath)\tools\scripts'
-
   - task: VSTest@2
     displayName: 'Test Assemblies **\release\*test*.dll;-:**\obj\**'
     inputs:

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -108,7 +108,6 @@ jobs:
       # Double-quote syntax with trailing backslash on each line concatenates lines without spaces
       AnalyzeTarget: "src\\AccessibilityInsights\\bin\\Debug\\*.exe;\
                       src\\AccessibilityInsights\\bin\\Debug\\*.dll;\
-                      src\\AccessibilityInsights.Automation\\bin\\Debug\\*.dll;\
                       src\\AccessibilityInsights.Extensions\\bin\\Debug\\*.dll;\
                       src\\AccessibilityInsights.Extensions.AzureDevOps\\bin\\Debug\\*.dll;\
                       src\\AccessibilityInsights.Extensions.GitHub\\bin\\Debug\\*.dll;\
@@ -128,7 +127,6 @@ jobs:
       # Double-quote syntax with trailing backslash on each line concatenates lines without spaces
       targets: "src\\AccessibilityInsights\\bin\\Debug\\*.exe;\
                 src\\AccessibilityInsights\\bin\\Debug\\AccessibilityInsights.*.dll;\
-                src\\AccessibilityInsights.Automation\\bin\\Debug\\AccessibilityInsights.*.dll;\
                 src\\AccessibilityInsights.Extensions\\bin\\Debug\\AccessibilityInsights.*.dll;\
                 src\\AccessibilityInsights.Extensions.AzureDevOps\\bin\\Debug\\AccessibilityInsights.*.dll\
                 src\\AccessibilityInsights.Extensions.GitHub\\bin\\Debug\\AccessibilityInsights.*.dll;\
@@ -217,7 +215,6 @@ jobs:
       # Double-quote syntax with trailing backslash on each line concatenates lines without spaces
       AnalyzeTarget: "src\\AccessibilityInsights\\bin\\Release\\*.exe;\
                       src\\AccessibilityInsights\\bin\\Release\\*.dll;\
-                      src\\AccessibilityInsights.Automation\\bin\\Release\\*.dll;\
                       src\\AccessibilityInsights.Extensions\\bin\\Release\\*.dll;\
                       src\\AccessibilityInsights.Extensions.AzureDevOps\\bin\\Release\\*.dll;\
                       src\\AccessibilityInsights.Extensions.GitHub\\bin\\Release\\*.dll;\
@@ -265,24 +262,6 @@ jobs:
       ArtifactName: '$(DropFolder)'
       publishLocation: FilePath
       TargetPath: '$(DropRoot)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact (NuGet): AccessibilityInsights.Automation.Windows'
-    inputs:
-      PathtoPublish: 'src\AccessibilityInsights.CI\bin\Release\NuGet'
-      ArtifactName: '$(DropFolder)'
-      publishLocation: FilePath
-      TargetPath: '$(DropRoot)'
-    continueOnError: true
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: (NuGet): AccessibilityInsights.RulesLibrary'
-    inputs:
-      PathtoPublish: 'src\AccessibilityInsights.Rules\bin\Release\NuGet'
-      ArtifactName: '$(DropFolder)'
-      publishLocation: FilePath
-      TargetPath: '$(DropRoot)'
-    continueOnError: true
 
   - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
     displayName: 'Publish Symbols'
@@ -347,7 +326,6 @@ jobs:
       # Double-quote syntax with trailing backslash on each line concatenates lines without spaces
       targets: "src\\AccessibilityInsights\\bin\\Debug\\*.exe;\
                 src\\AccessibilityInsights\\bin\\Debug\\AccessibilityInsights.*.dll;\
-                src\\AccessibilityInsights.Automation\\bin\\Debug\\AccessibilityInsights.*.dll;\
                 src\\AccessibilityInsights.Extensions\\bin\\Debug\\AccessibilityInsights.*.dll;\
                 src\\AccessibilityInsights.Extensions.AzureDevOps\\bin\\Debug\\AccessibilityInsights.*.dll\
                 src\\AccessibilityInsights.Extensions.GitHub\\bin\\Debug\\AccessibilityInsights.*.dll;\

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -55,14 +55,6 @@ jobs:
     inputs:
       ArtifactName: 'Compliance'
 
-  - task: PowerShell@2
-    displayName: 'Check Automation'
-    inputs:
-      targetType: 'filePath'
-      filePath: '$(Build.Repository.LocalPath)\tools\scripts\check-automation.ps1'
-      arguments: 'release'
-      workingDirectory: '$(Build.Repository.LocalPath)\tools\scripts'
-
   - task: VSTest@2
     displayName: 'Test Assemblies **\release\*test*.dll;-:**\obj\**'
     inputs:

--- a/docs/Scenarios.md
+++ b/docs/Scenarios.md
@@ -31,12 +31,6 @@ To make sure that a PR doesn't introduce a major regression, please run through 
   - Save events to disk using the "Save" button.
   - Go to live inspect mode.
   - Load events file using the "File Open" button -- it should match what you just saved.
-- Automation
-  - Build the debug configuration of the solution.
-  - Run the following commands from a command prompt at the root of your repo:
-    - `cd tools\scripts`
-    - `powershell -f check-automation.ps1`
-      - If the final message from the script says `*** AUTOMATION SUCCEEDED ***` in green text, then the script succeeded. Any other message (or any red text) indicates that the script failed and that a fix is required.
 
 ### Additional checks for UI related changes
 - Run the production version of Accessibility Insights for Windows against an instance of Accessibility Insights for Windows with the new changes.


### PR DESCRIPTION
#### Describe the change
PR [#353] removed the check-automation.ps1 file, but left some references in scripts and documentation. As such, the signed build failed. Remove the remaining references.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



