### PR TITLE
Change UpdateDialog to only be topmost when MainWindow is topmost

### DIFF
--- a/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml
+++ b/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml
@@ -11,7 +11,7 @@
         Icon="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Icons/BrandIcon.ico" Background="Transparent" AllowsTransparency="True"
         FocusManager.FocusedElement="{Binding ElementName=btnUpdateNow}" 
         xmlns:properties="clr-namespace:AccessibilityInsights.Properties"
-        ShowInTaskbar="False" Topmost="True" WindowStyle="None" Width="400" Height="48">
+        ShowInTaskbar="False" WindowStyle="None" Width="400" Height="48">
     <Window.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
     </Window.Resources>

--- a/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml.cs
+++ b/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Dialogs;
-using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Telemetry;
 using System;
 using System.Windows;
@@ -23,6 +22,7 @@ namespace AccessibilityInsights.Dialogs
         {
             InitializeComponent();
             this.ReleaseNotesUri = releaseNotesUri;
+            Topmost = App.Current.MainWindow.Topmost;
         }
 
         private void UpdateNow_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
#### Describe the change
UpdateDialog.Topmost now matches MainWindow.Topmost instead of always being true. This makes more sense because the scenarios where the two are out of sync are undesirable.

This addresses #351- [BUG] Update Dialog shows up on top of release notes. If the user has selected to be always on top, AI-Win will be on top of their web browser when they open release notes, so the update dialog should be as well. In @DaveTryon's scenario where always on top is not selected, the update dialog will no longer float on top of the release notes.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue #351 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



