### PR TITLE
Significantly improve LoadTestFile UITest coverage

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -164,7 +164,7 @@
         <Grid ClipToBounds="True"  Grid.Row="3">
             <TreeView x:Name="treeviewHierarchy"
                       ScrollViewer.ScrollChanged="treeviewHierarchy_ScrollChanged"
-                      Margin="0,0,2,0"
+                      Margin="0,0,2,0" AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.HierarchyControlUIATreeView}"
                       IsTextSearchEnabled="True" 
                       SelectedItemChanged="treeviewHierarchy_SelectedItemChanged" 
                       AutomationProperties.Name="{x:Static Properties:Resources.HierarchyControl_treeviewHierarchyAutomationName}"

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
@@ -37,7 +37,7 @@
                     <StackPanel Focusable="False">
                         <ListView x:Name="lvDetails" SizeChanged="lvDetails_SizeChanged"
                             AutomationProperties.LabeledBy="{Binding ElementName=labelResults}"
-                            BorderThickness="0" 
+                            BorderThickness="0" AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.ScannerResultsDetailsListView}"
                             Grid.IsSharedSizeScope="True" KeyboardNavigation.TabNavigation="Once"
                             SelectionMode="Extended"
                             SelectionChanged="lvDetails_SelectedItemChanged"
@@ -142,7 +142,10 @@
                             HorizontalAlignment="Left"
                             Click="BtnShowAll_Click" Cursor="Hand"
                             Margin="20,0,0,0">
-                            <TextBlock Name="tbShowAll" Text="{x:Static Properties:Resources.tbShowAllText}" Foreground="{DynamicResource ResourceKey=ActiveBlueBrush}" TextDecorations="Underline" Style="{DynamicResource SmallTextBlock}"/>
+                            <TextBlock Name="tbShowAll" Text="{x:Static Properties:Resources.tbShowAllText}"
+                                       Foreground="{DynamicResource ResourceKey=ActiveBlueBrush}"
+                                       TextDecorations="Underline" Style="{DynamicResource SmallTextBlock}"
+                                       AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.ScannerResultsShowAllButton}"/>
                         </Button>
                     </StackPanel>
                 </ScrollViewer>
@@ -160,7 +163,8 @@
                 </Expander.Header>
                 <Grid Margin="8,4,8,8">
                     <StackPanel Name="spHowToFix" Grid.Row="1" >
-                        <TextBox Text="{Binding Path=HowToFixText, Mode=OneWay}" AutomationProperties.LabeledBy="{Binding ElementName=labelFixFollowing}">
+                        <TextBox Text="{Binding Path=HowToFixText, Mode=OneWay}" AutomationProperties.LabeledBy="{Binding ElementName=labelFixFollowing}"
+                                 AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.ScannerResultsFixFollowingTextBox}">
                             <TextBox.Style>
                                 <Style TargetType="TextBox" BasedOn="{StaticResource TxtReadonlyText}">
                                     <Style.Triggers>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -77,14 +77,18 @@
                         <ColumnDefinition/>
                     </Grid.ColumnDefinitions>
                     <fabric:FabricIconControl VerticalAlignment="Center" HorizontalAlignment="Left"  Grid.Column="0"  GlyphName="AlertSolid" Foreground="#CC0000" GlyphSize="Custom" FontSize="14"/>
-                    <TextBlock Name="tbSubTitle" Grid.Column="1" VerticalAlignment="Center" Style="{StaticResource tbRowStyle}" TextWrapping="Wrap" MinWidth="300" HorizontalAlignment="Left" Margin="0,2,-0.333,4">
+                    <TextBlock Name="tbSubTitle" Grid.Column="1" VerticalAlignment="Center" Style="{StaticResource tbRowStyle}"
+                               TextWrapping="Wrap" MinWidth="300" HorizontalAlignment="Left" Margin="0,2,-0.333,4"
+                               AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.AutomatedChecksResultsTextBlock}">
                         <Run Name="runFailures" Text="{x:Static Properties:Resources.runFailuresTextOneFailure}"/>
                         <Run Text="{x:Static Properties:Resources.AutomatedChecksControl_tbSubtitleRun}"/>
                     </TextBlock>
                 </Grid>
             </Grid>
             <Border Grid.Row="5" Grid.Column="1" BorderBrush="#EAEAEA" BorderThickness="0,1,0,0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
-                <ListView AutomationProperties.LabeledBy="{Binding ElementName=lblTitle}" KeyboardNavigation.TabNavigation="Once" Name="lvResults" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderThickness="0" >
+                <ListView AutomationProperties.LabeledBy="{Binding ElementName=lblTitle}" KeyboardNavigation.TabNavigation="Once"
+                          Name="lvResults" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderThickness="0"
+                          AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.AutomatedChecksResultsListView}">
                     <ListView.View>
                         <local:CustomGridView x:Name="gv">
                             <GridViewColumn Width="26" DisplayMemberBinding="{x:Null}">
