### PR TITLE
Adding assert text messages in UI tests

### DIFF
--- a/src/UITests/GettingStartedPage.cs
+++ b/src/UITests/GettingStartedPage.cs
@@ -17,25 +17,18 @@ namespace UITests
         public void GettingStartedPageTests()
         {
             VerifyGettingStartedTitle();
-            VerifyAccessibility();
+            driver.VerifyAccessibility(TestContext, "GettingStarted", 0);
         }
 
         private void VerifyGettingStartedTitle()
         {
-            Assert.AreEqual("Accessibility Insights for Windows - ", driver.Title);
-        }
-
-        private void VerifyAccessibility()
-        {
-            var issueCount = driver.ScanAIWin(TestContext, "GettingStarted");
-            Assert.AreEqual(0, issueCount);
+            Assert.AreEqual("Accessibility Insights for Windows - ", driver.Title, "Getting Started title is incorrect");
         }
 
         [TestInitialize]
         public void TestInitialize()
         {
             Setup();
-
             driver.GettingStarted.DismissTelemetry();
         }
 

--- a/src/UITests/LiveMode.cs
+++ b/src/UITests/LiveMode.cs
@@ -29,7 +29,7 @@ namespace UITests
         private void TestTestResults()
         {
             RunTests();
-            ScanAccessibility();
+            driver.VerifyAccessibility(TestContext, "LiveMode", 0);
             ValidateTestModeTitle();
             driver.TestMode.AutomatedChecks.ValidateAutomatedChecks(12);
             driver.TestMode.AutomatedChecks.GoToAutomatedChecksElementDetails(4);
@@ -49,7 +49,7 @@ namespace UITests
             driver.LiveMode.RunTests();
             var testsComplete = WaitFor(() => !driver.Title.Contains("(Scanning)"), new TimeSpan(0, 0, 0, 0, 500), 10);
 
-            Assert.IsTrue(testsComplete);
+            Assert.IsTrue(testsComplete, "Tests did not complete - (Scanning) title was never found");
         }
 
         private void TestLiveMode()
@@ -58,25 +58,19 @@ namespace UITests
             var appSelected = WaitFor(() => driver.LiveMode.SelectedElementText == "window 'Wildlife Manager 2.0'", new TimeSpan(0, 0, 1), 5);
             driver.LiveMode.TogglePause();
 
-            Assert.IsTrue(appOpened);
-            Assert.IsTrue(appSelected);
+            Assert.IsTrue(appOpened, "Wildlife Manager may not have opened, its window title was not found");
+            Assert.IsTrue(appSelected, "Wildlife Manager was not selected in Live mode");
             VerifyLiveModeTitle();
         }
 
         private void VerifyLiveModeTitle()
         {
-            Assert.AreEqual("Accessibility Insights for Windows - Inspect - Live", driver.Title);
+            Assert.AreEqual("Accessibility Insights for Windows - Inspect - Live", driver.Title, "Live mode title is incorrect");
         }
 
         private void ValidateTestModeTitle()
         {
-            Assert.AreEqual("Accessibility Insights for Windows - Test - Test results", driver.Title);
-        }
-
-        private void ScanAccessibility()
-        {
-            var issueCount = driver.ScanAIWin(TestContext, "LiveMode");
-            Assert.AreEqual(0, issueCount);
+            Assert.AreEqual("Accessibility Insights for Windows - Test - Test results", driver.Title, "Test mode title is incorrect");
         }
 
         [TestInitialize]

--- a/src/UITests/LoadEventFile.cs
+++ b/src/UITests/LoadEventFile.cs
@@ -27,13 +27,7 @@ namespace UITests
             driver.Maximize();
             CheckEventLog();
             CheckPropertyView();
-            ScanWindow();
-        }
-
-        private void ScanWindow()
-        {
-            var issueCount = driver.ScanAIWin(TestContext, "EventPage");
-            Assert.AreEqual(0, issueCount);
+            driver.VerifyAccessibility(TestContext, "EventPage", 0);
         }
 
         /// <summary>
@@ -47,11 +41,11 @@ namespace UITests
             rows[0].Click();
 
             // Text is populated after the cell above is selected (blank otherwise)
-            Assert.AreEqual("09:58:37.859, EventRecorderNotification, Event Recorder", rows[0].Text);
+            Assert.AreEqual("09:58:37.859, EventRecorderNotification, Event Recorder", rows[0].Text, "Loaded event row has incorrect text");
 
             // 10 rows from the event log and 3 from the event details
             int numRows = GetNumEventDataRows();
-            Assert.AreEqual(13, numRows);
+            Assert.AreEqual(13, numRows, "We expected a different number of loaded event rows");
         }
 
         /// <summary>
@@ -66,7 +60,7 @@ namespace UITests
 
             // 10 rows from the event log and 10 from the event properties
             var rowCount = GetNumEventDataRows();
