### PR TITLE
Clear live mode when selection scope is changed

### DIFF
--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -838,7 +838,7 @@ namespace AccessibilityInsights
                 var scope = this.cbiEntireApp.IsSelected ? Axe.Windows.Actions.Enums.SelectionScope.App : Axe.Windows.Actions.Enums.SelectionScope.Element;
                 SelectAction.GetDefaultInstance().Scope = scope;
                 ConfigurationManager.GetDefaultInstance().AppConfig.IsUnderElementScope = (scope == Axe.Windows.Actions.Enums.SelectionScope.Element);
-                Logger.PublishTelemetryEvent(TelemetryAction.TestSelection_Set_Scope, TelemetryProperty.Scope, scope.ToString());                
+                Logger.PublishTelemetryEvent(TelemetryAction.TestSelection_Set_Scope, TelemetryProperty.Scope, scope.ToString());
                 SelectAction.GetDefaultInstance().ClearSelectedContext();
                 ctrlLiveMode.Clear();
                 HollowHighlightDriver.GetDefaultInstance().Clear();

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -838,8 +838,9 @@ namespace AccessibilityInsights
                 var scope = this.cbiEntireApp.IsSelected ? Axe.Windows.Actions.Enums.SelectionScope.App : Axe.Windows.Actions.Enums.SelectionScope.Element;
                 SelectAction.GetDefaultInstance().Scope = scope;
                 ConfigurationManager.GetDefaultInstance().AppConfig.IsUnderElementScope = (scope == Axe.Windows.Actions.Enums.SelectionScope.Element);
-                Logger.PublishTelemetryEvent(TelemetryAction.TestSelection_Set_Scope, TelemetryProperty.Scope, scope.ToString());
+                Logger.PublishTelemetryEvent(TelemetryAction.TestSelection_Set_Scope, TelemetryProperty.Scope, scope.ToString());                
                 SelectAction.GetDefaultInstance().ClearSelectedContext();
+                ctrlLiveMode.Clear();
                 HollowHighlightDriver.GetDefaultInstance().Clear();
             }
         }

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
@@ -307,6 +307,7 @@ namespace AccessibilityInsights.Modes
             ctrlHierarchy.Visibility = Visibility.Collapsed;
             spInstructions.Visibility = Visibility.Visible;
 
+            this.SelectedInHierarchyElement = null;
             this.ElementContext = null;
             this.ctrlHierarchy.Clear();
             this.ctrlTabs.Clear();


### PR DESCRIPTION
#### Describe the change
Addresses #381- AI-Win crashes if the user attempts to run tests immediately after changing the "What to select" value. Previously, the selected data was cleared when scope changed, but the ui was not changed to reflect this. This PR clears the ui so that the user cannot attempt to run tests in this scenario.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - #381 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



