### PR TITLE
Clean up telemetry

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryAction.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryAction.cs
@@ -9,139 +9,44 @@ namespace AccessibilityInsights.SharedUx.Telemetry
     {
 #pragma warning disable CA1707 // Identifiers should not contain underscores
         /// <summary>
-        /// Mode change event
-        /// </summary>
-        Mode_Changed,
-
-        /// <summary>
         /// Test request
         /// </summary>
         Test_Requested,
-        SingleRule_Tested_Results,
 
-        Selector_Change_ByMousePoint,
-        Selector_Change_ByKeyboard,
-        Hilighter_Turned_On,
-        Hilighter_Turned_Off,
         Hilighter_Expand_AllDescendants,
-        Hilighter_Screenshot_Turned_Off,
-        Hilighter_Screenshot_Turned_On,
 
-        Hierarchy_Select_View, // select hierarchy view
         Hierarchy_Save,
         Hierarchy_Load_NewFormat,
-        Hierarchy_Load_OldFormat,
-        Hierarchy_Load_Protocol,
-        Hierarchy_Select_Item,
-        Hierarchy_Change_TreeWalkMode,
-        Hierarchy_Refresh_Tree,
-        Hierarchy_MoveTo_Parent,
-        Hierarchy_Change_ShowAncestry,
-        Hierarchy_Change_ShowUncertain,
-        Hierarchy_RefreshAndExpand_Ancestor,
 
-        Event_Select_View,
         Event_Start_Record,
-        Event_Stop_Record,
         Event_Save,
         Event_Load,
-        Event_Select_Item,
-        Event_Open_Configuration, 
-        Event_Change_Configuration, 
 
-        Pattern_Select_Item, 
-        Pattern_Expand_Item, 
         Pattern_Invoke_Action,
-        Pattern_Missing_Action,
-        Pattern_Track_UnknownPattern,
 
-        Properties_Show_Basic, 
-        Properties_Show_All, 
-        Properties_FilterBy_Name, 
-
-        TextPattern_SearchBy_Name,
-        TextPattern_Show_TextRange,
-        TextPattern_Show_Annotation,
-        TextPattern_NoSupported_From,
-        TextPattern_Change_From,
-
-        TextRange_Select,
-        TextRange_AddToSelection,
-        TextRange_RemoveFromSelection,
-        TextRange_ScrollIntoTop,
-        TextRange_ScrollIntoBottom,
-        TextRange_GetChildren,
-        TextRange_GetEnclosingElement,
-        TextRange_Move,
-        TextRange_ExpandToEnclosingUnit,
-        TextRange_Clone,
-        TextRange_Compare,
-
-        Scan_Show_All,            // expand all test results. 
-        Scan_Navigate_HelpLink,
-        Scan_Navigate_Snippet,
-        Scan_Select_Item,
         Scan_File_Bug,
-        Scan_View_ExistingBug,
-        Scan_Save_File, // save a file from Automated check view.
-        Scan_Statistics,
-
         Issue_Save,
         Issue_File_Attempt,
-        Bug_Cancel,
 
-        Mainwindow_Open_Configuration, 
-        Mainwindow_Open_ProcessList, 
-        Mainwindow_Minimize_byHotkey,
-        Mainwindow_Maximize_byHotkey,
-        Mainwindow_Open_Help,
-        Mainwindow_Update_Configuration,
-        Mainwindow_Update_Hotkey,
-        Mainwindow_Login_Attempted,
-        Mainwindow_Login_Succeeded,
-        Mainwindow_Login_Failed,
-        Mainwindow_Logout_Requested,
         Mainwindow_Timer_Started,
         Mainwindow_Startup,
-
-        Connection_Click_Disconnect,
-        Connection_Click_Refresh,
-        Connection_Click_Next,
-        Connection_Click_Change,
-        Connection_Open_Configuration,
-
-        Splash_Uncheck_ShowThis,
-
-        Feedback_Open,
-        Feedback_Send,
-        Feedback_Cancel,
 
         /// <summary>
         /// Upgrade related traces
         /// </summary>
         Upgrade_Update_ReleaseNote,
-        Upgrade_Update_Start,
         Upgrade_Update_Dismiss,
-        Upgrade_Notify_MissingMSIInfo,
         Upgrade_InstallationError,
         Upgrade_GetUpgradeOption,
         Upgrade_DoInstallation,
 
-        SharedData_Load_MainConfiguration,
-        SharedData_Load_RecordConfiguration,
-
         TabStop_Record_On, // indicate whether TabStop Recording was on
-        TabStop_Record_Off,
-        TabStop_Clear_Records, // when clear button is clicked.
         TabStop_Select_Records, // When any of recorded element is selected. 
-        TabStop_Test_Looped, // While testing, if tabstop hits any of already recorded tab stops. 
 
         TestSelection_Set_Scope, // set the scope
 
-        ColorContrast_Open_HowToTest,
         ColorContrast_Click_Eyedropper,
         ColorContrast_Click_Dropdown,
-        ColorContrast_FileBug_OutsideGivenScope, // users can file a bug outside of the glimpse tested
         ColorContrast_Click_HexChange,
 
         ReleaseChannel_ChangeConsidered,

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
@@ -7,47 +7,27 @@ namespace AccessibilityInsights.SharedUx.Telemetry
     /// </summary>
     public enum TelemetryProperty
     {
-        Version, 
-        ModeName, 
+        Version,
+        ModeName,
         ModeSessionId,
-        FeedbackLevel,
-        Feedback, // contains the actual Feedback Text
-        ExceptionType,
-        UnhandledException,
-        HandledException,
         View,
         UIFramework,
-        Boolean,
         MSIVersion,
         By,
-        InteractionAllowed,
         Comment,
-        TextPatternFrom,
-        TextRangeType,
         IsAlreadyLoggedIn,
-        TextRangeUnit,
-        PromptIfNeeded,
         FileMode,
         ProtocolMode,
         Error,
-        TreeWalkMode,
         Scope, // to indicate the scope of selection
         TabStopLooped,
         TabStopCount,
         Seconds,
-        ControlType,
         RuleId,
-        TestResults, // parent container, has rule id and results
-        Results,
         SessionType,
         AppSessionID,
         PatternMethod,
-        FilesLoaded,
-        UpdatesMade,
         InstallationID,
-        ElementsInScan,
-        UpperBoundExceeded,
-        TeamID,
         UpdateTimedOut,
         UpdateInitializationTime,
         UpdateOptionWaitTime,
@@ -56,7 +36,6 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         UpdateResult,
         ReleaseChannel,
         ReleaseChannelConsidered,
-        ReleaseChannelChangeResult,  // Value from the ReleaseChannelChangeResult enum
         IssueReporter,
     }
 }

