### PR TITLE
Remove an accessible name to trigger UI test failure

### DIFF
--- a/src/AccessibilityInsights/Modes/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/StartUpModeControl.xaml
@@ -42,7 +42,7 @@
                 </Grid.RowDefinitions>
                 <TextBlock Name="tbVideo" FontSize="22" Padding="16,10,16,0" FontWeight="Light" Foreground="{DynamicResource ResourceKey=DarkGreyTextBrush}" Style="{StaticResource TbFocusable}" TextWrapping="Wrap"><Run Text="{x:Static properties:Resources.tbVideoText1}"/></TextBlock>
                 <TextBlock x:Name="videoDescription" Grid.Row="1" FontSize="12" Style="{StaticResource TbFocusable}" Padding="16,10" Foreground="{DynamicResource ResourceKey=DarkGreyTextBrush}" TextWrapping="Wrap" Text="{x:Static properties:Resources.tbVideoText2}"/>
-                <Button Style="{StaticResource BtnStandard}" Cursor="Hand" Grid.Row="2" Width="240" Height="121" BorderThickness="0" Name="btnVideo" Click="btnVideo_Click" AutomationProperties.LabeledBy="{Binding ElementName=videoDescription}" VerticalAlignment="Top">
+                <Button Style="{StaticResource BtnStandard}" Cursor="Hand" Grid.Row="2" Width="240" Height="121" BorderThickness="0" Name="btnVideo" Click="btnVideo_Click" VerticalAlignment="Top">
                     <Grid>
                         <Image Width="240" Height="135" Source="../Resources/video_thumb.png" AutomationProperties.Name="{x:Static properties:Resources.imageVideoAutomationPropertiesName}"/>
                         <Border Opacity=".40" Name="bdOverlay">


### PR DESCRIPTION
This PR should not be merged  & simply removes an accessible name in order to trigger a failure in the `VerifyAccessibility` UI test