### PR TITLE
Change WinAppDriver connection to retry instead of having a long delay

### DIFF
--- a/src/UITests/AIWinSession.cs
+++ b/src/UITests/AIWinSession.cs
@@ -61,7 +61,7 @@ namespace UITests
 
             process = Process.Start(exePath, configPathArgument);
 
-            const int attempts = 15; // this number should give us enough retries for the build to work
+            const int attempts = 10; // this number should give us enough retries for the build to work
             RetryAttemptToStartNewSession(attempts);
 
             driver = new AIWinDriver(session, process.Id);
@@ -83,10 +83,13 @@ namespace UITests
                 try
                 {
                     StartNewSession();
-                    Thread.Sleep(2000);
+                    Thread.Sleep(3000);
 
-                    // if the window title isn't set, ai-win is not ready for testing.
-                    if (string.IsNullOrEmpty(session?.Title)) continue;
+                    // if the session has these nulls, ai-win is not ready for testing.
+                    if (session == null || string.IsNullOrEmpty(session.Title) || session.SessionId == null)
+                    {
+                        continue;
+                    }
 
                     break;
                 }

--- a/src/UITests/AIWinSession.cs
+++ b/src/UITests/AIWinSession.cs
@@ -17,8 +17,8 @@ namespace UITests
     public class AIWinSession
     {
         protected const string WindowsApplicationDriverUrl = "http://127.0.0.1:4723";
-        private Process process;
-        private WindowsDriver<WindowsElement> session;
+        private Process _process;
+        private WindowsDriver<WindowsElement> _session;
         protected AIWinDriver driver;
         public TestContext TestContext { get; set; }
 
@@ -35,11 +35,11 @@ namespace UITests
 
             LaunchApplicationAndAttach();
 
-            Assert.IsNotNull(session);
-            Assert.IsNotNull(session.SessionId);
+            Assert.IsNotNull(_session);
+            Assert.IsNotNull(_session.SessionId);
 
             // Set implicit timeout to 1.5 seconds to ensure element search retries every 500 ms for at most three times
-            session.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(1.5);
+            _session.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(1.5);
         }
 
         /// <summary>
@@ -59,12 +59,12 @@ namespace UITests
             var exePath = Path.Combine(executingDirectory, "AccessibilityInsights.exe");
             var configPathArgument = $"--ConfigFolder \"{Path.Combine(TestContext.TestResultsDirectory, TestContext.TestName)}\"";
 
-            process = Process.Start(exePath, configPathArgument);
+            _process = Process.Start(exePath, configPathArgument);
 
             const int attempts = 10; // this number should give us enough retries for the build to work
             StartNewSessionWithRetry(attempts);
 
-            driver = new AIWinDriver(session, process.Id);
+            driver = new AIWinDriver(_session, _process.Id);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace UITests
         private void StartNewSessionWithRetry(int attempts)
         {
             // if the session and its title are present, ai-win is ready for testing.
-            while (attempts > 0 && string.IsNullOrEmpty(session?.Title))
+            while (attempts > 0 && string.IsNullOrEmpty(_session?.Title))
             {
                 attempts--;
 
@@ -90,10 +90,10 @@ namespace UITests
         {
             try
             {
-                process.Refresh(); // updates process.MainWindowHandle
+                _process.Refresh(); // updates process.MainWindowHandle
                 DesiredCapabilities appCapabilities = new DesiredCapabilities();
-                appCapabilities.SetCapability("appTopLevelWindow", process.MainWindowHandle.ToString("x"));
-                session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
+                appCapabilities.SetCapability("appTopLevelWindow", _process.MainWindowHandle.ToString("x"));
+                _session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
             }
             catch { }
         }
@@ -104,9 +104,9 @@ namespace UITests
 
             // closing ai-win like this stops it from saving the config. Will have to change this
             // if we ever want to use the saved config.
-            process?.Kill();
+            _process?.Kill();
 
-            session?.Quit();
+            _session?.Quit();
         }
 
         private bool IsWinAppDriverRunning()

--- a/src/UITests/AIWinSession.cs
+++ b/src/UITests/AIWinSession.cs
@@ -80,29 +80,27 @@ namespace UITests
             {
                 attempts--;
 
-                try
+                StartNewSession();
+                Thread.Sleep(3000);
+
+                // if the session and its title are present, ai-win is ready for testing.
+                if (!string.IsNullOrEmpty(session?.Title))
                 {
-                    StartNewSession();
-                    Thread.Sleep(3000);
-
-                    // if the session has these nulls, ai-win is not ready for testing.
-                    if (session == null || string.IsNullOrEmpty(session.Title) || session.SessionId == null)
-                    {
-                        continue;
-                    }
-
                     break;
                 }
-                catch { }
             }
         }
 
         private void StartNewSession()
         {
-            process.Refresh(); // updates process.MainWindowHandle
-            DesiredCapabilities appCapabilities = new DesiredCapabilities();
-            appCapabilities.SetCapability("appTopLevelWindow", process.MainWindowHandle.ToString("x"));
-            session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
+            try
+            {
+                process.Refresh(); // updates process.MainWindowHandle
+                DesiredCapabilities appCapabilities = new DesiredCapabilities();
+                appCapabilities.SetCapability("appTopLevelWindow", process.MainWindowHandle.ToString("x"));
+                session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
+            }
+            catch { }
         }
 
         public void TearDown()

--- a/src/UITests/AIWinSession.cs
+++ b/src/UITests/AIWinSession.cs
@@ -62,7 +62,7 @@ namespace UITests
             process = Process.Start(exePath, configPathArgument);
 
             const int attempts = 10; // this number should give us enough retries for the build to work
-            RetryAttemptToStartNewSession(attempts);
+            StartNewSessionWithRetry(attempts);
 
             driver = new AIWinDriver(session, process.Id);
         }
@@ -74,20 +74,15 @@ namespace UITests
         /// to start a new session repeatedly until ai-win is ready.
         /// </summary>
         /// <param name="attempts">Number of times to retry starting a new session</param>
-        private void RetryAttemptToStartNewSession(int attempts)
+        private void StartNewSessionWithRetry(int attempts)
         {
-            while (attempts > 0)
+            // if the session and its title are present, ai-win is ready for testing.
+            while (attempts > 0 && string.IsNullOrEmpty(session?.Title))
             {
                 attempts--;
 
                 StartNewSession();
                 Thread.Sleep(3000);
-
-                // if the session and its title are present, ai-win is ready for testing.
-                if (!string.IsNullOrEmpty(session?.Title))
-                {
-                    break;
-                }
             }
         }
 


### PR DESCRIPTION
#### Describe the change
We gave the UITests a loongg delay so that they would run on the ado build. This PR replaces that delay with a repeated retry so that quicker test machines don't have to wait as long to run ui tests. 

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



