### PR TITLE
Remove toggle-behavior of settings button

### DIFF
--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -684,19 +684,7 @@ namespace AccessibilityInsights
         /// <param name="e"></param>
         private void onbtnConfigClicked(object sender, RoutedEventArgs e)
         {
-            if (this.gridlayerConfig.Visibility == Visibility.Visible)
-            {
-                HideConfigurationMode();
-                UpdateMainWindowUI();
-                if (this.CurrentPage == AppPage.Inspect)
-                {
-                    HandleBackToSelectingState();
-                }
-            }
-            else
-            {
-                HandleConfigurationModeStart(false);
-            }
+            HandleConfigurationModeStart(false);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
@@ -34,7 +34,7 @@
                     <DockPanel LastChildFill="False" >
                         <Button DockPanel.Dock="Bottom" TabIndex="-3" x:Name="btnOk" Content="{x:Static properties:Resources.btnOkContent}" HorizontalAlignment="Left" VerticalAlignment="Top" Width="80" Height="24" Margin="20,20" IsDefault="True" Click="buttonOk_Click" Style="{StaticResource BtnSave}" IsEnabled="False"/>
                         <TabControl Name="tcTabs" DockPanel.Dock="Top" BorderThickness="0,1,0,0" BorderBrush="#FFEAEAEA" Style="{StaticResource tcScrolling}" SelectionChanged="TabControl_SelectionChanged">
-                            <TabItem Header="{x:Static properties:Resources.tcTabsApplicationHeader}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Application}">
+                            <TabItem Header="{x:Static properties:Resources.tcTabsApplicationHeader}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiApplication" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Application}">
                                 <controls:ApplicationSettingsControl x:Name="appSettingsCtrl"/>
                             </TabItem>
                             <TabItem Header="{x:Static properties:Resources.tcTabsConnectionHeader}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiConnection" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Connection}">

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml.cs
@@ -250,15 +250,9 @@ namespace AccessibilityInsights.Modes
 
             this.btnOk.IsEnabled = false;
 
-            if (HelperMethods.GeneralFileBugVisibility == Visibility.Collapsed)
-            {
-                tbiConnection.Visibility = Visibility.Collapsed;
-            }
-            else if (connection)
-            {
-                tbiConnection.IsSelected = true;
-            }
-
+            tbiConnection.Visibility = HelperMethods.GeneralFileBugVisibility;
+            var tabToSelect = connection ? tbiConnection : tbiApplication;
+            tabToSelect.IsSelected = true;
             await Dispatcher.InvokeAsync(() => (this.tcTabs.SelectedItem as UIElement).Focus(), System.Windows.Threading.DispatcherPriority.ApplicationIdle);
         }
 


### PR DESCRIPTION
#### Describe the change
This change responds to issue #364 by forcing the settings and connection buttons to always go to the application and connection tabs. Before this change, the settings button acts like a toggle - selecting it while in settings view will take the user out of settings view. Now, the settings button always goes to the application tab.

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #364 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 


![pr](https://user-images.githubusercontent.com/7775527/60042585-edb4d480-9672-11e9-9035-ecd13d31a8c3.gif)

