### PR TITLE
Upgrade from Axe.Windows 0.3.1 to Axe.Windows 0.3.2

### DIFF
--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -43,29 +43,32 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Axe.Windows.Actions, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Actions.dll</HintPath>
+    <Reference Include="Axe.Windows.Actions, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Actions.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Automation, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Automation.dll</HintPath>
+    <Reference Include="Axe.Windows.Automation, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Automation.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Core, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Core.dll</HintPath>
+    <Reference Include="Axe.Windows.Core, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Desktop, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Desktop.dll</HintPath>
+    <Reference Include="Axe.Windows.Desktop, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Desktop.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Rules, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Rules.dll</HintPath>
+    <Reference Include="Axe.Windows.Rules, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Rules.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.RuleSelection, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.RuleSelection.dll</HintPath>
+    <Reference Include="Axe.Windows.RuleSelection, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.RuleSelection.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Telemetry, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Telemetry.dll</HintPath>
+    <Reference Include="Axe.Windows.SystemAbstractions, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.SystemAbstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Win32, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Win32.dll</HintPath>
+    <Reference Include="Axe.Windows.Telemetry, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Telemetry.dll</HintPath>
+    </Reference>
+    <Reference Include="Axe.Windows.Win32, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Win32.dll</HintPath>
     </Reference>
     <Reference Include="Interop.UIAutomationClient, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -74,6 +77,9 @@
     </Reference>
     <Reference Include="Microsoft.mshtml, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Registry.4.5.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -84,6 +90,15 @@
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Drawing.Common.4.5.1\lib\net461\System.Drawing.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.AccessControl, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.4.5.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.5.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Windows.Interactivity.WPF.2.0.20525\lib\net40\System.Windows.Interactivity.dll</HintPath>

--- a/src/AccessibilityInsights.SharedUx/packages.config
+++ b/src/AccessibilityInsights.SharedUx/packages.config
@@ -1,14 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Axe.Windows" version="0.3.1-prerelease" targetFramework="net471" />
+  <package id="Axe.Windows" version="0.3.2-prerelease" targetFramework="net471" />
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.2" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.2" targetFramework="net471" />
   <package id="Microsoft.CodeQuality.Analyzers" version="2.9.2" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.NetCore.Analyzers" version="2.9.2" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.2" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net471" developmentDependency="true" />
+  <package id="Microsoft.Win32.Registry" version="4.5.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
+  <package id="System.Drawing.Common" version="4.5.1" targetFramework="net471" />
+  <package id="System.Security.AccessControl" version="4.5.0" targetFramework="net471" />
+  <package id="System.Security.Principal.Windows" version="4.5.0" targetFramework="net471" />
   <package id="System.Windows.Interactivity.WPF" version="2.0.20525" targetFramework="net471" />
   <package id="Text.Analyzers" version="2.6.4" targetFramework="net471" developmentDependency="true" />
 </packages>

--- a/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
+++ b/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
@@ -44,20 +44,20 @@
     <DefineConstants>$(DefineConstants);FAKES_SUPPORTED</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Axe.Windows.Actions, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Actions.dll</HintPath>
+    <Reference Include="Axe.Windows.Actions, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Actions.dll</HintPath>
     </Reference>
     <Reference Include="Axe.Windows.Actions.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\Axe.Windows.Actions.Fakes.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Automation, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Automation.dll</HintPath>
+    <Reference Include="Axe.Windows.Automation, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Automation.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Core, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Core.dll</HintPath>
+    <Reference Include="Axe.Windows.Core, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Desktop, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Desktop.dll</HintPath>
+    <Reference Include="Axe.Windows.Desktop, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Axe.Windows.Desktop.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\Axe.Windows.Desktop.Fakes.dll</HintPath>
@@ -68,17 +68,20 @@
     <Reference Include="AccessibilityInsights.SharedUx.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\AccessibilityInsights.SharedUx.Fakes.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Rules, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Rules.dll</HintPath>
