### PR TITLE
Stop publishing the MSI to the drop share

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -3,7 +3,6 @@ trigger: none
 pr: none
 variables:
   BuildPlatform: 'x86'
-  DropFolder: 'signed'
   MAICreateNuget: 'true'
   PublicRelease: 'true'
   SignAppForRelease: 'true'
@@ -268,14 +267,6 @@ jobs:
     inputs:
       SearchPattern: '**\bin\**\*.pdb'
     continueOnError: true
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: $(DropFolder)'
-    inputs:
-      PathtoPublish: 'src\MSI\bin\Release\msi'
-      ArtifactName: '$(DropFolder)'
-      publishLocation: FilePath
-      TargetPath: '$(DropRoot)'
 
   - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
     displayName: 'Publish Symbols'


### PR DESCRIPTION
#### Describe the change
Stop publishing the MSI to the drop share because we are no longer using it. The MSI files built from the master branch auto-release to GitHub as Canary builds. The MSI files built from other branches are available as build artifacts. Once this PR is merged, I'll also update the build definition to stop defining DropRoot as a build variable, and clean up the MSI files that are already there.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



