### PR TITLE
Fix check for prompting for upgrades

### DIFF
--- a/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
@@ -84,11 +84,9 @@ namespace AccessibilityInsights
             }
 
             autoUpdateOption = updateOption;
-            if (autoUpdateOption == AutoUpdateOption.Current || autoUpdateOption == AutoUpdateOption.Unknown)
-            {
-                return false;
-            }
-            return true;
+
+            return autoUpdateOption == AutoUpdateOption.OptionalUpgrade
+                || autoUpdateOption == AutoUpdateOption.RequiredUpgrade;
         }
 
         /// <summary>


### PR DESCRIPTION
#### Describe the change
Decision about showing the upgrade should return false for `AutoUpdateOption.NewerThanCurrent`. This is a new enum value, but the consuming logic in the UI wasn't updated to handle the new value.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #394 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



