### PR TITLE
Promote Build 1.1.883.1 to Production channel as an optional upgrade

### DIFF
--- a/Channels/Production/release_info.json
+++ b/Channels/Production/release_info.json
@@ -1,8 +1,8 @@
 {
   "default": {
-    "current_version": "1.1.0837.02",
+    "current_version": "1.1.0883.01",
     "minimum_version": "1.1.0837.02",
-    "installer_url": "https://www.github.com/Microsoft/accessibility-insights-windows/releases/download/v1.1.0837.02/AccessibilityInsights.msi",
-    "release_notes_url": "https://www.github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.0837.02"
+    "installer_url": "https://www.github.com/Microsoft/accessibility-insights-windows/releases/download/v1.1.0883.01/AccessibilityInsights.msi",
+    "release_notes_url": "https://www.github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.0883.01"
   }
 }

--- a/Channels/Production/release_notes.md
+++ b/Channels/Production/release_notes.md
@@ -1,45 +1,28 @@
-## April 24th, 2019 Production Release ([v1.1.0837.02](https://github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.0837.02))
+## June 18th, 2019 Production Release ([v1.1.0883.01](https://github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.0883.01))
 
-Welcome to the April 24th, 2019 release of Accessibility Insights for Windows.
+Welcome to the June 18th, 2019 release of Accessibility Insights for Windows.
 
-Installation Link: [https://github.com/Microsoft/accessibility-insights-windows/releases/download/v1.1.0837.02/AccessibilityInsights.msi](https://github.com/Microsoft/accessibility-insights-windows/releases/download/v1.1.0837.02/AccessibilityInsights.msi)
+Installation Link: [https://github.com/Microsoft/accessibility-insights-windows/releases/download/v1.1.0883.01/AccessibilityInsights.msi](https://github.com/Microsoft/accessibility-insights-windows/releases/download/v1.1.0883.01/AccessibilityInsights.msi)
 
 Documentation Link: [https://accessibilityinsights.io/docs/en/windows/overview](https://accessibilityinsights.io/docs/en/windows/overview)
 
 ### Highlights
 
-  - [GitHub Issue Filing](#github-issue-filing)
-  - [New Rules](#new-rules)
-  - [Multiple Release Channels](#multiple-release-channels)
-  
-#### GitHub Issue Filing
+  - [Axe.Windows](#axe.windows)
+  - [Telemetry Improvements](#telemetry-improvements)
 
-GitHub users can now file issues directly from inside Accessibility Insights for Windows. Bug filing from Azure DevOps is still supported, and you can freely switch between the two.
+#### Axe.Windows
 
-#### New Rules
+The core scanning code from Accessibility Insights for Windows has been moved into a separate GitHub repo (https://github.com/microsoft/axe-windows). Accessibility Insights now gets its core scanning code from that location. This code will be handled separately to make this functionality more broadly available to the accessibility community.
 
-We've added the following accessibility rule based on community feedback:
-- Generate a warning if items in a listbox have duplicated names [#133](https://github.com/Microsoft/accessibility-insights-windows/issues/133)
+#### Telemetry Improvements
 
-#### Multiple Release Channels
-
-You can now choose how frequently your client updates:
-- The **Production** channel updates every 2-4 weeks.
-- The **Insider** channel updates every 1-2 weeks.
-- The **Canary** channel updates multiple times per week.
-
-You'll be in the **Production** channel by default, but you can change your channel at any time via the **Settings** page
+We identified a few points in the code where we had no telemetry about failures that users might be experiencing. We added these data points to help us make the product better. No additional customer data is exposed.
 
 ### Bug Fixes
 
-- Improved Automatic color contrast detection in High Contrast White theme [#144](https://github.com/Microsoft/accessibility-insights-windows/issues/144)
-- Properly display event details when loading an event details file [#161](https://github.com/Microsoft/accessibility-insights-windows/issues/161)
-- Fixed the appearance of the restore button when the app was maximized [#199](https://github.com/Microsoft/accessibility-insights-windows/issues/199)
-- Clarified the color descriptions in the Color Contrast Analyzer [#210](https://github.com/Microsoft/accessibility-insights-windows/issues/210)
-- ListItems within a Spinner control or a ControlViewSpinner control are no longer treated as errors [#268](https://github.com/Microsoft/accessibility-insights-windows/issues/268), [#272](https://github.com/Microsoft/accessibility-insights-windows/issues/272)
-- Modified the description shown when a SplitButton control has a MenuItem child [#269](https://github.com/Microsoft/accessibility-insights-windows/issues/269)
-- Added a splash screen to the startup sequence [#202](https://github.com/Microsoft/accessibility-insights-windows/issues/202)
-- Fix a typo in the message to configure for Issue filing [#306](https://github.com/Microsoft/accessibility-insights-windows/issues/306)
-- Include telemetry context when reporting Exceptions [PR #312](https://github.com/Microsoft/accessibility-insights-windows/pull/312)
-- Filter out extended characters when filing issues in AzureDevOps [PR #314](https://github.com/Microsoft/accessibility-insights-windows/pull/314)
-- Fix an error that was causing the app to hang on some machines [#317](https://github.com/Microsoft/accessibility-insights-windows/issues/317)
+- Prevent Accessibility Insights from hiding the UAC dialog during upgrade or channel switch [#336](https://github.com/Microsoft/accessibility-insights-windows/issues/336)
+- Improve the color contrast (including high contrast) in the buttons of the upgrade dialog [#342](https://github.com/Microsoft/accessibility-insights-windows/issues/342)
+- Prevent the upgrade dialog from floating above the browser when viewing release notes [#351](https://github.com/Microsoft/accessibility-insights-windows/issues/351)
+- Make the highlighter more intuitive when opening an events file [#365](https://github.com/Microsoft/accessibility-insights-windows/issues/365)
+- Fix a couple of issues when entering custom hot keys [#378](https://github.com/Microsoft/accessibility-insights-windows/pull/378)


### PR DESCRIPTION
#### Describe the change
Build 1.1.883.1 has been in the Insider channel for 2 weeks without reported issue. We want to promote it to the Production channel. This snaps us to our pattern of allowing Production clients to remain on the Current-1 version. Release notes were copied from the Insider channel release notes, then updated with the new date and channel.

#### PR checklist

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



