### PR TITLE
Add UITest for Connection settings tab

### DIFF
--- a/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml
+++ b/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml
@@ -17,6 +17,8 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
         <TextBlock x:Name="connectionInstr" Grid.Row="0" Text="{x:Static Properties:Resources.tbURLPlaceHolder}" TextWrapping="Wrap" Margin="0 9px"  FontSize="{DynamicResource StandardTextSize}" />
-        <local:PlaceHolderTextBox Grid.Row="1" x:Name="tbURL" AutomationProperties.Name="{x:Static Properties:Resources.tbURLPlaceHolder}" Width="294px" Height="32px" VerticalContentAlignment="Center" FontSize="{DynamicResource StandardTextSize}" />
+        <local:PlaceHolderTextBox Grid.Row="1" x:Name="tbURL" AutomationProperties.Name="{x:Static Properties:Resources.tbURLPlaceHolder}"
+                                  Width="294px" Height="32px" VerticalContentAlignment="Center" FontSize="{DynamicResource StandardTextSize}"
+                                  AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.IssueConfigurationUrlTextBox}"/>
     </Grid>
 </src:IssueConfigurationControl>

--- a/src/AccessibilityInsights.Extensions.GitHub/Extensions.GitHub.csproj
+++ b/src/AccessibilityInsights.Extensions.GitHub/Extensions.GitHub.csproj
@@ -71,6 +71,7 @@
     <Compile Include="IssueFormatterFactory.cs" />
     <Compile Include="LinkValidator.cs" />
     <Compile Include="NoFailuresIssueFormatter.cs" />
+    <Compile Include="Properties\AutomationIDs.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/AccessibilityInsights.Extensions.GitHub/Properties/AutomationIDs.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/Properties/AutomationIDs.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+namespace AccessibilityInsights.Extensions.GitHub.Properties
+{
+    public static class AutomationIDs
+    {
+#pragma warning disable CA1056 // Uri properties should not be strings
+        public static string IssueConfigurationUrlTextBox { get; } = nameof(IssueConfigurationUrlTextBox);
+#pragma warning restore CA1056 // Uri properties should not be strings
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml
@@ -6,7 +6,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:Properties="clr-namespace:AccessibilityInsights.SharedUx.Properties"
-             mc:Ignorable="d"
+             mc:Ignorable="d" AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.ConnectionControl}"
              DataContext="{Binding RelativeSource={RelativeSource Self}}">
     <UserControl.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>

--- a/src/AccessibilityInsights.SharedUx/Properties/AutomationIDs.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/AutomationIDs.cs
@@ -8,6 +8,7 @@ namespace AccessibilityInsights.SharedUx.Properties
         public static string AutomatedChecksResultsListView { get; } = nameof(AutomatedChecksResultsListView);
         public static string AutomatedChecksResultsTextBlock { get; } = nameof(AutomatedChecksResultsTextBlock);
         public static string AutomatedChecksUIATreeButton { get; } = nameof(AutomatedChecksUIATreeButton);
+        public static string ConnectionControl { get; } = nameof(ConnectionControl);
         public static string HierarchyControlTestElementButton { get; } = nameof(HierarchyControlTestElementButton);
         public static string HierarchyControlUIATreeView { get; } = nameof(HierarchyControlUIATreeView);
         public static string InspectTabsElementTextBlock { get; } = nameof(InspectTabsElementTextBlock);
@@ -25,6 +26,7 @@ namespace AccessibilityInsights.SharedUx.Properties
         public static string EventModeControl { get; } = nameof(EventModeControl);
         public static string SettingsButton { get; } = nameof(SettingsButton);
         public static string SettingsApplicationTabItem { get; } = nameof(SettingsApplicationTabItem);
+        public static string SettingsConnectionTabItem { get; } = nameof(SettingsConnectionTabItem);
         public static string SettingsAboutTabItem { get; } = nameof(SettingsAboutTabItem);
         public static string ChannelComboBox { get; } = nameof(ChannelComboBox);
         public static string SaveAndCloseButton { get; } = nameof(SaveAndCloseButton);

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
@@ -39,7 +39,7 @@
                             <TabItem Header="{x:Static properties:Resources.tcTabsApplicationHeader}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsApplicationTabItem}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiApplication" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Application}">
                                 <controls:ApplicationSettingsControl x:Name="appSettingsCtrl"/>
                             </TabItem>
