### PR TITLE
Fix error in Upgrade_DoInstallation telemetry

### DIFF
--- a/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
@@ -119,7 +119,7 @@ namespace AccessibilityInsights
         /// </summary>
         private async void DownLoadInstaller(IAutoUpdate autoUpdate)
         {
-            UpdateResult result = UpdateResult.Unknown;
+            UpdateResult updateResult = UpdateResult.Unknown;
 
             // If the window is topmost, the UAC prompt from the version switcher will appear behind the main window.
             // To prevent this, save the previous topmost state, ensure that the main window is not topmost when the
@@ -130,11 +130,11 @@ namespace AccessibilityInsights
             {
                 ctrlProgressRing.Activate();
                 Topmost = false;
-                result = await autoUpdate.UpdateAsync().ConfigureAwait(true);
+                updateResult = await autoUpdate.UpdateAsync().ConfigureAwait(true);
 
                 Logger.PublishTelemetryEvent(TelemetryEventFactory.ForUpgradeDoInstallation(
-                    autoUpdate.GetUpdateTime(), _updateOption.ToString()));
-                if (result == UpdateResult.Success)
+                    autoUpdate.GetUpdateTime(), updateResult.ToString()));
+                if (updateResult == UpdateResult.Success)
                 {
                     this.Close();
                     return;
@@ -149,7 +149,7 @@ namespace AccessibilityInsights
 
             Topmost = previousTopmostSetting;
             ctrlProgressRing.Deactivate();
-            Logger.PublishTelemetryEvent(TelemetryEventFactory.ForUpgradeInstallationError(result.ToString()));
+            Logger.PublishTelemetryEvent(TelemetryEventFactory.ForUpgradeInstallationError(updateResult.ToString()));
 
             string message = _updateOption == AutoUpdateOption.RequiredUpgrade
                 ? GetMessageForRequiredUpdateFailure() : GetMessageForOptionalUpdateFailure();


### PR DESCRIPTION
#### Describe the change
Fix an error in Upgrade_DoInstallation telemetry (the wrong value was being used for the result). Instead of passing an `UpdateResult` (values of *Unknown*, *Success*, or *NoUpdateAvailable*, we were passing in the `AutoUpdateOption` (values of *Unknown*, *NewerThanCurrent*, *Current*, *OptionalUpgrade*, or *RequiredUpgrade*). The `AutoUpdateOption` is already being sent in the Upgrade_GetUpgradeOption telemetry, so we're currently sending the `AutoUpdateOption` twice but never sending the `AutoUpdateOption`)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
