### PR TITLE
Add initial UI tests for loading an event

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/EventDetailControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventDetailControl.xaml
@@ -22,7 +22,7 @@
                     <ColumnDefinition Width="{Binding Path=Width, 
            RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UIElement},Mode=OneWayToSource}"/>
                 </Grid.ColumnDefinitions>
-                <customcontrols:CustomDataGrid x:Name="dgEvents" AutomationProperties.AutomationId="dgEventDetails" GotKeyboardFocus="dgEvents_GotKeyboardFocus"
+                <customcontrols:CustomDataGrid x:Name="dgEvents" GotKeyboardFocus="dgEvents_GotKeyboardFocus"
                   AutomationProperties.Name="{x:Static Properties:Resources.EventDetailControlAutomationPropertiesName}"
                   Style="{StaticResource dgStyle}" CellStyle="{StaticResource dgcStyle}" RowStyle="{StaticResource dgrStyle}" ColumnHeaderStyle="{StaticResource dgchStyle}">
                     <i:Interaction.Behaviors>

--- a/src/AccessibilityInsights.SharedUx/Controls/EventDetailControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventDetailControl.xaml
@@ -22,7 +22,7 @@
                     <ColumnDefinition Width="{Binding Path=Width, 
            RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UIElement},Mode=OneWayToSource}"/>
                 </Grid.ColumnDefinitions>
-                <customcontrols:CustomDataGrid x:Name="dgEvents" GotKeyboardFocus="dgEvents_GotKeyboardFocus"
+                <customcontrols:CustomDataGrid x:Name="dgEvents" AutomationProperties.AutomationId="dgEventDetails" GotKeyboardFocus="dgEvents_GotKeyboardFocus"
                   AutomationProperties.Name="{x:Static Properties:Resources.EventDetailControlAutomationPropertiesName}"
                   Style="{StaticResource dgStyle}" CellStyle="{StaticResource dgcStyle}" RowStyle="{StaticResource dgrStyle}" ColumnHeaderStyle="{StaticResource dgchStyle}">
                     <i:Interaction.Behaviors>

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -153,6 +153,7 @@
             <customcontrols:CustomDataGrid x:Name="dgEvents" GotKeyboardFocus="dgEvents_GotKeyboardFocus"
                       AutomationProperties.LabeledBy="{Binding ElementName=labelEvents}"
                       AutomationProperties.AcceleratorKey="Alt+V"
+                      AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.EventsDataGrid}"
                       Height="Auto" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"
                       SelectionChanged="listEvents_SelectionChanged" SelectionMode="Single"
                       HorizontalContentAlignment="Stretch"

--- a/src/AccessibilityInsights.SharedUx/Properties/AutomationIDs.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/AutomationIDs.cs
@@ -11,5 +11,7 @@ namespace AccessibilityInsights.SharedUx.Properties
         public static string MainWinBreadCrumbTwoButton { get; } = nameof(MainWinBreadCrumbTwoButton);
         public static string StartUpModeExitButton { get; } = nameof(StartUpModeExitButton);
         public static string TelemetryDialogExitButton { get; } = nameof(TelemetryDialogExitButton);
+        public static string EventsDataGrid { get; } = nameof(EventsDataGrid);
+        public static string EventModeControl { get; } = nameof(EventModeControl);
     }
 }

--- a/src/AccessibilityInsights/Modes/EventModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/EventModeControl.xaml
@@ -9,8 +9,10 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:properties="clr-namespace:AccessibilityInsights.Properties"
+             xmlns:sharedUxProperties="clr-namespace:AccessibilityInsights.SharedUx.Properties;assembly=AccessibilityInsights.SharedUx"
              mc:Ignorable="d"
              AutomationProperties.Name="{x:Static properties:Resources.EventModeControlAutomationPropertiesName}" Height="600" Width="600"
+             AutomationProperties.AutomationId="{x:Static sharedUxProperties:AutomationIDs.EventModeControl}"
              IsVisibleChanged="UserControl_IsVisibleChanged">
     <Grid Panel.ZIndex="1">
         <Grid.RowDefinitions>

--- a/src/UITests/AIWinSession.cs
+++ b/src/UITests/AIWinSession.cs
@@ -48,9 +48,17 @@ namespace UITests
         private void SetupEventListening()
         {
             var log = new EventLog("Application");
-            log.EntryWritten += new EntryWrittenEventHandler((_, args) => Events.Add(args.Entry));
+            log.EntryWritten += AddEvent;
             log.EnableRaisingEvents = true;
         }
