### PR TITLE
temporarily skip UI tests in the compliance build

### DIFF
--- a/build/compliance-build.yml
+++ b/build/compliance-build.yml
@@ -58,6 +58,7 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: release
       rerunFailedTests: true
+      testFiltercriteria: 'TestCategory!=UITest'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
@@ -147,7 +148,7 @@ jobs:
       testAssemblyVer2: |
         **\*test*.dll
         !**\obj\**
-      testFiltercriteria: 'TestCategory!=RequiresNetwork'
+      testFiltercriteria: 'TestCategory!=RequiresNetwork&TestCategory!=UITest'
       vsTestVersion: 15.0
       codeCoverageEnabled: false
       platform: '$(BuildPlatform)'

--- a/src/UITests/GettingStartedPage.cs
+++ b/src/UITests/GettingStartedPage.cs
@@ -13,6 +13,7 @@ namespace UITests
         /// </summary>
         [TestMethod]
         [TestCategory("NoStrongName")]
+        [TestCategory("UITest")]
         public void GettingStartedPageTests()
         {
             VerifyGettingStartedTitle();

--- a/src/UITests/LoadTestFile.cs
+++ b/src/UITests/LoadTestFile.cs
@@ -21,6 +21,7 @@ namespace UITests
         /// </summary>
         [TestMethod]
         [TestCategory("NoStrongName")]
+        [TestCategory("UITest")]
         public void LoadTestFileTests()
         {
             ScanResultsInUIATreePage();

--- a/src/UITests/TelemetryDialog.cs
+++ b/src/UITests/TelemetryDialog.cs
@@ -13,6 +13,7 @@ namespace UITests
         /// </summary>
         [TestMethod]
         [TestCategory("NoStrongName")]
+        [TestCategory("UITest")]
         public void TelemetryDialogTests()
         {
             VerifyTelemetryDialog();


### PR DESCRIPTION
We need to get the Screen Resolution Utility extension in the account where the compliance build runs. Until this happens, the UI tests must be skipped. The extension is available and running with our PR builds.