### PR TITLE
Fixing merge conflict in telemetry dialog

### DIFF
--- a/src/UITests/TelemetryDialog.cs
+++ b/src/UITests/TelemetryDialog.cs
@@ -20,8 +20,8 @@ namespace UITests
 
         private void VerifyTelemetryDialog()
         {
-            var result = driver.ScanAIWin(TestContext.ResultsDirectory);
-            Assert.AreEqual(0, result.errors);
+            var issueCount = driver.ScanAIWin(TestContext);
+            Assert.AreEqual(0, issueCount);
 
             driver.GettingStarted.DismissTelemetry();
         }


### PR DESCRIPTION
Two previous PRs led to a mismatch in the signature of ScanAIWin. This updates the usage in TelemetryDialog to utilize the new signature.