### PR TITLE
Use VS to update to System.Runtime 4.3.1

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
@@ -131,6 +131,10 @@
     <Reference Include="System.Net.Http.Formatting, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.6\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/packages.config
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/packages.config
@@ -31,7 +31,7 @@
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net471" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net471" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net471" />
-  <package id="System.Runtime" version="4.3.0" targetFramework="net471" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="net471" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net471" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net471" />
   <package id="System.Runtime.Serialization.Json" version="4.3.0" targetFramework="net471" />


### PR DESCRIPTION
#### Describe the change
Use VS to update to System.Runtime 4.3.1. Change suggested by dependabot in #484, done through Visual Studio. Validated by ensuring that ADO issue filing still works from a locally built MSI 

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



