### PR TITLE
Update how version and UIAccess are displayed

### DIFF
--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/AutoUpdate.cs
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/AutoUpdate.cs
@@ -236,9 +236,13 @@ namespace AccessibilityInsights.Extensions.GitHubAutoUpdate
                         {
                             return AutoUpdateOption.RequiredUpgrade;
                         }
-                        else if (_installedVersion < _currentChannelVersion)
+                        if (_installedVersion < _currentChannelVersion)
                         {
                             return AutoUpdateOption.OptionalUpgrade;
+                        }
+                        if (_installedVersion > _currentChannelVersion)
+                        {
+                            return AutoUpdateOption.NewerThanCurrent;
                         }
                         return AutoUpdateOption.Current;
                     }

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/AutoUpdateUnitTests.cs
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/AutoUpdateUnitTests.cs
@@ -15,6 +15,7 @@ namespace Extensions.GitHubAutoUpdateUnitTests
     {
         private const string TestInstalledVersion = "1.1.1234";
         private const string UplevelVersion = "1.1.1260";
+        private const string DownlevelVersion = "1.1.1200";
         private const ReleaseChannel DefaultReleaseChannel = ReleaseChannel.Production;
 
         private static readonly IChannelInfoProvider InertChannelInfoProvider =
@@ -42,6 +43,14 @@ namespace Extensions.GitHubAutoUpdateUnitTests
             MinimumVersion = new Version(UplevelVersion),
             InstallAsset = GetInstallerPath(UplevelVersion),
             ReleaseNotesAsset = GetReleaseNotesPath(UplevelVersion)
+        };
+
+        private static readonly ChannelInfo PreReleaseChannelInfo = new ChannelInfo
+        {
+            CurrentVersion = new Version(DownlevelVersion),
+            MinimumVersion = new Version(DownlevelVersion),
+            InstallAsset = GetInstallerPath(DownlevelVersion),
+            ReleaseNotesAsset = GetReleaseNotesPath(DownlevelVersion)
         };
 
         private static string GetInstallerPath(string version)
@@ -174,6 +183,20 @@ namespace Extensions.GitHubAutoUpdateUnitTests
             Assert.AreEqual(RequiredUpgradeChannelInfo.CurrentVersion, update.CurrentChannelVersion);
             Assert.AreEqual(RequiredUpgradeChannelInfo.MinimumVersion, update.MinimumChannelVersion);
             Assert.AreEqual(RequiredUpgradeChannelInfo.ReleaseNotesAsset, update.ReleaseNotesUri.ToString());
+            providerMock.VerifyAll();
+        }
+
+        [TestMethod]
+        [Timeout(2000)]
+        public void UpdateOptionAsync_ConfigShowsPrereleaseBuild_ReturnsNewerThanCurrent()
+        {
+            Mock<IChannelInfoProvider> providerMock = BuildChannelInfoProvider(DefaultReleaseChannel, PreReleaseChannelInfo);
+            AutoUpdate update = BuildAutoUpdate(channelProvider: providerMock.Object);
+            Assert.AreEqual(AutoUpdateOption.NewerThanCurrent, update.UpdateOptionAsync.Result);
+            Assert.AreEqual(TestInstalledVersion, update.InstalledVersion.ToString());
+            Assert.AreEqual(PreReleaseChannelInfo.CurrentVersion, update.CurrentChannelVersion);
+            Assert.AreEqual(PreReleaseChannelInfo.MinimumVersion, update.MinimumChannelVersion);
+            Assert.AreEqual(PreReleaseChannelInfo.ReleaseNotesAsset, update.ReleaseNotesUri.ToString());
             providerMock.VerifyAll();
         }
 

--- a/src/AccessibilityInsights.Extensions/Interfaces/Upgrades/UpgradeOption.cs
+++ b/src/AccessibilityInsights.Extensions/Interfaces/Upgrades/UpgradeOption.cs
@@ -13,6 +13,11 @@ namespace AccessibilityInsights.Extensions.Interfaces.Upgrades
         Unknown,
 
         /// <summary>
