### PR TITLE
Add a UI test for the settings page

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/ChannelConfigControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ChannelConfigControl.xaml
@@ -23,7 +23,8 @@
                Style="{StaticResource LblH4}" Name="lblChannel"/>
         <ComboBox Grid.Row="1" Margin="0,8,0,12" ItemsSource="{Binding Path=Channels}"
                   MaxWidth="154" MinWidth="154" HorizontalAlignment="Left"
-                  SelectedItem="{Binding CurrentChannel}" AutomationProperties.LabeledBy="{Binding ElementName=lblChannel}"/>
+                  SelectedItem="{Binding CurrentChannel}" AutomationProperties.LabeledBy="{Binding ElementName=lblChannel}"
+                  AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.ChannelComboBox}"/>
         <TextBlock Focusable="True" Grid.Row="2" Style="{StaticResource TxtTelemetrySettingInfo}"
                    TextWrapping="Wrap" HorizontalAlignment="Left" Text="{Binding ChannelDescription}"/>
     </Grid>

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -42,7 +42,7 @@
         <TextBlock Padding="0" FontSize="14" Margin="0,8,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlNotices" AutomationProperties.Name="{x:Static Properties:Resources.hlThirdpartyNoticesName}" 
                        Click="FileLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 
-                       NavigateUri="thirdpartynotices.html" TextDecorations="None">
+                       NavigateUri="thirdpartynotices.html" TextDecorations="None" AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.ThirdPartyNoticesHyperlink}">
                 <Run Text="{x:Static Properties:Resources.hlThirdpartyNoticesName}" />
             </Hyperlink>
         </TextBlock>

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
@@ -75,6 +75,7 @@
             <StackPanel Grid.Row="4" Orientation="Horizontal" Margin="1,5,0,0">
                 <Button x:Name="btnHotkeyPause" HorizontalAlignment="Left" Height="16" VerticalAlignment="Top" Width="120" 
                         VerticalContentAlignment="Center" Style="{StaticResource BtnHotkey}" 
+                        AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.HotkeyPauseButton}"
                         Click="btnToggleHk_Click">
                     <AutomationProperties.Name>
                         <MultiBinding StringFormat="{x:Static Properties:Resources.MultiBindingStringFormat}">

--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
@@ -12,7 +12,8 @@
         Title="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}" Height="162" Width="319" 
         KeyDown="Window_KeyDown" KeyUp="Window_KeyUp" 
         WindowStartupLocation="CenterOwner"
-        ShowInTaskbar="False" Topmost="True">
+        ShowInTaskbar="False" Topmost="True"
+        AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.HotkeyGrabDialog}">
     <Window.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
     </Window.Resources>

--- a/src/AccessibilityInsights.SharedUx/Properties/AutomationIDs.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/AutomationIDs.cs
@@ -13,5 +13,15 @@ namespace AccessibilityInsights.SharedUx.Properties
         public static string TelemetryDialogExitButton { get; } = nameof(TelemetryDialogExitButton);
         public static string EventsDataGrid { get; } = nameof(EventsDataGrid);
         public static string EventModeControl { get; } = nameof(EventModeControl);
+        public static string SettingsButton { get; } = nameof(SettingsButton);
+        public static string SettingsApplicationTabItem { get; } = nameof(SettingsApplicationTabItem);
+        public static string SettingsAboutTabItem { get; } = nameof(SettingsAboutTabItem);
+        public static string ChannelComboBox { get; } = nameof(ChannelComboBox);
+        public static string SaveAndCloseButton { get; } = nameof(SaveAndCloseButton);
+        public static string PauseButton { get; } = nameof(PauseButton);
+        public static string HotkeyPauseButton { get; } = nameof(HotkeyPauseButton);
+        public static string HotkeyGrabDialog { get; } = nameof(HotkeyGrabDialog);
+        public static string MainWindow { get; } = nameof(MainWindow);
+        public static string ThirdPartyNoticesHyperlink { get; } = nameof(ThirdPartyNoticesHyperlink);
     }
 }

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -23,7 +23,8 @@
         DataContext="{Binding RelativeSource={RelativeSource Self}}"
         WindowStyle="SingleBorderWindow"
         BorderBrush="{DynamicResource ResourceKey=WindowBorderBrush}"
-        Topmost="True" KeyUp="Window_KeyUp" StateChanged="onStateChanged" Closing="Window_Closing" Height="601.918">
+        Topmost="True" KeyUp="Window_KeyUp" StateChanged="onStateChanged" Closing="Window_Closing" Height="601.918"
+        AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWindow}">
     <Window.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
     </Window.Resources>
