### PR TITLE
Remove debug ui tests in signed build

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -15,10 +15,6 @@ jobs:
   parameters:
     configuration: release
 
-- template: ui-test-job.yml
-  parameters:
-    configuration: debug
-
 - job: ComplianceRelease
   pool:
     vmImage: 'windows-2019'


### PR DESCRIPTION
Debug UI tests are failing in the signed build with:

Initialization method UITests.LiveMode.TestInitialize threw exception. System.ComponentModel.Win32Exception: A referral was returned from the server.
    at System.Diagnostics.Process.StartWithShellExecuteEx(ProcessStartInfo startInfo)
   at System.Diagnostics.Process.Start()
   at System.Diagnostics.Process.Start(ProcessStartInfo startInfo)
   at System.Diagnostics.Process.Start(String fileName, String arguments)
   at UITests.AIWinSession.LaunchApplicationAndAttach() in \src\UITests\AIWinSession.cs:line 71
   at UITests.AIWinSession.Setup() in \src\UITests\AIWinSession.cs:line 36
   at UITests.LiveMode.TestInitialize() in \src\UITests\LiveMode.cs:line 85

This PR removes the debug UI tests to unblock that build. The release UI tests still run. Our PR builds still run the tests in both configurations.