### PR TITLE
Rename and reorder Automation IDs for readability

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/ChannelConfigControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ChannelConfigControl.xaml
@@ -24,7 +24,7 @@
         <ComboBox Grid.Row="1" Margin="0,8,0,12" ItemsSource="{Binding Path=Channels}"
                   MaxWidth="154" MinWidth="154" HorizontalAlignment="Left"
                   SelectedItem="{Binding CurrentChannel}" AutomationProperties.LabeledBy="{Binding ElementName=lblChannel}"
-                  AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.ChannelComboBox}"/>
+                  AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.SettingsChannelComboBox}"/>
         <TextBlock Focusable="True" Grid.Row="2" Style="{StaticResource TxtTelemetrySettingInfo}"
                    TextWrapping="Wrap" HorizontalAlignment="Left" Text="{Binding ChannelDescription}"/>
     </Grid>

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -153,7 +153,7 @@
             <customcontrols:CustomDataGrid x:Name="dgEvents" GotKeyboardFocus="dgEvents_GotKeyboardFocus"
                       AutomationProperties.LabeledBy="{Binding ElementName=labelEvents}"
                       AutomationProperties.AcceleratorKey="Alt+V"
-                      AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.EventsDataGrid}"
+                      AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.EventRecordControlEventsDataGrid}"
                       Height="Auto" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"
                       SelectionChanged="listEvents_SelectionChanged" SelectionMode="Single"
                       HorizontalContentAlignment="Stretch"

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -42,7 +42,7 @@
         <TextBlock Padding="0" FontSize="14" Margin="0,8,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlNotices" AutomationProperties.Name="{x:Static Properties:Resources.hlThirdpartyNoticesName}" 
                        Click="FileLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 
-                       NavigateUri="thirdpartynotices.html" TextDecorations="None" AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.ThirdPartyNoticesHyperlink}">
+                       NavigateUri="thirdpartynotices.html" TextDecorations="None" AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.SettingsThirdPartyNoticesHyperlink}">
                 <Run Text="{x:Static Properties:Resources.hlThirdpartyNoticesName}" />
             </Hyperlink>
         </TextBlock>

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
@@ -75,7 +75,7 @@
             <StackPanel Grid.Row="4" Orientation="Horizontal" Margin="1,5,0,0">
                 <Button x:Name="btnHotkeyPause" HorizontalAlignment="Left" Height="16" VerticalAlignment="Top" Width="120" 
                         VerticalContentAlignment="Center" Style="{StaticResource BtnHotkey}" 
-                        AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.HotkeyPauseButton}"
+                        AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.SettingsHotkeyPauseButton}"
                         Click="btnToggleHk_Click">
                     <AutomationProperties.Name>
                         <MultiBinding StringFormat="{x:Static Properties:Resources.MultiBindingStringFormat}">

--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
@@ -13,7 +13,7 @@
         KeyDown="Window_KeyDown" KeyUp="Window_KeyUp" 
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False" Topmost="True"
-        AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.HotkeyGrabDialog}">
+        AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.SettingsHotkeyGrabDialog}">
     <Window.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
     </Window.Resources>