@@ -170,6 +171,7 @@
                         </Button>
                         <Button Width="40" Height="40"
                                     x:Name="btnConfig" Grid.Row="1"
+                                    AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsButton}"
                                     AutomationProperties.Name="{x:Static properties:Resources.btnConfigAutomationPropertiesName}"
                                     AutomationProperties.HelpText="{x:Static properties:Resources.btnConfigAutomationPropertiesHelpText}"
                                     Style="{StaticResource btnLeftNav}" Click="onbtnConfigClicked">
@@ -372,7 +374,8 @@
                             <Button x:Name="btnPause"
                                 VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
                                 Click="btnPause_Click"
-                                AutomationProperties.Name="{x:Static properties:Resources.btnPauseAutomationPropertiesNameOn}">
+                                AutomationProperties.Name="{x:Static properties:Resources.btnPauseAutomationPropertiesNameOn}"
+                                AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.PauseButton}">
                                 <i:Interaction.Behaviors>
                                     <behaviors:KeyboardToolTipButtonBehavior/>
                                 </i:Interaction.Behaviors>

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
@@ -9,6 +9,7 @@
              xmlns:fabric="clr-namespace:AccessibilityInsights.CommonUxComponents.Controls;assembly=AccessibilityInsights.CommonUxComponents"
              xmlns:local="clr-namespace:AccessibilityInsights.Modes"
              xmlns:properties="clr-namespace:AccessibilityInsights.Properties"
+             xmlns:sharedProps="clr-namespace:AccessibilityInsights.SharedUx.Properties;assembly=AccessibilityInsights.SharedUx"
              mc:Ignorable="d" AutomationProperties.Name="{x:Static properties:Resources.ConfigurationModeControlAutomationPropertiesName}"
              d:DesignHeight="550" d:DesignWidth="500">
     <UserControl.Resources>
@@ -32,9 +33,10 @@
                 </Grid>
                 <Grid Grid.Row="1">
                     <DockPanel LastChildFill="False" >
-                        <Button DockPanel.Dock="Bottom" TabIndex="-3" x:Name="btnOk" Content="{x:Static properties:Resources.btnOkContent}" HorizontalAlignment="Left" VerticalAlignment="Top" Width="80" Height="24" Margin="20,20" IsDefault="True" Click="buttonOk_Click" Style="{StaticResource BtnSave}" IsEnabled="False"/>
+                        <Button DockPanel.Dock="Bottom" TabIndex="-3" x:Name="btnOk" Content="{x:Static properties:Resources.btnOkContent}" HorizontalAlignment="Left" VerticalAlignment="Top" Width="80" Height="24" Margin="20,20" IsDefault="True" Click="buttonOk_Click" Style="{StaticResource BtnSave}" IsEnabled="False" 
+                                AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SaveAndCloseButton}"/>
                         <TabControl Name="tcTabs" DockPanel.Dock="Top" BorderThickness="0,1,0,0" BorderBrush="#FFEAEAEA" Style="{StaticResource tcScrolling}" SelectionChanged="TabControl_SelectionChanged">
-                            <TabItem Header="{x:Static properties:Resources.tcTabsApplicationHeader}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiApplication" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Application}">
+                            <TabItem Header="{x:Static properties:Resources.tcTabsApplicationHeader}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsApplicationTabItem}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiApplication" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Application}">
                                 <controls:ApplicationSettingsControl x:Name="appSettingsCtrl"/>
                             </TabItem>
                             <TabItem Header="{x:Static properties:Resources.tcTabsConnectionHeader}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiConnection" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Connection}">
@@ -43,7 +45,7 @@
                             <TabItem Header="{x:Static properties:Resources.tcTabsWhatsNewHeader}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.About}">
                                 <controls:WhatsNewTabControl x:Name="whatsNewTabCtrl"/>
                             </TabItem>
-                            <TabItem Header="{x:Static properties:Resources.tcTabsAboutHeader}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Feedback}">
+                            <TabItem Header="{x:Static properties:Resources.tcTabsAboutHeader}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsAboutTabItem}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Feedback}">
                                 <controls:AboutTabControl x:Name="aboutTabCtrl"/>
                             </TabItem>
                         </TabControl>

--- a/src/UITests/GettingStartedPage.cs
+++ b/src/UITests/GettingStartedPage.cs
@@ -27,7 +27,7 @@ namespace UITests
 
         private void VerifyAccessibility()
         {
-            var issueCount = driver.ScanAIWin(TestContext);
+            var issueCount = driver.ScanAIWin(TestContext, "GettingStarted");
             Assert.AreEqual(0, issueCount);
         }
 