+
+        private void ClearEventListening()
+        {
+            var log = new EventLog("Application");
+            log.EntryWritten -= AddEvent;
+        }
+
+        private void AddEvent(object sender, EntryWrittenEventArgs args) => Events.Add(args.Entry);
 
         private void LaunchApplicationAndAttach()
         {
@@ -100,6 +108,7 @@ namespace UITests
 
         public void TearDown()
         {
+            ClearEventListening();
             AttachEvents();
 
             // closing ai-win like this stops it from saving the config. Will have to change this

--- a/src/UITests/LoadEventFile.cs
+++ b/src/UITests/LoadEventFile.cs
@@ -12,8 +12,8 @@ namespace UITests
     [TestClass]
     public class LoadEventFile : AIWinSession
     {
-        static readonly string EventFileName = "WildlifeManagerTest.a11yevent";
-        static readonly string TestFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}\\TestFiles";
+        const string EventFileName = "WildlifeManagerTest.a11yevent";
+        static readonly string TestFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestFiles");
 
         /// <summary>
         /// The entry point for this test scenario. Every TestMethod  will restart ai-win, so
@@ -27,7 +27,6 @@ namespace UITests
             driver.Maximize();
             CheckEventLog();
             CheckPropertyView();
-            CheckPatternsView();
             ScanWindow();
         }
 
@@ -42,7 +41,7 @@ namespace UITests
         /// </summary>
         private void CheckEventLog()
         {
-            var eventGrid = driver.FindElementByAccessibilityId("ctrlEventMode");
+            var eventGrid = driver.FindElementByAccessibilityId(AccessibilityInsights.SharedUx.Properties.AutomationIDs.EventModeControl);
             var rows = eventGrid.FindElementsByClassName("DataGridRow");
 
             rows[0].Click();
@@ -51,7 +50,8 @@ namespace UITests
             Assert.AreEqual("09:58:37.859, EventRecorderNotification, Event Recorder", rows[0].Text);
 
             // 10 rows from the event log and 3 from the event details
-            Assert.AreEqual(rows.Count, 13);
+            int numRows = GetNumEventDataRows();
+            Assert.AreEqual(13, numRows);
         }
 
         /// <summary>
@@ -59,26 +59,21 @@ namespace UITests
         /// </summary>
         private void CheckPropertyView()
         {
-            var eventGrid = driver.FindElementByAccessibilityId("dgEvents");
+            // Click on 3rd event to see its properties
+            var eventGrid = driver.FindElementByAccessibilityId(AccessibilityInsights.SharedUx.Properties.AutomationIDs.EventsDataGrid);
             var eventRows = eventGrid.FindElementsByClassName("DataGridRow");
             eventRows[2].Click();
-            var propertyGrid = driver.FindElementByAccessibilityId("dgProperties");
-            var propertyRows = propertyGrid.FindElementsByClassName("DataGridRow");
 
-            // propertyRows.Count is 0, need to understand why
-            // Assert.AreEqual(propertyRows.Count, 10);
+            // 10 rows from the event log and 10 from the event properties
+            var rowCount = GetNumEventDataRows();
+            Assert.AreEqual(20, rowCount);
         }
 
-        /// <summary>
-        /// Validate the patterns from the 3rd event (list item Owl)
-        /// </summary>
-        private void CheckPatternsView()
+        private int GetNumEventDataRows()
         {
-            var patternTree = driver.FindElementByAccessibilityId("treePatterns");
-            var patternItems = patternTree.FindElementsByClassName("TreeViewItem");
-
-            // patternItems.Count is 0, need to understand why
-            // Assert.AreEqual(3, patternItems.Count);
+            var control = driver.FindElementByAccessibilityId(AccessibilityInsights.SharedUx.Properties.AutomationIDs.EventModeControl);
+            var rows = control.FindElementsByClassName("DataGridRow");
+            return rows.Count;
         }
 
         [TestInitialize]

--- a/src/UITests/LoadEventFile.cs
+++ b/src/UITests/LoadEventFile.cs
@@ -26,7 +26,6 @@ namespace UITests
         {
             driver.Maximize();
             CheckEventLog();
-            CheckEventDetails();
             CheckPropertyView();
             CheckPatternsView();
             ScanWindow();
@@ -43,26 +42,16 @@ namespace UITests
         /// </summary>
         private void CheckEventLog()
         {
-            var eventGrid = driver.FindElementByAccessibilityId("dgEvents");
+            var eventGrid = driver.FindElementByAccessibilityId("ctrlEventMode");
             var rows = eventGrid.FindElementsByClassName("DataGridRow");
-            Assert.AreEqual(rows.Count, 10);
 
             rows[0].Click();
 
             // Text is populated after the cell above is selected (blank otherwise)
             Assert.AreEqual("09:58:37.859, EventRecorderNotification, Event Recorder", rows[0].Text);
-        }
 
-        /// <summary>
-        /// Validate the event details pane in the bottom right
-        /// </summary>
-        private void CheckEventDetails()
-        {
-            var detailGrid = driver.FindElementByAccessibilityId("dgEventDetails");
-            var rows = detailGrid.FindElementsByClassName("DataGridRow");
-
-            // rows.Count is 0, need to understand why
-            // Assert.AreEqual(3, rows.Count);
+            // 10 rows from the event log and 3 from the event details
+            Assert.AreEqual(rows.Count, 13);
         }
 
         /// <summary>

--- a/src/UITests/LoadEventFile.cs
+++ b/src/UITests/LoadEventFile.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Reflection;
+
+namespace UITests
+{
+    /// <summary>
+    /// Start the app, open an A11yEvent file, spot check loaded data, exit app
+    /// </summary>
+    [TestClass]
+    public class LoadEventFile : AIWinSession
+    {
+        static readonly string EventFileName = "WildlifeManagerTest.a11yevent";
+        static readonly string TestFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}\\TestFiles";
+
+        /// <summary>
+        /// The entry point for this test scenario. Every TestMethod  will restart ai-win, so
+        /// we want to use them sparingly.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("NoStrongName")]
+        [TestCategory("UITest")]
+        public void LoadEventFileTests()
+        {
+            driver.Maximize();
+            CheckEventLog();
+            CheckEventDetails();
+            CheckPropertyView();
+            CheckPatternsView();
+            ScanWindow();
+        }
+
+        private void ScanWindow()
+        {
+            var issueCount = driver.ScanAIWin(TestContext);
+            Assert.AreEqual(0, issueCount);
+        }
+
+        /// <summary>
+        /// Click the first row in the event log
+        /// </summary>
+        private void CheckEventLog()
+        {
+            var eventGrid = driver.FindElementByAccessibilityId("dgEvents");
+            var rows = eventGrid.FindElementsByClassName("DataGridRow");
+            Assert.AreEqual(rows.Count, 10);
+
+            rows[0].Click();
+
+            // Text is populated after the cell above is selected (blank otherwise)
+            Assert.AreEqual("09:58:37.859, EventRecorderNotification, Event Recorder", rows[0].Text);
+        }
+
+        /// <summary>
+        /// Validate the event details pane in the bottom right
+        /// </summary>
+        private void CheckEventDetails()
+        {
+            var detailGrid = driver.FindElementByAccessibilityId("dgEventDetails");
+            var rows = detailGrid.FindElementsByClassName("DataGridRow");
+
+            // rows.Count is 0, need to understand why
+            // Assert.AreEqual(3, rows.Count);
+        }
+
+        /// <summary>
+        /// Validate the event properties from the 3rd event (list item Owl)
+        /// </summary>
+        private void CheckPropertyView()
+        {
+            var eventGrid = driver.FindElementByAccessibilityId("dgEvents");
+            var eventRows = eventGrid.FindElementsByClassName("DataGridRow");
+            eventRows[2].Click();
+            var propertyGrid = driver.FindElementByAccessibilityId("dgProperties");
+            var propertyRows = propertyGrid.FindElementsByClassName("DataGridRow");
+
+            // propertyRows.Count is 0, need to understand why
+            // Assert.AreEqual(propertyRows.Count, 10);
+        }
+
+        /// <summary>
+        /// Validate the patterns from the 3rd event (list item Owl)
+        /// </summary>
+        private void CheckPatternsView()
+        {
+            var patternTree = driver.FindElementByAccessibilityId("treePatterns");
+            var patternItems = patternTree.FindElementsByClassName("TreeViewItem");
+
+            // patternItems.Count is 0, need to understand why
+            // Assert.AreEqual(3, patternItems.Count);
+        }
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            Setup();
+
+            driver.GettingStarted.DismissTelemetry();
+            driver.GettingStarted.DismissStartupPage();
+            driver.ToggleHighlighter();
+            driver.LiveMode.OpenFile(TestFilePath, EventFileName);
+        }
+
+        [TestCleanup]
+        public void TestCleanup() => TearDown();
+    }
+}

