### PR TITLE
Improve color contrast of blue buttons in app

### DIFF
--- a/src/AccessibilityInsights.CommonUxComponents/Dialogs/MessageDialog.xaml
+++ b/src/AccessibilityInsights.CommonUxComponents/Dialogs/MessageDialog.xaml
@@ -26,6 +26,6 @@
                 Content="{x:Static Properties:Resources.btnCloseAutomationPropertiesName1}"
                 AutomationProperties.Name="{x:Static Properties:Resources.btnCloseAutomationPropertiesName1}"
                 Margin="270,10,30,10" Click="btnClose_Click"
-                IsDefault="True" Style="{DynamicResource BtnBlue}"/>
+                IsDefault="True" Style="{DynamicResource BtnBlueRounded}"/>
     </Grid>
 </Window>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TelemetryApproveContainedDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TelemetryApproveContainedDialog.xaml
@@ -63,7 +63,7 @@
         </Grid>
         <Grid Grid.Row="4" Margin="1,24,24,0">
             <Button x:Name="btnExit" UseLayoutRounding="True"
-                        Width="100" Height="30" VerticalAlignment="Bottom" HorizontalAlignment="Right" Click="btnExit_Click" Content="{x:Static properties:Resources.btnExitContentTelemetryOK}" Style="{StaticResource BtnBlue}"/>
+                        Width="100" Height="30" VerticalAlignment="Bottom" HorizontalAlignment="Right" Click="btnExit_Click" Content="{x:Static properties:Resources.btnExitContentTelemetryOK}" Style="{StaticResource BtnBlueRounded}"/>
         </Grid>
     </Grid>
 </dialogs:ContainedDialog>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -9,9 +9,9 @@
     <SolidColorBrush po:Freeze="True" x:Key="TextBrushGray" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TextBrushDark" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonHoverBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="WhiteTextHoverBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonHoverRedBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="DarkBorderBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="DarkButtonHoverBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="DarkGreyTextBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TabHoverBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActiveBlueBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
@@ -23,6 +23,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="LightIconBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="WindowTextBrush" Color="{x:Static SystemColors.WindowTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonBlueBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonBlueBGBrushHover" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedTextBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
@@ -41,7 +42,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="ToggleSliderBlueBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="LoadingBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SnapshotBtnBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="ButtonBlueHoverBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SnapshotBtnHoverBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="RadioBulletBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="WhiteTextBrush" Color="{x:Static SystemColors.ControlTextColor}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -12,7 +12,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="DarkBorderBrush" Color="#E4E4E4"/>
     <SolidColorBrush po:Freeze="True" x:Key="DarkGreyTextBrush" Color="#333333"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedBrush" Color="#F4F4F4"/> 
-    <SolidColorBrush po:Freeze="True" x:Key="DarkButtonHoverBrush" Color="DodgerBlue"/>
     <SolidColorBrush po:Freeze="True" x:Key="LoadingBrush" Color="#0000FF"/>
     <SolidColorBrush po:Freeze="True" x:Key="DisabledOverlayBrush" Color="#FDFDFD"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedTabBrush" Color="#EFF6FC"/>
@@ -35,14 +34,16 @@
     <SolidColorBrush po:Freeze="True" x:Key="SelectedTextBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="IconBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="WhiteTextBrush" Color="#FFFFFF"/>
+    <SolidColorBrush po:Freeze="True" x:Key="WhiteTextHoverBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="BorderBrush" Color="#C7C7C7"/>
     <SolidColorBrush po:Freeze="True" x:Key="LightIconBrush" Color="#EAEAEA"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonBackgroundBrush" Color="Transparent"/>
     <SolidColorBrush po:Freeze="True" x:Key="ToggleSliderBlueBrush" Color="#FF0078D6"/>
-    <SolidColorBrush po:Freeze="True" x:Key="ButtonBlueBGBrush" Color="#FF0078D6"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonBlueBGBrush" Color="#FF0078D4"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonBlueBGBrushHover" Color="#FF0067B5"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonBlueBGBrushActive" Color="#FF005A9E"/>
     <SolidColorBrush po:Freeze="True" x:Key="SettingsTabBgBrush" Color="Transparent"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonGreyBGBrush" Color="#CCCCCC"/>
-    <SolidColorBrush po:Freeze="True" x:Key="ButtonBlueHoverBrush" Color="#005A9E"/>
     <SolidColorBrush po:Freeze="True" x:Key="LightBackgroundBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="GreyBackgroundBrush" Color="#EAEAEA"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActiveModeBrush" Color="#FFFFFF"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -108,7 +108,7 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="{DynamicResource ResourceKey=ButtonBlueHoverBrush}"/>
+                            <Setter Property="Background" Value="{DynamicResource ResourceKey=ButtonBlueBGBrushHover}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Background" Value="{DynamicResource ResourceKey=LightGreyBrush}"/>
@@ -578,7 +578,7 @@
         </Setter>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="Background" Value="{DynamicResource ResourceKey=DarkButtonHoverBrush}"/>
+                <Setter Property="Background" Value="{DynamicResource ResourceKey=ButtonBlueBGBrushHover}"/>
             </Trigger>
             <Trigger Property="IsFocused" Value="true">
                 <Setter Property="BorderBrush" Value="White"/>
@@ -905,7 +905,7 @@
             </Setter.Value>
         </Setter>
     </Style>
-    <Style TargetType="{x:Type Button}" x:Key="BtnBlueSquared">
+    <Style TargetType="{x:Type Button}" x:Key="BtnBlueBase">
         <Setter Property="Background" Value="{DynamicResource ResourceKey=ButtonBlueBGBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource ResourceKey=WhiteTextBrush}"/>
         <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
@@ -917,17 +917,34 @@
                 <ControlTemplate TargetType="{x:Type Button}">
                     <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}"
                                         Background="{TemplateBinding Background}"
