### PR TITLE
Changing usages of VS 2017 to VS 2019

### DIFF
--- a/build/compliance-build.yml
+++ b/build/compliance-build.yml
@@ -29,7 +29,7 @@ jobs:
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
     inputs:
-      vsVersion: 15.0
+      vsVersion: 16.0
       platform: '$(BuildPlatform)'
       configuration: release
 
@@ -76,7 +76,7 @@ jobs:
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
     inputs:
-      vsVersion: 15.0
+      vsVersion: 16.0
       platform: '$(BuildPlatform)'
       configuration: debug
 

--- a/build/compliance-build.yml
+++ b/build/compliance-build.yml
@@ -11,7 +11,7 @@ variables:
 jobs:
 - job: Release
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   steps:
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet 4.3.0'
@@ -65,7 +65,7 @@ jobs:
 
 - job: Debug
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   steps:
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet 4.3.0'

--- a/build/compliance-build.yml
+++ b/build/compliance-build.yml
@@ -53,7 +53,7 @@ jobs:
       testAssemblyVer2: |
         **\*test*.dll
         !**\obj\**
-      vsTestVersion: 15.0
+      vsTestVersion: 16.0
       codeCoverageEnabled: false
       platform: '$(BuildPlatform)'
       configuration: release
@@ -149,7 +149,7 @@ jobs:
         **\*test*.dll
         !**\obj\**
       testFiltercriteria: 'TestCategory!=RequiresNetwork&TestCategory!=UITest'
-      vsTestVersion: 15.0
+      vsTestVersion: 16.0
       codeCoverageEnabled: false
       platform: '$(BuildPlatform)'
       configuration: debug

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -30,7 +30,7 @@ jobs:
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
     inputs:
-      vsVersion: 15.0
+      vsVersion: 16.0
       platform: '$(BuildPlatform)'
       configuration: release
 
@@ -89,7 +89,7 @@ jobs:
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
     inputs:
-      vsVersion: 15.0
+      vsVersion: 16.0
       platform: '$(BuildPlatform)'
       configuration: debug
 
@@ -144,6 +144,6 @@ jobs:
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
     inputs:
-      vsVersion: 15.0
+      vsVersion: 16.0
       platform: '$(BuildPlatform)'
       configuration: debug

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -10,7 +10,7 @@ variables:
 jobs:
 - job: Release
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   variables:
     FAKES_SUPPORTED: 1
   steps:
@@ -76,7 +76,7 @@ jobs:
 
 - job: Debug
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   variables:
     FAKES_SUPPORTED: 1
   steps:
@@ -133,7 +133,7 @@ jobs:
 
 - job: build_without_fakes
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   steps:
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet 4.3.0'

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -59,7 +59,7 @@ jobs:
       testAssemblyVer2: |
         **\*test*.dll
         !**\obj\**
-      vsTestVersion: 15.0
+      vsTestVersion: 16.0
       codeCoverageEnabled: true
       platform: '$(BuildPlatform)'
       configuration: release
@@ -119,7 +119,7 @@ jobs:
         **\*test*.dll
         !**\obj\**
       testFiltercriteria: 'TestCategory!=RequiresNetwork'
-      vsTestVersion: 15.0
+      vsTestVersion: 16.0
       codeCoverageEnabled: false
       platform: '$(BuildPlatform)'
       configuration: debug

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -34,7 +34,7 @@ jobs:
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
     inputs:
-      vsVersion: 15.0
+      vsVersion: 16.0
       platform: '$(BuildPlatform)'
       configuration: release
 
@@ -85,7 +85,7 @@ jobs:
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
     inputs:
-      vsVersion: 15.0
+      vsVersion: 16.0
       platform: '$(BuildPlatform)'
       configuration: debug
 
@@ -204,7 +204,7 @@ jobs:
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
     inputs:
-      vsVersion: 15.0
+      vsVersion: 16.0
       platform: '$(BuildPlatform)'
       configuration: release
 

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -60,7 +60,7 @@ jobs:
       testAssemblyVer2: |
         **\*test*.dll
         !**\obj\**
-      vsTestVersion: 15.0
+      vsTestVersion: 16.0
       codeCoverageEnabled: false
       platform: '$(BuildPlatform)'
       configuration: release
@@ -174,7 +174,7 @@ jobs:
         **\*test*.dll
         !**\obj\**
       testFiltercriteria: 'TestCategory!=RequiresNetwork'
-      vsTestVersion: 15.0
+      vsTestVersion: 16.0
       codeCoverageEnabled: false
       platform: '$(BuildPlatform)'
       configuration: debug
@@ -255,7 +255,7 @@ jobs:
       testAssemblyVer2: |
         **\*test*.dll
         !**\obj\**
-      vsTestVersion: 15.0
+      vsTestVersion: 16.0
       codeCoverageEnabled: false
       platform: '$(BuildPlatform)'
       configuration: release

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -13,7 +13,7 @@ variables:
 jobs:
 - job: ComplianceRelease
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   variables:
     PublicRelease: 'false'
     SignAppForRelease: 'false'
@@ -71,7 +71,7 @@ jobs:
 
 - job: ComplianceDebug
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   variables:
     PublicRelease: 'false'
     SignAppForRelease: 'false'
@@ -185,7 +185,7 @@ jobs:
   - ComplianceRelease
   - ComplianceDebug
   condition: and(succeeded(), succeeded())
-  pool: VSEng-MicroBuildVS2017
+  pool: VSEng-MicroBuildVS2019
   steps:
   - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
     displayName: 'Install Localization Plugin'


### PR DESCRIPTION
This PR changes usages of VS 2017 to VS 2019. The PR was made from VS 2019 after opening the same solution saved by VS 2017. Exploring whether the builds still pass, whether other changes will show up, etc.