--- a/src/AccessibilityInsights.SharedUxTests/Telemetry/LoggerUnitTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Telemetry/LoggerUnitTests.cs
@@ -78,11 +78,12 @@ namespace AccessibilityInsights.SharedUXTests.Telemetry
             const string value2 = "February";
             const string value3 = "March";
 
+            // Specific values of TelemetryProperty are unimportant for this test
             Dictionary<TelemetryProperty, string> input = new Dictionary<TelemetryProperty, string>
             {
-                { TelemetryProperty.AppSessionID, value1 },
-                { TelemetryProperty.HandledException, value2 },
-                { TelemetryProperty.SessionType, value3 },
+                { (TelemetryProperty)1, value1 },
+                { (TelemetryProperty)2, value2 },
+                { (TelemetryProperty)3, value3 },
             };
 
             IReadOnlyDictionary<string, string> output = Logger.ConvertFromProperties(input);
@@ -103,9 +104,8 @@ namespace AccessibilityInsights.SharedUXTests.Telemetry
             {
                 TelemetrySink.IsTelemetryAllowed = false;
 
-                // TelemetryAction used here is arbitrary
-                Logger.PublishTelemetryEvent(TelemetryAction.Bug_Cancel,
-                    TelemetryProperty.By, "abc");
+                // Specific values of TelemetryAction and TelemetryProperty are unimportant for this test
+                Logger.PublishTelemetryEvent((TelemetryAction)0, (TelemetryProperty)0, "abc");
             }
         }
 