--- a/src/UITests/TestFiles/WildlifeManagerTest.a11yevent
+++ b/src/UITests/TestFiles/WildlifeManagerTest.a11yevent
@@ -1,0 +1,1725 @@
+﻿[
+  {
+    "EventId": 0,
+    "TimeStamp": "09:58:37.859",
+    "Properties": [
+      {
+        "Key": "Message",
+        "Value": "Succeeded to register an event listener"
+      },
+      {
+        "Key": "Event Id",
+        "Value": 20005
+      },
+      {
+        "Key": "Event Name",
+        "Value": "AutomationFocusChanged"
+      }
+    ],
+    "Element": null
+  },
+  {
+    "EventId": 20005,
+    "TimeStamp": "09:58:38.455",
+    "Properties": null,
+    "Element": {
+      "Orientation": 0,
+      "Glimpse": " ''",
+      "UniqueId": 0,
+      "Properties": {
+        "30002": {
+          "Value": 4000,
+          "Id": 30002,
+          "Name": "ProcessId"
+        },
+        "30003": {
+          "Value": 50025,
+          "Id": 30003,
+          "Name": "ControlType"
+        },
+        "30008": {
+          "Value": false,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus"
+        },
+        "30009": {
+          "Value": false,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable"
+        },
+        "30010": {
+          "Value": false,
+          "Id": 30010,
+          "Name": "IsEnabled"
+        },
+        "30015": {
+          "Value": 0,
+          "Id": 30015,
+          "Name": "Culture"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword"
+        },
+        "30020": {
+          "Value": 0,
+          "Id": 30020,
+          "Name": "NativeWindowHandle"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm"
+        },
+        "30103": {
+          "Value": false,
+          "Id": 30103,
+          "Name": "IsDataValidForForm"
+        },
+        "30107": {
+          "Value": "[pid:4000,providerId:0x0 Main(parent link):Unidentified Provider (unmanaged:Windows.UI.Xaml.dll)]",
+          "Id": 30107,
+          "Name": "ProviderDescription"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects"
+        },
+        "30173": {
+          "Value": 80050,
+          "Id": 30173,
+          "Name": "HeadingLevel"
+        },
+        "30174": {
+          "Value": false,
+          "Id": 30174,
+          "Name": "IsDialog"
+        }
+      },
+      "PlatformProperties": {},
+      "Patterns": [],
+      "Children": [],
+      "TreeWalkerMode": 0,
+      "IsAncestorOfSelected": false,
+      "ScanResults": null,
+      "IssueDisplayText": null
+    }
+  },
+  {
+    "EventId": 20005,
+    "TimeStamp": "09:58:39.076",
+    "Properties": null,
+    "Element": {
+      "Orientation": 0,
+      "Glimpse": "list item 'Owl'",
+      "UniqueId": 0,
+      "Properties": {
+        "30000": {
+          "Value": [
+            7,
+            20264,
+            9886408
+          ],
+          "Id": 30000,
+          "Name": "RuntimeId"
+        },
+        "30001": {
+          "Value": [
+            869.0,
+            995.0,
+            400.0,
+            40.0
+          ],
+          "Id": 30001,
+          "Name": "BoundingRectangle"
+        },
+        "30002": {
+          "Value": 20264,
+          "Id": 30002,
+          "Name": "ProcessId"
+        },
+        "30003": {
+          "Value": 50007,
+          "Id": 30003,
+          "Name": "ControlType"
+        },
+        "30004": {
+          "Value": "list item",
+          "Id": 30004,
+          "Name": "LocalizedControlType"
+        },
+        "30005": {
+          "Value": "Owl",
+          "Id": 30005,
+          "Name": "Name"
+        },
+        "30008": {
+          "Value": true,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus"
+        },
+        "30009": {
+          "Value": true,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable"
+        },
+        "30010": {
+          "Value": true,
+          "Id": 30010,
+          "Name": "IsEnabled"
+        },
+        "30012": {
+          "Value": "ListBoxItem",
+          "Id": 30012,
+          "Name": "ClassName"
+        },
+        "30015": {
+          "Value": 0,
+          "Id": 30015,
+          "Name": "Culture"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword"
+        },
+        "30020": {
+          "Value": 0,
+          "Id": 30020,
+          "Name": "NativeWindowHandle"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation"
+        },
+        "30024": {
+          "Value": "WPF",
+          "Id": 30024,
+          "Name": "FrameworkId"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm"
+        },
+        "30103": {
+          "Value": false,
+          "Id": 30103,
+          "Name": "IsDataValidForForm"
+        },
+        "30107": {
+          "Value": "[pid:20264,providerId:0x0 Main(parent link):Unidentified Provider (managed:MS.Internal.Automation.ElementProxy, PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)]",
+          "Id": 30107,
+          "Name": "ProviderDescription"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects"
+        },
+        "30173": {
+          "Value": 80050,
+          "Id": 30173,
+          "Name": "HeadingLevel"
+        },
+        "30174": {
+          "Value": false,
+          "Id": 30174,
+          "Name": "IsDialog"
+        },
+        "30079": {
+          "Value": true,
+          "Id": 30079,
+          "Name": "SelectionItemPattern.IsSelected"
+        },
+        "30080": {
+          "Value": "list view \"\"",
+          "Id": 30080,
+          "Name": "SelectionItemPattern.SelectionContainer"
+        }
+      },
+      "PlatformProperties": {},
+      "Patterns": [
+        {
+          "Name": "SelectionItemPattern",
+          "Id": 10010,
+          "Properties": [
+            {
+              "Name": "IsSelected",
+              "Value": true,
+              "NodeValue": "IsSelected = True"
+            }
+          ],
+          "IsUIActionable": true
+        },
+        {
+          "Name": "ScrollItemPattern",
+          "Id": 10017,
+          "Properties": [],
+          "IsUIActionable": false
+        },
+        {
+          "Name": "SynchronizedInputPattern",
+          "Id": 10021,
+          "Properties": [],
+          "IsUIActionable": false
+        }
+      ],
+      "Children": [],
+      "TreeWalkerMode": 0,
+      "IsAncestorOfSelected": false,
+      "ScanResults": null,
+      "IssueDisplayText": null
+    }
+  },
+  {
+    "EventId": 20005,
+    "TimeStamp": "09:58:39.186",
+    "Properties": null,
+    "Element": {
+      "Orientation": 0,
+      "Glimpse": "edit ''",
+      "UniqueId": 0,
+      "Properties": {
+        "30000": {
+          "Value": [
+            7,
+            20264,
+            52579650
+          ],
+          "Id": 30000,
+          "Name": "RuntimeId"
+        },
+        "30001": {
+          "Value": [
+            865.0,
+            1245.0,
+            351.0,
+            148.0
+          ],
+          "Id": 30001,
+          "Name": "BoundingRectangle"
+        },
+        "30002": {
+          "Value": 20264,
+          "Id": 30002,
+          "Name": "ProcessId"
+        },
+        "30003": {
+          "Value": 50004,
+          "Id": 30003,
+          "Name": "ControlType"
+        },
+        "30004": {
+          "Value": "edit",
+          "Id": 30004,
+          "Name": "LocalizedControlType"
+        },
+        "30008": {
+          "Value": false,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus"
+        },
+        "30009": {
+          "Value": true,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable"
+        },
+        "30010": {
+          "Value": true,
+          "Id": 30010,
+          "Name": "IsEnabled"
+        },
+        "30012": {
+          "Value": "TextBox",
+          "Id": 30012,
+          "Name": "ClassName"
+        },
+        "30015": {
+          "Value": 0,
+          "Id": 30015,
+          "Name": "Culture"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword"
+        },
+        "30020": {
+          "Value": 0,
+          "Id": 30020,
+          "Name": "NativeWindowHandle"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation"
+        },
+        "30024": {
+          "Value": "WPF",
+          "Id": 30024,
+          "Name": "FrameworkId"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm"
+        },
+        "30103": {
+          "Value": false,
+          "Id": 30103,
+          "Name": "IsDataValidForForm"
+        },
+        "30107": {
+          "Value": "[pid:20264,providerId:0x0 Main(parent link):Unidentified Provider (managed:MS.Internal.Automation.ElementProxy, PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)]",
+          "Id": 30107,
+          "Name": "ProviderDescription"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects"
+        },
+        "30173": {
+          "Value": 80050,
+          "Id": 30173,
+          "Name": "HeadingLevel"
+        },
+        "30174": {
+          "Value": false,
+          "Id": 30174,
+          "Name": "IsDialog"
+        },
+        "30046": {
+          "Value": false,
+          "Id": 30046,
+          "Name": "ValuePattern.IsReadOnly"
+        },
+        "30053": {
+          "Value": -1.0,
+          "Id": 30053,
+          "Name": "ScrollPattern.HorizontalScrollPercent"
+        },
+        "30054": {
+          "Value": 100.0,
+          "Id": 30054,
+          "Name": "ScrollPattern.HorizontalViewSize"
+        },
+        "30055": {
+          "Value": -1.0,
+          "Id": 30055,
+          "Name": "ScrollPattern.VerticalScrollPercent"
+        },
+        "30056": {
+          "Value": 100.0,
+          "Id": 30056,
+          "Name": "ScrollPattern.VerticalViewSize"
+        },
+        "30057": {
+          "Value": false,
+          "Id": 30057,
+          "Name": "ScrollPattern.HorizontallyScrollable"
+        },
+        "30058": {
+          "Value": false,
+          "Id": 30058,
+          "Name": "ScrollPattern.VerticallyScrollable"
+        }
+      },
+      "PlatformProperties": {},
+      "Patterns": [
+        {
+          "Name": "ValuePattern",
+          "Id": 10002,
+          "Properties": [
+            {
+              "Name": "IsReadOnly",
+              "Value": false,
+              "NodeValue": "IsReadOnly = False"
+            },
+            {
+              "Name": "Value",
+              "Value": "",
+              "NodeValue": "Value = \"\""
+            }
+          ],
+          "IsUIActionable": false
+        },
+        {
+          "Name": "ScrollPattern",
+          "Id": 10004,
+          "Properties": [
+            {
+              "Name": "HorizontallyScrollable",
+              "Value": false,
+              "NodeValue": "HorizontallyScrollable = False"
+            },
+            {
+              "Name": "HorizontalScrollPercent",
+              "Value": -1.0,
+              "NodeValue": "HorizontalScrollPercent = -1"
+            },
+            {
+              "Name": "HorizontalViewSize",
+              "Value": 100.0,
+              "NodeValue": "HorizontalViewSize = 100"
+            },
+            {
+              "Name": "VerticallyScrollable",
+              "Value": false,
+              "NodeValue": "VerticallyScrollable = False"
+            },
+            {
+              "Name": "VerticalScrollPercent",
+              "Value": -1.0,
+              "NodeValue": "VerticalScrollPercent = -1"
+            },
+            {
+              "Name": "VerticalViewSize",
+              "Value": 100.0,
+              "NodeValue": "VerticalViewSize = 100"
+            }
+          ],
+          "IsUIActionable": false
+        },
+        {
+          "Name": "TextPattern",
+          "Id": 10014,
+          "Properties": [
+            {
+              "Name": "SupportedTextSelection",
+              "Value": 1,
+              "NodeValue": "SupportedTextSelection = SupportedTextSelection_Single"
+            }
+          ],
+          "IsUIActionable": true
+        },
+        {
+          "Name": "SynchronizedInputPattern",
+          "Id": 10021,
+          "Properties": [],
+          "IsUIActionable": false
+        }
+      ],
+      "Children": [],
+      "TreeWalkerMode": 0,
+      "IsAncestorOfSelected": false,
+      "ScanResults": null,
+      "IssueDisplayText": null
+    }
+  },
+  {
+    "EventId": 20005,
+    "TimeStamp": "09:58:39.439",
+    "Properties": null,
+    "Element": {
+      "Orientation": 0,
+      "Glimpse": "list item 'Owl'",
+      "UniqueId": 0,
+      "Properties": {
+        "30000": {
+          "Value": [
+            7,
+            20264,
+            9886408
+          ],
+          "Id": 30000,
+          "Name": "RuntimeId"
+        },
+        "30001": {
+          "Value": [
+            869.0,
+            995.0,
+            400.0,
+            40.0
+          ],
+          "Id": 30001,
+          "Name": "BoundingRectangle"
+        },
+        "30002": {
+          "Value": 20264,
+          "Id": 30002,
+          "Name": "ProcessId"
+        },
+        "30003": {
+          "Value": 50007,
+          "Id": 30003,
+          "Name": "ControlType"
+        },
+        "30004": {
+          "Value": "list item",
+          "Id": 30004,
+          "Name": "LocalizedControlType"
+        },
+        "30005": {
+          "Value": "Owl",
+          "Id": 30005,
+          "Name": "Name"
+        },
+        "30008": {
+          "Value": true,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus"
+        },
+        "30009": {
+          "Value": true,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable"
+        },
+        "30010": {
+          "Value": true,
+          "Id": 30010,
+          "Name": "IsEnabled"
+        },
+        "30012": {
+          "Value": "ListBoxItem",
+          "Id": 30012,
+          "Name": "ClassName"
+        },
+        "30015": {
+          "Value": 0,
+          "Id": 30015,
+          "Name": "Culture"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword"
+        },
+        "30020": {
+          "Value": 0,
+          "Id": 30020,
+          "Name": "NativeWindowHandle"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation"
+        },
+        "30024": {
+          "Value": "WPF",
+          "Id": 30024,
+          "Name": "FrameworkId"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm"
+        },
+        "30103": {
+          "Value": false,
+          "Id": 30103,
+          "Name": "IsDataValidForForm"
+        },
+        "30107": {
+          "Value": "[pid:20264,providerId:0x0 Main(parent link):Unidentified Provider (managed:MS.Internal.Automation.ElementProxy, PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)]",
+          "Id": 30107,
+          "Name": "ProviderDescription"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects"
+        },
+        "30173": {
+          "Value": 80050,
+          "Id": 30173,
+          "Name": "HeadingLevel"
+        },
+        "30174": {
+          "Value": false,
+          "Id": 30174,
+          "Name": "IsDialog"
+        },
+        "30079": {
+          "Value": true,
+          "Id": 30079,
+          "Name": "SelectionItemPattern.IsSelected"
+        },
+        "30080": {
+          "Value": "list view \"\"",
+          "Id": 30080,
+          "Name": "SelectionItemPattern.SelectionContainer"
+        }
+      },
+      "PlatformProperties": {},
+      "Patterns": [
+        {
+          "Name": "SelectionItemPattern",
+          "Id": 10010,
+          "Properties": [
+            {
+              "Name": "IsSelected",
+              "Value": true,
+              "NodeValue": "IsSelected = True"
+            }
+          ],
+          "IsUIActionable": true
+        },
+        {
+          "Name": "ScrollItemPattern",
+          "Id": 10017,
+          "Properties": [],
+          "IsUIActionable": false
+        },
+        {
+          "Name": "SynchronizedInputPattern",
+          "Id": 10021,
+          "Properties": [],
+          "IsUIActionable": false
+        }
+      ],
+      "Children": [],
+      "TreeWalkerMode": 0,
+      "IsAncestorOfSelected": false,
+      "ScanResults": null,
+      "IssueDisplayText": null
+    }
+  },
+  {
+    "EventId": 20005,
+    "TimeStamp": "09:58:41.721",
+    "Properties": null,
+    "Element": {
+      "Orientation": 0,
+      "Glimpse": "edit ''",
+      "UniqueId": 0,
+      "Properties": {
+        "30000": {
+          "Value": [
+            7,
+            20264,
+            52579650
+          ],
+          "Id": 30000,
+          "Name": "RuntimeId"
+        },
+        "30001": {
+          "Value": [
+            865.0,
+            1245.0,
+            351.0,
+            148.0
+          ],
+          "Id": 30001,
+          "Name": "BoundingRectangle"
+        },
+        "30002": {
+          "Value": 20264,
+          "Id": 30002,
+          "Name": "ProcessId"
+        },
+        "30003": {
+          "Value": 50004,
+          "Id": 30003,
+          "Name": "ControlType"
+        },
+        "30004": {
+          "Value": "edit",
+          "Id": 30004,
+          "Name": "LocalizedControlType"
+        },
+        "30008": {
+          "Value": true,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus"
+        },
+        "30009": {
+          "Value": true,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable"
+        },
+        "30010": {
+          "Value": true,
+          "Id": 30010,
+          "Name": "IsEnabled"
+        },
+        "30012": {
+          "Value": "TextBox",
+          "Id": 30012,
+          "Name": "ClassName"
+        },
+        "30015": {
+          "Value": 0,
+          "Id": 30015,
+          "Name": "Culture"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword"
+        },
+        "30020": {
+          "Value": 0,
+          "Id": 30020,
+          "Name": "NativeWindowHandle"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation"
+        },
+        "30024": {
+          "Value": "WPF",
+          "Id": 30024,
+          "Name": "FrameworkId"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm"
+        },
+        "30103": {
+          "Value": false,
+          "Id": 30103,
+          "Name": "IsDataValidForForm"
+        },
+        "30107": {
+          "Value": "[pid:20264,providerId:0x0 Main(parent link):Unidentified Provider (managed:MS.Internal.Automation.ElementProxy, PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)]",
+          "Id": 30107,
+          "Name": "ProviderDescription"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects"
+        },
+        "30173": {
+          "Value": 80050,
+          "Id": 30173,
+          "Name": "HeadingLevel"
+        },
+        "30174": {
+          "Value": false,
+          "Id": 30174,
+          "Name": "IsDialog"
+        },
+        "30046": {
+          "Value": false,
+          "Id": 30046,
+          "Name": "ValuePattern.IsReadOnly"
+        },
+        "30053": {
+          "Value": -1.0,
+          "Id": 30053,
+          "Name": "ScrollPattern.HorizontalScrollPercent"
+        },
+        "30054": {
+          "Value": 100.0,
+          "Id": 30054,
+          "Name": "ScrollPattern.HorizontalViewSize"
+        },
+        "30055": {
+          "Value": -1.0,
+          "Id": 30055,
+          "Name": "ScrollPattern.VerticalScrollPercent"
+        },
+        "30056": {
+          "Value": 100.0,
+          "Id": 30056,
+          "Name": "ScrollPattern.VerticalViewSize"
+        },
+        "30057": {
+          "Value": false,
+          "Id": 30057,
+          "Name": "ScrollPattern.HorizontallyScrollable"
+        },
+        "30058": {
+          "Value": false,
+          "Id": 30058,
+          "Name": "ScrollPattern.VerticallyScrollable"
+        }
+      },
+      "PlatformProperties": {},
+      "Patterns": [
+        {
+          "Name": "ValuePattern",
+          "Id": 10002,
+          "Properties": [
+            {
+              "Name": "IsReadOnly",
+              "Value": false,
+              "NodeValue": "IsReadOnly = False"
+            },
+            {
+              "Name": "Value",
+              "Value": "",
+              "NodeValue": "Value = \"\""
+            }
+          ],
+          "IsUIActionable": false
+        },
+        {
+          "Name": "ScrollPattern",
+          "Id": 10004,
+          "Properties": [
+            {
+              "Name": "HorizontallyScrollable",
+              "Value": false,
+              "NodeValue": "HorizontallyScrollable = False"
+            },
+            {
+              "Name": "HorizontalScrollPercent",
+              "Value": -1.0,
+              "NodeValue": "HorizontalScrollPercent = -1"
+            },
+            {
+              "Name": "HorizontalViewSize",
+              "Value": 100.0,
+              "NodeValue": "HorizontalViewSize = 100"
+            },
+            {
+              "Name": "VerticallyScrollable",
+              "Value": false,
+              "NodeValue": "VerticallyScrollable = False"
+            },
+            {
+              "Name": "VerticalScrollPercent",
+              "Value": -1.0,
+              "NodeValue": "VerticalScrollPercent = -1"
+            },
+            {
+              "Name": "VerticalViewSize",
+              "Value": 100.0,
+              "NodeValue": "VerticalViewSize = 100"
+            }
+          ],
+          "IsUIActionable": false
+        },
+        {
+          "Name": "TextPattern",
+          "Id": 10014,
+          "Properties": [
+            {
+              "Name": "SupportedTextSelection",
+              "Value": 1,
+              "NodeValue": "SupportedTextSelection = SupportedTextSelection_Single"
+            }
+          ],
+          "IsUIActionable": true
+        },
+        {
+          "Name": "SynchronizedInputPattern",
+          "Id": 10021,
+          "Properties": [],
+          "IsUIActionable": false
+        }
+      ],
+      "Children": [],
+      "TreeWalkerMode": 0,
+      "IsAncestorOfSelected": false,
+      "ScanResults": null,
+      "IssueDisplayText": null
+    }
+  },
+  {
+    "EventId": 20005,
+    "TimeStamp": "09:58:42.672",
+    "Properties": null,
+    "Element": {
+      "Orientation": 0,
+      "Glimpse": " ''",
+      "UniqueId": 0,
+      "Properties": {
+        "30002": {
+          "Value": 4000,
+          "Id": 30002,
+          "Name": "ProcessId"
+        },
+        "30003": {
+          "Value": 50025,
+          "Id": 30003,
+          "Name": "ControlType"
+        },
+        "30008": {
+          "Value": false,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus"
+        },
+        "30009": {
+          "Value": false,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable"
+        },
+        "30010": {
+          "Value": false,
+          "Id": 30010,
+          "Name": "IsEnabled"
+        },
+        "30015": {
+          "Value": 0,
+          "Id": 30015,
+          "Name": "Culture"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword"
+        },
+        "30020": {
+          "Value": 0,
+          "Id": 30020,
+          "Name": "NativeWindowHandle"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm"
+        },
+        "30103": {
+          "Value": false,
+          "Id": 30103,
+          "Name": "IsDataValidForForm"
+        },
+        "30107": {
+          "Value": "[pid:4000,providerId:0x0 Main(parent link):Unidentified Provider (unmanaged:Windows.UI.Xaml.dll)]",
+          "Id": 30107,
+          "Name": "ProviderDescription"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects"
+        },
+        "30173": {
+          "Value": 80050,
+          "Id": 30173,
+          "Name": "HeadingLevel"
+        },
+        "30174": {
+          "Value": false,
+          "Id": 30174,
+          "Name": "IsDialog"
+        }
+      },
+      "PlatformProperties": {},
+      "Patterns": [],
+      "Children": [],
+      "TreeWalkerMode": 0,
+      "IsAncestorOfSelected": false,
+      "ScanResults": null,
+      "IssueDisplayText": null
+    }
+  },
+  {
+    "EventId": 20005,
+    "TimeStamp": "09:58:43.306",
+    "Properties": null,
+    "Element": {
+      "Orientation": 0,
+      "Glimpse": "pane ''",
+      "UniqueId": 0,
+      "Properties": {
+        "30000": {
+          "Value": [
+            42,
+            2230004,
+            4,
+            50929
+          ],
+          "Id": 30000,
+          "Name": "RuntimeId"
+        },
+        "30001": {
+          "Value": [
+            1531.0,
+            818.0,
+            668.0,
+            228.0
+          ],
+          "Id": 30001,
+          "Name": "BoundingRectangle"
+        },
+        "30002": {
+          "Value": 21520,
+          "Id": 30002,
+          "Name": "ProcessId"
+        },
+        "30003": {
+          "Value": 50033,
+          "Id": 30003,
+          "Name": "ControlType"
+        },
+        "30004": {
+          "Value": "pane",
+          "Id": 30004,
+          "Name": "LocalizedControlType"
+        },
+        "30008": {
+          "Value": false,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus"
+        },
+        "30009": {
+          "Value": false,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable"
+        },
+        "30010": {
+          "Value": true,
+          "Id": 30010,
+          "Name": "IsEnabled"
+        },
+        "30015": {
+          "Value": 1033,
+          "Id": 30015,
+          "Name": "Culture"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword"
+        },
+        "30020": {
+          "Value": 0,
+          "Id": 30020,
+          "Name": "NativeWindowHandle"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation"
+        },
+        "30024": {
+          "Value": "MicrosoftEdge",
+          "Id": 30024,
+          "Name": "FrameworkId"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm"
+        },
+        "30103": {
+          "Value": true,
+          "Id": 30103,
+          "Name": "IsDataValidForForm"
+        },
+        "30107": {
+          "Value": "[pid:21520,providerId:0x0 Main(parent link):Unidentified Provider (unmanaged:edgehtml.dll)]",
+          "Id": 30107,
+          "Name": "ProviderDescription"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects"
+        },
+        "30173": {
+          "Value": 80050,
+          "Id": 30173,
+          "Name": "HeadingLevel"
+        },
+        "30174": {
+          "Value": false,
+          "Id": 30174,
+          "Name": "IsDialog"
+        }
+      },
+      "PlatformProperties": {},
+      "Patterns": [
+        {
+          "Name": "ScrollItemPattern",
+          "Id": 10017,
+          "Properties": [],
+          "IsUIActionable": false
+        }
+      ],
+      "Children": [],
+      "TreeWalkerMode": 0,
+      "IsAncestorOfSelected": false,
+      "ScanResults": null,
+      "IssueDisplayText": null
+    }
+  },
+  {
+    "EventId": 20005,
+    "TimeStamp": "09:58:43.368",
+    "Properties": null,
+    "Element": {
+      "Orientation": 0,
+      "Glimpse": "pane ''",
+      "UniqueId": 0,
+      "Properties": {
+        "30000": {
+          "Value": [
+            42,
+            2230004,
+            4,
+            50929
+          ],
+          "Id": 30000,
+          "Name": "RuntimeId"
+        },
+        "30001": {
+          "Value": [
+            1531.0,
+            818.0,
+            668.0,
+            228.0
+          ],
+          "Id": 30001,
+          "Name": "BoundingRectangle"
+        },
+        "30002": {
+          "Value": 21520,
+          "Id": 30002,
+          "Name": "ProcessId"
+        },
+        "30003": {
+          "Value": 50033,
+          "Id": 30003,
+          "Name": "ControlType"
+        },
+        "30004": {
+          "Value": "pane",
+          "Id": 30004,
+          "Name": "LocalizedControlType"
+        },
+        "30008": {
+          "Value": false,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus"
+        },
+        "30009": {
+          "Value": false,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable"
+        },
+        "30010": {
+          "Value": true,
+          "Id": 30010,
+          "Name": "IsEnabled"
+        },
+        "30015": {
+          "Value": 1033,
+          "Id": 30015,
+          "Name": "Culture"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword"
+        },
+        "30020": {
+          "Value": 0,
+          "Id": 30020,
+          "Name": "NativeWindowHandle"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation"
+        },
+        "30024": {
+          "Value": "MicrosoftEdge",
+          "Id": 30024,
+          "Name": "FrameworkId"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm"
+        },
+        "30103": {
+          "Value": true,
+          "Id": 30103,
+          "Name": "IsDataValidForForm"
+        },
+        "30107": {
+          "Value": "[pid:21520,providerId:0x0 Main(parent link):Unidentified Provider (unmanaged:edgehtml.dll)]",
+          "Id": 30107,
+          "Name": "ProviderDescription"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects"
+        },
+        "30173": {
+          "Value": 80050,
+          "Id": 30173,
+          "Name": "HeadingLevel"
+        },
+        "30174": {
+          "Value": false,
+          "Id": 30174,
+          "Name": "IsDialog"
+        }
+      },
+      "PlatformProperties": {},
+      "Patterns": [
+        {
+          "Name": "ScrollItemPattern",
+          "Id": 10017,
+          "Properties": [],
+          "IsUIActionable": false
+        }
+      ],
+      "Children": [],
+      "TreeWalkerMode": 0,
+      "IsAncestorOfSelected": false,
+      "ScanResults": null,
+      "IssueDisplayText": null
+    }
+  },
+  {
+    "EventId": 20005,
+    "TimeStamp": "09:58:43.599",
+    "Properties": null,
+    "Element": {
+      "Orientation": 0,
+      "Glimpse": "pane ''",
+      "UniqueId": 0,
+      "Properties": {
+        "30000": {
+          "Value": [
+            42,
+            2230004,
+            4,
+            50929
+          ],
+          "Id": 30000,
+          "Name": "RuntimeId"
+        },
+        "30001": {
+          "Value": [
+            1531.0,
+            818.0,
+            668.0,
+            228.0
+          ],
+          "Id": 30001,
+          "Name": "BoundingRectangle"
+        },
+        "30002": {
+          "Value": 21520,
+          "Id": 30002,
+          "Name": "ProcessId"
+        },
+        "30003": {
+          "Value": 50033,
+          "Id": 30003,
+          "Name": "ControlType"
+        },
+        "30004": {
+          "Value": "pane",
+          "Id": 30004,
+          "Name": "LocalizedControlType"
+        },
+        "30008": {
+          "Value": false,
+          "Id": 30008,
+          "Name": "HasKeyboardFocus"
+        },
+        "30009": {
+          "Value": false,
+          "Id": 30009,
+          "Name": "IsKeyboardFocusable"
+        },
+        "30010": {
+          "Value": true,
+          "Id": 30010,
+          "Name": "IsEnabled"
+        },
+        "30015": {
+          "Value": 1033,
+          "Id": 30015,
+          "Name": "Culture"
+        },
+        "30016": {
+          "Value": true,
+          "Id": 30016,
+          "Name": "IsControlElement"
+        },
+        "30017": {
+          "Value": true,
+          "Id": 30017,
+          "Name": "IsContentElement"
+        },
+        "30019": {
+          "Value": false,
+          "Id": 30019,
+          "Name": "IsPassword"
+        },
+        "30020": {
+          "Value": 0,
+          "Id": 30020,
+          "Name": "NativeWindowHandle"
+        },
+        "30022": {
+          "Value": false,
+          "Id": 30022,
+          "Name": "IsOffscreen"
+        },
+        "30023": {
+          "Value": 0,
+          "Id": 30023,
+          "Name": "Orientation"
+        },
+        "30024": {
+          "Value": "MicrosoftEdge",
+          "Id": 30024,
+          "Name": "FrameworkId"
+        },
+        "30025": {
+          "Value": false,
+          "Id": 30025,
+          "Name": "IsRequiredForForm"
+        },
+        "30103": {
+          "Value": true,
+          "Id": 30103,
+          "Name": "IsDataValidForForm"
+        },
+        "30107": {
+          "Value": "[pid:21520,providerId:0x0 Main(parent link):Unidentified Provider (unmanaged:edgehtml.dll)]",
+          "Id": 30107,
+          "Name": "ProviderDescription"
+        },
+        "30111": {
+          "Value": false,
+          "Id": 30111,
+          "Name": "OptimizeForVisualContent"
+        },
+        "30135": {
+          "Value": 0,
+          "Id": 30135,
+          "Name": "LiveSetting"
+        },
+        "30150": {
+          "Value": false,
+          "Id": 30150,
+          "Name": "IsPeripheral"
+        },
+        "30162": {
+          "Value": 0,
+          "Id": 30162,
+          "Name": "FillType"
+        },
+        "30163": {
+          "Value": 0,
+          "Id": 30163,
+          "Name": "VisualEffects"
+        },
+        "30173": {
+          "Value": 80050,
+          "Id": 30173,
+          "Name": "HeadingLevel"
+        },
+        "30174": {
+          "Value": false,
+          "Id": 30174,
+          "Name": "IsDialog"
+        }
+      },
+      "PlatformProperties": {},
+      "Patterns": [
+        {
+          "Name": "ScrollItemPattern",
+          "Id": 10017,
+          "Properties": [],
+          "IsUIActionable": false
+        }
+      ],
+      "Children": [],
+      "TreeWalkerMode": 0,
+      "IsAncestorOfSelected": false,
+      "ScanResults": null,
+      "IssueDisplayText": null
+    }
+  }
+]