-                                        CornerRadius="2">
-                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" Margin="{TemplateBinding Padding}"/>
+                                        CornerRadius="{TemplateBinding Border.CornerRadius}">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" TextBlock.Foreground="{TemplateBinding Foreground}"/>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="{DynamicResource ResourceKey=DarkButtonHoverBrush}"/>
+                <Setter Property="Background" Value="{DynamicResource ResourceKey=ButtonBlueBGBrushHover}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=WhiteTextHoverBrush}"/>
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ResourceKey=ButtonBlueBGBrushActive}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Background" Value="{DynamicResource ResourceKey=LightGreyBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonDisabledBrush}"/>
             </Trigger>
         </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type Button}" x:Key="BtnBlueRounded" BasedOn="{StaticResource BtnBlueBase}">
+        <Setter Property="Border.CornerRadius" Value="4"/>
+    </Style>
+    <Style TargetType="{x:Type Button}" x:Key="BtnBlueSquared" BasedOn="{StaticResource BtnBlueBase}">
+        <Setter Property="Border.CornerRadius" Value="2"/>
+    </Style>
+    <Style TargetType="{x:Type Button}" x:Key="BtnBlueSharpSquared" BasedOn="{StaticResource BtnBlueBase}">
+        <Setter Property="Border.CornerRadius" Value="0"/>
     </Style>
     <Style TargetType="{x:Type Button}" x:Key="BtnGreySquared">
         <Setter Property="Background" Value="{DynamicResource ResourceKey=GreyBackgroundBrush}"/>
@@ -998,30 +1015,6 @@
         <Setter Property="Background" Value="{DynamicResource ResourceKey=KeyBGBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource ResourceKey=LeftNavBorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
-    </Style>
-    <Style TargetType="{x:Type Button}" x:Key="BtnBlue">
-        <Setter Property="Background" Value="{DynamicResource ResourceKey=ButtonBlueBGBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=WhiteTextBrush}"/>
-        <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
-        <Setter Property="FontSize" Value="12"/>
-        <Setter Property="BorderThickness" Value="{DynamicResource ResourceKey=BtnBrdrThickness}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource ResourceKey=BtnBrderBrush}"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type Button}">
-                    <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}"
-                                        Background="{TemplateBinding Background}"
-                                        CornerRadius="4">
-                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                    </Border>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-        <Style.Triggers>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="{DynamicResource ResourceKey=DarkButtonHoverBrush}"/>
-            </Trigger>
-        </Style.Triggers>
     </Style>
     <Style TargetType="{x:Type CheckBox}" x:Key="CkbxLeftSide">
         <Style.Resources>

--- a/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml
+++ b/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml
@@ -35,13 +35,13 @@
                 <fabric:FabricIconControl Grid.Column="0" VerticalAlignment="Center" Margin="8px 4px 4px 0" GlyphName="Info" GlyphSize="Small" Foreground="#333333"></fabric:FabricIconControl>
                 <TextBlock x:Name="txtUpdateNotice" Grid.Column="1" Margin="0 0 24px 0" LineHeight="15px" FontSize="11px" VerticalAlignment="Center"></TextBlock>
             </Grid>
-            <Button x:Name="btnUpdateNow" Click="UpdateNow_Click" Grid.Column="1" BorderThickness="0" Background="{DynamicResource ResourceKey=ActiveBlueBrush}" BorderBrush="{x:Null}">
-                <TextBlock Text="{x:Static properties:Resources.btnUpdateNowText}" Margin="8px" LineHeight="15px"  FontSize="11px" FontWeight="SemiBold" Foreground="{DynamicResource ResourceKey=WhiteTextBrush}" VerticalAlignment="Center"></TextBlock>
+            <Button x:Name="btnUpdateNow" Click="UpdateNow_Click" Grid.Column="1" Style="{StaticResource BtnBlueSharpSquared}">
+                <TextBlock Text="{x:Static properties:Resources.btnUpdateNowText}" Margin="8px" LineHeight="15px"  FontSize="11px" FontWeight="SemiBold" VerticalAlignment="Center"></TextBlock>
             </Button>