@@ -115,9 +115,9 @@ namespace AccessibilityInsights.SharedUXTests.Telemetry
         {
             using (ShimsContext.Create())
             {
-                // TelemetryAction used here is arbitrary
-                const TelemetryAction action = TelemetryAction.ColorContrast_Click_Eyedropper;
-                const TelemetryProperty property = TelemetryProperty.Comment;
+                // Specific values of TelemetryAction and TelemetryProperty are unimportant for this test
+                const TelemetryAction action = (TelemetryAction)4;
+                const TelemetryProperty property = (TelemetryProperty)5;
                 const string value = "Friday";
                 string actualName = null;
                 IReadOnlyDictionary<string, string> actualTelemetryPropertyBag = null;
@@ -146,10 +146,13 @@ namespace AccessibilityInsights.SharedUXTests.Telemetry
         {
             using (ShimsContext.Create())
             {
+                // Specific values of TelemetryAction and TelemetryProperty are unimportant for this test
+                TelemetryAction action = (TelemetryAction)6;
+                TelemetryProperty property = (TelemetryProperty)7;
                 var fakeId = "id";
-                var fakeEvent = new TelemetryEvent(TelemetryAction.ColorContrast_Click_Dropdown, new Dictionary<TelemetryProperty, string>
+                var fakeEvent = new TelemetryEvent(action, new Dictionary<TelemetryProperty, string>
                 {
-                    { TelemetryProperty.AppSessionID, fakeId },
+                    { property, fakeId },
                 });
 
                 string actualName = null;
@@ -169,7 +172,7 @@ namespace AccessibilityInsights.SharedUXTests.Telemetry
 
                 Assert.AreEqual(fakeEvent.Action.ToString(), actualName);
                 Assert.AreEqual(1, actualTelemetryPropertyBag.Count);
-                Assert.AreEqual(fakeId, actualTelemetryPropertyBag[TelemetryProperty.AppSessionID.ToString()]);
+                Assert.AreEqual(fakeId, actualTelemetryPropertyBag[property.ToString()]);
             }
         }
 
@@ -181,8 +184,8 @@ namespace AccessibilityInsights.SharedUXTests.Telemetry
             {
                 TelemetrySink.IsTelemetryAllowed = false;
 
-                // TelemetryAction used here is arbitrary
-                Logger.PublishTelemetryEvent(TelemetryAction.ColorContrast_Click_Dropdown, null);
+                // Specific value of TelemetryAction is unimportant for this test
+                Logger.PublishTelemetryEvent((TelemetryAction)7, null);
             }
         }
 
@@ -192,9 +195,9 @@ namespace AccessibilityInsights.SharedUXTests.Telemetry
         {
             using (ShimsContext.Create())
             {
-                // TelemetryAction used here is arbitrary
-                const TelemetryAction action = TelemetryAction.ColorContrast_Click_Eyedropper;
-                const TelemetryProperty property = TelemetryProperty.Error;
+                // Specific values of TelemetryAction and TelemetryProperty are unimportant for this test
+                const TelemetryAction action = (TelemetryAction)8;
+                const TelemetryProperty property = (TelemetryProperty)9;
                 const string value = "Saturday";
                 string actualName = null;
                 IReadOnlyDictionary<TelemetryProperty, string> actualConverterInput = null;
@@ -250,7 +253,8 @@ namespace AccessibilityInsights.SharedUXTests.Telemetry
         {
             using (ShimsContext.Create())
             {
-                const TelemetryProperty expectedProperty = TelemetryProperty.Comment;
+                // Specific value of TelemetryProperty is unimportant for this test
+                const TelemetryProperty expectedProperty = (TelemetryProperty)9;
                 const string expectedValue = "carrot";
 
                 string actualProperty = null;

--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -122,6 +122,7 @@
       <Generator>MSBuild:Compile</Generator>
     </ApplicationDefinition>
     <Compile Include="Enums\CCAView.cs" />
+    <Compile Include="Misc\TelemetryEventFactory.cs" />
     <Compile Include="Modes\DialogContainerModeControl.xaml.cs">
       <DependentUpon>DialogContainerModeControl.xaml</DependentUpon>
     </Compile>

--- a/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml.cs
+++ b/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml.cs
@@ -44,6 +44,7 @@ namespace AccessibilityInsights.Dialogs
         /// <param name="e"></param>
         private void ReleaseNotes_Click(object sender, RoutedEventArgs e)
         {
+            string error = string.Empty;
             string releaseNotesString = string.Empty;
             try
             {
@@ -55,16 +56,19 @@ namespace AccessibilityInsights.Dialogs
                 }
                 else
                 {
-                    MessageDialog.Show(Properties.Resources.ReleaseNotes_ClickURLErrorMessage + " " + releaseNotesString);
+                    error = Properties.Resources.ReleaseNotes_ClickURLErrorMessage + " " + releaseNotesString;
+                    MessageDialog.Show(error);
                 }
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
             {
                 ex.ReportException();
-                MessageDialog.Show(Properties.Resources.ReleaseNotes_ClickLoadErrorMessage + " " + releaseNotesString);
+                error = Properties.Resources.ReleaseNotes_ClickLoadErrorMessage + " " + releaseNotesString;
+                MessageDialog.Show(error);
             }
 #pragma warning restore CA1031 // Do not catch general exception types
+            Logger.PublishTelemetryEvent(TelemetryAction.Upgrade_Update_ReleaseNote, TelemetryProperty.Error, error);
         }
     }
 }

--- a/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml.cs
+++ b/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Dialogs;
+using AccessibilityInsights.Misc;
 using AccessibilityInsights.SharedUx.Telemetry;
 using System;
 using System.Windows;
@@ -68,7 +69,7 @@ namespace AccessibilityInsights.Dialogs
                 MessageDialog.Show(error);
             }
 #pragma warning restore CA1031 // Do not catch general exception types
-            Logger.PublishTelemetryEvent(TelemetryAction.Upgrade_Update_ReleaseNote, TelemetryProperty.Error, error);
+            Logger.PublishTelemetryEvent(TelemetryEventFactory.ForReleaseNotesClick(error));
         }
     }
 }

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -198,7 +198,7 @@ namespace AccessibilityInsights
             Logger.AddOrUpdateContextProperty(TelemetryProperty.AppSessionID, Guid.NewGuid().ToString());
             Logger.AddOrUpdateContextProperty(TelemetryProperty.SessionType, "Desktop");
             Logger.AddOrUpdateContextProperty(TelemetryProperty.ReleaseChannel, ConfigurationManager.GetDefaultInstance().AppConfig.ReleaseChannel.ToString());