@@ -95,7 +99,11 @@
                                             <ColumnDefinition Width="*"/>
                                         </Grid.ColumnDefinitions>
                                         <CheckBox Grid.Column="0" VerticalAlignment="Center" Name="chbxSelectAll" Click="chbxSelectAll_Click" AutomationProperties.Name="{x:Static Properties:Resources.chbxSelectAllAutomationPropertiesName}" IsEnabled="True"/>
-                                        <Button Grid.Column="1" Name="btnExpandAll" Margin="0,-2,0,0" HorizontalAlignment="Left" Style="{StaticResource BtnStandard}" Width="8" Height="8" Padding="0" BorderThickness="0" Click="btnExpandAll_Click" AutomationProperties.Name="{x:Static Properties:Resources.btnExpandAllAutomationPropertiesName}" IsHitTestVisible="True">
+                                        <Button Grid.Column="1" Name="btnExpandAll" Margin="0,-2,0,0" HorizontalAlignment="Left"
+                                                Style="{StaticResource BtnStandard}" Width="8" Height="8" Padding="0"
+                                                BorderThickness="0" Click="btnExpandAll_Click" IsHitTestVisible="True"
+                                                AutomationProperties.Name="{x:Static Properties:Resources.btnExpandAllAutomationPropertiesName}"
+                                                AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.AutomatedChecksExpandAllButton}">
                                             <Grid>
                                                 <AccessText Text="_c" Opacity="0"/>
                                                 <fabric:FabricIconControl x:Name="fabicnExpandAll" GlyphName="CaretSolidRight" GlyphSize="Custom" FontSize="8" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}" Margin="0,2,0,-2"/>

--- a/src/AccessibilityInsights.SharedUx/Properties/AutomationIDs.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/AutomationIDs.cs
@@ -4,11 +4,19 @@ namespace AccessibilityInsights.SharedUx.Properties
 {
     public static class AutomationIDs
     {
+        public static string AutomatedChecksExpandAllButton{ get; } = nameof(AutomatedChecksExpandAllButton);
+        public static string AutomatedChecksResultsListView { get; } = nameof(AutomatedChecksResultsListView);
+        public static string AutomatedChecksResultsTextBlock { get; } = nameof(AutomatedChecksResultsTextBlock);
         public static string AutomatedChecksUIATreeButton { get; } = nameof(AutomatedChecksUIATreeButton);
+        public static string HierarchyControlUIATreeView { get; } = nameof(HierarchyControlUIATreeView);
         public static string MainWinLoadButton { get; } = nameof(MainWinLoadButton);
         public static string MainWinHighlightButton { get; } = nameof(MainWinHighlightButton);
         public static string MainWinBreadCrumbOneButton { get; } = nameof(MainWinBreadCrumbOneButton);
         public static string MainWinBreadCrumbTwoButton { get; } = nameof(MainWinBreadCrumbTwoButton);
+        public static string ScannerResultsDetailsListView { get; } = nameof(ScannerResultsDetailsListView);
+        public static string ScannerResultsFixFollowingTextBox { get; } = nameof(ScannerResultsFixFollowingTextBox);
+        public static string ScannerResultsShowAllButton { get; } = nameof(ScannerResultsShowAllButton);
+        public static string SnapshotModeControl { get; } = nameof(SnapshotModeControl);
         public static string StartUpModeExitButton { get; } = nameof(StartUpModeExitButton);
         public static string TelemetryDialogExitButton { get; } = nameof(TelemetryDialogExitButton);
         public static string EventsDataGrid { get; } = nameof(EventsDataGrid);

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml
@@ -8,8 +8,9 @@
              xmlns:fabric="clr-namespace:AccessibilityInsights.CommonUxComponents.Controls;assembly=AccessibilityInsights.CommonUxComponents"
              xmlns:properties="clr-namespace:AccessibilityInsights.Properties"
              xmlns:controls="clr-namespace:AccessibilityInsights.SharedUx.Controls;assembly=AccessibilityInsights.SharedUx"
+             xmlns:sharedProps="clr-namespace:AccessibilityInsights.SharedUx.Properties;assembly=AccessibilityInsights.SharedUx"
              xmlns:Util="clr-namespace:AccessibilityInsights.SharedUx.Utilities;assembly=AccessibilityInsights.SharedUx"
-             mc:Ignorable="d"
+             mc:Ignorable="d" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SnapshotModeControl}"
              AutomationProperties.Name="{x:Static properties:Resources.SnapshotModeControlAutomationPropertiesName}" Height="600" Width="600">
     <Grid Panel.ZIndex="1">
         <Grid.RowDefinitions>

--- a/src/UITests/LoadTestFile.cs
+++ b/src/UITests/LoadTestFile.cs
@@ -18,8 +18,8 @@ namespace UITests
     [TestClass]
     public class LoadTestFile : AIWinSession
     {
-        readonly string TestFileName = "WildlifeManagerTest.a11ytest";
-        readonly string TestFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}\\TestFiles";
+        const string TestFileName = "WildlifeManagerTest.a11ytest";
+        readonly string TestFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestFiles");
 
         /// <summary>
         /// The entry point for this test scenario. Every TestMethod will restart ai-win, so

--- a/src/UITests/LoadTestFile.cs
+++ b/src/UITests/LoadTestFile.cs
@@ -1,7 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Properties;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace UITests
@@ -12,11 +18,11 @@ namespace UITests
     [TestClass]
     public class LoadTestFile : AIWinSession
     {
-        static readonly string TestFileName = "WildlifeManagerTest.a11ytest";
-        static readonly string TestFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}\\TestFiles";
+        readonly string TestFileName = "WildlifeManagerTest.a11ytest";
+        readonly string TestFilePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}\\TestFiles";
 
         /// <summary>
