### PR TITLE
Hide highlighters by default when opening an Event file (Fix Issue #365)

### DIFF
--- a/src/AccessibilityInsights/Modes/EventModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/EventModeControl.xaml.cs
@@ -8,7 +8,6 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Desktop.Types;
 using Axe.Windows.Desktop.UIAutomation.EventHandlers;
 using AccessibilityInsights.SharedUx.Controls.CustomControls;
-using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.SharedUx.Interfaces;
 using AccessibilityInsights.SharedUx.Settings;
@@ -30,8 +29,6 @@ namespace AccessibilityInsights.Modes
     public partial class EventModeControl : UserControlWithPanes, IModeControl
     {
         private ElementContext ElementContext;
-
-        private bool _showHighlighter = true;
 
         /// <summary>
         /// MainWindow to access shared methods
@@ -125,8 +122,6 @@ namespace AccessibilityInsights.Modes
                     this.ctrlTabs.IsRecordingChanged(isStarted);
                 }
             });
-
-            _showHighlighter = true;
         }
 
         /// <summary>
@@ -197,12 +192,8 @@ namespace AccessibilityInsights.Modes
         private void UpdateUI(A11yElement element)
         {
             this.ctrlTabs.SetElement(element, false);
-            if (_showHighlighter)
-            {
-                HollowHighlightDriver.GetDefaultInstance().SetElement(element);
-            }
+            HollowHighlightDriver.GetDefaultInstance().SetElement(element);
         }
-
 
         /// <summary>
         /// Hide control and hilighter
@@ -253,7 +244,11 @@ namespace AccessibilityInsights.Modes
             this.ctrlTabs.CurrentMode = InspectTabMode.LoadedEvents;
 
             this.ctrlEvents.LoadEventRecords(el);
-            _showHighlighter = false;
+            if (HollowHighlightDriver.GetDefaultInstance().IsEnabled)
+            {
+                HollowHighlightDriver.GetDefaultInstance().IsEnabled = false;
+                MainWin.SetHighlightBtnState(false);
+            }
         }
 
         // <summary>
@@ -263,7 +258,6 @@ namespace AccessibilityInsights.Modes
         {
             CurrentLayout.LayoutEvent.ColumnSnapWidth = this.columnSnap.Width.Value;
         }
-
 
         // <summary>
         // Updates Window size with stored data and adjusts layout for event Mode

--- a/src/AccessibilityInsights/Modes/EventModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/EventModeControl.xaml.cs
@@ -244,9 +244,11 @@ namespace AccessibilityInsights.Modes
             this.ctrlTabs.CurrentMode = InspectTabMode.LoadedEvents;
 
             this.ctrlEvents.LoadEventRecords(el);
-            if (HollowHighlightDriver.GetDefaultInstance().IsEnabled)
+            HollowHighlightDriver highlightDriver = HollowHighlightDriver.GetDefaultInstance();
+            if (highlightDriver.IsEnabled)
             {
-                HollowHighlightDriver.GetDefaultInstance().IsEnabled = false;
+                highlightDriver.IsEnabled = false;
+                highlightDriver.HighlighterMode = HighlighterMode.Highlighter;
                 MainWin.SetHighlightBtnState(false);
             }
         }

--- a/src/AccessibilityInsights/Modes/EventModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/EventModeControl.xaml.cs
@@ -31,6 +31,8 @@ namespace AccessibilityInsights.Modes
     {
         private ElementContext ElementContext;
 
+        private bool _showHighlighter = true;
+
         /// <summary>
         /// MainWindow to access shared methods
         /// </summary>
@@ -123,7 +125,9 @@ namespace AccessibilityInsights.Modes
                     this.ctrlTabs.IsRecordingChanged(isStarted);
                 }
             });
-        }        
+
+            _showHighlighter = true;
+        }
 
         /// <summary>
         /// Handles selection change in events list
@@ -193,7 +197,10 @@ namespace AccessibilityInsights.Modes
         private void UpdateUI(A11yElement element)
         {
             this.ctrlTabs.SetElement(element, false);
-            HollowHighlightDriver.GetDefaultInstance().SetElement(element);
+            if (_showHighlighter)
+            {
+                HollowHighlightDriver.GetDefaultInstance().SetElement(element);
+            }
         }
 
 
@@ -246,6 +253,7 @@ namespace AccessibilityInsights.Modes
             this.ctrlTabs.CurrentMode = InspectTabMode.LoadedEvents;
 
             this.ctrlEvents.LoadEventRecords(el);
+            _showHighlighter = false;
         }
 
         // <summary>


### PR DESCRIPTION
#### Describe the change
The current highlighter behavior is strange after opening an events file. It is enabled by default and always draws with the snapshot beaker (which doesn't work). This change does 2 things:
1. When the opening an events file, the global highlighter state is disabled by default (and the command bar reflects this state).
2. The user can optionally enable the highlighter via the command bar. When this happens, the highlighter is just the highlighter--no snapshot button, no tooltip.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #365 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

GIF shows highlight behavior while recording, as well as after loading a saved file (off by default, highlighter only when enabled)
![FixFor365](https://user-images.githubusercontent.com/45672944/58518557-86376200-8164-11e9-8391-c0c15d8a728a.gif)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
