### PR TITLE
Fix hot key issues

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
@@ -11,7 +11,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
     /// Interaction logic for HotkeyGrabDialog.xaml
     /// </summary>
     public partial class HotkeyGrabDialog : Window
-    {        
+    {
         /// <summary>
         /// Modifier key
         /// </summary>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
@@ -74,7 +74,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
 
             if (ModKey != ModifierKeys.None)
             {
-                this.lbModifiers.Content = ModKey.ToString();
+                this.lbModifiers.Content = GetCleanModifierString();
             }
 
             if (SelectedKey != Key.None)
@@ -84,11 +84,23 @@ namespace AccessibilityInsights.SharedUx.Dialogs
 
             if(ModKey != ModifierKeys.None && SelectedKey != Key.None)
             {
-                ButtonParent.Content = string.Format(CultureInfo.InvariantCulture, "{0} + {1}", ModKey.ToString(), GetCleanKeyString());
+                ButtonParent.Content = string.Format(CultureInfo.InvariantCulture, "{0} + {1}", GetCleanModifierString(), GetCleanKeyString());
                 this.Close();
             }
         }
 
+        /// <summary>
+        /// Get the string to represent ModKeys. This string removes any spaces that get
+        /// injected by .NET (for compatibility with existing settings)
+        /// </summary>
+        /// <returns></returns>
+        private string GetCleanModifierString()
+        {
+            if (ModKey == ModifierKeys.None)
+                return string.Empty;
+
+            return ModKey.ToString().Replace(" ", "");
+        }
         /// <summary>
         /// Get clean key string for display
         /// </summary>

--- a/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKey.cs
+++ b/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKey.cs
@@ -73,7 +73,7 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
             {
                 if (atoms.Count() == 2)
                 {
-                    hk.Modifier = GetMofidifier(atoms.ElementAt(0));
+                    hk.Modifier = GetModifier(atoms.ElementAt(0));
 
                     hk.Key = GetKey(atoms.ElementAt(1));
                 }
@@ -103,10 +103,10 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
         /// </summary>
         /// <param name="mods">modifiers. comma separated</param>
         /// <returns></returns>
-        private static HotkeyModifier GetMofidifier(string mods)
+        private static HotkeyModifier GetModifier(string mods)
         {
             var fms = from m in mods.Split(',')
-                     select $"MOD_{m.ToUpperInvariant()}";
+                     select $"MOD_{m.Trim().ToUpperInvariant()}";
 
             HotkeyModifier result = HotkeyModifier.MOD_NoModifier;
 

--- a/src/AccessibilityInsights.SharedUxTests/KeyboardHelpers/HotKeyUnitTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/KeyboardHelpers/HotKeyUnitTests.cs
@@ -11,6 +11,7 @@ namespace AccessibilityInsights.SharedUxTests.KeyboardHelpers
     public class HotKeyUnitTests
     {
         [TestMethod]
+        [Timeout(1000)]
         public void GetInstance_ShiftF10_HasCorrectCharacteristics()
         {
             HotKey hotkey = HotKey.GetInstance("shift+F10");
@@ -19,9 +20,19 @@ namespace AccessibilityInsights.SharedUxTests.KeyboardHelpers
         }
 
         [TestMethod]
+        [Timeout(1000)]
         public void GetInstance_ControlShiftF9_HasCorrectCharacteristics()
         {
             HotKey hotkey = HotKey.GetInstance("control,shift+F9");
+            Assert.AreEqual(Keys.F9, hotkey.Key);
+            Assert.AreEqual(HotkeyModifier.MOD_SHIFT | HotkeyModifier.MOD_CONTROL, hotkey.Modifier);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void GetInstance_ControlShiftF9WithSpaces_HasCorrectCharacteristics()
+        {
+            HotKey hotkey = HotKey.GetInstance(" control , shift + F9 ");
             Assert.AreEqual(Keys.F9, hotkey.Key);
             Assert.AreEqual(HotkeyModifier.MOD_SHIFT | HotkeyModifier.MOD_CONTROL, hotkey.Modifier);
         }

--- a/src/AccessibilityInsights.SharedUxTests/KeyboardHelpers/HotKeyUnitTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/KeyboardHelpers/HotKeyUnitTests.cs
@@ -12,7 +12,7 @@ namespace AccessibilityInsights.SharedUxTests.KeyboardHelpers
     {
         [TestMethod]
         [Timeout(1000)]
-        public void GetInstance_ShiftF10_HasCorrectCharacteristics()
+        public void GetInstance_ShiftF10_PropertiesAreCorrect()
         {
             HotKey hotkey = HotKey.GetInstance("shift+F10");
             Assert.AreEqual(Keys.F10, hotkey.Key);
@@ -21,7 +21,7 @@ namespace AccessibilityInsights.SharedUxTests.KeyboardHelpers
 
         [TestMethod]
         [Timeout(1000)]
-        public void GetInstance_ControlShiftF9_HasCorrectCharacteristics()
+        public void GetInstance_ControlShiftF9_PropertiesAreCorrect()
         {
             HotKey hotkey = HotKey.GetInstance("control,shift+F9");
             Assert.AreEqual(Keys.F9, hotkey.Key);
@@ -30,7 +30,7 @@ namespace AccessibilityInsights.SharedUxTests.KeyboardHelpers
 
         [TestMethod]
         [Timeout(1000)]
-        public void GetInstance_ControlShiftF9WithSpaces_HasCorrectCharacteristics()
+        public void GetInstance_ControlShiftF9WithSpaces_PropertiesAreCorrect()
         {
             HotKey hotkey = HotKey.GetInstance(" control , shift + F9 ");
             Assert.AreEqual(Keys.F9, hotkey.Key);


### PR DESCRIPTION
#### Describe the change
HotKeys have 2 issues:
1. When adding multiple modifiers via the UI, extra spaces get added. This causes the "check for duplicates" to fail to find duplicates
2. When parsing the multiple modifiers with spaces, the modifiers get completely lost. This is just weird.

To maintain compatibility with default and previously broken customizations, we're removing the spaces when generated in the UI, and we're respecting the spaces if they exist. Added a unit test to cover the case with spaces; fixed a typo in a method name

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

