### PR TITLE
Move HighlighterColor to shared ux

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Dialogs;
+using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.SharedUx.Highlighting;
 using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.SharedUx.ViewModels;
-using Axe.Windows.Core.Enums;
 using Axe.Windows.Desktop.Types;
 using Axe.Windows.Desktop.UIAutomation.Support;
 using System;
@@ -31,7 +31,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             this.ViewModel = trvm;
             InitializeComponent();
             this.cbAttributes.ItemsSource = TextAttributeType.GetInstance().GetTemplate();
-            this.Hilighter = new TextRangeHilighter(HighlighterColor.GreenTextBrush); // green color
+            this.Hilighter = new TextRangeHilighter(HighlighterColorTemp.GreenTextBrush); // green color
         }
 
         private void Window_Loaded(object sender, RoutedEventArgs e)

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml.cs
@@ -31,7 +31,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             this.ViewModel = trvm;
             InitializeComponent();
             this.cbAttributes.ItemsSource = TextAttributeType.GetInstance().GetTemplate();
-            this.Hilighter = new TextRangeHilighter(HighlighterColorTemp.GreenTextBrush); // green color
+            this.Hilighter = new TextRangeHilighter(HighlighterColor.GreenTextBrush); // green color
         }
 
         private void Window_Loaded(object sender, RoutedEventArgs e)

