### PR TITLE
Port HotKey classes from axe-windows to SharedUx

### DIFF
--- a/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKey.cs
+++ b/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKey.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.Win32;
+using System;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace AccessibilityInsights.SharedUx.KeyboardHelpers
+{
+    /// <summary>
+    /// Class for hot key
+    /// </summary>
+    public class Hotkey
+    {
+        /// <summary>
+        /// this value will be set by Hotkey Handler
+        /// </summary>
+        public int Id { get; internal set; }
+
+        public Keys Key { get; internal set; }
+        public HotkeyModifier Modifier { get; internal set; }
+
+        public Action Action { get; set; }
+
+        public uint ErrorCode { get; private set; }
+
+        /// <summary>
+        /// Register hot key
+        /// </summary>
+        /// <param name="hWnd"></param>
+        public bool Register(IntPtr hWnd)
+        {
+            this.ErrorCode = 0;
+
+            if(NativeMethods.RegisterHotKey(hWnd, Id, (int)this.Modifier, Key.GetHashCode()) == false)
+            {
+                ErrorCode = NativeMethods.GetLastError();
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Unregister HotKey
+        /// </summary>
+        /// <param name="hWnd"></param>
+        public bool Unregister(IntPtr hWnd)
+        {
+            this.ErrorCode = 0;
+
+            if(NativeMethods.UnregisterHotKey(hWnd, Id) == false)
+            {
+                ErrorCode = NativeMethods.GetLastError();
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Get an instance of HotKey based on given string
+        /// </summary>
+        /// <param name="txt"></param>
+        /// <returns></returns>
+        public static Hotkey GetInstance(string txt)
+        {
+            var atoms = from a in txt.Split(new char[] { '+' }, StringSplitOptions.RemoveEmptyEntries)
+                        select a.Trim();
+            var hk = new Hotkey();
+
+            try
+            {
+                if (atoms.Count() == 2)
+                {
+                    hk.Modifier = GetMofidifier(atoms.ElementAt(0));
+
+                    hk.Key = GetKey(atoms.ElementAt(1));
+                }
+                else
+                {
+                    throw new ArgumentException($"Hotkey format is not Modifier + Key: {txt}");
+                }
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch
+            {
+                return null;
+            }
+#pragma warning restore CA1031 // Do not catch general exception types
+
+            return hk;
+        }
+
+        private static Keys GetKey(string a)
+        {
+            KeysConverter kc = new KeysConverter();
+            return (Keys)kc.ConvertFromInvariantString(a.ToUpperInvariant());
+        }
+
+        /// <summary>
+        /// Get Modifier value from given text
+        /// </summary>
+        /// <param name="mods">modifiers. comma separated</param>
+        /// <returns></returns>
+        private static HotkeyModifier GetMofidifier(string mods)
+        {
+            var fms = from m in mods.Split(',')
+                     select $"MOD_{m.ToUpperInvariant()}";
+
+            HotkeyModifier result = HotkeyModifier.MOD_NoModifier;
+
+            foreach (var fm in fms)
+            {
+                if (Enum.TryParse<HotkeyModifier>(fm, out HotkeyModifier tmp) == false)
+                {
+                    result = HotkeyModifier.MOD_NoModifier;
+                    break;
+                }
+                else
+                {
+                    if (result == HotkeyModifier.MOD_NoModifier)
+                    {
+                        result = tmp;
+                    }
+                    else
+                    {
+                        result |= tmp;
+                    }
+
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKey.cs
+++ b/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKey.cs
@@ -10,7 +10,7 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
     /// <summary>
     /// Class for hot key
     /// </summary>
-    public class Hotkey
+    public class HotKey
     {
         /// <summary>
         /// this value will be set by Hotkey Handler
@@ -63,11 +63,11 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
         /// </summary>
         /// <param name="txt"></param>
         /// <returns></returns>
-        public static Hotkey GetInstance(string txt)
+        public static HotKey GetInstance(string txt)
         {
             var atoms = from a in txt.Split(new char[] { '+' }, StringSplitOptions.RemoveEmptyEntries)
                         select a.Trim();
-            var hk = new Hotkey();
+            var hk = new HotKey();
 
             try
             {

--- a/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKeyHandler.cs
+++ b/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKeyHandler.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Interop;
+
+namespace AccessibilityInsights.SharedUx.KeyboardHelpers
+{
+    /// <summary>
+    /// Hotkey handler 
+    /// singleton
+    /// this is not thread safe.
+    /// </summary>
+    public class HotKeyHandler
+    {
+        readonly IntPtr hWnd;
+        private HwndSource source;
+        int idCount = 0;
+        readonly List<Hotkey> HotKeyList = new List<Hotkey>();
+
+        private HotKeyHandler(IntPtr hWnd)
+        {
+            this.hWnd = hWnd; 
+            source = HwndSource.FromHwnd(hWnd);
+        }
+
+        public void RegisterHotKey(Hotkey hk)
+        {
+            if (Find(hk) == null)
+            {
+                // Add the hook if needed
+                if (!HotKeyList.Any())
+                {
+                    source.AddHook(HandleHotKeys);
+                }
+
+                hk.Id = idCount;
+                this.HotKeyList.Add(hk);
+                idCount++;
+
+                hk.Register(hWnd);
+            }
+            // in case with matched one, silently exit
+        }
+
+        /// <summary>
+        /// Find matched key in the existing list
+        /// </summary>
+        /// <param name="hk"></param>
+        /// <returns></returns>
+        private Hotkey Find(Hotkey hk)
+        {
+            return (from k in this.HotKeyList
+                    where k.Key == hk.Key && k.Modifier == hk.Modifier
+                    select k).FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Check whether the given hotkey combination exists or not.
+        /// </summary>
+        /// <param name="hk"></param>
+        /// <returns></returns>
+        public bool Exist(Hotkey hk)
+        {
+            return Find(hk) != null;
+        }
+
+        /// <summary>
+        /// Clear the Hotkeys
+        /// </summary>
+        public void ClearHotkeys()
+        {
+            foreach (var k in this.HotKeyList)
+            {
+                k.Unregister(this.hWnd);
+            }
+
+            this.HotKeyList.Clear();
+            source.RemoveHook(HandleHotKeys);
+        }
+
+        /// <summary>
+        /// Find matched hot key by id
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        private Hotkey Find(int id)
+        {
+            return (from k in this.HotKeyList
+                    where k.Id == id
+                    select k).FirstOrDefault();
+        }
+
+        /// <summary>
+        /// HotKey handler 
+        /// </summary>
+        /// <param name="hwnd"></param>
+        /// <param name="msg"></param>
+        /// <param name="wParam"></param>
+        /// <param name="lParam"></param>
+        /// <param name="handled"></param>
+        /// <returns></returns>
+        private IntPtr HandleHotKeys(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            const int WM_HOTKEY = 0x0312;
+            switch (msg)
+            {
+                case WM_HOTKEY:
+                    var id = wParam.ToInt32();
+                    var hk = Find(id);
+                    hk.Action();
+                    break;
+            }
+            return IntPtr.Zero;
+        }
+
+        #region static code
+        static HotKeyHandler singleton = null;
+
+        public static HotKeyHandler GetHotkeyHandler(IntPtr hWnd)
+        {
+            if (singleton == null)
+            {
+                singleton = new HotKeyHandler(hWnd);
+            }
+
+            return singleton;
+        }
+        #endregion
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKeyHandler.cs
+++ b/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKeyHandler.cs
@@ -25,6 +25,11 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
             source = HwndSource.FromHwnd(hWnd);
         }
 
+        ~HotKeyHandler()
+        {
+            ClearHotkeys();
+        }
+
         public void RegisterHotKey(HotKey hk)
         {
             if (Find(hk) == null)

--- a/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKeyHandler.cs
+++ b/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKeyHandler.cs
@@ -17,7 +17,7 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
         readonly IntPtr hWnd;
         private HwndSource source;
         int idCount = 0;
-        readonly List<Hotkey> HotKeyList = new List<Hotkey>();
+        readonly List<HotKey> HotKeyList = new List<HotKey>();
 
         private HotKeyHandler(IntPtr hWnd)
         {
@@ -25,7 +25,7 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
             source = HwndSource.FromHwnd(hWnd);
         }
 
-        public void RegisterHotKey(Hotkey hk)
+        public void RegisterHotKey(HotKey hk)
         {
             if (Find(hk) == null)
             {
@@ -49,7 +49,7 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
         /// </summary>
         /// <param name="hk"></param>
         /// <returns></returns>
-        private Hotkey Find(Hotkey hk)
+        private HotKey Find(HotKey hk)
         {
             return (from k in this.HotKeyList
                     where k.Key == hk.Key && k.Modifier == hk.Modifier
@@ -61,7 +61,7 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
         /// </summary>
         /// <param name="hk"></param>
         /// <returns></returns>
-        public bool Exist(Hotkey hk)
+        public bool Exist(HotKey hk)
         {
             return Find(hk) != null;
         }
@@ -85,7 +85,7 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        private Hotkey Find(int id)
+        private HotKey Find(int id)
         {
             return (from k in this.HotKeyList
                     where k.Id == id

--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -420,6 +420,8 @@
     </Compile>
     <Compile Include="Enums\EventConfigNodeType.cs" />
     <Compile Include="Interfaces\ICCAMode.cs" />
+    <Compile Include="KeyboardHelpers\HotKey.cs" />
+    <Compile Include="KeyboardHelpers\HotKeyHandler.cs" />
     <Compile Include="Misc\ListViewSelectionLock.cs" />
     <Compile Include="Misc\SetupExceptionReporter.cs" />
     <Compile Include="Misc\VersionTools.cs" />

--- a/src/AccessibilityInsights.SharedUxTests/KeyboardHelpers/HotKeyUnitTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/KeyboardHelpers/HotKeyUnitTests.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.KeyboardHelpers;
+using AccessibilityInsights.Win32;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Windows.Forms;
+
+namespace AccessibilityInsights.SharedUxTests.KeyboardHelpers
+{
+    [TestClass]
+    public class HotKeyUnitTests
+    {
+        [TestMethod]
+        public void GetInstance_ShiftF10_HasCorrectCharacteristics()
+        {
+            HotKey hotkey = HotKey.GetInstance("shift+F10");
+            Assert.AreEqual(Keys.F10, hotkey.Key);
+            Assert.AreEqual(HotkeyModifier.MOD_SHIFT, hotkey.Modifier);
+        }
+
+        [TestMethod]
+        public void GetInstance_ControlShiftF9_HasCorrectCharacteristics()
+        {
+            HotKey hotkey = HotKey.GetInstance("control,shift+F9");
+            Assert.AreEqual(Keys.F9, hotkey.Key);
+            Assert.AreEqual(HotkeyModifier.MOD_SHIFT | HotkeyModifier.MOD_CONTROL, hotkey.Modifier);
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
+++ b/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
@@ -118,6 +118,7 @@
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
   </ItemGroup>
   <Choose>
@@ -132,6 +133,7 @@
     <Compile Include="Converters\BoolToVisibilityConverterTests.cs" />
     <Compile Include="FileIssue\FileIssueActionTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
     <Compile Include="FileIssue\IssueReporterManagerTests.cs" />
+    <Compile Include="KeyboardHelpers\HotKeyUnitTests.cs" />
     <Compile Include="Settings\ConfigurationModelTests.cs" />
     <Compile Include="Settings\LayoutTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -166,6 +168,10 @@
     <ProjectReference Include="..\AccessibilityInsights.SharedUx\SharedUx.csproj">
       <Project>{723ddc93-8ab7-403c-9d03-c90b01cae774}</Project>
       <Name>SharedUx</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\AccessibilityInsights.Win32\Win32.csproj">
+      <Project>{608e7ef9-c670-4152-a056-46448e2f1e18}</Project>
+      <Name>Win32</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup />

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -407,7 +407,7 @@ namespace AccessibilityInsights
                 DisableElementSelector();
                 this.timerAutoSnap.Dispose();
                 this.timerSelector.Dispose();
-                this.HotkeyHandler.Dispose(); // no more hot key handling. 
+                this.HotkeyHandler.ClearHotkeys(); // no more hot key handling.
 
                 var layout = ConfigurationManager.GetDefaultInstance().AppLayout;
 

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -179,7 +179,7 @@ namespace AccessibilityInsights
         /// <param name="errmsg"></param>
         private void SetHotKey(string hkcombo, Action action, string errmsg)
         {
-            var hk = Hotkey.GetInstance(hkcombo);
+            var hk = HotKey.GetInstance(hkcombo);
 
             if (hk != null)
             {

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -6,11 +6,11 @@ using AccessibilityInsights.Extensions;
 using AccessibilityInsights.Misc;
 using AccessibilityInsights.SetupLibrary;
 using AccessibilityInsights.SharedUx.Highlighting;
+using AccessibilityInsights.SharedUx.KeyboardHelpers;
 using AccessibilityInsights.SharedUx.Settings;
 using AccessibilityInsights.SharedUx.Telemetry;
-using Axe.Windows.Actions;
-using Axe.Windows.Desktop.Keyboard;
 using AccessibilityInsights.Win32;
+using Axe.Windows.Actions;
 using System;
 using System.Globalization;
 using System.Windows;
@@ -24,7 +24,7 @@ namespace AccessibilityInsights
     /// </summary>
     public partial class MainWindow
     {
-        public HotkeysHandler HotkeyHandler { get; private set; }
+        public HotKeyHandler HotkeyHandler { get; private set; }
         readonly TreeNavigator TreeNavigator = null;
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace AccessibilityInsights
         /// </summary>
         private void InitHotKeys()
         {
-            this.HotkeyHandler = HotkeysHandler.GetHotkeyHandler(new WindowInteropHelper(this).Handle);
+            this.HotkeyHandler = HotKeyHandler.GetHotkeyHandler(new WindowInteropHelper(this).Handle);
 
             SetHotKeyForModeSwitch();
             SetHotKeyForToggleRecord();

--- a/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
@@ -569,7 +569,7 @@ namespace AccessibilityInsights
         /// <param name="testconfig"></param>
         internal void HandleConfigurationChanged(IReadOnlyDictionary<string, object> changes)
         {
-            HotkeyHandler?.Dispose();
+            HotkeyHandler?.ClearHotkeys();
             InitHotKeys();
 
             var configManager = ConfigurationManager.GetDefaultInstance();


### PR DESCRIPTION
#### Describe the change
The HotKey handlers were in desktop by mistake. They belong in SharedUx. Port the classes over. The HotKeyHandlers class was blending an IDisposable with a singleton, which is a bizarre mix. I converted it to not use IDisposable.

#### PR checklist
Tested by running through multiple Hotkey scenarios (loading, changing, triggering, saving, etc.)

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



