### PR TITLE
Use VS to update to ApplicationInsights 2.10.0

### DIFF
--- a/src/AccessibilityInsights.Extensions.Telemetry/Extensions.Telemetry.csproj
+++ b/src/AccessibilityInsights.Extensions.Telemetry/Extensions.Telemetry.csproj
@@ -42,8 +42,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.2.8.1\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.2.10.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -51,6 +51,7 @@
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="OSHelpers.cs" />

--- a/src/AccessibilityInsights.Extensions.Telemetry/packages.config
+++ b/src/AccessibilityInsights.Extensions.Telemetry/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.8.1" targetFramework="net471" />
+  <package id="Microsoft.ApplicationInsights" version="2.10.0" targetFramework="net471" />
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.2" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.2" targetFramework="net471" />
   <package id="Microsoft.CodeQuality.Analyzers" version="2.9.2" targetFramework="net471" developmentDependency="true" />

--- a/src/AccessibilityInsights.Extensions.TelemetryTests/Extensions.TelemetryTests.csproj
+++ b/src/AccessibilityInsights.Extensions.TelemetryTests/Extensions.TelemetryTests.csproj
@@ -44,8 +44,8 @@
     <Reference Include="AccessibilityInsights.Extensions.Telemetry.Fakes" Condition="$(FAKES_SUPPORTED) == 1">
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\AccessibilityInsights.Extensions.Telemetry.Fakes.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.2.8.1\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.2.10.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.QualityTools.Testing.Fakes, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="$(FAKES_SUPPORTED) == 1" />
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -71,6 +71,7 @@
     <Compile Include="OSHelpersUnitTests.cs" Condition="$(FAKES_SUPPORTED) == 1" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\..\build\delaysign.targets" />

--- a/src/AccessibilityInsights.Extensions.TelemetryTests/app.config
+++ b/src/AccessibilityInsights.Extensions.TelemetryTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/AccessibilityInsights.Extensions.TelemetryTests/packages.config
+++ b/src/AccessibilityInsights.Extensions.TelemetryTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.8.1" targetFramework="net471" />
+  <package id="Microsoft.ApplicationInsights" version="2.10.0" targetFramework="net471" />
   <package id="MSTest.TestAdapter" version="1.4.0" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="1.4.0" targetFramework="net471" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net471" />

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -111,6 +111,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                    <File Source="..\AccessibilityInsights.Extensions.Telemetry\bin\Release\AccessibilityInsights.Extensions.Telemetry.dll" Id="telemetry_extension"/>
                    <File Source="..\AccessibilityInsights.Extensions.Telemetry\bin\Release\AccessibilityInsights.Extensions.Telemetry.dll.config" />
                    <File Source="..\AccessibilityInsights.Extensions.Telemetry\bin\Release\Microsoft.ApplicationInsights.dll" Id="applicationinsights_extension" />
+                   <File Source="..\AccessibilityInsights.Extensions.Telemetry\bin\Release\System.Diagnostics.DiagnosticSource.dll" Id="diagnosticsource_extension" />
 
                    <!-- AzureDevOps Extension Assemblies -->
                    <File Source="..\AccessibilityInsights.Extensions.AzureDevOps\bin\Release\AccessibilityInsights.Extensions.AzureDevOps.dll" Id="extensions_AzureDevOps_extension"/>


### PR DESCRIPTION
#### Describe the change
Use VS to update to ApplicationInsights 2.10.0. This was suggested by dependabot in #483, but this does it via VS. Validation that telemetry from the privately built MSI is flowing normally into the telemetry pipeline.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



