### PR TITLE
Hide the highlighter by default when opening an Events file

### DIFF
--- a/src/AccessibilityInsights/Modes/EventModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/EventModeControl.xaml.cs
@@ -8,7 +8,6 @@ using Axe.Windows.Core.Bases;
 using Axe.Windows.Desktop.Types;
 using Axe.Windows.Desktop.UIAutomation.EventHandlers;
 using AccessibilityInsights.SharedUx.Controls.CustomControls;
-using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.SharedUx.Interfaces;
 using AccessibilityInsights.SharedUx.Settings;
@@ -123,7 +122,7 @@ namespace AccessibilityInsights.Modes
                     this.ctrlTabs.IsRecordingChanged(isStarted);
                 }
             });
-        }        
+        }
 
         /// <summary>
         /// Handles selection change in events list
@@ -142,7 +141,7 @@ namespace AccessibilityInsights.Modes
                 {
                     UpdateUI(null);
                 }
-                
+
                 this.ctrlTabs.CtrlEventMessage.SetEventMessage(msg);
             }
             else
@@ -196,7 +195,6 @@ namespace AccessibilityInsights.Modes
             HollowHighlightDriver.GetDefaultInstance().SetElement(element);
         }
 
-
         /// <summary>
         /// Hide control and hilighter
         /// </summary>
@@ -221,7 +219,7 @@ namespace AccessibilityInsights.Modes
                 this.SetFocusOnDefaultControl();
             }
             , System.Windows.Threading.DispatcherPriority.Input);
-            
+
             // Inspect tab control current mode to Events. 
             this.ctrlTabs.CurrentMode = InspectTabMode.Events;
         }
@@ -246,6 +244,13 @@ namespace AccessibilityInsights.Modes
             this.ctrlTabs.CurrentMode = InspectTabMode.LoadedEvents;
 
             this.ctrlEvents.LoadEventRecords(el);
+            HollowHighlightDriver highlightDriver = HollowHighlightDriver.GetDefaultInstance();
+            if (highlightDriver.IsEnabled)
+            {
+                highlightDriver.IsEnabled = false;
+                highlightDriver.HighlighterMode = HighlighterMode.Highlighter;
+                MainWin.SetHighlightBtnState(false);
+            }
         }
 
         // <summary>
@@ -255,7 +260,6 @@ namespace AccessibilityInsights.Modes
         {
             CurrentLayout.LayoutEvent.ColumnSnapWidth = this.columnSnap.Width.Value;
         }
-
 
         // <summary>
         // Updates Window size with stored data and adjusts layout for event Mode
@@ -273,7 +277,7 @@ namespace AccessibilityInsights.Modes
         {
             return;
         }
-        
+
         /// <summary>
         /// Handle Refresh request
         /// </summary>
@@ -303,7 +307,7 @@ namespace AccessibilityInsights.Modes
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-#pragma warning disable CA1801 
+#pragma warning disable CA1801
         private void UserControl_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
 #pragma warning restore CA1801
         {
@@ -324,4 +328,3 @@ namespace AccessibilityInsights.Modes
         }
     }
 }
-


### PR DESCRIPTION
Note: This is a reprise of #375, which was auto-closed when I deleted the wrong branch from my fork 😒 
 
#### Describe the change
The current highlighter behavior is strange after opening an events file. It is enabled by default and always draws with the snapshot beaker (which doesn't work). This change does 2 things:

1. When the opening an events file, the global highlighter state is disabled by default (and the command bar reflects this state).
2. The user can optionally enable the highlighter via the command bar. When this happens, the highlighter is just the highlighter--no snapshot button, no tooltip.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #365 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

![FixFor365](https://user-images.githubusercontent.com/45672944/58668774-d93d2080-82ee-11e9-8f54-a3b89d595ab3.gif)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