--- a/src/UITests/UILibrary/AIWinDriver.cs
+++ b/src/UITests/UILibrary/AIWinDriver.cs
@@ -61,5 +61,7 @@ namespace UITests.UILibrary
         public string Title => Session.Title;
 
         public void ToggleHighlighter() => Session.FindElementByAccessibilityId(AutomationIDs.MainWinHighlightButton).Click();
+
+        public void Maximize() => Session.Manage().Window.Maximize();
     }
 }

--- a/src/UITests/UITests.csproj
+++ b/src/UITests/UITests.csproj
@@ -108,10 +108,14 @@
     <Compile Include="GettingStartedPage.cs" />
     <Compile Include="UILibrary\Settings.cs" />
     <Compile Include="UILibrary\TestMode.cs" />
+    <Compile Include="LoadEventFile.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+    <None Include="TestFiles\WildlifeManagerTest.a11yevent">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestFiles\WildlifeManagerTest.a11ytest">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
This PR adds an initial UI test for event-loading. It opens a saved event file, clicks to show certain events, and then verifies the number of rows in the window. Getting more granular (e.g. how many property rows vs event detail rows) was difficult due to WinAppDriver oddities. We may explore that further in a future PR. For now, we validate the number of rows across various views and verify there are no accessibility issues. This PR only touches test code and automation IDs in our UI.