-            Logger.PublishTelemetryEvent(TelemetryAction.Mainwindow_Startup, null);
+            Logger.PublishTelemetryEvent(TelemetryAction.Mainwindow_Startup);
         }
 
         /// <summary>
@@ -838,7 +838,7 @@ namespace AccessibilityInsights
                 var scope = this.cbiEntireApp.IsSelected ? Axe.Windows.Actions.Enums.SelectionScope.App : Axe.Windows.Actions.Enums.SelectionScope.Element;
                 SelectAction.GetDefaultInstance().Scope = scope;
                 ConfigurationManager.GetDefaultInstance().AppConfig.IsUnderElementScope = (scope == Axe.Windows.Actions.Enums.SelectionScope.Element);
-                Logger.PublishTelemetryEvent(TelemetryAction.TestSelection_Set_Scope, TelemetryProperty.Scope, scope.ToString());
+                Logger.PublishTelemetryEvent(Misc.TelemetryEventFactory.ForSetScope(scope.ToString()));
                 SelectAction.GetDefaultInstance().ClearSelectedContext();
                 ctrlLiveMode.Clear();
                 HollowHighlightDriver.GetDefaultInstance().Clear();

--- a/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Windows;
 using System.Windows.Automation;
+using AccessibilityInsights.Misc;
 
 namespace AccessibilityInsights
 {
@@ -239,11 +240,8 @@ namespace AccessibilityInsights
                 // Based on Ux model feedback from PM team, we decided to go to AutomatedTestResults as default page view for snapshot.
                 StartTestMode(TestView.AutomatedTestResults);
 
-                Logger.PublishTelemetryEvent(TelemetryAction.Test_Requested, new Dictionary<TelemetryProperty, string>
-                {
-                    { TelemetryProperty.By, method.ToString() },
-                    { TelemetryProperty.Scope, SelectAction.GetDefaultInstance().Scope.ToString() }
-                });
+                Logger.PublishTelemetryEvent(TelemetryEventFactory.ForTestRequested(
+                    method.ToString(), SelectAction.GetDefaultInstance().Scope.ToString()));
             }
             HollowHighlightDriver.GetDefaultInstance().Clear();
             UpdateMainWindowUI();