-        /// The entry point for this test scenario. Every TestMethod  will restart ai-win, so
+        /// The entry point for this test scenario. Every TestMethod will restart ai-win, so
         /// we want to use them sparingly.
         /// </summary>
         [TestMethod]
@@ -24,14 +30,15 @@ namespace UITests
         [TestCategory("UITest")]
         public void LoadTestFileTests()
         {
-            ScanResultsInUIATreePage();
             ScanAutomatedChecks();
+            ScanResultsInUIATreePage();
+            ValidateAutomatedChecks();
+            ValidateResultsInUIATree();
         }
 
         private void ScanResultsInUIATreePage()
         {
             driver.TestMode.AutomatedChecks.ViewInUIATree();
-
             var issueCount = driver.ScanAIWin(TestContext);
 
             Assert.AreEqual(0, issueCount);
@@ -42,6 +49,120 @@ namespace UITests
         {
             var issueCount = driver.ScanAIWin(TestContext);
             Assert.AreEqual(0, issueCount);
+        }
+
+        private void ValidateFirstSelectedElement()
+        {
+            ValidateFirstResults();
+            ValidateFirstDetails();
+            ValidateFirstTree();
+        }
+
+        private void ValidateFirstResults()
+        {
+            var resultsList = driver.FindElementByAccessibilityId(AutomationIDs.ScannerResultsDetailsListView);
+            var resultsFailedOnly = resultsList.FindElementsByClassName("ListViewItem");
+            driver.FindElementByAccessibilityId(AutomationIDs.ScannerResultsShowAllButton).Click();
+            var resultsAll = resultsList.FindElementsByClassName("ListViewItem");
+            var fixFollowTb = driver.FindElementByAccessibilityId(AutomationIDs.ScannerResultsFixFollowingTextBox);
+
+            Assert.IsFalse(string.IsNullOrEmpty(fixFollowTb.Text));
+            Assert.AreEqual(2, resultsFailedOnly.Count);
+            Assert.AreEqual(28, resultsAll.Count);
+
+            resultsAll[0].SendKeys(Keys.Control + Keys.Tab);
+        }
+
+        private void ValidateFirstDetails()
+        {
+            var tree = driver.FindElementByAccessibilityId(AutomationIDs.HierarchyControlUIATreeView);
+            var nodes = tree.FindElementsByClassName("TreeViewItem");
+            var props = driver.FindElementByAccessibilityId(AutomationIDs.SnapshotModeControl).FindElementsByClassName("DataGridRow");
+            props[0].Click();
+            var patterns = GetPatternsNodes(AutomationIDs.SnapshotModeControl, nodes);
+
+            Assert.AreEqual("InvokePattern", patterns.First().Text);
+            Assert.AreEqual("Name, Ok", props[0].Text);
+            Assert.AreEqual(3, patterns.Count());
+            Assert.AreEqual(10, props.Count);
+        }
+
+        private void ValidateFirstTree()
+        {
+            var tree = driver.FindElementByAccessibilityId(AutomationIDs.HierarchyControlUIATreeView);
+            var nodes = tree.FindElementsByClassName("TreeViewItem");
+            nodes.First().SendKeys(Keys.Left);
+
+            Assert.AreEqual(16, nodes.Count);
+            Assert.AreEqual("pane 'Desktop 1' has failed test results in descendants.", nodes.First().Text);
+        }
+
+        private void ValidateRootElement()
+        {
+            ValidateRootDetails();
+            ValidateRootResults();
+        }
+
+        private void ValidateRootDetails()
+        {
+            var props = driver.FindElementByAccessibilityId(AutomationIDs.SnapshotModeControl).FindElementsByClassName("DataGridRow");
+            props[0].Click();
+            var text = props[0].Text;
+            var tree = driver.FindElementByAccessibilityId(AutomationIDs.HierarchyControlUIATreeView);
+            var nodes = tree.FindElementsByClassName("TreeViewItem");
+            var patterns = GetPatternsNodes(AutomationIDs.SnapshotModeControl, nodes);
+
+            Assert.AreEqual("Name, Desktop 1", text);
+            Assert.AreEqual(10, patterns.Count());
+            Assert.AreEqual("LegacyIAccessiblePattern", patterns.First().Text);
+            Assert.AreEqual(10, props.Count);
+
+            patterns.Last().SendKeys(Keys.Control + Keys.Tab);
+        }
+
+        private void ValidateRootResults()
+        {
+            var resultsList = driver.FindElementByAccessibilityId(AutomationIDs.ScannerResultsDetailsListView);
+            var results = resultsList.FindElementsByClassName("ListViewItem");
+            var fixFollowTb = driver.FindElementByAccessibilityId(AutomationIDs.ScannerResultsFixFollowingTextBox);
+
+            Assert.IsTrue(string.IsNullOrEmpty(fixFollowTb.Text));
+            Assert.AreEqual(0, results.Count);
+        }
+
+        private void ValidateResultsInUIATree()
+        {
+            ValidateFirstSelectedElement();
+            ValidateRootElement();
+        }
+
+        private void ValidateAutomatedChecks()
+        {
+            driver.FindElementByAccessibilityId(AutomationIDs.AutomatedChecksExpandAllButton).Click();
+            var resultsGrid = driver.FindElementByAccessibilityId(AutomationIDs.AutomatedChecksResultsListView);
+            var results = resultsGrid.FindElementsByClassName("ListViewItem");
+            var resultsText = driver.FindElementByAccessibilityId(AutomationIDs.AutomatedChecksResultsTextBlock).Text;
+            var resultCount = int.Parse(resultsText.Split()[0]);
+
+            Assert.AreEqual(12, resultCount);
+            Assert.AreEqual(resultCount, results.Count);
+
+            results[0].FindElementByClassName("Button").Click();
+        }
+
+        private IEnumerable<AppiumWebElement> GetPatternsNodes(string parentId, ReadOnlyCollection<AppiumWebElement> nonPatternNodes)
+        {
+            var parent = driver.FindElementByAccessibilityId(parentId);
+            var allnodes = parent.FindElementsByClassName("TreeViewItem");
+            var patterns = allnodes.Except(nonPatternNodes);
+
+            foreach (var pattern in patterns)
+            {
+                pattern.SendKeys(Keys.Right);
+            }
+
+            allnodes = parent.FindElementsByClassName("TreeViewItem");
+            return allnodes.Except(nonPatternNodes);
         }
 
         [TestInitialize]

--- a/src/UITests/LoadTestFile.cs
+++ b/src/UITests/LoadTestFile.cs
@@ -118,6 +118,8 @@ namespace UITests
             Assert.AreEqual("LegacyIAccessiblePattern", patterns.First().Text);
             Assert.AreEqual(10, props.Count);
 
+            // since we've already got an element to use SendKeys, we
+            // switch to the results tab in prepartion for next test
             patterns.Last().SendKeys(Keys.Control + Keys.Tab);
         }
 

--- a/src/UITests/UILibrary/LiveMode.cs
+++ b/src/UITests/UILibrary/LiveMode.cs
@@ -34,11 +34,11 @@ namespace UITests.UILibrary
 
             var folderTextbox = Session.FindElementByAccessibilityId(OpenFileFolderTextBoxAutomationID);
             folderTextbox.SendKeys(folder);
-            folderTextbox.SendKeys(OpenQA.Selenium.Keys.Enter);
+            folderTextbox.SendKeys(Keys.Enter);
 
             var fileTextbox = Session.FindElementByAccessibilityId(OpenFileFileTextBoxAutomationID);
             fileTextbox.SendKeys(fileName);
-            fileTextbox.SendKeys(OpenQA.Selenium.Keys.Enter);
+            fileTextbox.SendKeys(Keys.Enter);
         }
     }
 }


### PR DESCRIPTION
#### Describe the change
Expands coverage of LoadTestFile UITest to:
- Verify the count of results in listview and textblock above listview
- Expand results and click through to the results in UIA tree view for a specific element
- Spot check UIA tree
- Verify the correct number of results show up and that there is some how to fix text
- Spot check properties and patterns
- Switch to a different element in the UIA tree
- Repeat some validation for newly selected element

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



