### PR TITLE
Removing dependency on deleted debug UI test job

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -188,7 +188,6 @@ jobs:
   dependsOn: 
   - ComplianceRelease
   - ComplianceDebug
-  - UITestsdebug
   - UITestsrelease
   condition: and(succeeded(), succeeded())
   pool: VSEng-MicroBuildVS2019


### PR DESCRIPTION
We removed the debug UI test job int he signed build but forgot to remove the dependency on it. Removing now so the signed build fully runs.