+        /// Current installation is ahead of the current version
+        /// </summary>
+        NewerThanCurrent,
+
+        /// <summary>
         /// No upgrade exists
         /// </summary>
         Current,

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -16,11 +16,14 @@
     <StackPanel Margin="20,10,20,0">
         <Label Padding="0" FontSize="20" FontWeight="Bold" Content="{x:Static Properties:Resources.LabelContentAccessibilityInsightsForWindows}"/>
         <Label Padding="0" FontSize="14" Margin="0,5,0,0" Content="{x:Static Properties:Resources.LabelContentByMicrosoftCorporation}" />
-        <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
-            <Label Padding="0" FontSize="14" Content="{x:Static Properties:Resources.LabelContentVersion}" />
-            <Label x:Name="lbVersion" Padding="0" FontSize="14" Margin="5,0,0,0"/>
-        </StackPanel>
-        <Label x:Name="lbUIAccess" Padding="0" FontSize="14" Margin="0,5,0,0" Content="{x:Static Properties:Resources.LabelUIAccessAvailable}" />
+        <TextBlock Padding="0" FontSize="14" Margin="0,5,0,0" HorizontalAlignment="Left">
+            <Hyperlink x:Name="hlVersion" AutomationProperties.Name="{x:Static Properties:Resources.hlVersion}" 
+                    Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 
+                    TextDecorations="None">
+                <Run Text="{x:Static Properties:Resources.Placeholder}" />
+            </Hyperlink>
+        </TextBlock>
+        <Label x:Name="lbUIAccess" Padding="0" FontSize="14" Margin="0,5,0,0" Content="{x:Static Properties:Resources.Placeholder}" />
         <TextBlock Padding="0" FontSize="14" Margin="0,32,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlHelp" AutomationProperties.Name="{x:Static Properties:Resources.hlHelpName}" 
                        Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -9,6 +9,7 @@
              xmlns:fabric="clr-namespace:AccessibilityInsights.CommonUxComponents.Controls;assembly=AccessibilityInsights.CommonUxComponents"
              xmlns:Properties="clr-namespace:AccessibilityInsights.SharedUx.Properties"
              mc:Ignorable="d" 
+             DataContext="{Binding RelativeSource={RelativeSource Self}, Path=ViewModel}"
              d:DesignHeight="400" d:DesignWidth="400">
     <UserControl.Resources>
         <ResourceDictionary Source="..\..\Resources\Styles.xaml"/>
@@ -19,11 +20,11 @@
         <TextBlock Padding="0" FontSize="14" Margin="0,5,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlVersion" AutomationProperties.Name="{x:Static Properties:Resources.hlVersion}" 
                     Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 
-                    TextDecorations="None">
-                <Run Text="{x:Static Properties:Resources.Placeholder}" />
+                    NavigateUri="{Binding Path=VersionInfoUri}" TextDecorations="None">
+                <Run Text="{Binding Path=VersionInfoLabel, Mode=OneWay}" />
             </Hyperlink>
         </TextBlock>
-        <Label x:Name="lbUIAccess" Padding="0" FontSize="14" Margin="0,5,0,0" Content="{x:Static Properties:Resources.Placeholder}" />
+        <Label x:Name="lbUIAccess" Padding="0" FontSize="14" Margin="0,5,0,0" Content="{Binding Path=UIAccessStatus, Mode=OneWay}" />
         <TextBlock Padding="0" FontSize="14" Margin="0,32,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlHelp" AutomationProperties.Name="{x:Static Properties:Resources.hlHelpName}" 
                        Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -20,6 +20,7 @@
             <Label Padding="0" FontSize="14" Content="{x:Static Properties:Resources.LabelContentVersion}" />
             <Label x:Name="lbVersion" Padding="0" FontSize="14" Margin="5,0,0,0"/>
         </StackPanel>
