### PR TITLE
Adding a11ytest file to output of UI tests, clean up some lingering code

### DIFF
--- a/src/AccessibilityInsights/Modes/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/StartUpModeControl.xaml
@@ -156,7 +156,7 @@
             <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.ckbxDontShowContent}" Name="ckbxDontShow" FontSize="12" Foreground="{DynamicResource ResourceKey=DarkGreyTextBrush}" 
                       FontWeight="SemiBold" Style="{StaticResource CkbxRightSide}" VerticalAlignment="Center"
                       FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
-            <Button Grid.Column="2" x:Name="btnExit"  Click="btnExit_Click" UseLayoutRounding="True" AutomationProperties.Name="Button" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.StartUpModeExitButton}"
+            <Button Grid.Column="2" x:Name="btnExit"  Click="btnExit_Click" UseLayoutRounding="True" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.StartUpModeExitButton}"
                     Width="100" Height="30" VerticalAlignment="Bottom" HorizontalAlignment="Right" Content="{x:Static properties:Resources.StartUpModeControl_btnExit}" Style="{StaticResource BtnBlueRounded}"/>
         </Grid>
     </Grid>

--- a/src/AccessibilityInsights/Modes/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/StartUpModeControl.xaml
@@ -156,7 +156,7 @@
             <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.ckbxDontShowContent}" Name="ckbxDontShow" FontSize="12" Foreground="{DynamicResource ResourceKey=DarkGreyTextBrush}" 
                       FontWeight="SemiBold" Style="{StaticResource CkbxRightSide}" VerticalAlignment="Center"
                       FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
-            <Button Grid.Column="2" x:Name="btnExit"  Click="btnExit_Click" UseLayoutRounding="True" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.StartUpModeExitButton}"
+            <Button Grid.Column="2" x:Name="btnExit"  Click="btnExit_Click" UseLayoutRounding="True" AutomationProperties.Name="Button" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.StartUpModeExitButton}"
                     Width="100" Height="30" VerticalAlignment="Bottom" HorizontalAlignment="Right" Content="{x:Static properties:Resources.StartUpModeControl_btnExit}" Style="{StaticResource BtnBlueRounded}"/>
         </Grid>
     </Grid>

--- a/src/UITests/GettingStartedPage.cs
+++ b/src/UITests/GettingStartedPage.cs
@@ -26,8 +26,8 @@ namespace UITests
 
         private void VerifyAccessibility()
         {
-            var result = driver.ScanAIWin(TestContext.ResultsDirectory);
-            Assert.AreEqual(0, result.errors);
+            var issueCount = driver.ScanAIWin(TestContext);
+            Assert.AreEqual(0, issueCount);
         }
 
         [TestInitialize]

--- a/src/UITests/LoadTestFile.cs
+++ b/src/UITests/LoadTestFile.cs
@@ -31,16 +31,16 @@ namespace UITests
         {
             driver.TestMode.AutomatedChecks.ViewInUIATree();
 
-            var result = driver.ScanAIWin(TestContext.ResultsDirectory);
+            var issueCount = driver.ScanAIWin(TestContext);
 
-            Assert.AreEqual(0, result.errors);
+            Assert.AreEqual(0, issueCount);
             driver.TestMode.ResultsInUIATree.BackToAutomatedChecks();
         }
 
         private void ScanAutomatedChecks()
         {
-            var result = driver.ScanAIWin(TestContext.ResultsDirectory);
-            Assert.AreEqual(0, result.errors);
+            var issueCount = driver.ScanAIWin(TestContext);
+            Assert.AreEqual(0, issueCount);
         }
 
         [TestInitialize]

--- a/src/UITests/UILibrary/AIWinDriver.cs
+++ b/src/UITests/UILibrary/AIWinDriver.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.Properties;
 using Axe.Windows.Automation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Appium.Windows;
+using System.IO;
 
 namespace UITests.UILibrary
 {
@@ -28,19 +30,30 @@ namespace UITests.UILibrary
             PID = pid;
         }
 
-        public (int errors, string file) ScanAIWin(string outputDir)
+        /// <summary>
+        /// Run an accessibility scan on Accessibility Insights for Windows
+        /// and add an a11ytest file to the given context's test results 
+        /// if there are any errors
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns>number of accessibility issues</returns>
+        public int ScanAIWin(TestContext context)
         {
-
+            var outputPath = Path.Combine(context.TestResultsDirectory, context.TestName);
             var config = Config.Builder.ForProcessId(PID)
                 .WithOutputFileFormat(OutputFileFormat.A11yTest)
-                .WithOutputDirectory(outputDir)
+                .WithOutputDirectory(outputPath)
                 .Build();
 
             var scanner = ScannerFactory.CreateScanner(config);
 
             var result = scanner.Scan();
+            if (result.ErrorCount > 0)
+            {
+                context.AddResultFile(result.OutputFile.A11yTest);
+            }
 
-            return (result.ErrorCount, result.OutputFile.A11yTest);
+            return result.ErrorCount;
         }
 
         public WindowsElement FindElementByAccessibilityId(string accessibilityId) => Session.FindElementByAccessibilityId(accessibilityId);


### PR DESCRIPTION
This change adds the a11y test file to UI test output, similar to how we add event logs. If a UI test fails because of an accessibility issue, the a11y test file should show up in the ADO attachments for that test.

We assume a 1:1 mapping between our test methods and a11y test files because any failure will stop test execution. If this changes in the future, we will need to ensure we can name each a11y test file differently. We could do this now via renaming / copying, but it would be nicer if Axe.Windows could accept a file name for the result file.

Here is an [example](https://dev.azure.com/accessibility-insights/Accessibility%20Insights/_build/results?buildId=1819&view=ms.vss-test-web.build-test-results-tab) of a failing accessibility issue.

-----

This PR also removes some unnecessary lifecycle code for `session`. Since it is no longer static, we can remove those lines. 

The event serialization was updated to handle a case where WinAppDriver was not running locally - this should be inconclusive, but locally it failed because test cleanup expected a valid event path.