### PR TITLE
Add video recording to ui tests

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -57,6 +57,7 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: release
       rerunFailedTests: true
+      runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Stop - WinAppDriver'

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -109,7 +109,7 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: debug
       rerunFailedTests: true
-      runSettingsFile: $(Build.ArtifactStagingDirectory)/UITests.runsettings
+      runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Stop - WinAppDriver'

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -109,6 +109,7 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: debug
       rerunFailedTests: true
+      runSettingsFile: $(Build.ArtifactStagingDirectory)/UITests.runsettings
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Stop - WinAppDriver'

--- a/src/UITests/UITests.csproj
+++ b/src/UITests/UITests.csproj
@@ -111,6 +111,9 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+    <None Include="UITests.runsettings">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AccessibilityInsights\AccessibilityInsights.csproj">

--- a/src/UITests/UITests.runsettings
+++ b/src/UITests/UITests.runsettings
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector uri="datacollector://microsoft/VideoRecorder/1.0" assemblyQualifiedName="Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorder.VideoRecorderDataCollector, Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorder, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" friendlyName="Screen and Voice Recorder">
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
#### Describe the change
This PR tries adds video recording to UI tests - you can see an example [here](https://dev.azure.com/accessibility-insights/Accessibility%20Insights/_build/results?buildId=1763&view=ms.vss-test-web.build-test-results-tab&runId=4870&resultId=100049&paneView=attachments)

docs [here](https://docs.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file?view=vs-2019#video-data-collector)

One side effect is that we have very small videos for unit tests as well. I've added a separate task to move our UI tests to a separate job to see if we exclude unit tests from the video capturing.

This change only affects our PR remote build, so no additional product validation was done