--- a/src/UITests/LoadEventFile.cs
+++ b/src/UITests/LoadEventFile.cs
@@ -32,7 +32,7 @@ namespace UITests
 
         private void ScanWindow()
         {
-            var issueCount = driver.ScanAIWin(TestContext);
+            var issueCount = driver.ScanAIWin(TestContext, "EventPage");
             Assert.AreEqual(0, issueCount);
         }
 

--- a/src/UITests/LoadTestFile.cs
+++ b/src/UITests/LoadTestFile.cs
@@ -32,7 +32,7 @@ namespace UITests
         {
             driver.TestMode.AutomatedChecks.ViewInUIATree();
 
-            var issueCount = driver.ScanAIWin(TestContext);
+            var issueCount = driver.ScanAIWin(TestContext, "UIATree");
 
             Assert.AreEqual(0, issueCount);
             driver.TestMode.ResultsInUIATree.BackToAutomatedChecks();
@@ -40,7 +40,7 @@ namespace UITests
 
         private void ScanAutomatedChecks()
         {
-            var issueCount = driver.ScanAIWin(TestContext);
+            var issueCount = driver.ScanAIWin(TestContext, "AutomatedChecks");
             Assert.AreEqual(0, issueCount);
         }
 

--- a/src/UITests/SettingsPage.cs
+++ b/src/UITests/SettingsPage.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Properties;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
+
+namespace UITests
+{
+    [TestClass]
+    public class SettingsPage : AIWinSession
+    {
+        /// <summary>
+        /// The entry point for this test scenario. Every TestMethod  will restart ai-win, so
+        /// we want to use them sparingly.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("NoStrongName")]
+        [TestCategory("UITest")]
+        public void SettingsPageTests()
+        {
+            CheckApplicationTab();
+            CheckShortcut();
+            CheckAboutTab();
+        }
+
+        /// <summary>
+        /// Changes the shortcut for pause/resume and validates the shortcut works
+        /// </summary>
+        private void CheckShortcut()
+        {
+            driver.FindElementByAccessibilityId(AutomationIDs.SettingsApplicationTabItem).Click();
+            var pauseHotkey = driver.FindElementByAccessibilityId(AutomationIDs.HotkeyPauseButton);
+            pauseHotkey.Click();
+
+            var hotkeyDialog = driver.FindElementByAccessibilityId(AutomationIDs.HotkeyGrabDialog);
+            hotkeyDialog.SendKeys(Keys.Shift);
+            hotkeyDialog.SendKeys(Keys.F6);
+
+            var saveAndClose = driver.FindElementByAccessibilityId(AutomationIDs.SaveAndCloseButton);
+            Assert.IsTrue(saveAndClose.Enabled);
+            saveAndClose.Click();
+
+            var pauseButton = driver.FindElementByAccessibilityId(AutomationIDs.PauseButton);
+            Assert.IsTrue(pauseButton.Text.Contains("Pause"));
+            var mainWindow = driver.FindElementByAccessibilityId(AutomationIDs.MainWindow);
+            mainWindow.SendKeys(Keys.Shift + Keys.F6);
+            Assert.IsTrue(pauseButton.Text.Contains("Resume"));
+        }
+
+        /// <summary>
+        /// Spot check the application tab and do an accessibility check
+        /// </summary>
+        private void CheckApplicationTab()
+        {
+            driver.FindElementByAccessibilityId(AutomationIDs.SettingsApplicationTabItem).Click();
+
+            var saveAndClose = driver.FindElementByAccessibilityId(AutomationIDs.SaveAndCloseButton);
+            Assert.IsFalse(saveAndClose.Enabled);
+
+            var channelOptions = driver.FindElementByAccessibilityId(AutomationIDs.ChannelComboBox);
+            Assert.AreEqual("Production", channelOptions.Text);
+            channelOptions.SendKeys(Keys.ArrowDown);
+            Assert.AreEqual("Insider", channelOptions.Text);
+            Assert.IsTrue(saveAndClose.Enabled);
+            channelOptions.SendKeys(Keys.ArrowUp);
+            Assert.AreEqual("Production", channelOptions.Text);
+            Assert.IsFalse(saveAndClose.Enabled);
+            CheckAccessibility("ApplicationTab");
+        }
+
+        /// <summary>
+        /// Spot check the about tab and do an accessibility check
+        /// </summary>
+        private void CheckAboutTab()
+        {
+            driver.GoToSettings();
+            driver.FindElementByAccessibilityId(AutomationIDs.SettingsAboutTabItem).Click();
+            var noticesLink = driver.FindElementByAccessibilityId(AutomationIDs.ThirdPartyNoticesHyperlink);
+            Assert.AreEqual("Third party notices", noticesLink.Text);
+            CheckAccessibility("AboutTab");
+        }
+
+        private void CheckAccessibility(string name)
+        {
+            var issueCount = driver.ScanAIWin(TestContext, name);
+            Assert.AreEqual(0, issueCount);
+        }
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            Setup();
+            driver.GettingStarted.DismissTelemetry();
+            driver.GettingStarted.DismissStartupPage();
+            driver.ToggleHighlighter();
+            driver.GoToSettings();
+            driver.Maximize();
+        }
+
+        [TestCleanup]
+        public void TestCleanup() => TearDown();
+    }
+}

