### PR TITLE
Adding initial ui-test-job template

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -8,7 +8,8 @@ variables:
   SignAppForRelease: 'false'
 
 jobs:
-- job: Build and unit tests Release
+- job: ReleaseBuildUnitTests
+  displayName: Build and unit tests (release)
   pool:
     vmImage: 'windows-2019'
   variables:
@@ -60,7 +61,8 @@ jobs:
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 
-- job: Build and unit tests Debug
+- job: DebugBuildUnitTests
+  displayName: Build and unit tests (debug)
   pool:
     vmImage: 'windows-2019'
   variables:

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -8,7 +8,7 @@ variables:
   SignAppForRelease: 'false'
 
 jobs:
-- job: Build and unit tests (Release)
+- job: Build and unit tests Release
   pool:
     vmImage: 'windows-2019'
   variables:
@@ -60,7 +60,7 @@ jobs:
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 
-- job: Build and unit tests (Debug)
+- job: Build and unit tests Debug
   pool:
     vmImage: 'windows-2019'
   variables:

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -9,7 +9,7 @@ variables:
 
 jobs:
 - job: ReleaseBuildUnitTests
-  displayName: Build and unit tests (release)
+  displayName: Build and run unit tests - release
   pool:
     vmImage: 'windows-2019'
   variables:
@@ -62,7 +62,7 @@ jobs:
     displayName: 'Component Detection'
 
 - job: DebugBuildUnitTests
-  displayName: Build and unit tests (debug)
+  displayName: Build and run unit tests - debug
   pool:
     vmImage: 'windows-2019'
   variables:

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -8,6 +8,14 @@ variables:
   SignAppForRelease: 'false'
 
 jobs:
+- template: ui-test-job.yml
+  parameters:
+    configuration: release
+
+- template: ui-test-job.yml
+  parameters:
+    configuration: debug
+
 - job: Release
   pool:
     vmImage: 'vs2017-win2016'
@@ -43,16 +51,6 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
 
-  - task: ms-autotest.screen-resolution-utility-task.screen-resolution-utlity-task.ScreenResolutionUtility@1
-    displayName: 'Set Screen Resolution'
-    inputs:
-      displaySettings: specific
-      width: 1920
-      height: 1080
-
-  - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
-    displayName: 'Start - WinAppDriver'
-
   - task: VSTest@2
     displayName: 'Test Assemblies **\release\*test*.dll;-:**\obj\**'
     inputs:
@@ -65,11 +63,7 @@ jobs:
       configuration: release
       rerunFailedTests: true
       runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
-
-  - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
-    displayName: 'Stop - WinAppDriver'
-    inputs:
-      OperationType: Stop
+      testFiltercriteria: 'TestCategory!=UITest'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
@@ -102,34 +96,19 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
 
-  - task: ms-autotest.screen-resolution-utility-task.screen-resolution-utlity-task.ScreenResolutionUtility@1
-    displayName: 'Set Screen Resolution'
-    inputs:
-      displaySettings: specific
-      width: 1920
-      height: 1080
-
-  - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
-    displayName: 'Start - WinAppDriver'
-
   - task: VSTest@2
     displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
     inputs:
       testAssemblyVer2: |
         **\*test*.dll
         !**\obj\**
-      testFiltercriteria: 'TestCategory!=RequiresNetwork'
+      testFiltercriteria: 'TestCategory!=UITest'
       vsTestVersion: 15.0
       codeCoverageEnabled: false
       platform: '$(BuildPlatform)'
       configuration: debug
       rerunFailedTests: true
       runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
-
-  - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
-    displayName: 'Stop - WinAppDriver'
-    inputs:
-      OperationType: Stop
 
 - job: build_without_fakes
   pool:

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -8,15 +8,7 @@ variables:
   SignAppForRelease: 'false'
 
 jobs:
-- template: ui-test-job.yml
-  parameters:
-    configuration: release
-
-- template: ui-test-job.yml
-  parameters:
-    configuration: debug
-
-- job: Release
+- job: Build and unit tests (Release)
   pool:
     vmImage: 'windows-2019'
   variables:
@@ -68,7 +60,7 @@ jobs:
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 
-- job: Debug
+- job: Build and unit tests (Debug)
   pool:
     vmImage: 'windows-2019'
   variables:
