### PR TITLE
Fix prerelease build text

### DIFF
--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -282,6 +282,10 @@
       <Project>{eee9cd52-ca10-41ae-ac6e-98ae4bbdfa2d}</Project>
       <Name>CommonUxComponents</Name>
     </ProjectReference>
+    <ProjectReference Include="..\AccessibilityInsights.Extensions.GitHubAutoUpdate\Extensions.GitHubAutoUpdate.csproj">
+      <Project>{80165ccc-6d76-4590-a16b-1790a35b08e4}</Project>
+      <Name>Extensions.GitHubAutoUpdate</Name>
+    </ProjectReference>
     <ProjectReference Include="..\AccessibilityInsights.Extensions\Extensions.csproj">
       <Project>{eaa85d0d-712d-4d85-a246-d3c699c6c602}</Project>
       <Name>Extensions</Name>

--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -282,10 +282,6 @@
       <Project>{eee9cd52-ca10-41ae-ac6e-98ae4bbdfa2d}</Project>
       <Name>CommonUxComponents</Name>
     </ProjectReference>
-    <ProjectReference Include="..\AccessibilityInsights.Extensions.GitHubAutoUpdate\Extensions.GitHubAutoUpdate.csproj">
-      <Project>{80165ccc-6d76-4590-a16b-1790a35b08e4}</Project>
-      <Name>Extensions.GitHubAutoUpdate</Name>
-    </ProjectReference>
     <ProjectReference Include="..\AccessibilityInsights.Extensions\Extensions.csproj">
       <Project>{eaa85d0d-712d-4d85-a246-d3c699c6c602}</Project>
       <Name>Extensions</Name>

--- a/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
@@ -221,6 +221,7 @@ namespace AccessibilityInsights
                 try
                 {
                     this.ShowUpgradeDialog();
+                    UpdateVersionString();
                 }
 #pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception ex)

--- a/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
@@ -276,7 +276,7 @@ namespace AccessibilityInsights
         {
             ReleaseChannel? channel = ConfigurationManager.GetDefaultInstance()?.AppConfig?.ReleaseChannel;
             if ((channel.HasValue && channel.Value != ReleaseChannel.Production)
-                || _updateOption != AutoUpdateOption.NewerThanCurrent)
+                || _updateOption == AutoUpdateOption.NewerThanCurrent)
             {
                 return string.Format(CultureInfo.InvariantCulture,
                     Properties.Resources.VersionBarPreReleaseVersion,

--- a/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
@@ -266,7 +266,11 @@ namespace AccessibilityInsights
         /// </summary>
         private void UpdateVersionString()
         {
-            this.lblVersion.Content = ComputeVersionBarString();
+            string content = ComputeVersionBarString();
+
+            this.lblVersion.Content = content;
+            this.lblVersion.Visibility = content.Length > 0 ?
+                Visibility.Visible : Visibility.Collapsed;
         }
 
         /// <summary>


### PR DESCRIPTION
#### Describe the change
There were 2 errors here:
1. The code to display the PreRelease used != when it should have used ==. Fixed by correcting the check.
2. There was a timing issue. UpdateVersionString was getting called before the AutoUpdate module completed, so it always used the default (which always set the PreRelease text because of the first error). Fixed by explicitly calling UpdateVersionString after the upgrade check completes.

Testing: Explicitly force all return states that the updater can return, confirm the version bar text is correctly set in each case.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - #449 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