-                            <TabItem Header="{x:Static properties:Resources.tcTabsConnectionHeader}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiConnection" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Connection}">
+                            <TabItem Header="{x:Static properties:Resources.tcTabsConnectionHeader}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsConnectionTabItem}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiConnection" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Connection}">
                                 <controls:ConnectionControl x:Name="connectionCtrl"/>
                             </TabItem>
                             <TabItem Header="{x:Static properties:Resources.tcTabsWhatsNewHeader}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.About}">

--- a/src/UITests/SettingsPage.cs
+++ b/src/UITests/SettingsPage.cs
@@ -3,6 +3,7 @@
 using AccessibilityInsights.SharedUx.Properties;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
+using GitHubAutomationIDs = AccessibilityInsights.Extensions.GitHub.Properties.AutomationIDs;
 
 namespace UITests
 {
@@ -20,6 +21,7 @@ namespace UITests
         {
             CheckApplicationTab();
             CheckShortcut();
+            CheckConnectionTab();
             CheckAboutTab();
         }
 
@@ -66,6 +68,32 @@ namespace UITests
             Assert.AreEqual("Production", channelOptions.Text);
             Assert.IsFalse(saveAndClose.Enabled);
             CheckAccessibility("ApplicationTab");
+        }
+
+
+        /// <summary>
+        /// Spot check the connection tab and do an accessibility check
+        /// </summary>
+        private void CheckConnectionTab()
+        {
+            driver.GoToSettings();
+            driver.FindElementByAccessibilityId(AutomationIDs.SettingsConnectionTabItem).Click();
+
+            var saveAndClose = driver.FindElementByAccessibilityId(AutomationIDs.SaveAndCloseButton);
+            var connectionControl = driver.FindElementByAccessibilityId(AutomationIDs.ConnectionControl);
+            var radioButtons = connectionControl.FindElementsByClassName("RadioButton");
+
+            Assert.IsFalse(saveAndClose.Enabled);
+            Assert.AreEqual(2, radioButtons.Count);
+            Assert.IsTrue(radioButtons[0].Text.Contains("Azure Boards"));
+            Assert.IsTrue(radioButtons[1].Text.Contains("GitHub"));
+
+            radioButtons[1].Click();
+            var urlTb = connectionControl.FindElementByAccessibilityId(GitHubAutomationIDs.IssueConfigurationUrlTextBox);
+            urlTb.SendKeys("https://github.com/microsoft/accessibility-insights-windows");
+            Assert.IsTrue(saveAndClose.Enabled);
+
+            CheckAccessibility("ConnectionTab");
         }
 
         /// <summary>

--- a/src/UITests/UITests.csproj
+++ b/src/UITests/UITests.csproj
@@ -126,6 +126,14 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\AccessibilityInsights.Extensions.AzureDevOps\Extensions.AzureDevOps.csproj">
+      <Project>{58dbf9fe-0029-408f-a8a4-23ae500e938d}</Project>
+      <Name>Extensions.AzureDevOps</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\AccessibilityInsights.Extensions.GitHub\Extensions.GitHub.csproj">
+      <Project>{f421aafd-d85f-49b8-b95e-ca17718c38dd}</Project>
+      <Name>Extensions.GitHub</Name>
+    </ProjectReference>
     <ProjectReference Include="..\AccessibilityInsights.SharedUx\SharedUx.csproj">
       <Project>{723ddc93-8ab7-403c-9d03-c90b01cae774}</Project>
       <Name>SharedUx</Name>


### PR DESCRIPTION
#### Describe the change
This PR adds a UITest that checks if the connection tab in settings has radio buttons for both issue filing extensions and does a basic validation of the save button's enabled state change. AutomationIDs are added as appropriate. 

[Screencap here](https://dev.azure.com/accessibility-insights/Accessibility%20Insights/_apis/test/Runs/5690/Results/100004/Attachments/3)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