--- a/src/AccessibilityInsights.SharedUx/Properties/AutomationIDs.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/AutomationIDs.cs
@@ -4,36 +4,36 @@ namespace AccessibilityInsights.SharedUx.Properties
 {
     public static class AutomationIDs
     {
-        public static string AutomatedChecksExpandAllButton{ get; } = nameof(AutomatedChecksExpandAllButton);
+        public static string AutomatedChecksExpandAllButton { get; } = nameof(AutomatedChecksExpandAllButton);
         public static string AutomatedChecksResultsListView { get; } = nameof(AutomatedChecksResultsListView);
         public static string AutomatedChecksResultsTextBlock { get; } = nameof(AutomatedChecksResultsTextBlock);
         public static string AutomatedChecksUIATreeButton { get; } = nameof(AutomatedChecksUIATreeButton);
         public static string ConnectionControl { get; } = nameof(ConnectionControl);
+        public static string EventModeControl { get; } = nameof(EventModeControl);
+        public static string EventRecordControlEventsDataGrid { get; } = nameof(EventRecordControlEventsDataGrid);
         public static string HierarchyControlTestElementButton { get; } = nameof(HierarchyControlTestElementButton);
         public static string HierarchyControlUIATreeView { get; } = nameof(HierarchyControlUIATreeView);
         public static string InspectTabsElementTextBlock { get; } = nameof(InspectTabsElementTextBlock);
-        public static string MainWinLoadButton { get; } = nameof(MainWinLoadButton);
-        public static string MainWinHighlightButton { get; } = nameof(MainWinHighlightButton);
         public static string MainWinBreadCrumbOneButton { get; } = nameof(MainWinBreadCrumbOneButton);
         public static string MainWinBreadCrumbTwoButton { get; } = nameof(MainWinBreadCrumbTwoButton);
+        public static string MainWinHighlightButton { get; } = nameof(MainWinHighlightButton);
+        public static string MainWinLoadButton { get; } = nameof(MainWinLoadButton);
+        public static string MainWinPauseButton { get; } = nameof(MainWinPauseButton);
+        public static string MainWinSettingsButton { get; } = nameof(MainWinSettingsButton);
+        public static string MainWindow { get; } = nameof(MainWindow);
         public static string ScannerResultsDetailsListView { get; } = nameof(ScannerResultsDetailsListView);
         public static string ScannerResultsFixFollowingTextBox { get; } = nameof(ScannerResultsFixFollowingTextBox);
         public static string ScannerResultsShowAllButton { get; } = nameof(ScannerResultsShowAllButton);
+        public static string SettingsAboutTabItem { get; } = nameof(SettingsAboutTabItem);
+        public static string SettingsApplicationTabItem { get; } = nameof(SettingsApplicationTabItem);
+        public static string SettingsChannelComboBox { get; } = nameof(SettingsChannelComboBox);
+        public static string SettingsConnectionTabItem { get; } = nameof(SettingsConnectionTabItem);
+        public static string SettingsHotkeyGrabDialog { get; } = nameof(SettingsHotkeyGrabDialog);
+        public static string SettingsHotkeyPauseButton { get; } = nameof(SettingsHotkeyPauseButton);
+        public static string SettingsSaveAndCloseButton { get; } = nameof(SettingsSaveAndCloseButton);
+        public static string SettingsThirdPartyNoticesHyperlink { get; } = nameof(SettingsThirdPartyNoticesHyperlink);
         public static string SnapshotModeControl { get; } = nameof(SnapshotModeControl);
         public static string StartUpModeExitButton { get; } = nameof(StartUpModeExitButton);
         public static string TelemetryDialogExitButton { get; } = nameof(TelemetryDialogExitButton);
-        public static string EventsDataGrid { get; } = nameof(EventsDataGrid);
-        public static string EventModeControl { get; } = nameof(EventModeControl);
-        public static string SettingsButton { get; } = nameof(SettingsButton);
-        public static string SettingsApplicationTabItem { get; } = nameof(SettingsApplicationTabItem);
-        public static string SettingsConnectionTabItem { get; } = nameof(SettingsConnectionTabItem);
-        public static string SettingsAboutTabItem { get; } = nameof(SettingsAboutTabItem);
-        public static string ChannelComboBox { get; } = nameof(ChannelComboBox);
-        public static string SaveAndCloseButton { get; } = nameof(SaveAndCloseButton);
-        public static string PauseButton { get; } = nameof(PauseButton);
-        public static string HotkeyPauseButton { get; } = nameof(HotkeyPauseButton);
-        public static string HotkeyGrabDialog { get; } = nameof(HotkeyGrabDialog);
-        public static string MainWindow { get; } = nameof(MainWindow);
-        public static string ThirdPartyNoticesHyperlink { get; } = nameof(ThirdPartyNoticesHyperlink);
     }
 }

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -171,7 +171,7 @@
                         </Button>
                         <Button Width="40" Height="40"
                                     x:Name="btnConfig" Grid.Row="1"
