### PR TITLE
Simplify YAML structure of PR builds

### DIFF
--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -1,0 +1,63 @@
+# This template contains jobs to build and run unit tests
+
+parameters:
+  configuration: ''
+  checkLicenseHeaders: ''
+  runComponentGovernance: ''
+
+jobs:
+- job: BuildAndUnitTests${{ parameters.configuration }}
+  displayName: Build and run unit tests - ${{ parameters.configuration }}
+  condition: succeeded()
+  pool:
+    vmImage: windows-2019
+  variables:
+    FAKES_SUPPORTED: 1
+  steps:
+  - ${{ if eq(parameters.checkLicenseHeaders, 'true') }}:
+    - task: PowerShell@2
+      displayName: 'License Header Check'
+      inputs:
+        targetType: "filePath"
+        filePath: tools\scripts\verification.scripts\LicenseHeaderVerification.ps1
+        arguments: '-target  $(Build.Repository.LocalPath) -licenseHeaderPath tools\scripts\verification.scripts\LicenseHeader.txt -extensions *.xaml,*.xml,*.cs,*.ps1 -addIfAbsent $false'
+
+  - task: NuGetToolInstaller@0
+    displayName: 'Use NuGet 4.3.0'
+
+  - task: NuGetCommand@2
+    displayName: 'NuGet restore'
+
+  - task: VSBuild@1
+    displayName: 'Build Solution **\*.sln'
+    inputs:
+      vsVersion: 16.0
+      platform: '$(BuildPlatform)'
+      configuration: ${{ parameters.configuration }}
+
+  - task: CopyFiles@2
+    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      Contents: **\bin\${{ parameters.configuration }}\**
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'
+
+  - task: VSTest@2
+    displayName: 'Test Assemblies **\release\*test*.dll;-:**\obj\**'
+    inputs:
+      testAssemblyVer2: |
+        **\*test*.dll
+        !**\obj\**
+      vsTestVersion: 16.0
+      codeCoverageEnabled: true
+      platform: '$(BuildPlatform)'
+      configuration: release
+      rerunFailedTests: true
+      runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
+      testFiltercriteria: 'TestCategory!=UITest'
+
+  - ${{ if eq(parameters.runComponentGovernance, 'true') }}:
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: 'Component Detection'

--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -38,7 +38,7 @@ jobs:
   - task: CopyFiles@2
     displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
     inputs:
-      Contents: **\bin\${{ parameters.configuration }}\**
+      Contents: ${{ format('**\bin\{0}\**', parameters.configuration) }}
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
   - task: PublishBuildArtifacts@1

--- a/build/build-without-fakes.yml
+++ b/build/build-without-fakes.yml
@@ -1,0 +1,20 @@
+parameters:
+  configuration: ''
+
+jobs:
+- job: build_without_fakes_${{ parameters.configuration }}
+  pool:
+    vmImage: 'windows-2019'
+  steps:
+  - task: NuGetToolInstaller@0
+    displayName: 'Use NuGet 4.3.0'
+
+  - task: NuGetCommand@2
+    displayName: 'NuGet restore'
+
+  - task: VSBuild@1
+    displayName: 'Build Solution **\*.sln'
+    inputs:
+      vsVersion: 16.0
+      platform: '$(BuildPlatform)'
+      configuration: ${{ parameters.configuration }}

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -8,118 +8,15 @@ variables:
   SignAppForRelease: 'false'
 
 jobs:
-- job: ReleaseBuildUnitTests
-  displayName: Build and run unit tests - release
-  pool:
-    vmImage: 'windows-2019'
-  variables:
-    FAKES_SUPPORTED: 1
-  steps:
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.3.0'
+- template: build-and-unit-tests.yml
+  parameters:
+    configuration: release
+    checkLicenseHeaders: true
+    runComponentGovernance: true
 
-  - task: NuGetCommand@2
-    displayName: 'NuGet restore'
-
-  - task: PowerShell@2
-    displayName: 'License Header Check'
-    inputs:
-      targetType: "filePath"
-      filePath: tools\scripts\verification.scripts\LicenseHeaderVerification.ps1
-      arguments: '-target  $(Build.Repository.LocalPath) -licenseHeaderPath tools\scripts\verification.scripts\LicenseHeader.txt -extensions *.xaml,*.xml,*.cs,*.ps1 -addIfAbsent $false'
-
-  - task: VSBuild@1
-    displayName: 'Build Solution **\*.sln'
-    inputs:
-      vsVersion: 16.0
-      platform: '$(BuildPlatform)'
-      configuration: release
-
-  - task: CopyFiles@2
-    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
-    inputs:
-      Contents: '**\bin\release\**'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: drop'
-
-  - task: VSTest@2
-    displayName: 'Test Assemblies **\release\*test*.dll;-:**\obj\**'
-    inputs:
-      testAssemblyVer2: |
-        **\*test*.dll
-        !**\obj\**
-      vsTestVersion: 16.0
-      codeCoverageEnabled: true
-      platform: '$(BuildPlatform)'
-      configuration: release
-      rerunFailedTests: true
-      runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
-      testFiltercriteria: 'TestCategory!=UITest'
-
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-    displayName: 'Component Detection'
-
-- job: DebugBuildUnitTests
-  displayName: Build and run unit tests - debug
-  pool:
-    vmImage: 'windows-2019'
-  variables:
-    FAKES_SUPPORTED: 1
-  steps:
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.3.0'
-
-  - task: NuGetCommand@2
-    displayName: 'NuGet restore'
-
-  - task: VSBuild@1
-    displayName: 'Build Solution **\*.sln'
-    inputs:
-      vsVersion: 16.0
-      platform: '$(BuildPlatform)'
-      configuration: debug
-
-  - task: CopyFiles@2
-    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
-    inputs:
-      Contents: '**\bin\debug\**'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: drop'
-
-  - task: VSTest@2
-    displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
-    inputs:
-      testAssemblyVer2: |
-        **\*test*.dll
-        !**\obj\**
-      testFiltercriteria: 'TestCategory!=UITest'
-      vsTestVersion: 16.0
-      codeCoverageEnabled: false
-      platform: '$(BuildPlatform)'
-      configuration: debug
-      rerunFailedTests: true
-      runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
-
-- job: build_without_fakes
-  pool:
-    vmImage: 'windows-2019'
-  steps:
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.3.0'
-
-  - task: NuGetCommand@2
-    displayName: 'NuGet restore'
-
-  - task: VSBuild@1
-    displayName: 'Build Solution **\*.sln'
-    inputs:
-      vsVersion: 16.0
-      platform: '$(BuildPlatform)'
-      configuration: debug
+- template: build-and-unit-tests.yml
+  parameters:
+    configuration: debug
 
 - template: ui-test-job.yml
   parameters:

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -25,3 +25,7 @@ jobs:
 - template: ui-test-job.yml
   parameters:
     configuration: debug
+
+- template: build-without-fakes.yml
+  parameters:
+    configuration: debug


### PR DESCRIPTION
This PR attempts to simplify the PR YAML build by creating and using a template for the build & unit test job. This template is called once with debug and again with release. There are template variables for CG and license header checks. There should be no functional change after this PR is merged - it is intended to simply rearrange how the tasks are defined.