+    <Reference Include="Axe.Windows.Rules, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Rules.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.RuleSelection, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.RuleSelection.dll</HintPath>
+    <Reference Include="Axe.Windows.RuleSelection, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.RuleSelection.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Telemetry, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Telemetry.dll</HintPath>
+    <Reference Include="Axe.Windows.SystemAbstractions, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.SystemAbstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Win32, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Win32.dll</HintPath>
+    <Reference Include="Axe.Windows.Telemetry, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Telemetry.dll</HintPath>
+    </Reference>
+    <Reference Include="Axe.Windows.Win32, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Win32.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
@@ -91,6 +94,9 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Registry.4.5.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.10.1\lib\net45\Moq.dll</HintPath>
@@ -109,8 +115,17 @@
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Drawing.Common.4.5.1\lib\net461\System.Drawing.Common.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.AccessControl, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.4.5.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.5.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/src/AccessibilityInsights.SharedUxTests/packages.config
+++ b/src/AccessibilityInsights.SharedUxTests/packages.config
@@ -1,13 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Axe.Windows" version="0.3.1-prerelease" targetFramework="net471" />
+  <package id="Axe.Windows" version="0.3.2-prerelease" targetFramework="net471" />
   <package id="Castle.Core" version="4.3.1" targetFramework="net471" />
+  <package id="Microsoft.Win32.Registry" version="4.5.0" targetFramework="net471" />
   <package id="Moq" version="4.10.1" targetFramework="net471" />
   <package id="MSTest.TestAdapter" version="1.4.0" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="1.4.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
+  <package id="System.Drawing.Common" version="4.5.1" targetFramework="net471" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net471" />
+  <package id="System.Security.AccessControl" version="4.5.0" targetFramework="net471" />
+  <package id="System.Security.Principal.Windows" version="4.5.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net471" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net471" />
 </packages>

--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -53,32 +53,38 @@
     <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Axe.Windows.Actions, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Actions.dll</HintPath>
+    <Reference Include="Axe.Windows.Actions, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Actions.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Automation, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Automation.dll</HintPath>
+    <Reference Include="Axe.Windows.Automation, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Automation.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Core, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Core.dll</HintPath>
+    <Reference Include="Axe.Windows.Core, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Desktop, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Desktop.dll</HintPath>
+    <Reference Include="Axe.Windows.Desktop, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Desktop.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Rules, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Rules.dll</HintPath>
+    <Reference Include="Axe.Windows.Rules, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Rules.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.RuleSelection, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.RuleSelection.dll</HintPath>
+    <Reference Include="Axe.Windows.RuleSelection, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.RuleSelection.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Telemetry, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Telemetry.dll</HintPath>
+    <Reference Include="Axe.Windows.SystemAbstractions, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.SystemAbstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Win32, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Win32.dll</HintPath>
+    <Reference Include="Axe.Windows.Telemetry, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Telemetry.dll</HintPath>
+    </Reference>
+    <Reference Include="Axe.Windows.Win32, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Win32.dll</HintPath>
     </Reference>
     <Reference Include="CommandLine, Version=2.5.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
       <HintPath>..\packages\CommandLineParser.2.5.0\lib\net461\CommandLine.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Registry.4.5.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -87,6 +93,15 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Drawing.Common.4.5.1\lib\net461\System.Drawing.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.AccessControl, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.4.5.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.5.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>

--- a/src/AccessibilityInsights/packages.config
+++ b/src/AccessibilityInsights/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Axe.Windows" version="0.3.1-prerelease" targetFramework="net471" />
+  <package id="Axe.Windows" version="0.3.2-prerelease" targetFramework="net471" />
   <package id="CommandLineParser" version="2.5.0" targetFramework="net471" />
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.2" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.2" targetFramework="net471" />
@@ -8,8 +8,12 @@
   <package id="Microsoft.NetCore.Analyzers" version="2.9.2" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.2" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net471" developmentDependency="true" />
+  <package id="Microsoft.Win32.Registry" version="4.5.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
+  <package id="System.Drawing.Common" version="4.5.1" targetFramework="net471" />
+  <package id="System.Security.AccessControl" version="4.5.0" targetFramework="net471" />
+  <package id="System.Security.Principal.Windows" version="4.5.0" targetFramework="net471" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net471" />
   <package id="System.Windows.Interactivity.WPF" version="2.0.20525" targetFramework="net471" />
   <package id="Text.Analyzers" version="2.6.4" targetFramework="net471" developmentDependency="true" />

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -69,7 +69,11 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
               <File Source="..\AccessibilityInsights\bin\Release\Axe.Windows.Win32.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\CommandLine.dll"/>
               <File Source="..\AccessibilityInsights\bin\Release\Microsoft.Deployment.WindowsInstaller.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\Microsoft.Win32.Registry.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\Newtonsoft.Json.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\System.Drawing.Common.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\System.Security.AccessControl.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\System.Security.Principal.Windows.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\System.ValueTuple.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\System.Windows.Interactivity.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\ThirdPartyNotices.html"/>

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -64,6 +64,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
               <File Source="..\AccessibilityInsights\bin\Release\Axe.Windows.Desktop.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\Axe.Windows.Rules.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\Axe.Windows.RuleSelection.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\Axe.Windows.SystemAbstractions.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\Axe.Windows.Telemetry.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\Axe.Windows.Win32.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\CommandLine.dll"/>

