### PR TITLE
Remove PrototolMode. Fix where I had misused it in telemetry

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
@@ -17,7 +17,6 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         Comment,
         IsAlreadyLoggedIn,
         FileMode,
-        ProtocolMode,
         Error,
         Scope, // to indicate the scope of selection
         TabStopLooped,

--- a/src/AccessibilityInsights/MainWindowHelpers/TestMode.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/TestMode.cs
@@ -196,8 +196,7 @@ namespace AccessibilityInsights
 
             var v = SelectAction.GetDefaultInstance().SelectLoadedData(path, selectedElementId);
 
-            TelemetryProperty mode = selectedElementId.HasValue ? TelemetryProperty.ProtocolMode : TelemetryProperty.FileMode;
-            Logger.PublishTelemetryEvent(TelemetryAction.Hierarchy_Load_NewFormat, mode, v.Item2.Mode.ToString());
+            Logger.PublishTelemetryEvent(TelemetryEventFactory.ForLoadDataFile(v.Item2.Mode.ToString()));
 
             if (v.Item2.Mode == A11yFileMode.Test && !selectedElementId.HasValue)
             {

--- a/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
+++ b/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
@@ -97,5 +97,14 @@ namespace AccessibilityInsights.Misc
                     { TelemetryProperty.Scope, scope },
                 });
         }
+
+        public static TelemetryEvent ForLoadDataFile(string mode)
+        {
+            return new TelemetryEvent(TelemetryAction.Hierarchy_Load_NewFormat,
+                new Dictionary<TelemetryProperty, string>
+                {
+                    { TelemetryProperty.FileMode, mode },
+                });
+        }
     }
 }


### PR DESCRIPTION
#### Describe the change
A recent change used ProtocolMode incorrectly (although it would have never appeared in the telemetry stream). Removing it completely, since it's currently an unsupported feature and we don't really know how we want it to be at this time.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