-                                    AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsButton}"
+                                    AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinSettingsButton}"
                                     AutomationProperties.Name="{x:Static properties:Resources.btnConfigAutomationPropertiesName}"
                                     AutomationProperties.HelpText="{x:Static properties:Resources.btnConfigAutomationPropertiesHelpText}"
                                     Style="{StaticResource btnLeftNav}" Click="onbtnConfigClicked">
@@ -375,7 +375,7 @@
                                 VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
                                 Click="btnPause_Click"
                                 AutomationProperties.Name="{x:Static properties:Resources.btnPauseAutomationPropertiesNameOn}"
-                                AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.PauseButton}">
+                                AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinPauseButton}">
                                 <i:Interaction.Behaviors>
                                     <behaviors:KeyboardToolTipButtonBehavior/>
                                 </i:Interaction.Behaviors>

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
@@ -34,7 +34,7 @@
                 <Grid Grid.Row="1">
                     <DockPanel LastChildFill="False" >
                         <Button DockPanel.Dock="Bottom" TabIndex="-3" x:Name="btnOk" Content="{x:Static properties:Resources.btnOkContent}" HorizontalAlignment="Left" VerticalAlignment="Top" Width="80" Height="24" Margin="20,20" IsDefault="True" Click="buttonOk_Click" Style="{StaticResource BtnSave}" IsEnabled="False" 
-                                AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SaveAndCloseButton}"/>
+                                AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsSaveAndCloseButton}"/>
                         <TabControl Name="tcTabs" DockPanel.Dock="Top" BorderThickness="0,1,0,0" BorderBrush="#FFEAEAEA" Style="{StaticResource tcScrolling}" SelectionChanged="TabControl_SelectionChanged">
                             <TabItem Header="{x:Static properties:Resources.tcTabsApplicationHeader}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsApplicationTabItem}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiApplication" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Application}">
                                 <controls:ApplicationSettingsControl x:Name="appSettingsCtrl"/>

