### PR TITLE
Don't block build if WinAppDriver Stop command has error

### DIFF
--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -42,5 +42,6 @@ jobs:
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Stop - WinAppDriver'
+    continueOnError: true
     inputs:
       OperationType: Stop


### PR DESCRIPTION
#### Describe the change
We've seen some issues with the WinAppDriver Stop build task. Since tests have already finished at that point, the build should continue.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



