### PR TITLE
Update the existing Jaws repaint glitch workaround

### DIFF
--- a/src/AccessibilityInsights.CommonUxComponents/Controls/ProgressRingControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/ProgressRingControl.xaml.cs
@@ -94,22 +94,11 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
         }
 
         /// <summary>
-        /// Check if any 3rd party Screen Reader such as Jaws is running
-        /// </summary>
-        public static bool IsExternalScreenReaderActive()
-        {
-            const int SPI_GETSCREENREADER = 0x0046;  // 0x0046 is for SPI_GETSCREENREADER
-            bool active = false;
-            bool success = NativeMethods.SystemParametersInfo(SPI_GETSCREENREADER, 0, out active, 0);
-            return success && active;
-        }
-
-        /// <summary>
         /// Check if any Screen Reader is running
         /// </summary>
         public static bool IsScreenReaderActive()
         {
-            return (IsInternalScreenReaderActive() || IsExternalScreenReaderActive()) && AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged);
+            return (IsInternalScreenReaderActive() || NativeMethods.IsExternalScreenReaderActive()) && AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.Win32/Win32Helper.cs
+++ b/src/AccessibilityInsights.Win32/Win32Helper.cs
@@ -84,5 +84,15 @@ namespace AccessibilityInsights.Win32
         {
             return r | g << 8 | b << 16;
         }
+
+        /// <summary>
+        /// Check if a 3rd party Screen Reader such as Jaws is running
+        /// </summary>
+        public static bool IsExternalScreenReaderActive()
+        {
+            const int SPI_GETSCREENREADER = 0x0046;  // Defined in winuser.h
+            bool success = NativeMethods.SystemParametersInfo(SPI_GETSCREENREADER, 0, out bool active, 0);
+            return success && active;
+        }
     }
 }

--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
@@ -9,6 +9,7 @@ using AccessibilityInsights.SharedUx.Interfaces;
 using AccessibilityInsights.SharedUx.Settings;
 using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.SharedUx.Utilities;
+using AccessibilityInsights.Win32;
 using Axe.Windows.Actions;
 using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Actions.Enums;
@@ -193,7 +194,7 @@ namespace AccessibilityInsights.Modes
 
                                         // This needs to happen before the call to ctrlAutomatedChecks.SetElement. Otherwise,
                                         // ctrlAutomatedChecks's checkboxes become out of sync with the highlighter
-                                        Application.Current.MainWindow.Visibility = Visibility.Visible; 
+                                        Application.Current.MainWindow.Visibility = Visibility.Visible;
                                     })).Wait();
                                 }
                             }
@@ -261,8 +262,13 @@ namespace AccessibilityInsights.Modes
                 // Improves the reliability of the rendering but does not solve across the board issues seen with all WPF apps.
                 this.Dispatcher.BeginInvoke(DispatcherPriority.Send, new Action(() =>
                 {
-                    Application.Current.MainWindow.InvalidateVisual();
-                    Application.Current.MainWindow.Visibility = Visibility.Visible;
+                    // This is a workaround for a repaint issue caused by an interaction between Jaws and WPF
+                    if (NativeMethods.IsExternalScreenReaderActive())
+                    {
+                        Application.Current.MainWindow.Visibility = Visibility.Hidden;
+                        Application.Current.MainWindow.InvalidateVisual();
+                        Application.Current.MainWindow.Visibility = Visibility.Visible;
+                    }
                     this.tbiAutomatedChecks.Focus();
                 })).Wait();
             });


### PR DESCRIPTION
#### Describe the change
Update the existing Jaws repaint glitch workaround. This glitch is apparently caused by interaction of WPF and the Jaws-installed screen driver. Hide the window before invalidating and forcing a repaint. To minimize flash, only do this is we have reason to believe that Jaws is on the machine.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #379 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

Old behavior without Jaws
![WithoutJaws-Old](https://user-images.githubusercontent.com/45672944/59867466-1cfdd580-9343-11e9-9006-4e1329e26ba0.gif)

Old behavior with Jaws
![WithJaws-Old](https://user-images.githubusercontent.com/45672944/59867464-1cfdd580-9343-11e9-9fb4-9a02511fc64a.gif)

New behavior without Jaws
![WithoutJaws-New](https://user-images.githubusercontent.com/45672944/59867467-1cfdd580-9343-11e9-8e44-5fcfc2f2ffe9.gif)

New behavior with Jaws
![WithJaws-New](https://user-images.githubusercontent.com/45672944/59867465-1cfdd580-9343-11e9-934d-6bd538553c54.gif)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



