### PR TITLE
Generalize CODEOWNERS to use whole-team alias

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners for everything in the repository.
-*   @Microsoft/accessibility-insights-windows-code-owners
+*   @microsoft/accessibility-insights-code-owners


### PR DESCRIPTION
#### Describe the change

We've started updating all the accessibility insights repos to use a shared CODEOWNERS team, rather than maintaining separate ones per project. This brings accessibility-insights-windows up to date with this new policy.

#### PR checklist

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