@@ -126,3 +118,11 @@ jobs:
       vsVersion: 16.0
       platform: '$(BuildPlatform)'
       configuration: debug
+
+- template: ui-test-job.yml
+  parameters:
+    configuration: release
+
+- template: ui-test-job.yml
+  parameters:
+    configuration: debug

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -4,8 +4,8 @@ parameters:
   configuration: ''
 
 jobs:
-- job: UITests${{ parameters.configuration }}
-  displayName: UITests ${{ parameters.configuration }}
+- job: Build and run UI Tests - ${{ parameters.configuration }}
+  displayName: Build and run UI Tests - ${{ parameters.configuration }}
   condition: succeeded()
   pool:
     vmImage: windows-2019
@@ -35,10 +35,8 @@ jobs:
         **\*test*.dll
         !**\obj\**
       vsTestVersion: 16.0
-      codeCoverageEnabled: true
       platform: '$(BuildPlatform)'
       configuration: ${{ parameters.configuration }}
-      rerunFailedTests: true
       runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
       testFiltercriteria: 'TestCategory=UITest'
 

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -4,7 +4,7 @@ parameters:
   configuration: ''
 
 jobs:
-- job: Build and run UI Tests ${{ parameters.configuration }}
+- job: UITests${{ parameters.configuration }}
   displayName: Build and run UI Tests - ${{ parameters.configuration }}
   condition: succeeded()
   pool:

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -25,7 +25,7 @@ jobs:
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Start - WinAppDriver'
-	inputs:
+    inputs:
       AgentResolution: 1080p
 
   - task: VSTest@2

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -1,0 +1,47 @@
+# This template contains jobs to run UI tests using WinAppDriver.
+
+parameters:
+  configuration: ''
+
+jobs:
+- job: UITests${{ parameters.configuration }}
+  displayName: UITests ${{ parameters.configuration }}
+  condition: succeeded()
+  pool:
+    vmImage: windows-2019
+  steps:
+  - task: NuGetToolInstaller@0
+    displayName: 'Use NuGet 4.3.0'
+
+  - task: NuGetCommand@2
+    displayName: 'NuGet restore'
+
+  - task: VSBuild@1
+    displayName: 'Build Solution **\*.sln'
+    inputs:
+      vsVersion: 16.0
+      platform: '$(BuildPlatform)'
+      configuration: ${{ parameters.configuration }}
+
+  - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
+    displayName: 'Start - WinAppDriver'
+      AgentResolution: 1080p
+
+  - task: VSTest@2
+    displayName: 'Test Assemblies **\release\*test*.dll;-:**\obj\**'
+    inputs:
+      testAssemblyVer2: |
+        **\*test*.dll
+        !**\obj\**
+      vsTestVersion: 16.0
+      codeCoverageEnabled: true
+      platform: '$(BuildPlatform)'
+      configuration: ${{ parameters.configuration }}
+      rerunFailedTests: true
+      runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
+	  testFiltercriteria: 'TestCategory=UITest'
+
+  - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
+    displayName: 'Stop - WinAppDriver'
+    inputs:
+      OperationType: Stop

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -25,6 +25,7 @@ jobs:
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Start - WinAppDriver'
+	inputs:
       AgentResolution: 1080p
 
   - task: VSTest@2

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -40,7 +40,7 @@ jobs:
       configuration: ${{ parameters.configuration }}
       rerunFailedTests: true
       runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
-	  testFiltercriteria: 'TestCategory=UITest'
+      testFiltercriteria: 'TestCategory=UITest'
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Stop - WinAppDriver'

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -4,7 +4,7 @@ parameters:
   configuration: ''
 
 jobs:
-- job: Build and run UI Tests - ${{ parameters.configuration }}
+- job: Build and run UI Tests ${{ parameters.configuration }}
   displayName: Build and run UI Tests - ${{ parameters.configuration }}
   condition: succeeded()
   pool:


### PR DESCRIPTION
We're experimenting with creating separate jobs for our UI tests that can run in parallel. We're using YAML templates in order to accomplish this. This PR adds a template for the ui-test-job and executes it from the prebuild file. If it works, we have opportunities to refactor some of our other build scripts via templates.