--- a/src/UITests/LoadEventFile.cs
+++ b/src/UITests/LoadEventFile.cs
@@ -60,7 +60,7 @@ namespace UITests
         private void CheckPropertyView()
         {
             // Click on 3rd event to see its properties
-            var eventGrid = driver.FindElementByAccessibilityId(AccessibilityInsights.SharedUx.Properties.AutomationIDs.EventsDataGrid);
+            var eventGrid = driver.FindElementByAccessibilityId(AccessibilityInsights.SharedUx.Properties.AutomationIDs.EventRecordControlEventsDataGrid);
             var eventRows = eventGrid.FindElementsByClassName("DataGridRow");
             eventRows[2].Click();
 

--- a/src/UITests/SettingsPage.cs
+++ b/src/UITests/SettingsPage.cs
@@ -31,18 +31,18 @@ namespace UITests
         private void CheckShortcut()
         {
             driver.FindElementByAccessibilityId(AutomationIDs.SettingsApplicationTabItem).Click();
-            var pauseHotkey = driver.FindElementByAccessibilityId(AutomationIDs.HotkeyPauseButton);
+            var pauseHotkey = driver.FindElementByAccessibilityId(AutomationIDs.SettingsHotkeyPauseButton);
             pauseHotkey.Click();
 
-            var hotkeyDialog = driver.FindElementByAccessibilityId(AutomationIDs.HotkeyGrabDialog);
+            var hotkeyDialog = driver.FindElementByAccessibilityId(AutomationIDs.SettingsHotkeyGrabDialog);
             hotkeyDialog.SendKeys(Keys.Shift);
             hotkeyDialog.SendKeys(Keys.F6);
 
-            var saveAndClose = driver.FindElementByAccessibilityId(AutomationIDs.SaveAndCloseButton);
+            var saveAndClose = driver.FindElementByAccessibilityId(AutomationIDs.SettingsSaveAndCloseButton);
             Assert.IsTrue(saveAndClose.Enabled);
             saveAndClose.Click();
 
-            var pauseButton = driver.FindElementByAccessibilityId(AutomationIDs.PauseButton);
+            var pauseButton = driver.FindElementByAccessibilityId(AutomationIDs.MainWinPauseButton);
             Assert.IsTrue(pauseButton.Text.Contains("Pause"));
             var mainWindow = driver.FindElementByAccessibilityId(AutomationIDs.MainWindow);
             mainWindow.SendKeys(Keys.Shift + Keys.F6);
@@ -56,10 +56,10 @@ namespace UITests
         {
             driver.FindElementByAccessibilityId(AutomationIDs.SettingsApplicationTabItem).Click();
 
-            var saveAndClose = driver.FindElementByAccessibilityId(AutomationIDs.SaveAndCloseButton);
+            var saveAndClose = driver.FindElementByAccessibilityId(AutomationIDs.SettingsSaveAndCloseButton);
             Assert.IsFalse(saveAndClose.Enabled);
 
-            var channelOptions = driver.FindElementByAccessibilityId(AutomationIDs.ChannelComboBox);
+            var channelOptions = driver.FindElementByAccessibilityId(AutomationIDs.SettingsChannelComboBox);
             Assert.AreEqual("Production", channelOptions.Text);
             channelOptions.SendKeys(Keys.ArrowDown);
             Assert.AreEqual("Insider", channelOptions.Text);
@@ -79,7 +79,7 @@ namespace UITests
             driver.GoToSettings();
             driver.FindElementByAccessibilityId(AutomationIDs.SettingsConnectionTabItem).Click();
 
-            var saveAndClose = driver.FindElementByAccessibilityId(AutomationIDs.SaveAndCloseButton);
+            var saveAndClose = driver.FindElementByAccessibilityId(AutomationIDs.SettingsSaveAndCloseButton);
             var connectionControl = driver.FindElementByAccessibilityId(AutomationIDs.ConnectionControl);
             var radioButtons = connectionControl.FindElementsByClassName("RadioButton");
 
@@ -103,7 +103,7 @@ namespace UITests
         {
             driver.GoToSettings();
             driver.FindElementByAccessibilityId(AutomationIDs.SettingsAboutTabItem).Click();
-            var noticesLink = driver.FindElementByAccessibilityId(AutomationIDs.ThirdPartyNoticesHyperlink);
+            var noticesLink = driver.FindElementByAccessibilityId(AutomationIDs.SettingsThirdPartyNoticesHyperlink);
             Assert.AreEqual("Third party notices", noticesLink.Text);
             CheckAccessibility("AboutTab");
         }

--- a/src/UITests/UILibrary/AIWinDriver.cs
+++ b/src/UITests/UILibrary/AIWinDriver.cs
@@ -65,7 +65,7 @@ namespace UITests.UILibrary
 
         public void ToggleHighlighter() => Session.FindElementByAccessibilityId(AutomationIDs.MainWinHighlightButton).Click();
 
-        public void GoToSettings() => Session.FindElementByAccessibilityId(AutomationIDs.SettingsButton).Click();
+        public void GoToSettings() => Session.FindElementByAccessibilityId(AutomationIDs.MainWinSettingsButton).Click();
 
         public void Maximize() => Session.Manage().Window.Maximize();
     }


### PR DESCRIPTION
#### Describe the change
This change renames some of the Automation IDs so that each is scoped by the control it comes from. After doing this, I alphabetized the list. This change should only affect our UI tests.

#### PR checklist

- [UI tests validated] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- (no) Does this address an existing issue? If yes, Issue# - 
- (no) Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