--- a/src/UITests/SettingsPage.cs
+++ b/src/UITests/SettingsPage.cs
@@ -92,7 +92,6 @@ namespace UITests
             Setup();
             driver.GettingStarted.DismissTelemetry();
             driver.GettingStarted.DismissStartupPage();
-            driver.ToggleHighlighter();
             driver.GoToSettings();
             driver.Maximize();
         }

--- a/src/UITests/TelemetryDialog.cs
+++ b/src/UITests/TelemetryDialog.cs
@@ -21,7 +21,7 @@ namespace UITests
 
         private void VerifyTelemetryDialog()
         {
-            var issueCount = driver.ScanAIWin(TestContext);
+            var issueCount = driver.ScanAIWin(TestContext, "TelemetryDialog");
             Assert.AreEqual(0, issueCount);
 
             driver.GettingStarted.DismissTelemetry();

--- a/src/UITests/UILibrary/AIWinDriver.cs
+++ b/src/UITests/UILibrary/AIWinDriver.cs
@@ -37,7 +37,7 @@ namespace UITests.UILibrary
         /// </summary>
         /// <param name="context"></param>
         /// <returns>number of accessibility issues</returns>
-        public int ScanAIWin(TestContext context)
+        public int ScanAIWin(TestContext context, string fileName)
         {
             var outputPath = Path.Combine(context.TestResultsDirectory, context.TestName);
             var config = Config.Builder.ForProcessId(PID)
@@ -50,7 +50,9 @@ namespace UITests.UILibrary
             var result = scanner.Scan();
             if (result.ErrorCount > 0)
             {
-                context.AddResultFile(result.OutputFile.A11yTest);
+                var newPath = Path.Combine(outputPath, $"{fileName}.a11ytest");
+                File.Move(result.OutputFile.A11yTest, newPath);
+                context.AddResultFile(newPath);
             }
 
             return result.ErrorCount;
@@ -62,6 +64,9 @@ namespace UITests.UILibrary
 
         public void ToggleHighlighter() => Session.FindElementByAccessibilityId(AutomationIDs.MainWinHighlightButton).Click();
 
+        public void GoToSettings() => Session.FindElementByAccessibilityId(AutomationIDs.SettingsButton).Click();
+
         public void Maximize() => Session.Manage().Window.Maximize();
+
     }
 }

--- a/src/UITests/UILibrary/AIWinDriver.cs
+++ b/src/UITests/UILibrary/AIWinDriver.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Automation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Appium.Windows;
 using System.IO;
+using static System.FormattableString;
 
 namespace UITests.UILibrary
 {
@@ -50,7 +51,7 @@ namespace UITests.UILibrary
             var result = scanner.Scan();
             if (result.ErrorCount > 0)
             {
-                var newPath = Path.Combine(outputPath, $"{fileName}.a11ytest");
+                var newPath = Path.Combine(outputPath, Invariant($"{fileName}.a11ytest"));
                 File.Move(result.OutputFile.A11yTest, newPath);
                 context.AddResultFile(newPath);
             }
@@ -67,6 +68,5 @@ namespace UITests.UILibrary
         public void GoToSettings() => Session.FindElementByAccessibilityId(AutomationIDs.SettingsButton).Click();
 
         public void Maximize() => Session.Manage().Window.Maximize();
-
     }
 }

--- a/src/UITests/UITests.csproj
+++ b/src/UITests/UITests.csproj
@@ -98,6 +98,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AIWinSession.cs" />
+    <Compile Include="SettingsPage.cs" />
     <Compile Include="TelemetryDialog.cs" />
     <Compile Include="LoadTestFile.cs" />
     <Compile Include="UILibrary\AIWinDriver.cs" />


### PR DESCRIPTION
This UI test includes the following:
- spot-checking the application settings tab
- accessibility testing of the application settings tab
- spot-checking the about tab
- accessibility testing of the about tab
- changing a keyboard shortcut and validating it works
- validating the save and close button becomes enabled with changed options

Here's a video: https://dev.azure.com/accessibility-insights/Accessibility%20Insights/_build/results?buildId=1880&view=ms.vss-test-web.build-test-results-tab&runId=5176&resultId=100147&paneView=attachments