--- a/src/AccessibilityInsights/MainWindowHelpers/TestMode.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/TestMode.cs
@@ -196,11 +196,8 @@ namespace AccessibilityInsights
 
             var v = SelectAction.GetDefaultInstance().SelectLoadedData(path, selectedElementId);
 
-            if (selectedElementId.HasValue)
-            {
-                Logger.PublishTelemetryEvent(TelemetryAction.Hierarchy_Load_Protocol, TelemetryProperty.ProtocolMode, v.Item2.Mode.ToString());
-            }
-            Logger.PublishTelemetryEvent(TelemetryAction.Hierarchy_Load_NewFormat, TelemetryProperty.FileMode, v.Item2.Mode.ToString());
+            TelemetryProperty mode = selectedElementId.HasValue ? TelemetryProperty.ProtocolMode : TelemetryProperty.FileMode;
+            Logger.PublishTelemetryEvent(TelemetryAction.Hierarchy_Load_NewFormat, mode, v.Item2.Mode.ToString());
 
             if (v.Item2.Mode == A11yFileMode.Test && !selectedElementId.HasValue)
             {

--- a/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
+++ b/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SetupLibrary;
+using AccessibilityInsights.SharedUx.Telemetry;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace AccessibilityInsights.Misc
+{
+    /// <summary>
+    /// Factory to create TelemetryEvents. To be used where TelemetryActions have properties, but the
+    /// underlying types aren't too specialized
+    /// </summary>
+    internal static class TelemetryEventFactory
+    {
+        private static string GetTimeSpanTelemetryString(TimeSpan? timeSpan)
+        {
+            // Because return values are used for telemetry, they do not need to be localized
+            return timeSpan.HasValue ? timeSpan.Value.ToString() : "unknown";
+        }
+
+        public static TelemetryEvent ForReleaseChannelChangeConsidered(ReleaseChannel oldChannel, ReleaseChannel newChannel)
+        {
+            return new TelemetryEvent(TelemetryAction.ReleaseChannel_ChangeConsidered,
+                new Dictionary<TelemetryProperty, string>
+                {
+                    { TelemetryProperty.ReleaseChannel, oldChannel.ToString() },
+                    { TelemetryProperty.ReleaseChannelConsidered, newChannel.ToString() },
+                });
+        }
+
+        public static TelemetryEvent ForReleaseNotesClick(string error)
+        {
+            return new TelemetryEvent(TelemetryAction.Upgrade_Update_ReleaseNote,
+                new Dictionary<TelemetryProperty, string>
+                {
+                    { TelemetryProperty.Error, error },
+                });
+        }
+
+        public static TelemetryEvent ForTestRequested(string method, string scope)
+        {
+            return new TelemetryEvent(TelemetryAction.Test_Requested,
+                new Dictionary<TelemetryProperty, string>
+                {
+                    { TelemetryProperty.By, method },
+                    { TelemetryProperty.Scope, scope },
+                });
+        }
+
+        public static TelemetryEvent ForUpgradeDismissed(Version installedVersion)
+        {
+            return new TelemetryEvent(TelemetryAction.Upgrade_Update_Dismiss,
+                new Dictionary<TelemetryProperty, string>
+                {
+                    { TelemetryProperty.MSIVersion, installedVersion.ToString() },
+                });
+        }
+
+        public static TelemetryEvent ForUpgradeInstallationError(string error)
+        {
+            return new TelemetryEvent(TelemetryAction.Upgrade_InstallationError,
+                new Dictionary<TelemetryProperty, string>
+                {
+                    { TelemetryProperty.Error, error },
+                });
+        }
+
+        public static TelemetryEvent ForUpgradeDoInstallation(TimeSpan? duration, string updateResult)
+        {
+            return new TelemetryEvent(TelemetryAction.Upgrade_DoInstallation,
+                new Dictionary<TelemetryProperty, string>
+                {
+                    { TelemetryProperty.UpdateInstallerUpdateTime, GetTimeSpanTelemetryString(duration) },
+                    { TelemetryProperty.UpdateResult, updateResult },
+                });
+        }
+
+        public static TelemetryEvent ForGetUpgradeOption(TimeSpan? initializationTime, TimeSpan? optionWaitTime, string updateOption, bool timedOut)
+        {
+            return new TelemetryEvent(TelemetryAction.Upgrade_GetUpgradeOption,
+                new Dictionary<TelemetryProperty, string>
+                {
+                    { TelemetryProperty.UpdateInitializationTime, GetTimeSpanTelemetryString(initializationTime) },
+                    { TelemetryProperty.UpdateOptionWaitTime, GetTimeSpanTelemetryString(optionWaitTime) },
+                    { TelemetryProperty.UpdateOption, updateOption },
+                    { TelemetryProperty.UpdateTimedOut, timedOut.ToString(CultureInfo.InvariantCulture) },
+                });
+        }
+
+        public static TelemetryEvent ForSetScope(string scope)
+        {
+            return new TelemetryEvent(TelemetryAction.TestSelection_Set_Scope,
+                new Dictionary<TelemetryProperty, string>
+                {
+                    { TelemetryProperty.Scope, scope },
+                });
+        }
+    }
+}

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
@@ -6,6 +6,7 @@ using AccessibilityInsights.SetupLibrary;
 using AccessibilityInsights.SharedUx.Controls.CustomControls;
 using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Settings;
+using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.SharedUx.Utilities;
 using System;
 using System.Collections.Generic;
@@ -150,10 +151,19 @@ namespace AccessibilityInsights.Modes
 
         private async Task<bool> HandleReleaseSwitch()
         {
+            if (appSettingsCtrl.SelectedReleaseChannel == Configuration.ReleaseChannel)
+                return false;
+
+            Logger.PublishTelemetryEvent(TelemetryAction.ReleaseChannel_ChangeConsidered,
+                new Dictionary<TelemetryProperty, string>
+                {
+                    { TelemetryProperty.ReleaseChannel, Configuration.ReleaseChannel.ToString() },
+                    { TelemetryProperty.ReleaseChannelConsidered, appSettingsCtrl.SelectedReleaseChannel.ToString() },
+                });
+
             var channelDialog = new ChangeChannelContainedDialog(appSettingsCtrl.SelectedReleaseChannel);
 
-            if (appSettingsCtrl.SelectedReleaseChannel == Configuration.ReleaseChannel ||
-                !await MainWin.ctrlDialogContainer.ShowDialog(channelDialog).ConfigureAwait(false))
+            if (!await MainWin.ctrlDialogContainer.ShowDialog(channelDialog).ConfigureAwait(false))
             {
                 return false;
             }

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Dialogs;
 using AccessibilityInsights.Extensions.Helpers;
+using AccessibilityInsights.Misc;
 using AccessibilityInsights.SetupLibrary;
 using AccessibilityInsights.SharedUx.Controls.CustomControls;
 using AccessibilityInsights.SharedUx.Dialogs;
@@ -154,12 +155,8 @@ namespace AccessibilityInsights.Modes
             if (appSettingsCtrl.SelectedReleaseChannel == Configuration.ReleaseChannel)
                 return false;
 
-            Logger.PublishTelemetryEvent(TelemetryAction.ReleaseChannel_ChangeConsidered,
-                new Dictionary<TelemetryProperty, string>
-                {
-                    { TelemetryProperty.ReleaseChannel, Configuration.ReleaseChannel.ToString() },
-                    { TelemetryProperty.ReleaseChannelConsidered, appSettingsCtrl.SelectedReleaseChannel.ToString() },
-                });
+            Logger.PublishTelemetryEvent(TelemetryEventFactory.ForReleaseChannelChangeConsidered(
+                Configuration.ReleaseChannel, appSettingsCtrl.SelectedReleaseChannel));
 
             var channelDialog = new ChangeChannelContainedDialog(appSettingsCtrl.SelectedReleaseChannel);
 


### PR DESCRIPTION
#### Describe the change
- Connect 2 recently-added telemetry events that were never connected.
- Change the Logger unit tests to be independent of specific values for TelemetryProperty and TelemetryAction
- Remove unused values for TelemetryProperty and TelemetryAction. I've confirmed with the existing telemetry that none of these values are being used in current builds. Many of these old values were remnants of code that was removed more than a year ago.
- Create AccessibilityInsights.Misc.TelemetryEventFactory to combine several closely-related pieces of code into a single class. This replaces most of the instances in the AccessibilityInsights project where Logger.PublishTelemetryEvent was being called with one or more TelemetryProperty values)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