-            <Button x:Name="btnUpdateLater" Click="UpdateLater_Click" Grid.Column="2" BorderThickness="0" Background="{DynamicResource ResourceKey=ActiveBlueBrush}" BorderBrush="{x:Null}">
+            <Button x:Name="btnUpdateLater" Click="UpdateLater_Click" Grid.Column="2" Style="{StaticResource BtnBlueSharpSquared}">
                 <TextBlock Text="{x:Static properties:Resources.btnUpdateLaterText}" Margin="8px" LineHeight="15px" FontSize="11px" FontWeight="SemiBold" Foreground="{DynamicResource ResourceKey=WhiteTextBrush}" VerticalAlignment="Center"></TextBlock>
             </Button>
-            <Button x:Name="btnReleaseNotes" Click="ReleaseNotes_Click" Grid.Column="3" BorderThickness="0" Background="{DynamicResource ResourceKey=ActiveBlueBrush}" BorderBrush="{x:Null}">
+            <Button x:Name="btnReleaseNotes" Click="ReleaseNotes_Click" Grid.Column="3" Style="{StaticResource BtnBlueSharpSquared}">
                 <TextBlock Text="{x:Static properties:Resources.btnReleaseNotesText}" Margin="8px" LineHeight="15px" FontSize="11px" FontWeight="SemiBold" Foreground="{DynamicResource ResourceKey=WhiteTextBrush}" VerticalAlignment="Center"></TextBlock>
             </Button>
         </Grid>

--- a/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml
+++ b/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml
@@ -27,12 +27,12 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition/>
             </Grid.ColumnDefinitions>
-            <Grid Grid.Column="0" Background="#F4F4F4">
+            <Grid Grid.Column="0" Background="{DynamicResource ResourceKey=LightGreyBrush}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
-                <fabric:FabricIconControl Grid.Column="0" VerticalAlignment="Center" Margin="8px 4px 4px 0" GlyphName="Info" GlyphSize="Small" Foreground="#333333"></fabric:FabricIconControl>
+                <fabric:FabricIconControl Grid.Column="0" VerticalAlignment="Center" Margin="8px 4px 4px 0" GlyphName="Info" GlyphSize="Small" Foreground="{DynamicResource ResourceKey=IconBrush}"></fabric:FabricIconControl>
                 <TextBlock x:Name="txtUpdateNotice" Grid.Column="1" Margin="0 0 24px 0" LineHeight="15px" FontSize="11px" VerticalAlignment="Center"></TextBlock>
             </Grid>
             <Button x:Name="btnUpdateNow" Click="UpdateNow_Click" Grid.Column="1" Style="{StaticResource BtnBlueSharpSquared}">

--- a/src/AccessibilityInsights/Modes/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/StartUpModeControl.xaml
@@ -157,7 +157,7 @@
                       FontWeight="SemiBold" Style="{StaticResource CkbxRightSide}" VerticalAlignment="Center"
                       FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
             <Button Grid.Column="2" x:Name="btnExit"  Click="btnExit_Click" UseLayoutRounding="True"
-                    Width="100" Height="30" VerticalAlignment="Bottom" HorizontalAlignment="Right" Content="{x:Static properties:Resources.StartUpModeControl_btnExit}" Style="{StaticResource BtnBlue}"/>
+                    Width="100" Height="30" VerticalAlignment="Bottom" HorizontalAlignment="Right" Content="{x:Static properties:Resources.StartUpModeControl_btnExit}" Style="{StaticResource BtnBlueRounded}"/>
         </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
#### Describe the change

To address #342- [BUG] Insufficient contrast ratio for Update button, this PR updates the hover and active state colors of the blue buttons in our app. This had a side effect of fixing some pretty serious high contrast theme issues with our update dialog. I included screenshots of the most significantly affected buttons--I can add more for the other buttons if desired, but there are a lot and the changes are minor.

There should only be visual changes from this PR.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue #342
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Update button hover state (before/after on top/bottom):

Normal:
![image](https://user-images.githubusercontent.com/4615491/58356181-7c8fc080-7e2b-11e9-9fcf-58f72d9d57a7.png)
![image](https://user-images.githubusercontent.com/4615491/58355840-895fe480-7e2a-11e9-8ae7-b808a83165c9.png)

HC White:
![image](https://user-images.githubusercontent.com/4615491/58356124-481c0480-7e2b-11e9-960d-990edd283eed.png)
![image](https://user-images.githubusercontent.com/4615491/58356073-1e62dd80-7e2b-11e9-8f74-b83783e4d24f.png)

HC Black:
![image](https://user-images.githubusercontent.com/4615491/58356151-6124b580-7e2b-11e9-84fd-840ef59fa954.png)
![image](https://user-images.githubusercontent.com/4615491/58356050-08edb380-7e2b-11e9-83c8-b9ed2db183d0.png)

Other blue buttons were touched with varying levels of improvement along the same lines as those above.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