--- a/src/UITests/UITests.csproj
+++ b/src/UITests/UITests.csproj
@@ -43,29 +43,32 @@
     <Reference Include="Appium.Net, Version=4.0.0.6, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Appium.WebDriver.4.0.0.6-beta\lib\net45\Appium.Net.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Actions, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Actions.dll</HintPath>
+    <Reference Include="Axe.Windows.Actions, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Actions.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Automation, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Automation.dll</HintPath>
+    <Reference Include="Axe.Windows.Automation, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Automation.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Core, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Core.dll</HintPath>
+    <Reference Include="Axe.Windows.Core, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Desktop, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Desktop.dll</HintPath>
+    <Reference Include="Axe.Windows.Desktop, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Desktop.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Rules, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Rules.dll</HintPath>
+    <Reference Include="Axe.Windows.Rules, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Rules.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.RuleSelection, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.RuleSelection.dll</HintPath>
+    <Reference Include="Axe.Windows.RuleSelection, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.RuleSelection.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Telemetry, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Telemetry.dll</HintPath>
+    <Reference Include="Axe.Windows.SystemAbstractions, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.SystemAbstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Axe.Windows.Win32, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Axe.Windows.0.3.1-prerelease\lib\net471\Axe.Windows.Win32.dll</HintPath>
+    <Reference Include="Axe.Windows.Telemetry, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Telemetry.dll</HintPath>
+    </Reference>
+    <Reference Include="Axe.Windows.Win32, Version=0.3.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Axe.Windows.0.3.2-prerelease\lib\net471\Axe.Windows.Win32.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
@@ -75,6 +78,9 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Registry.4.5.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -89,6 +95,15 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Drawing.Common.4.5.1\lib\net461\System.Drawing.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.AccessControl, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.4.5.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.5.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="WebDriver, Version=3.141.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Selenium.WebDriver.3.141.0\lib\net45\WebDriver.dll</HintPath>

--- a/src/UITests/packages.config
+++ b/src/UITests/packages.config
@@ -1,13 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Axe.Windows" version="0.3.1-prerelease" targetFramework="net471" />
   <package id="Appium.WebDriver" version="4.0.0.6-beta" targetFramework="net471" />
+  <package id="Axe.Windows" version="0.3.2-prerelease" targetFramework="net471" />
   <package id="Castle.Core" version="4.3.1" targetFramework="net471" />
   <package id="DotNetSeleniumExtras.PageObjects" version="3.11.0" targetFramework="net471" />
+  <package id="Microsoft.Win32.Registry" version="4.5.0" targetFramework="net471" />
   <package id="MSTest.TestAdapter" version="1.4.0" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="1.4.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
   <package id="Selenium.Support" version="3.141.0" targetFramework="net471" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
+  <package id="System.Drawing.Common" version="4.5.1" targetFramework="net471" />
+  <package id="System.Security.AccessControl" version="4.5.0" targetFramework="net471" />
+  <package id="System.Security.Principal.Windows" version="4.5.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
#### Describe the change
Update to Axe.Windows 0.3.2 (VS made all of the changes to the .csproj and .config files). Manually update Product.wxs to reflect the revised fileset (1 new assembly in Axe.Windows, 4 new dependent assemblies).

While validating this, I found an issue (cause unknown) in the thread handling, with the following behavior:
1. Start AIWin under the debugger
2. Open a file (A11yEvent or A11yTest)
3. Close AIWin

The UI closes and the app should be done, but a thread is still running, meaning that you need to kill the app via the debugger. This problem is limited to running with the debugger, so it should not be a blocker for customer use.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