+        <Label x:Name="lbUIAccess" Padding="0" FontSize="14" Margin="0,5,0,0" Content="{x:Static Properties:Resources.LabelUIAccessAvailable}" />
         <TextBlock Padding="0" FontSize="14" Margin="0,32,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlHelp" AutomationProperties.Name="{x:Static Properties:Resources.hlHelpName}" 
                        Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml.cs
@@ -5,6 +5,7 @@ using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.Win32;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
@@ -22,11 +23,8 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
         public AboutTabControl()
         {
             InitializeComponent();
-            lbVersion.Content = VersionTools.GetAppVersion();
-            if (!NativeMethods.IsRunningWithUIAccess())
-            {
-                lbUIAccess.Content = Properties.Resources.LabelUIAccessAvailable;
-            }
+            InitializeVersionInformationLink();
+            InitializeUIAccessLabel();
         }
 
         /// <summary>
@@ -76,6 +74,23 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
                 // silently ignore. 
             }
 #pragma warning restore CA1031 // Do not catch general exception types
+        }
+
+        private void InitializeVersionInformationLink()
+        {
+            string version = VersionTools.GetAppVersion();
+            hlVersion.NavigateUri = new Uri(string.Format(CultureInfo.InvariantCulture,
+                Properties.Resources.VersionLinkFormat, version), UriKind.Absolute);
+            hlVersion.Inlines.Clear();
+            hlVersion.Inlines.Add(string.Format(CultureInfo.InvariantCulture,
+                Properties.Resources.VersionLinkContentFormat, version));
+        }
+
+        private void InitializeUIAccessLabel()
+        {
+            lbUIAccess.Content = NativeMethods.IsRunningWithUIAccess() ?
+                Properties.Resources.LabelUIAccessAvailable :
+                Properties.Resources.LabelUIAccessNotAvailable;
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.Misc;
 using AccessibilityInsights.SharedUx.Telemetry;
+using AccessibilityInsights.Win32;
 using System;
 using System.Diagnostics;
 using System.Windows;
@@ -22,6 +23,10 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
         {
             InitializeComponent();
             lbVersion.Content = VersionTools.GetAppVersion();
+            if (!NativeMethods.IsRunningWithUIAccess())
+            {
+                lbUIAccess.Content = Properties.Resources.LabelUIAccessAvailable;
+            }
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml.cs
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using AccessibilityInsights.SharedUx.Misc;
 using AccessibilityInsights.SharedUx.Telemetry;
-using AccessibilityInsights.Win32;
+using AccessibilityInsights.SharedUx.ViewModels;
 using System;
 using System.Diagnostics;
-using System.Globalization;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
@@ -17,14 +16,15 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
     /// </summary>
     public partial class AboutTabControl : UserControl
     {
+        // ViewModel computes dialog values at run time
+        public AboutTabViewModel ViewModel { get; } = new AboutTabViewModel();
+
         /// <summary>
         /// Constructor
         /// </summary>
         public AboutTabControl()
         {
             InitializeComponent();
-            InitializeVersionInformationLink();
-            InitializeUIAccessLabel();
         }
 
         /// <summary>
@@ -36,13 +36,13 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
         {
             var uri = ((Hyperlink)sender).NavigateUri;
 
-            var path = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, uri.OriginalString);
+            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, uri.OriginalString);
 
             try
             {
-                if (System.IO.File.Exists(path))
+                if (File.Exists(path))
                 {
-                    System.Diagnostics.Process.Start(path);
+                    Process.Start(path);
                 }
             }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -74,23 +74,6 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
                 // silently ignore. 
             }
 #pragma warning restore CA1031 // Do not catch general exception types
-        }
-
-        private void InitializeVersionInformationLink()
-        {
-            string version = VersionTools.GetAppVersion();
-            hlVersion.NavigateUri = new Uri(string.Format(CultureInfo.InvariantCulture,
-                Properties.Resources.VersionLinkFormat, version), UriKind.Absolute);
-            hlVersion.Inlines.Clear();
-            hlVersion.Inlines.Add(string.Format(CultureInfo.InvariantCulture,
-                Properties.Resources.VersionLinkContentFormat, version));
-        }
-
-        private void InitializeUIAccessLabel()
-        {
-            lbUIAccess.Content = NativeMethods.IsRunningWithUIAccess() ?
-                Properties.Resources.LabelUIAccessAvailable :
-                Properties.Resources.LabelUIAccessNotAvailable;
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3095,15 +3095,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to *** placeholder ***.
-        /// </summary>
-        public static string Placeholder {
-            get {
-                return ResourceManager.GetString("Placeholder", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Read our.
         /// </summary>
         public static string PrivacyLearnMore1 {
@@ -4382,7 +4373,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://github.com/microsoft/accessibility-insights-windows/releases/tag/v{0}.
+        ///   Looks up a localized string similar to https://github.com/microsoft/accessibility-insights-windows/releases/tag/v{0}.{1}.{2:0000}.{3:00}.
         /// </summary>
         public static string VersionLinkFormat {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -2236,6 +2236,24 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string labelEventsContent {
             get {
                 return ResourceManager.GetString("labelEventsContent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to UIAccess: Available.
+        /// </summary>
+        public static string LabelUIAccessAvailable {
+            get {
+                return ResourceManager.GetString("LabelUIAccessAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to UIAccess: Not Available.
+        /// </summary>
+        public static string LabelUIAccessNotAvailable {
+            get {
+                return ResourceManager.GetString("LabelUIAccessNotAvailable", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2015,6 +2015,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Version.
+        /// </summary>
+        public static string hlVersion {
+            get {
+                return ResourceManager.GetString("hlVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Type a keyboard shortcut.
         /// </summary>
         public static string HotkeyGrabDialogWindowTitle {
@@ -2213,15 +2222,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Version:.
-        /// </summary>
-        public static string LabelContentVersion {
-            get {
-                return ResourceManager.GetString("LabelContentVersion", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to 0.
         /// </summary>
         public static string LabelContentZero {
@@ -2240,7 +2240,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to UIAccess: Available.
+        ///   Looks up a localized string similar to UIAccess is available.
         /// </summary>
         public static string LabelUIAccessAvailable {
             get {
@@ -2249,7 +2249,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to UIAccess: Not Available.
+        ///   Looks up a localized string similar to UIAccess is not available.
         /// </summary>
         public static string LabelUIAccessNotAvailable {
             get {
@@ -3091,6 +3091,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string PatternViewModel_GetActionButtonText_Explore {
             get {
                 return ResourceManager.GetString("PatternViewModel_GetActionButtonText_Explore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to *** placeholder ***.
+        /// </summary>
+        public static string Placeholder {
+            get {
+                return ResourceManager.GetString("Placeholder", resourceCulture);
             }
         }
         
@@ -4360,6 +4369,24 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string TTAutomationPropertiesName {
             get {
                 return ResourceManager.GetString("TTAutomationPropertiesName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Version {0}.
+        /// </summary>
+        public static string VersionLinkContentFormat {
+            get {
+                return ResourceManager.GetString("VersionLinkContentFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to https://github.com/microsoft/accessibility-insights-windows/releases/tag/v{0}.
+        /// </summary>
+        public static string VersionLinkFormat {
+            get {
+                return ResourceManager.GetString("VersionLinkFormat", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -246,9 +246,6 @@
   <data name="LabelContentByMicrosoftCorporation" xml:space="preserve">
     <value>by Microsoft Corporation</value>
   </data>
-  <data name="LabelContentVersion" xml:space="preserve">
-    <value>Version:</value>
-  </data>
   <data name="hlTermsName" xml:space="preserve">
     <value>License terms</value>
   </data>
@@ -1569,9 +1566,24 @@ Do you want to change the channel? </value>
     <comment>Title for window containing screenshot</comment>
   </data>
   <data name="LabelUIAccessAvailable" xml:space="preserve">
-    <value>UIAccess: Available</value>
+    <value>UIAccess is available</value>
   </data>
   <data name="LabelUIAccessNotAvailable" xml:space="preserve">
-    <value>UIAccess: Not Available</value>
+    <value>UIAccess is not available</value>
+  </data>
+  <data name="hlVersion" xml:space="preserve">
+    <value>Version</value>
+  </data>
+  <data name="Placeholder" xml:space="preserve">
+    <value>*** placeholder ***</value>
+    <comment>Gets replaced at runtime</comment>
+  </data>
+  <data name="VersionLinkContentFormat" xml:space="preserve">
+    <value>Version {0}</value>
+    <comment>{0} is the placeholder for the app version string</comment>
+  </data>
+  <data name="VersionLinkFormat" xml:space="preserve">
+    <value>https://github.com/microsoft/accessibility-insights-windows/releases/tag/v{0}</value>
+    <comment>(0) is the placeholder for the app version string</comment>
   </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1574,16 +1574,12 @@ Do you want to change the channel? </value>
   <data name="hlVersion" xml:space="preserve">
     <value>Version</value>
   </data>
-  <data name="Placeholder" xml:space="preserve">
-    <value>*** placeholder ***</value>
-    <comment>Gets replaced at runtime</comment>
-  </data>
   <data name="VersionLinkContentFormat" xml:space="preserve">
     <value>Version {0}</value>
     <comment>{0} is the placeholder for the app version string</comment>
   </data>
   <data name="VersionLinkFormat" xml:space="preserve">
-    <value>https://github.com/microsoft/accessibility-insights-windows/releases/tag/v{0}</value>
-    <comment>(0) is the placeholder for the app version string</comment>
+    <value>https://github.com/microsoft/accessibility-insights-windows/releases/tag/v{0}.{1}.{2:0000}.{3:00}</value>
+    <comment>{0} - {3} are placeholders for the 4 fields of a Version object</comment>
   </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1561,11 +1561,17 @@ Do you want to change the channel? </value>
   <data name="ChangeChannelContainedDialog_BtnExit" xml:space="preserve">
     <value>Do not change channel</value>
   </data>
-<data name="ChangeChannelContainedDialog_BtnOk" xml:space="preserve">
+  <data name="ChangeChannelContainedDialog_BtnOk" xml:space="preserve">
     <value>Change channel</value>
   </data>
   <data name="ScreenshotWindowTitle" xml:space="preserve">
     <value>Accessibility Insights for Windows - Screenshot</value>
     <comment>Title for window containing screenshot</comment>
+  </data>
+  <data name="LabelUIAccessAvailable" xml:space="preserve">
+    <value>UIAccess: Available</value>
+  </data>
+  <data name="LabelUIAccessNotAvailable" xml:space="preserve">
+    <value>UIAccess: Not Available</value>
   </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -527,6 +527,7 @@
     <Compile Include="Utilities\HelperMethods.cs" />
     <Compile Include="Utilities\InstallationInfo.cs" />
     <Compile Include="Utilities\ReferenceHolder.cs" />
+    <Compile Include="ViewModels\AboutTabViewModel.cs" />
     <Compile Include="ViewModels\BaseActionViewModel.cs" />
     <Compile Include="ViewModels\LogoViewModel.cs" />
     <Compile Include="ViewModels\ColorContrastViewModel.cs" />

--- a/src/AccessibilityInsights.SharedUx/ViewModels/AboutTabViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/AboutTabViewModel.cs
@@ -15,10 +15,16 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     {
 #pragma warning disable CA1822
 
+        /// <summary>
+        /// Provides the text for the UIAccess label
+        /// </summary>
         public string UIAccessStatus => NativeMethods.IsRunningWithUIAccess() ?
             Properties.Resources.LabelUIAccessAvailable :
             Properties.Resources.LabelUIAccessNotAvailable;
 
+        /// <summary>
+        /// Provides a Uri to the release notes for this version
+        /// </summary>
         public Uri VersionInfoUri
         {
             get
@@ -44,7 +50,9 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             }
         }
 
-
+        /// <summary>
+        /// Provides the version-specific label
+        /// </summary>
         public string VersionInfoLabel => string.Format(CultureInfo.InvariantCulture,
             Properties.Resources.VersionLinkContentFormat, VersionTools.GetAppVersion());
 

--- a/src/AccessibilityInsights.SharedUx/ViewModels/AboutTabViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/AboutTabViewModel.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Misc;
+using AccessibilityInsights.SharedUx.Telemetry;
+using AccessibilityInsights.Win32;
+using System;
+using System.Globalization;
+
+namespace AccessibilityInsights.SharedUx.ViewModels
+{
+    /// <summary>
+    /// A view model for the AboutTabControl.xaml.cs
+    /// </summary>
+    public class AboutTabViewModel : ViewModelBase
+    {
+#pragma warning disable CA1822
+
+        public string UIAccessStatus => NativeMethods.IsRunningWithUIAccess() ?
+            Properties.Resources.LabelUIAccessAvailable :
+            Properties.Resources.LabelUIAccessNotAvailable;
+
+        public Uri VersionInfoUri
+        {
+            get
+            {
+                try
+                {
+                    string compressedVersion = VersionTools.GetAppVersion();
+                    Version version = Version.Parse(compressedVersion);
+                    return new Uri(string.Format(CultureInfo.InvariantCulture,
+                        Properties.Resources.VersionLinkFormat,
+                        version.Major,
+                        version.Minor,
+                        version.Build,
+                        version.Revision));
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception e)
+                {
+                    e.ReportException();
+                    return null;
+                }
+#pragma warning restore CA1031 // Do not catch general exception types
+            }
+        }
+
+
+        public string VersionInfoLabel => string.Format(CultureInfo.InvariantCulture,
+            Properties.Resources.VersionLinkContentFormat, VersionTools.GetAppVersion());
+
+#pragma warning restore CA1822
+    }
+}

--- a/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
@@ -8,11 +8,9 @@ using AccessibilityInsights.SharedUx.Interfaces;
 using AccessibilityInsights.SharedUx.Misc;
 using AccessibilityInsights.SharedUx.Settings;
 using Axe.Windows.Actions;
-using AccessibilityInsights.Win32;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Controls;
@@ -272,7 +270,7 @@ namespace AccessibilityInsights
         }
 
         /// <summary>
-        /// Set version text, per https://github.com/microsoft/accessibility-insights-windows/issues/347
+        /// Compute version text, per https://github.com/microsoft/accessibility-insights-windows/issues/347
         /// </summary>
         private string ComputeVersionBarString()
         {

--- a/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Enums;
+using AccessibilityInsights.Extensions.Interfaces.Upgrades;
 using AccessibilityInsights.SetupLibrary;
 using AccessibilityInsights.SharedUx.Highlighting;
 using AccessibilityInsights.SharedUx.Interfaces;
@@ -263,28 +264,28 @@ namespace AccessibilityInsights
         }
 
         /// <summary>
-        /// Set version text
-        /// [(ReleaseChannel) - ]Version - UIAccess state
+        /// Set version text, per https://github.com/microsoft/accessibility-insights-windows/issues/347
         /// </summary>
         private void UpdateVersionString()
         {
-            StringBuilder sb = new StringBuilder();
+            this.lblVersion.Content = ComputeVersionBarString();
+        }
 
+        /// <summary>
+        /// Set version text, per https://github.com/microsoft/accessibility-insights-windows/issues/347
+        /// </summary>
+        private string ComputeVersionBarString()
+        {
             ReleaseChannel? channel = ConfigurationManager.GetDefaultInstance()?.AppConfig?.ReleaseChannel;
-
-            if (channel.HasValue && channel.Value != ReleaseChannel.Production)
+            if ((channel.HasValue && channel.Value != ReleaseChannel.Production)
+                || _updateOption != AutoUpdateOption.NewerThanCurrent)
             {
-                sb.AppendFormat(CultureInfo.InvariantCulture, "({0}) - ", channel.Value);
+                return string.Format(CultureInfo.InvariantCulture,
+                    Properties.Resources.VersionBarPreReleaseVersion,
+                    VersionTools.GetAppVersion());
             }
 
-            sb.AppendFormat(CultureInfo.InvariantCulture, Properties.Resources.UpdateVersionStringVer, VersionTools.GetAppVersion());
-
-            if (NativeMethods.IsRunningWithUIAccess())
-            {
-                sb.Append(Properties.Resources.UpdateVersionStringUIAccess);
-            }
-
-            this.lblVersion.Content = sb.ToString();
+            return string.Empty;
         }
 
         public void HandleToggleStatusChanged(bool isEnabled)

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -1503,20 +1503,11 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to  - UIAccess.
+        ///   Looks up a localized string similar to Prerelease Build ({0}).
         /// </summary>
-        public static string UpdateVersionStringUIAccess {
+        public static string VersionBarPreReleaseVersion {
             get {
-                return ResourceManager.GetString("UpdateVersionStringUIAccess", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to ver {0}.
-        /// </summary>
-        public static string UpdateVersionStringVer {
-            get {
-                return ResourceManager.GetString("UpdateVersionStringVer", resourceCulture);
+                return ResourceManager.GetString("VersionBarPreReleaseVersion", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -550,11 +550,9 @@ Please ensure that you are opening a valid test file using the most recent relea
   <data name="CultureInfoErrorMessage" xml:space="preserve">
     <value>"{0}" is not proper hotkey combination. Hotkey should be [Shift|Ctrl|Alt|Window]+[a single key including function key]</value>
   </data>
-  <data name="UpdateVersionStringVer" xml:space="preserve">
-    <value>ver {0}</value>
-  </data>
-  <data name="UpdateVersionStringUIAccess" xml:space="preserve">
-    <value> - UIAccess</value>
+  <data name="VersionBarPreReleaseVersion" xml:space="preserve">
+    <value>Prerelease Build ({0})</value>
+    <comment>{0} receives the build version</comment>
   </data>
   <data name="UpdateDialogWindowTitle" xml:space="preserve">
     <value>There is an update available</value>


### PR DESCRIPTION
#### Describe the change
Update how version and UIAccess are displayed. Make the UIAccess status more accessible as a result.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #347 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Changes to the version bar:
- UIAccess information has been removed from the version bar.
- In prerelease versions (defined as being on Canary or Insider channel, or running a build newer than the current build in the Production channel), the build is called out as a Prerelease build.
- If the Channel is Production AND the version isn't newer than the current Production build, the version bar will be empty.

Changes to the about dialog appear below:
- The version label is now a hyperlink that points to the version-specific release notes.
- UIAccess availability is now displayed in the about dialog.
Screenshot of new about page (with highlighted differences) appears below. The lack of UIAccess support and the connection dialog are expected, as I was running an unsigned build from my build environment:
![image](https://user-images.githubusercontent.com/45672944/59630899-56440480-90fb-11e9-8634-d7e79e604a5e.png)

[Uri was corrected to include leading zeros in iteration 4] Clicking on the version hyperlink opens https://github.com/microsoft/accessibility-insights-windows/releases/tag/v1.1.0897.01 in the default browser. This page will exist for all customer builds. In my case, since no published build happens to match the auto-assigned local version, the link results in a 404 error. This will not be a problem for customer builds.

Implementation note: I wanted to leverage the code that already exists to determine what builds are expected in the Production channel. To do this, I've added a new state to AutoUpdateOption. This state indicates that the current build is newer than the build supported in the current channel, and this is then used to identify cases where we're on the Production channel, but on a prerelease build.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



