### PR TITLE
Add event logs to test result

### DIFF
--- a/src/UITests/AIWinSession.cs
+++ b/src/UITests/AIWinSession.cs
@@ -82,6 +82,7 @@ namespace UITests
         public void TearDown()
         {
             TestContext.AddResultFile(SerializeRecordedEvents());
+            Events.Clear();
 
             // closing ai-win like this stops it from saving the config. Will have to change this
             // if we ever want to use the saved config.
@@ -94,7 +95,6 @@ namespace UITests
 
             session.Quit();
             session = null;
-            Events.Clear();
         }
 
         private bool IsWinAppDriverRunning()
@@ -105,7 +105,7 @@ namespace UITests
 
         private string SerializeRecordedEvents()
         {
-            var path = Path.Combine(TestContext.TestResultsDirectory + "events.txt");
+            var path = Path.Combine(TestContext.TestResultsDirectory, TestContext.TestName, "events.txt");
             using (StreamWriter w = File.AppendText(path))
             {
                 foreach (var e in Events)

--- a/src/UITests/AIWinSession.cs
+++ b/src/UITests/AIWinSession.cs
@@ -81,6 +81,8 @@ namespace UITests
 
         public void TearDown()
         {
+            TestContext.AddResultFile(SerializeRecordedEvents());
+
             // closing ai-win like this stops it from saving the config. Will have to change this
             // if we ever want to use the saved config.
             process.Kill();
@@ -99,6 +101,19 @@ namespace UITests
         {
             var processes = Process.GetProcessesByName("WinAppDriver");
             return processes.Length > 0;
+        }
+
+        private string SerializeRecordedEvents()
+        {
+            var path = Path.Combine(TestContext.TestResultsDirectory + "events.txt");
+            using (StreamWriter w = File.AppendText(path))
+            {
+                foreach (var e in Events)
+                {
+                    w.WriteLine($"{e.TimeGenerated},{e.Source},{e.Message}");
+                }
+            }
+            return path;
         }
     }
 }

--- a/src/UITests/LoadTestFile.cs
+++ b/src/UITests/LoadTestFile.cs
@@ -55,6 +55,6 @@ namespace UITests
         }
 
         [TestCleanup]
-        public void ClassCleanup() => TearDown();
+        public void TestCleanup() => TearDown();
     }
 }


### PR DESCRIPTION
#### Describe the change
This PR creates a result file including Windows Event Logs for the duration of the test run. It attaches this result file to the TestContext so that the Visual Studio Test Runner can pick it up in the remote build.

UITest change only