--- a/src/AccessibilityInsights.SharedUx/Enums/HighlighterColor.cs
+++ b/src/AccessibilityInsights.SharedUx/Enums/HighlighterColor.cs
@@ -4,12 +4,11 @@ namespace AccessibilityInsights.SharedUx.Enums
 {
     /// <summary>
     /// These values (as strings) correspond to keys of SolidColorBrushes 
-    /// found in the HighlightStyle.xaml resource dictionary
+    /// found in the Brushes.xaml resource dictionary
     /// </summary>
     public enum HighlighterColor
     {
         DefaultBrush, // This is the default highlighter color
-        SnapshotRootBrush,
         TextBrush,
         GreenTextBrush
     }

--- a/src/AccessibilityInsights.SharedUx/Enums/HighlighterColor.cs
+++ b/src/AccessibilityInsights.SharedUx/Enums/HighlighterColor.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+namespace AccessibilityInsights.SharedUx.Enums
+{
+    /// <summary>
+    /// These values (as strings) correspond to keys of SolidColorBrushes 
+    /// found in the HighlightStyle.xaml resource dictionary
+    /// </summary>
+    public enum HighlighterColorTemp
+    {
+        DefaultBrush, // This is the default highlighter color
+        SnapshotRootBrush,
+        TextBrush,
+        GreenTextBrush
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Enums/HighlighterColor.cs
+++ b/src/AccessibilityInsights.SharedUx/Enums/HighlighterColor.cs
@@ -6,7 +6,7 @@ namespace AccessibilityInsights.SharedUx.Enums
     /// These values (as strings) correspond to keys of SolidColorBrushes 
     /// found in the HighlightStyle.xaml resource dictionary
     /// </summary>
-    public enum HighlighterColorTemp
+    public enum HighlighterColor
     {
         DefaultBrush, // This is the default highlighter color
         SnapshotRootBrush,

--- a/src/AccessibilityInsights.SharedUx/Highlighting/Highlighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/Highlighter.cs
@@ -29,7 +29,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// Hilighter constructor
         /// </summary>
         /// <param name="color">RGB in int value</param>
-        public Highlighter(HighlighterColorTemp color = HighlighterColorTemp.DefaultBrush, bool hasSnapshot = false)
+        public Highlighter(HighlighterColor color = HighlighterColor.DefaultBrush, bool hasSnapshot = false)
         {
             var brush = GetBrush(color);
             this.WndClassNameBase = Guid.NewGuid().ToString();
@@ -205,7 +205,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// </summary>
         /// <param name="colorKey"></param>
         /// <returns></returns>
-        private static SolidColorBrush GetBrush(HighlighterColorTemp color)
+        private static SolidColorBrush GetBrush(HighlighterColor color)
         {
             return Application.Current.Resources[$"HL{color.ToString()}"] as SolidColorBrush;
         }

--- a/src/AccessibilityInsights.SharedUx/Highlighting/Highlighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/Highlighter.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.Win32;
-using Axe.Windows.Core.Enums;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -30,7 +29,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// Hilighter constructor
         /// </summary>
         /// <param name="color">RGB in int value</param>
-        public Highlighter(HighlighterColor color = HighlighterColor.DefaultBrush, bool hasSnapshot = false)
+        public Highlighter(HighlighterColorTemp color = HighlighterColorTemp.DefaultBrush, bool hasSnapshot = false)
         {
             var brush = GetBrush(color);
             this.WndClassNameBase = Guid.NewGuid().ToString();
@@ -206,7 +205,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// </summary>
         /// <param name="colorKey"></param>
         /// <returns></returns>
-        private static SolidColorBrush GetBrush(HighlighterColor color)
+        private static SolidColorBrush GetBrush(HighlighterColorTemp color)
         {
             return Application.Current.Resources[$"HL{color.ToString()}"] as SolidColorBrush;
         }

--- a/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
@@ -143,7 +143,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// <param name="hasSnapshotButton"></param>
         private HollowHighlightDriver(bool hasSnapshot)
         {
-            this.Highlighter = new Highlighter(HighlighterColorTemp.DefaultBrush, hasSnapshot);
+            this.Highlighter = new Highlighter(HighlighterColor.DefaultBrush, hasSnapshot);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
@@ -3,7 +3,6 @@
 using AccessibilityInsights.SharedUx.Enums;
 using Axe.Windows.Actions;
 using Axe.Windows.Core.Bases;
-using Axe.Windows.Core.Enums;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -144,7 +143,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// <param name="hasSnapshotButton"></param>
         private HollowHighlightDriver(bool hasSnapshot)
         {
-            this.Highlighter = new Highlighter(HighlighterColor.DefaultBrush, hasSnapshot);
+            this.Highlighter = new Highlighter(HighlighterColorTemp.DefaultBrush, hasSnapshot);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Highlighting/TextRangeHilighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/TextRangeHilighter.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Enums;
+using AccessibilityInsights.SharedUx.Enums;
 using Axe.Windows.Desktop.Utility;
 using System;
 using System.Collections.Generic;
@@ -18,16 +18,15 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// <summary>
         /// Hilighter color
         /// </summary>
-        private HighlighterColor Color;
+        private HighlighterColorTemp Color;
 
         private List<Highlighter> Hilighters;
-
 
         /// <summary>
         /// constructor
         /// </summary>
         /// <param name="color"></param>
-        public TextRangeHilighter(HighlighterColor color = HighlighterColor.TextBrush)
+        public TextRangeHilighter(HighlighterColorTemp color = HighlighterColorTemp.TextBrush)
         {
             this.Color = color;
             this.Hilighters = new List<Highlighter>();

--- a/src/AccessibilityInsights.SharedUx/Highlighting/TextRangeHilighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/TextRangeHilighter.cs
@@ -18,7 +18,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// <summary>
         /// Hilighter color
         /// </summary>
-        private HighlighterColorTemp Color;
+        private HighlighterColor Color;
 
         private List<Highlighter> Hilighters;
 
@@ -26,7 +26,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// constructor
         /// </summary>
         /// <param name="color"></param>
-        public TextRangeHilighter(HighlighterColorTemp color = HighlighterColorTemp.TextBrush)
+        public TextRangeHilighter(HighlighterColor color = HighlighterColor.TextBrush)
         {
             this.Color = color;
             this.Hilighters = new List<Highlighter>();

--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -330,6 +330,7 @@
     </Compile>
     <Compile Include="Enums\FileFilters.cs" />
     <Compile Include="Enums\FontSize.cs" />
+    <Compile Include="Enums\HighlighterColor.cs" />
     <Compile Include="Enums\HighlighterMode.cs" />
     <Compile Include="Enums\HighlighterType.cs" />
     <Compile Include="Enums\FileBugRequestSource.cs" />


### PR DESCRIPTION
#### Describe the change
The HighlighterColor enum is defined in axe-windows (https://github.com/microsoft/axe-windows/blob/master/src/Core/Enums/HighlighterColor.cs), but it is only used in AIWin. This change ports it to AIWin. A separate change will remove it from axe-windows. If you look at the commits, you'll see that I went through a step where the enum was named HighlighterColorTemp to make sure that there weren't any lurking references. Goal is that the UI is unchanged, other that the enum is defined in a different assembly

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed? (Ran highlighter scenarios)
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



