### PR TITLE
Add LiveMode TestCategory to temporarily disable flaky UI test

### DIFF
--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -38,7 +38,7 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: ${{ parameters.configuration }}
       runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
-      testFiltercriteria: 'TestCategory=UITest'
+      testFiltercriteria: 'TestCategory=Integration&TestCategory!=LiveMode'
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Stop - WinAppDriver'

--- a/src/UITests/GettingStartedPage.cs
+++ b/src/UITests/GettingStartedPage.cs
@@ -12,8 +12,7 @@ namespace UITests
         /// we want to use them sparingly.
         /// </summary>
         [TestMethod]
-        [TestCategory("NoStrongName")]
-        [TestCategory("UITest")]
+        [TestCategory(TestCategory.NoStrongName), TestCategory(TestCategory.Integration)]
         public void GettingStartedPageTests()
         {
             VerifyGettingStartedTitle();

--- a/src/UITests/LiveMode.cs
+++ b/src/UITests/LiveMode.cs
@@ -18,8 +18,7 @@ namespace UITests
         /// we want to use them sparingly.
         /// </summary>
         [TestMethod]
-        [TestCategory("NoStrongName")]
-        [TestCategory("UITest")]
+        [TestCategory(TestCategory.NoStrongName), TestCategory(TestCategory.Integration), TestCategory(TestCategory.LiveMode)]
         public void LiveModeTests()
         {
             TestLiveMode();

--- a/src/UITests/LoadEventFile.cs
+++ b/src/UITests/LoadEventFile.cs
@@ -20,8 +20,7 @@ namespace UITests
         /// we want to use them sparingly.
         /// </summary>
         [TestMethod]
-        [TestCategory("NoStrongName")]
-        [TestCategory("UITest")]
+        [TestCategory(TestCategory.NoStrongName), TestCategory(TestCategory.Integration)]
         public void LoadEventFileTests()
         {
             driver.Maximize();

--- a/src/UITests/LoadTestFile.cs
+++ b/src/UITests/LoadTestFile.cs
@@ -20,8 +20,7 @@ namespace UITests
         /// we want to use them sparingly.
         /// </summary>
         [TestMethod]
-        [TestCategory("NoStrongName")]
-        [TestCategory("UITest")]
+        [TestCategory(TestCategory.NoStrongName), TestCategory(TestCategory.Integration)]
         public void LoadTestFileTests()
         {
             driver.VerifyAccessibility(TestContext, "AutomatedChecks", 0);

--- a/src/UITests/SettingsPage.cs
+++ b/src/UITests/SettingsPage.cs
@@ -15,8 +15,7 @@ namespace UITests
         /// we want to use them sparingly.
         /// </summary>
         [TestMethod]
-        [TestCategory("NoStrongName")]
-        [TestCategory("UITest")]
+        [TestCategory(TestCategory.NoStrongName), TestCategory(TestCategory.Integration)]
         public void SettingsPageTests()
         {
             CheckApplicationTab();

--- a/src/UITests/TelemetryDialog.cs
+++ b/src/UITests/TelemetryDialog.cs
@@ -12,8 +12,7 @@ namespace UITests
         /// we want to use them sparingly.
         /// </summary>
         [TestMethod]
-        [TestCategory("NoStrongName")]
-        [TestCategory("UITest")]
+        [TestCategory(TestCategory.NoStrongName), TestCategory(TestCategory.Integration)]
         public void TelemetryDialogTests()
         {
             VerifyTelemetryDialog();

--- a/src/UITests/TestCategory.cs
+++ b/src/UITests/TestCategory.cs
@@ -1,4 +1,6 @@
-﻿namespace UITests
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+namespace UITests
 {
     public static class TestCategory
     {

--- a/src/UITests/TestCategory.cs
+++ b/src/UITests/TestCategory.cs
@@ -1,0 +1,9 @@
+﻿namespace UITests
+{
+    public static class TestCategory
+    {
+        public const string Integration = "Integration";
+        public const string NoStrongName = "NoStrongName";
+        public const string LiveMode = "LiveMode";
+    }
+}

--- a/src/UITests/UITests.csproj
+++ b/src/UITests/UITests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="SettingsPage.cs" />
     <Compile Include="TelemetryDialog.cs" />
     <Compile Include="LoadTestFile.cs" />
+    <Compile Include="TestCategory.cs" />
     <Compile Include="UILibrary\AIWinDriver.cs" />
     <Compile Include="UILibrary\EventsMode.cs" />
     <Compile Include="UILibrary\GettingStarted.cs" />


### PR DESCRIPTION
#### Describe the change
This PR uses TestCategory to disable the LiveMode UI test until it can be made more dependable.
The TestCategory class is introduced to define TestCategories in a more structured way. This is in line with [what axe-windows does](https://github.com/microsoft/axe-windows/blob/master/src/UnitTestSharedLibrary/TestCategory.cs).

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