-            Assert.AreEqual(20, rowCount);
+            Assert.AreEqual(20, rowCount, "We expected a different number of loaded event rows after selecting properties");
         }
 
         private int GetNumEventDataRows()

--- a/src/UITests/LoadTestFile.cs
+++ b/src/UITests/LoadTestFile.cs
@@ -24,7 +24,7 @@ namespace UITests
         [TestCategory("UITest")]
         public void LoadTestFileTests()
         {
-            ScanAutomatedChecks();
+            driver.VerifyAccessibility(TestContext, "AutomatedChecks", 0);
             ScanResultsInUIATreePage();
             driver.TestMode.AutomatedChecks.ValidateAutomatedChecks(12);
             driver.TestMode.AutomatedChecks.GoToAutomatedChecksElementDetails(0);
@@ -35,16 +35,8 @@ namespace UITests
         {
             driver.TestMode.AutomatedChecks.ViewInUIATree();
 
-            var issueCount = driver.ScanAIWin(TestContext, "UIATree");
-
-            Assert.AreEqual(0, issueCount);
+            driver.VerifyAccessibility(TestContext, "UIATree", 0);
             driver.TestMode.ResultsInUIATree.BackToAutomatedChecks();
-        }
-
-        private void ScanAutomatedChecks()
-        {
-            var issueCount = driver.ScanAIWin(TestContext, "AutomatedChecks");
-            Assert.AreEqual(0, issueCount);
         }
 
         private void ValidateFirstSelectedElement()

--- a/src/UITests/SettingsPage.cs
+++ b/src/UITests/SettingsPage.cs
@@ -39,14 +39,14 @@ namespace UITests
             hotkeyDialog.SendKeys(Keys.F6);
 
             var saveAndClose = driver.FindElementByAccessibilityId(AutomationIDs.SettingsSaveAndCloseButton);
-            Assert.IsTrue(saveAndClose.Enabled);
+            Assert.IsTrue(saveAndClose.Enabled, "Save and close should be enabled");
             saveAndClose.Click();
 
             var pauseButton = driver.FindElementByAccessibilityId(AutomationIDs.MainWinPauseButton);
-            Assert.IsTrue(pauseButton.Text.Contains("Pause"));
+            Assert.IsTrue(pauseButton.Text.Contains("Pause"), "Live mode should be running, but the pause button doesn't say 'Pause'");
             var mainWindow = driver.FindElementByAccessibilityId(AutomationIDs.MainWindow);
             mainWindow.SendKeys(Keys.Shift + Keys.F6);
-            Assert.IsTrue(pauseButton.Text.Contains("Resume"));
+            Assert.IsTrue(pauseButton.Text.Contains("Resume"), "Live mode should be paused, but the pause button doesn't say 'Resume'");
         }
 
         /// <summary>
@@ -57,17 +57,17 @@ namespace UITests
             driver.FindElementByAccessibilityId(AutomationIDs.SettingsApplicationTabItem).Click();
 
             var saveAndClose = driver.FindElementByAccessibilityId(AutomationIDs.SettingsSaveAndCloseButton);
-            Assert.IsFalse(saveAndClose.Enabled);
+            Assert.IsFalse(saveAndClose.Enabled, "Save and close should be disabled");
 
             var channelOptions = driver.FindElementByAccessibilityId(AutomationIDs.SettingsChannelComboBox);
-            Assert.AreEqual("Production", channelOptions.Text);
+            Assert.AreEqual("Production", channelOptions.Text, "Default channel should be production");
             channelOptions.SendKeys(Keys.ArrowDown);
-            Assert.AreEqual("Insider", channelOptions.Text);
-            Assert.IsTrue(saveAndClose.Enabled);
+            Assert.AreEqual("Insider", channelOptions.Text, "Insider should be the second channel in the combobox");
+            Assert.IsTrue(saveAndClose.Enabled, "Save and close should be enabled after changing to insider");
             channelOptions.SendKeys(Keys.ArrowUp);
-            Assert.AreEqual("Production", channelOptions.Text);
-            Assert.IsFalse(saveAndClose.Enabled);
-            CheckAccessibility("ApplicationTab");
+            Assert.AreEqual("Production", channelOptions.Text, "Insider should change to production after navigating up with the arrow key");
+            Assert.IsFalse(saveAndClose.Enabled, "Save and close should be disabled after changing back to default production channel");
+            driver.VerifyAccessibility(TestContext, "ApplicationTab", 0);
         }
 
 
@@ -83,17 +83,17 @@ namespace UITests
             var connectionControl = driver.FindElementByAccessibilityId(AutomationIDs.ConnectionControl);
             var radioButtons = connectionControl.FindElementsByClassName("RadioButton");
 
