### PR TITLE
Show first tab stop in tab stops test

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
@@ -396,7 +396,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         /// </summary>
         /// <param name="message"></param>
         private void OnFocusChanged(EventMessage message)
-    {
+        {
             // only when focus is chosen
             if (message.EventId == EventType.UIA_AutomationFocusChangedEventId)
             {

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
@@ -240,7 +240,6 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                         TurnOnHighlighter();
                         StartRecordingEvent();
                         var ha = ClearOverlayDriver.GetDefaultInstance();
-                        ClearOverlayDriver.BringMainWindowOfPOIElementToFront();
                         ha.MarkSelectedElement();
                         this.Toast = new ToastNotification();
                         ha.ShowToast(Toast);
@@ -256,7 +255,6 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
         }
 
-
         /// <summary>
         /// Collapse the toast notification 
         /// </summary>
@@ -269,9 +267,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 {
                     this.Toast.Visibility = Visibility.Collapsed;
                 });
-
             });
-
         }
 
         /// <summary>
@@ -363,9 +359,9 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 TabStopCount = 0;
                 IsTabStopLooped = false;
 
-                this.EventHandler?.RegisterAutomationEventListener(EventType.UIA_AutomationFocusChangedEventId, this.OnFocusChanged);
-
-                this.lvElements.Items.Clear();
+                CurrentElement = null;
+                EventHandler?.RegisterAutomationEventListener(EventType.UIA_AutomationFocusChangedEventId, this.OnFocusChanged);
+                lvElements.Items.Clear();
                 IsRecordingActive = true;
                 Logger.PublishTelemetryEvent(TelemetryAction.TabStop_Record_On,
                     TelemetryProperty.Scope, SelectAction.GetDefaultInstance().Scope.ToString());
@@ -400,7 +396,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         /// </summary>
         /// <param name="message"></param>
         private void OnFocusChanged(EventMessage message)
-        {
+    {
             // only when focus is chosen
             if (message.EventId == EventType.UIA_AutomationFocusChangedEventId)
             {
@@ -448,6 +444,17 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                     message.Dispose();
                 }
             }
+            else if (IsMessageRegisterSuccess(message))
+            {
+                ClearOverlayDriver.BringMainWindowOfPOIElementToFront();
+            }
+        }
+
+        private static bool IsMessageRegisterSuccess(EventMessage message)
+        {
+            // sadly, these strings are hardcoded into axe-windows at the moment they are populated...
+            return message.EventId == EventType.UIA_EventRecorderNotificationEventId
+                && message.Properties.Any(p => p.Key == "Message" && p.Value == "Succeeded to register an event listener");
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
@@ -360,7 +360,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 IsTabStopLooped = false;
 
                 CurrentElement = null;
-                EventHandler?.RegisterAutomationEventListener(EventType.UIA_AutomationFocusChangedEventId, this.EventMessageRecieved);
+                EventHandler?.RegisterAutomationEventListener(EventType.UIA_AutomationFocusChangedEventId, this.EventMessageReceived);
                 lvElements.Items.Clear();
                 IsRecordingActive = true;
                 Logger.PublishTelemetryEvent(TelemetryAction.TabStop_Record_On,
@@ -391,7 +391,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             return false;
         }
 
-        private void EventMessageRecieved(EventMessage message)
+        private void EventMessageReceived(EventMessage message)
         {
             switch (message.EventId)
             {


### PR DESCRIPTION
#### Describe the change
Previously, started listening to events and then set focus to the target element. This didn't work because the UIA event listener wasn't actually registered before the focus changed--there is a slight gap between `RegisterAutomationEventListener` completing and the listener actually starting.
This PR delays setting focus on the target element until we get a message from the event listener confirming that it has started listening.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue #151
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.
![before](https://user-images.githubusercontent.com/4615491/60050982-c8ca5c80-9686-11e9-824a-44d91bd95568.gif)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