-            Assert.IsFalse(saveAndClose.Enabled);
-            Assert.AreEqual(2, radioButtons.Count);
-            Assert.IsTrue(radioButtons[0].Text.Contains("Azure Boards"));
-            Assert.IsTrue(radioButtons[1].Text.Contains("GitHub"));
+            Assert.IsFalse(saveAndClose.Enabled, "Save and close should be disabled");
+            Assert.AreEqual(2, radioButtons.Count, "There should be two connection extensions");
+            Assert.IsTrue(radioButtons[0].Text.Contains("Azure Boards"), "The first connection should be Azure Boards");
+            Assert.IsTrue(radioButtons[1].Text.Contains("GitHub"), "The second connection should be GitHub");
 
             radioButtons[1].Click();
             var urlTb = connectionControl.FindElementByAccessibilityId(GitHubAutomationIDs.IssueConfigurationUrlTextBox);
             urlTb.SendKeys("https://github.com/microsoft/accessibility-insights-windows");
-            Assert.IsTrue(saveAndClose.Enabled);
+            Assert.IsTrue(saveAndClose.Enabled, "The save and close button should be enabled after configuring GitHub");
 
-            CheckAccessibility("ConnectionTab");
+            driver.VerifyAccessibility(TestContext, "ConnectionTab", 0);
         }
 
         /// <summary>
@@ -104,14 +104,8 @@ namespace UITests
             driver.GoToSettings();
             driver.FindElementByAccessibilityId(AutomationIDs.SettingsAboutTabItem).Click();
             var noticesLink = driver.FindElementByAccessibilityId(AutomationIDs.SettingsThirdPartyNoticesHyperlink);
-            Assert.AreEqual("Third party notices", noticesLink.Text);
-            CheckAccessibility("AboutTab");
-        }
-
-        private void CheckAccessibility(string name)
-        {
-            var issueCount = driver.ScanAIWin(TestContext, name);
-            Assert.AreEqual(0, issueCount);
+            Assert.AreEqual("Third party notices", noticesLink.Text, "The notices link text is incorrect");
+            driver.VerifyAccessibility(TestContext, "AboutTab", 0);
         }
 
         [TestInitialize]

--- a/src/UITests/TelemetryDialog.cs
+++ b/src/UITests/TelemetryDialog.cs
@@ -21,9 +21,7 @@ namespace UITests
 
         private void VerifyTelemetryDialog()
         {
-            var issueCount = driver.ScanAIWin(TestContext, "TelemetryDialog");
-            Assert.AreEqual(0, issueCount);
-
+            driver.VerifyAccessibility(TestContext, "TelemetryDialog", 0);
             driver.GettingStarted.DismissTelemetry();
         }
 

--- a/src/UITests/UILibrary/AIWinDriver.cs
+++ b/src/UITests/UILibrary/AIWinDriver.cs
@@ -62,7 +62,7 @@ namespace UITests.UILibrary
         public void VerifyAccessibility(TestContext context, string fileName, int expectedIssueCount)
         {
             var issueCount = this.ScanAIWin(context, fileName);
-            Assert.AreEqual(expectedIssueCount, issueCount, "axe.windows found accessibility issues, check a11ytest file in test artifacts");
+            Assert.AreEqual(expectedIssueCount, issueCount, $"axe.windows found accessibility issues, check {fileName}.a11ytest file in test artifacts");
         }
 
         public WindowsElement FindElementByAccessibilityId(string accessibilityId) => Session.FindElementByAccessibilityId(accessibilityId);

--- a/src/UITests/UILibrary/AIWinDriver.cs
+++ b/src/UITests/UILibrary/AIWinDriver.cs
@@ -38,7 +38,7 @@ namespace UITests.UILibrary
         /// </summary>
         /// <param name="context"></param>
         /// <returns>number of accessibility issues</returns>
-        public int ScanAIWin(TestContext context, string fileName)
+        private int ScanAIWin(TestContext context, string fileName)
         {
             var outputPath = Path.Combine(context.TestResultsDirectory, context.TestName);
             var config = Config.Builder.ForProcessId(PID)
@@ -57,6 +57,12 @@ namespace UITests.UILibrary
             }
 
             return result.ErrorCount;
+        }
+
+        public void VerifyAccessibility(TestContext context, string fileName, int expectedIssueCount)
+        {
+            var issueCount = this.ScanAIWin(context, fileName);
+            Assert.AreEqual(expectedIssueCount, issueCount, "axe.windows found accessibility issues, check a11ytest file in test artifacts");
         }
 
         public WindowsElement FindElementByAccessibilityId(string accessibilityId) => Session.FindElementByAccessibilityId(accessibilityId);


### PR DESCRIPTION
This PR only modifies the UI Tests. We add messages to the asserts so that errors are more actionable. This is particularly important because a test method includes a full scenario with multiple screens and checks.