### PR TITLE
Add WCAG 2.1 support to color contrast dialog

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -204,7 +204,7 @@
                                         <Setter.Value>
                                             <MultiBinding StringFormat="{}{0} {1}">
                                                 <Binding RelativeSource="{RelativeSource Self}" Path="Text"></Binding>
-                                                <Binding ElementName="regularText" Path="Text"></Binding>
+                                                <Binding ElementName="regularSizeText" Path="Text"></Binding>
                                             </MultiBinding>
                                         </Setter.Value>
                                     </Setter>
@@ -263,7 +263,7 @@
                                         <Setter.Value>
                                             <MultiBinding StringFormat="{}{0} {1}">
                                                 <Binding RelativeSource="{RelativeSource Self}" Path="Text"></Binding>
-                                                <Binding ElementName="largeText" Path="Text"></Binding>
+                                                <Binding ElementName="largeSizeText" Path="Text"></Binding>
                                             </MultiBinding>
                                         </Setter.Value>
                                     </Setter>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -345,13 +345,14 @@
                     <StackPanel Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="4 0">
                         <TextBlock x:Name="nonTextObject" Text="{x:Static Properties:Resources.ColorContrast_NonTextObjectsText}" FontSize="{DynamicResource ConstLargeTextSize}" FontWeight="SemiBold" Margin="0 8 0 0"/>
                         <TextBlock  Margin="0 0 0 8">
-                            <!--  Non-standard line break before the hyperlink is intentional to avoid whitespace before the link -->
+                            <!--  Non-standard line breaks around the hyperlink are intentional to avoid whitespaces around the link -->
                             <Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.ColorContrast_RequiresNonTextObjectsPre}" /><Hyperlink
                                 TextDecorations="{x:Null}" AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_11}" Click="hlWCAG_1_4_11_Click">
                                 <Run Text="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_11}" />
-                            </Hyperlink>
-                            <Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.TextNewForWCAG_2_1}" />
-                            <Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.ColorContrast_RequiresNonTextObjectsPost}" />
+                            </Hyperlink><Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.ColorContrast_RequiresNonTextObjectsPost}" />
+                            <Border Margin="6,0,0,-7" VerticalAlignment="Center" Background="{DynamicResource ResourceKey=LightGreyBrush}" CornerRadius="10">
+                                <TextBlock Text="{x:Static Properties:Resources.TextNewForWCAG_2_1}" Margin="6,4,6,4" Foreground="Black"/>
+                            </Border>
                         </TextBlock>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal"

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -392,11 +392,11 @@
                                                       Grid.Row="0"
                                                       Grid.Column="0"
                                                       VerticalAlignment="Center"
-                                                      Margin="18 0 0 0"
+                                                      Margin="12 0 0 0"
                                                       Background="Transparent"
                                                       Foreground="{Binding Path=ContrastVM.SecondColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"
-                                                      GlyphName="ToggleThumb"
-                                                      GlyphSize="Small">
+                                                      GlyphName="LocationDot"
+                                                      GlyphSize="Large">
                             </fabric:FabricIconControl>
                         </Grid>
                     </StackPanel>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -166,6 +166,8 @@
                         <RowDefinition MinHeight="30px"/>
                         <RowDefinition MinHeight="56px"/>
                         <RowDefinition MinHeight="56px"/>
+                        <RowDefinition MinHeight="56px"/>
+                        <RowDefinition MinHeight="56px"/>
                     </Grid.RowDefinitions>
                     <Border Grid.Row="0" Grid.ColumnSpan="4" BorderBrush="{DynamicResource ResourceKey=GreyBackgroundBrush}" 
                         BorderThickness="0,0,0,1" Background="{x:Null}" />
@@ -213,7 +215,7 @@
                     <StackPanel Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="4 0">
                         <TextBlock x:Name="regularSizeText" Text="{x:Static Properties:Resources.TextBlockTextRegularSize}" FontSize="{DynamicResource ConstLargeTextSize}" FontWeight="SemiBold" Margin="0 8 0 0"/>
                         <TextBlock  Margin="0 0 0 8">
-                            <!--  Non-standard line breaks around the hyperlink is intentional to avoid whitespaces around the link -->
+                            <!--  Non-standard line breaks around the hyperlink are intentional to avoid whitespaces around the link -->
                             <Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.ColorContrast_RequiresRegularSizePre}" /><Hyperlink
                                 TextDecorations="{x:Null}" AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" Click="hlWCAG_1_4_3_Click">
                                 <Run Text="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" />
@@ -272,7 +274,7 @@
                     <StackPanel Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="4 0">
                         <TextBlock x:Name="largeSizeText" Text="{x:Static Properties:Resources.TextBlockTextLargeSize}" FontSize="{DynamicResource ConstLargeTextSize}" FontWeight="SemiBold" Margin="0 8 0 0"/>
                         <TextBlock  Margin="0 0 0 8">
-                            <!--  Non-standard line breaks around the hyperlink is intentional to avoid whitespaces around the link -->
+                            <!--  Non-standard line breaks around the hyperlink are intentional to avoid whitespaces around the link -->
                             <Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.ColorContrast_RequiresLargeSizePre}" /><Hyperlink
                                 TextDecorations="{x:Null}" AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" Click="hlWCAG_1_4_3_Click">
                                 <Run Text="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" />
@@ -298,6 +300,88 @@
                            Foreground="{Binding Path=ContrastVM.SecondColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" 
                            Background="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"
                            AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_LargeSampleHelpText}" HorizontalAlignment="Left"/>
+                    </StackPanel>
+                    <Border Grid.Row="4" Grid.ColumnSpan="4" BorderBrush="{DynamicResource ResourceKey=GreyBackgroundBrush}"
+                        BorderThickness="0,0,0,1" Background="{x:Null}" />
+                    <StackPanel Orientation="Horizontal" Grid.Row="5" Grid.Column="1" Margin="4,4">
+                        <fabric:FabricIconControl x:Name="graphicalObjectGlyph" VerticalAlignment="Center" Margin="0 0 2 0">
+                            <fabric:FabricIconControl.Style>
+                                <Style TargetType="fabric:FabricIconControl" BasedOn="{StaticResource GlyphToForeground}">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Path=ContrastVM.PassNonTextObjects, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" Value="False">
+                                            <Setter Property="GlyphName" Value="AlertSolid"></Setter>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding Path=ContrastVM.PassNonTextObjects, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" Value="True">
+                                            <Setter Property="GlyphName" Value="CompletedSolid"></Setter>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </fabric:FabricIconControl.Style>
+                        </fabric:FabricIconControl>
+                        <TextBlock x:Name="nonTextObjectResult" FontWeight="SemiBold" KeyboardNavigation.IsTabStop="True" Focusable="True" FontSize="{DynamicResource ConstStandardTextSize}" Margin="8 0 0 0" 
+                               AutomationProperties.HelpText="{x:Static Properties:Resources.ColorContrast_SmallTextResultHelpText}" VerticalAlignment="Center">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Path=ContrastVM.PassNonTextObjects, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" Value="False">
+                                            <Setter Property="Text" Value="{x:Static Properties:Resources.SetterValueFail}"></Setter>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding Path=ContrastVM.PassNonTextObjects, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" Value="True">
+                                            <Setter Property="Text" Value="{x:Static Properties:Resources.SetterValuePass}"></Setter>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                    <Setter Property="AutomationProperties.Name">
+                                        <Setter.Value>
+                                            <MultiBinding StringFormat="{}{0} {1}">
+                                                <Binding RelativeSource="{RelativeSource Self}" Path="Text"></Binding>
+                                                <Binding ElementName="nonTextObject" Path="Text"></Binding>
+                                            </MultiBinding>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </StackPanel>
+                    <StackPanel Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="4 0">
+                        <TextBlock x:Name="nonTextObject" Text="{x:Static Properties:Resources.ColorContrast_NonTextObjectsText}" FontSize="{DynamicResource ConstLargeTextSize}" FontWeight="SemiBold" Margin="0 8 0 0"/>
+                        <TextBlock  Margin="0 0 0 8">
+                            <!--  Non-standard line break before the hyperlink is intentional to avoid whitespace before the link -->
+                            <Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.ColorContrast_RequiresNonTextObjectsPre}" /><Hyperlink
+                                TextDecorations="{x:Null}" AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_11}" Click="hlWCAG_1_4_11_Click">
+                                <Run Text="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_11}" />
+                            </Hyperlink>
+                            <Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.TextNewForWCAG_2_1}" />
+                            <Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.ColorContrast_RequiresNonTextObjectsPost}" />
+                        </TextBlock>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal"
+                                Grid.Row="6"
+                                Grid.Column="2"
+                                HorizontalAlignment="Left"
+                                Margin="4,0"
+                                Width="Auto"
+                                Background="{Binding Path=ContrastVM.SecondColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}">
+                        <fabric:FabricIconControl x:Name="nonTextObjectSample1"
+                                                  VerticalAlignment="Center"
+                                                  Margin="10 0 8 0"
+                                                  Foreground="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"
+                                                  GlyphName="CheckboxCompositeReversed"
+                                                  GlyphSize="Larger">
+                        </fabric:FabricIconControl>
+                        <fabric:FabricIconControl x:Name="nonTextObjectSample2"
+                                                  VerticalAlignment="Center"
+                                                  Margin="10 0 8 0"
+                                                  Foreground="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"
+                                                  GlyphName="ToggleOn"
+                                                  GlyphSize="Larger">
+                        </fabric:FabricIconControl>
+                        <fabric:FabricIconControl x:Name="nonTextObjectSample3"
+                                                  VerticalAlignment="Center"
+                                                  Margin="10 0 10 0"
+                                                  Foreground="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"
+                                                  GlyphName="ToggleFilled"
+                                                  GlyphSize="Larger">
+                        </fabric:FabricIconControl>
                     </StackPanel>
                 </Grid>
             </Grid>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -375,13 +375,30 @@
                                                   GlyphName="ToggleOn"
                                                   GlyphSize="Larger">
                         </fabric:FabricIconControl>
-                        <fabric:FabricIconControl x:Name="nonTextObjectSample3"
-                                                  VerticalAlignment="Center"
-                                                  Margin="10 0 10 0"
-                                                  Foreground="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"
-                                                  GlyphName="ToggleFilled"
-                                                  GlyphSize="Larger">
-                        </fabric:FabricIconControl>
+                        <Grid Margin="10 0 8 0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <fabric:FabricIconControl x:Name="nonTestObjectSample3Underlay"
+                                                      Grid.Row="0"
+                                                      Grid.Column="0"
+                                                      VerticalAlignment="Center"
+                                                      Margin="0 0 8 0"
+                                                      Foreground="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"
+                                                      GlyphName="ToggleFilled"
+                                                      GlyphSize="Larger">
+                            </fabric:FabricIconControl>
+                            <fabric:FabricIconControl x:Name="nonTestObjectSample3Overlay"
+                                                      Grid.Row="0"
+                                                      Grid.Column="0"
+                                                      VerticalAlignment="Center"
+                                                      Margin="18 0 0 0"
+                                                      Background="Transparent"
+                                                      Foreground="{Binding Path=ContrastVM.SecondColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"
+                                                      GlyphName="ToggleThumb"
+                                                      GlyphSize="Small">
+                            </fabric:FabricIconControl>
+                        </Grid>
                     </StackPanel>
                 </Grid>
             </Grid>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -351,7 +351,7 @@
                                 <Run Text="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_11}" />
                             </Hyperlink><Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.ColorContrast_RequiresNonTextObjectsPost}" />
                             <Border Margin="6,0,0,-7" VerticalAlignment="Center" Background="{DynamicResource ResourceKey=LightGreyBrush}" CornerRadius="10">
-                                <TextBlock Text="{x:Static Properties:Resources.TextNewForWCAG_2_1}" Margin="6,4,6,4" Foreground="Black"/>
+                                <TextBlock Text="{x:Static Properties:Resources.TextNewForWCAG_2_1}" Margin="6,4,6,4" Foreground="{DynamicResource ResourceKey=WindowTextBrush}"/>
                             </Border>
                         </TextBlock>
                     </StackPanel>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -42,38 +42,27 @@
                 <Label Grid.Row="0" Content="{x:Static Properties:Resources.ColorContrastAutomationPropertiesName}"
                 FontSize="{DynamicResource ConstXXLTextSize}"
                 Style="{StaticResource lblHeader}" HorizontalAlignment="Left" Margin="0,0,0,16"/>
-                <Grid Grid.Row="1" Grid.ColumnSpan="2" Height="24" VerticalAlignment="Top">
+                <TextBlock Grid.Row="1" FontSize="{DynamicResource StandardTextSize}" Margin="0,0,0,0" TextWrapping="Wrap" Grid.ColumnSpan="2" VerticalAlignment="Center">
+                <Run FontSize="{DynamicResource StandardTextSize}" Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.ColorContrast_IntroRun}" />
+                <Hyperlink
+                    TextDecorations="{x:Null}" AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_IntroLink}" Click="hlLearnAboutColorContrast_Click">
+                    <Run Text="{x:Static Properties:Resources.ColorContrast_IntroLink}" />
+                </Hyperlink>
+                </TextBlock>
+                <Grid Grid.Row="2" Grid.ColumnSpan="2" Height="24" Margin="0,16,0,0" VerticalAlignment="Top">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="4"/>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="4"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <Label Name="lblAutoDetect" Content="{x:Static Properties:Resources.lblAutoDetectContent}" Grid.Column="1" VerticalAlignment="Center" Style="{StaticResource lblDark}"/>
-                    <ToggleButton Style="{StaticResource tgbSlider}" Grid.Column="3" Name="tgbtnAutoDetect" Margin="20,0,0,0" AutomationProperties.LabeledBy="{Binding ElementName=lblAutoDetect}" Click="TgbtnAutoDetect_Click">
+                    <Label Name="lblAutoDetect" Content="{x:Static Properties:Resources.lblAutoDetectContent}" Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource lblDark}"/>
+                    <ToggleButton Style="{StaticResource tgbSlider}" Grid.Column="2" Name="tgbtnAutoDetect" Margin="20,0,0,0" AutomationProperties.LabeledBy="{Binding ElementName=lblAutoDetect}" Click="TgbtnAutoDetect_Click">
                         <ToggleButton.ToolTip>
                             <Run Text="{x:Static Properties:Resources.CCToggleToolTip}"/>
                         </ToggleButton.ToolTip>
                     </ToggleButton>
                 </Grid>
-                <TextBlock Grid.Row="2"  Margin="0,16,0,0" Grid.ColumnSpan="2" VerticalAlignment="Center">
-                <Run FontWeight="SemiBold" FontSize="{DynamicResource ConstXLTextSize}" Text="{x:Static Properties:Resources.RunTextHowToTest}" />
-                <Hyperlink TextDecorations="{x:Null}" ToolTip="{x:Static Properties:Resources.RunTextHowToTest}" AutomationProperties.Name="{x:Static Properties:Resources.RunTextHowToTest}" Click="hlHowToTest_Click">
-                    <fabric:FabricIconControl GlyphName="Info" GlyphSize="Small" Margin="0,0,0,-2" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
-                </Hyperlink>
-                </TextBlock>
-                <TextBlock Grid.Row="3" FontSize="{DynamicResource StandardTextSize}" TextWrapping="Wrap" KeyboardNavigation.IsTabStop="True"
-                         Margin="0 5 115 4" Grid.ColumnSpan="2" Foreground="{DynamicResource ResourceKey=TextBrushGray}" Style="{StaticResource TbFocusable}">
-                <Run Text="{x:Static Properties:Resources.ColorContrast_HowToTestAuto}" AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_HowToTestAuto}"/>
-                </TextBlock>
-                <TextBlock Grid.Row="4" FontSize="{DynamicResource StandardTextSize}" TextWrapping="Wrap" KeyboardNavigation.IsTabStop="True" Foreground="{DynamicResource ResourceKey=TextBrushGray}"
-                         Margin="0 4 115 10" Grid.ColumnSpan="2" Style="{StaticResource TbFocusable}">
-                        <Run Text="{x:Static Properties:Resources.ColorContrast_HowToTestManualPre}"/>
-                        <fabric:FabricIconControl GlyphName="Eyedropper" GlyphSize="Default" Foreground="{DynamicResource ResourceKey=TextBrushGray}" FontSize="{DynamicResource StandardTextSize}"/>
-                        <Run Text="{x:Static Properties:Resources.ColorContrast_HowToTestManualPost}"/>
-                </TextBlock>
-                <Label Grid.Row="5"  Margin="0,6,0,5" Grid.ColumnSpan="2" VerticalAlignment="Center" Style="{StaticResource lblXLHeader}" Content="{x:Static Properties:Resources.ColorContrast_Analyzer}"></Label>
-                <Grid Grid.Row="6" Grid.Column="0">
+                <Grid Grid.Row="3" Grid.Column="0" Margin="0,16,0,0">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" MinWidth="240"/>
                         <ColumnDefinition Width="1*"/>
@@ -111,7 +100,7 @@
                                />
                     </StackPanel>
                 </Grid>
-                <Grid Grid.Row="6" Grid.Column="1">
+                <Grid Grid.Row="3" Grid.Column="1" Margin="0,16,0,0">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" MinWidth="240"/>
                         <ColumnDefinition Width="1*"/>
@@ -146,7 +135,7 @@
                         </StackPanel>
                     </Border>
                 </Grid>
-                <Grid Grid.Row="8" Margin="0,12,115,0" Grid.ColumnSpan="2">
+                <Grid Grid.Row="4" Margin="0,12,115,0" Grid.ColumnSpan="2">
                     <Grid.Resources>
                         <Style TargetType="{x:Type TextBlock}">
                             <Setter Property="FontSize" Value="12"/>
@@ -166,6 +155,7 @@
                         </Style>
                     </Grid.Resources>
                     <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="4"/>
                         <ColumnDefinition Width="80"/>
                         <ColumnDefinition Width="180"/>
                         <ColumnDefinition Width="*"/>
@@ -177,11 +167,11 @@
                         <RowDefinition MinHeight="56px"/>
                         <RowDefinition MinHeight="56px"/>
                     </Grid.RowDefinitions>
-                    <Border Grid.Row="0" Grid.ColumnSpan="3" BorderBrush="{DynamicResource ResourceKey=GreyBackgroundBrush}" 
+                    <Border Grid.Row="0" Grid.ColumnSpan="4" BorderBrush="{DynamicResource ResourceKey=GreyBackgroundBrush}" 
                         BorderThickness="0,0,0,1" Background="{x:Null}" />
-                    <TextBlock Text="{x:Static Properties:Resources.TextBlockTextResult}" Grid.Row="0" Grid.Column="0"/>
-                    <TextBlock Text="{x:Static Properties:Resources.TextBlockTextTextSize}" Grid.Row="0" Grid.Column="1"/>
-                    <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="0" Margin="4,4">
+                    <TextBlock FontWeight="Bold" Text="{x:Static Properties:Resources.TextBlockTextResult}" Grid.Row="0" Grid.Column="1"/>
+                    <TextBlock FontWeight="Bold" Text="{x:Static Properties:Resources.TextBlockTextElement}" Grid.Row="0" Grid.Column="2"/>
+                    <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1" Margin="4,4">
                         <fabric:FabricIconControl x:Name="smallTextGlyph" VerticalAlignment="Center" Margin="0 0 2 0">
                             <fabric:FabricIconControl.Style>
                                 <Style TargetType="fabric:FabricIconControl" BasedOn="{StaticResource GlyphToForeground}">
@@ -220,21 +210,27 @@
                             </TextBlock.Style>
                         </TextBlock>
                     </StackPanel>
-                    <StackPanel Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Margin="4 0">
-                        <TextBlock x:Name="regularText" Text="{x:Static Properties:Resources.TextBlockTextRegular}" FontSize="{DynamicResource ConstStandardTextSize}" Margin="0 8 0 0"/>
-                        <TextBlock Text="{x:Static Properties:Resources.TextBlockTextRequiresRatio}" Margin="0 0 0 8"/>
+                    <StackPanel Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="4 0">
+                        <TextBlock x:Name="regularSizeText" Text="{x:Static Properties:Resources.TextBlockTextRegularSize}" FontSize="{DynamicResource ConstLargeTextSize}" FontWeight="SemiBold" Margin="0 8 0 0"/>
+                        <TextBlock  Margin="0 0 0 8">
+                            <!--  Non-standard line breaks around the hyperlink is intentional to avoid whitespaces around the link -->
+                            <Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.ColorContrast_RequiresRegularSizePre}" /><Hyperlink
+                                TextDecorations="{x:Null}" AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" Click="hlWCAG_1_4_3_Click">
+                                <Run Text="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" />
+                            </Hyperlink><Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.ColorContrast_RequiresRegularSizePost}" />
+                        </TextBlock>
                     </StackPanel>
-                    <TextBlock x:Name="smallSample" Text="{x:Static Properties:Resources.smallSampleText}" Grid.Row="2" Grid.Column="1" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"
+                    <TextBlock x:Name="smallSample" Text="{x:Static Properties:Resources.smallSampleText}" Grid.Row="2" Grid.Column="2" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"
                        Foreground="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" 
                        Background="{Binding Path=ContrastVM.SecondColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" 
                        AutomationProperties.HelpText="{x:Static Properties:Resources.ColorContrast_SmallSampleHelpText}" HorizontalAlignment="Left" FontSize="{DynamicResource ConstStandardTextSize}"/>
-                    <TextBlock x:Name="smallSampleInverted" Text="{x:Static Properties:Resources.smallSampleText}" Grid.Row="2" Grid.Column="2" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"
+                    <TextBlock x:Name="smallSampleInverted" Text="{x:Static Properties:Resources.smallSampleText}" Grid.Row="2" Grid.Column="3" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"
                        Foreground="{Binding Path=ContrastVM.SecondColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" 
                        Background="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" 
                        AutomationProperties.HelpText="{x:Static Properties:Resources.ColorContrast_SmallSampleHelpText}" HorizontalAlignment="Left" FontSize="{DynamicResource ConstStandardTextSize}"/>
-                    <Border Grid.Row="2" Grid.ColumnSpan="3" BorderBrush="{DynamicResource ResourceKey=GreyBackgroundBrush}"
+                    <Border Grid.Row="2" Grid.ColumnSpan="4" BorderBrush="{DynamicResource ResourceKey=GreyBackgroundBrush}"
                         BorderThickness="0,0,0,1" Background="{x:Null}" />
-                    <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="0" Margin="4,4">
+                    <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" Margin="4,4">
                         <fabric:FabricIconControl x:Name="largeTextGlyph" VerticalAlignment="Center" Margin="0 0 2 0">
                             <fabric:FabricIconControl.Style>
                                 <Style TargetType="fabric:FabricIconControl" BasedOn="{StaticResource GlyphToForeground}">
@@ -273,12 +269,17 @@
                             </TextBlock.Style>
                         </TextBlock>
                     </StackPanel>
-                    <StackPanel Grid.Row="3" Grid.Column="1" VerticalAlignment="Center" Margin="4 0">
-                        <TextBlock x:Name="largeText" Text="{x:Static Properties:Resources.ColorContrast_Large}" FontSize="{DynamicResource ConstStandardTextSize}"/>
-                        <TextBlock Text="{x:Static Properties:Resources.ColorContrast_FontSizes}" Margin="0"/>
-                        <TextBlock Text="{x:Static Properties:Resources.ColorContrast_Requires}" Margin="0 0 0 8"/>
+                    <StackPanel Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="4 0">
+                        <TextBlock x:Name="largeSizeText" Text="{x:Static Properties:Resources.TextBlockTextLargeSize}" FontSize="{DynamicResource ConstLargeTextSize}" FontWeight="SemiBold" Margin="0 8 0 0"/>
+                        <TextBlock  Margin="0 0 0 8">
+                            <!--  Non-standard line breaks around the hyperlink is intentional to avoid whitespaces around the link -->
+                            <Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.ColorContrast_RequiresLargeSizePre}" /><Hyperlink
+                                TextDecorations="{x:Null}" AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" Click="hlWCAG_1_4_3_Click">
+                                <Run Text="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" />
+                            </Hyperlink><Run Foreground="{DynamicResource ResourceKey=TextBrushGray}" Text="{x:Static Properties:Resources.ColorContrast_RequiresLargeSizePost}" />
+                        </TextBlock>
                     </StackPanel>
-                    <StackPanel Grid.Row="4" Grid.Column="1">
+                    <StackPanel Grid.Row="4" Grid.Column="2">
                         <TextBlock x:Name="smallSampleBold" Text="{x:Static Properties:Resources.smallSampleText}" Grid.Row="0" FontSize="{DynamicResource ConstStandardTextSize}" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"
                            Foreground="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" 
                            Background="{Binding Path=ContrastVM.SecondColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"
@@ -288,7 +289,7 @@
                            Background="{Binding Path=ContrastVM.SecondColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"
                            AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_LargeSampleHelpText}" HorizontalAlignment="Left"/>
                     </StackPanel>
-                    <StackPanel Grid.Row="4" Grid.Column="2">
+                    <StackPanel Grid.Row="4" Grid.Column="3">
                         <TextBlock x:Name="smallSampleBoldInverted" Text="{x:Static Properties:Resources.smallSampleText}" Grid.Row="0" FontSize="{DynamicResource ConstStandardTextSize}" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"
                            Foreground="{Binding Path=ContrastVM.SecondColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" 
                            Background="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
@@ -32,7 +32,9 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
     /// </summary>
     public partial class ColorContrast : UserControl
     {
-        const string HelpURL = @"https://go.microsoft.com/fwlink/?linkid=2075365";
+        const string LearnAboutColorContrastURL = @"https://accessibilityinsights.io/docs/en/windows/getstarted/colorcontrast";
+        const string WCAG_1_4_3_URL = @"https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html";
+        const string WCAG_1_4_11_URL = @"https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html";
 
         public ElementContext ElementContext { get; private set; }
 
@@ -218,19 +220,40 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         }
 
         /// <summary>
-        /// Open the How to test link
+        /// Open the "WCAG 1.4.3" link
         /// </summary>
-        private void hlHowToTest_Click(object sender, RoutedEventArgs e)
+        private void hlWCAG_1_4_3_Click(object sender, RoutedEventArgs e)
+        {
+            OpenLink(WCAG_1_4_3_URL);
+        }
+
+        /// <summary>
+        /// Open the "WCAG 1.4.11" link
+        /// </summary>
+        private void hlWCAG_1_4_11_Click(object sender, RoutedEventArgs e)
+        {
+            OpenLink(WCAG_1_4_11_URL);
+        }
+
+        /// <summary>
+        /// Open the "Learn about analyzing color contrast" link
+        /// </summary>
+        private void hlLearnAboutColorContrast_Click(object sender, RoutedEventArgs e)
+        {
+            OpenLink(LearnAboutColorContrastURL);
+        }
+
+        private void OpenLink(string target)
         {
             try
             {
-                Process.Start(new ProcessStartInfo(HelpURL));
+                Process.Start(new ProcessStartInfo(target));
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
             {
                 ex.ReportException();
-                MessageDialog.Show(string.Format(CultureInfo.InvariantCulture, Properties.Resources.ColorContrast_hlHowToTest_Click, HelpURL));
+                MessageDialog.Show(string.Format(CultureInfo.InvariantCulture, Properties.Resources.ColorContrast_OpenLinkFailed, target));
             }
 #pragma warning restore CA1031 // Do not catch general exception types
         }

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1005,57 +1005,20 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (14 pt. bold or 18 pt. regular).
+        ///   Looks up a localized string similar to Learn more about analyzing color contrast..
         /// </summary>
-        public static string ColorContrast_FontSizes {
+        public static string ColorContrast_IntroLink {
             get {
-                return ResourceManager.GetString("ColorContrast_FontSizes", resourceCulture);
+                return ResourceManager.GetString("ColorContrast_IntroLink", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to open link:
-        ///{0}.
+        ///   Looks up a localized string similar to This color contrast analyzer checks for color contrast ratios and measures them against the WCAG AA guidelines..
         /// </summary>
-        public static string ColorContrast_hlHowToTest_Click {
+        public static string ColorContrast_IntroRun {
             get {
-                return ResourceManager.GetString("ColorContrast_hlHowToTest_Click", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Auto-detect an element’s color contrast ratio by hovering over or keyboard focusing on an element in your target application..
-        /// </summary>
-        public static string ColorContrast_HowToTestAuto {
-            get {
-                return ResourceManager.GetString("ColorContrast_HowToTestAuto", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to button, choosing a color from the drop-down color picker, or entering a hex code value..
-        /// </summary>
-        public static string ColorContrast_HowToTestManualPost {
-            get {
-                return ResourceManager.GetString("ColorContrast_HowToTestManualPost", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to You can manually test the color contrast ratio by selecting colors with the eyedropper.
-        /// </summary>
-        public static string ColorContrast_HowToTestManualPre {
-            get {
-                return ResourceManager.GetString("ColorContrast_HowToTestManualPre", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Large.
-        /// </summary>
-        public static string ColorContrast_Large {
-            get {
-                return ResourceManager.GetString("ColorContrast_Large", resourceCulture);
+                return ResourceManager.GetString("ColorContrast_IntroRun", resourceCulture);
             }
         }
         
@@ -1065,6 +1028,16 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string ColorContrast_LargeSampleHelpText {
             get {
                 return ResourceManager.GetString("ColorContrast_LargeSampleHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to open link:
+        ///{0}.
+        /// </summary>
+        public static string ColorContrast_OpenLinkFailed {
+            get {
+                return ResourceManager.GetString("ColorContrast_OpenLinkFailed", resourceCulture);
             }
         }
         
@@ -1087,11 +1060,38 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (Requires ratio ≥ 3.0).
+        ///   Looks up a localized string similar to ).
         /// </summary>
-        public static string ColorContrast_Requires {
+        public static string ColorContrast_RequiresLargeSizePost {
             get {
-                return ResourceManager.GetString("ColorContrast_Requires", resourceCulture);
+                return ResourceManager.GetString("ColorContrast_RequiresLargeSizePost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Requires a ratio of at least 3:1 (.
+        /// </summary>
+        public static string ColorContrast_RequiresLargeSizePre {
+            get {
+                return ResourceManager.GetString("ColorContrast_RequiresLargeSizePre", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ).
+        /// </summary>
+        public static string ColorContrast_RequiresRegularSizePost {
+            get {
+                return ResourceManager.GetString("ColorContrast_RequiresRegularSizePost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Requires a ratio of at least 4.5:1 (.
+        /// </summary>
+        public static string ColorContrast_RequiresRegularSizePre {
+            get {
+                return ResourceManager.GetString("ColorContrast_RequiresRegularSizePre", resourceCulture);
             }
         }
         
@@ -1132,39 +1132,38 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to New for WCAG 2.1.
+        /// </summary>
+        public static string ColorContrast_TextBlock_NewForWCAG_2_1 {
+            get {
+                return ResourceManager.GetString("ColorContrast_TextBlock_NewForWCAG_2_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to WCAG 1.4.11.
+        /// </summary>
+        public static string ColorContrast_TextBlock_WCAG_1_4_11 {
+            get {
+                return ResourceManager.GetString("ColorContrast_TextBlock_WCAG_1_4_11", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to WCAG 1.4.3.
+        /// </summary>
+        public static string ColorContrast_TextBlock_WCAG_1_4_3 {
+            get {
+                return ResourceManager.GetString("ColorContrast_TextBlock_WCAG_1_4_3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Color contrast analyzer.
         /// </summary>
         public static string ColorContrastAutomationPropertiesName {
             get {
                 return ResourceManager.GetString("ColorContrastAutomationPropertiesName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Regular requires ratio &gt;= {0}.
-        /// </summary>
-        public static string ColorContrastViewModel_GetBugInformation {
-            get {
-                return ResourceManager.GetString("ColorContrastViewModel_GetBugInformation", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Color contrast ratio is less than required.
-        /// </summary>
-        public static string ColorContrastViewModel_GetBugInformation_Color_contrast_ratio_is_less_than_required {
-            get {
-                return ResourceManager.GetString("ColorContrastViewModel_GetBugInformation_Color_contrast_ratio_is_less_than_requir" +
-                        "ed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Large (14pt+bold or 18pt) requires ratio &gt;= {0}.
-        /// </summary>
-        public static string ColorContrastViewModel_GetBugInformation1 {
-            get {
-                return ResourceManager.GetString("ColorContrastViewModel_GetBugInformation1", resourceCulture);
             }
         }
         
@@ -4038,11 +4037,29 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Element.
+        /// </summary>
+        public static string TextBlockTextElement {
+            get {
+                return ResourceManager.GetString("TextBlockTextElement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to HOW TO FIX.
         /// </summary>
         public static string TextBlockTextHowToFix {
             get {
                 return ResourceManager.GetString("TextBlockTextHowToFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Large text (14 pt. bold or 18 pt. regular).
+        /// </summary>
+        public static string TextBlockTextLargeSize {
+            get {
+                return ResourceManager.GetString("TextBlockTextLargeSize", resourceCulture);
             }
         }
         
@@ -4056,11 +4073,11 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Regular.
+        ///   Looks up a localized string similar to Regular text.
         /// </summary>
-        public static string TextBlockTextRegular {
+        public static string TextBlockTextRegularSize {
             get {
-                return ResourceManager.GetString("TextBlockTextRegular", resourceCulture);
+                return ResourceManager.GetString("TextBlockTextRegularSize", resourceCulture);
             }
         }
         
@@ -4088,15 +4105,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string TextBlockTextSampleText {
             get {
                 return ResourceManager.GetString("TextBlockTextSampleText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Text size.
-        /// </summary>
-        public static string TextBlockTextTextSize {
-            get {
-                return ResourceManager.GetString("TextBlockTextTextSize", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1032,6 +1032,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Graphical objects and UI components.
+        /// </summary>
+        public static string ColorContrast_NonTextObjectsText {
+            get {
+                return ResourceManager.GetString("ColorContrast_NonTextObjectsText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to open link:
         ///{0}.
         /// </summary>
@@ -1074,6 +1083,24 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string ColorContrast_RequiresLargeSizePre {
             get {
                 return ResourceManager.GetString("ColorContrast_RequiresLargeSizePre", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ).
+        /// </summary>
+        public static string ColorContrast_RequiresNonTextObjectsPost {
+            get {
+                return ResourceManager.GetString("ColorContrast_RequiresNonTextObjectsPost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Requires a ratio of at least 3:1 (.
+        /// </summary>
+        public static string ColorContrast_RequiresNonTextObjectsPre {
+            get {
+                return ResourceManager.GetString("ColorContrast_RequiresNonTextObjectsPre", resourceCulture);
             }
         }
         
@@ -1128,15 +1155,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string ColorContrast_tbConfidenceAutomationName {
             get {
                 return ResourceManager.GetString("ColorContrast_tbConfidenceAutomationName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to New for WCAG 2.1.
-        /// </summary>
-        public static string ColorContrast_TextBlock_NewForWCAG_2_1 {
-            get {
-                return ResourceManager.GetString("ColorContrast_TextBlock_NewForWCAG_2_1", resourceCulture);
             }
         }
         
@@ -4159,6 +4177,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string textboxSearchAutomationPropertiesName1 {
             get {
                 return ResourceManager.GetString("textboxSearchAutomationPropertiesName1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ADD PILL! New for WCAG 2.1.
+        /// </summary>
+        public static string TextNewForWCAG_2_1 {
+            get {
+                return ResourceManager.GetString("TextNewForWCAG_2_1", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -4181,7 +4181,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ADD PILL! New for WCAG 2.1.
+        ///   Looks up a localized string similar to New for WCAG 2.1.
         /// </summary>
         public static string TextNewForWCAG_2_1 {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1573,13 +1573,22 @@ Do you want to change the channel? </value>
   <data name="ColorContrast_RequiresRegularSizePost" xml:space="preserve">
     <value>)</value>
   </data>
-  <data name="ColorContrast_TextBlock_NewForWCAG_2_1" xml:space="preserve">
-    <value>New for WCAG 2.1</value>
-  </data>
   <data name="ColorContrast_TextBlock_WCAG_1_4_11" xml:space="preserve">
     <value>WCAG 1.4.11</value>
   </data>
   <data name="ColorContrast_TextBlock_WCAG_1_4_3" xml:space="preserve">
     <value>WCAG 1.4.3</value>
+  </data>
+  <data name="ColorContrast_NonTextObjectsText" xml:space="preserve">
+    <value>Graphical objects and UI components</value>
+  </data>
+  <data name="ColorContrast_RequiresNonTextObjectsPost" xml:space="preserve">
+    <value>)</value>
+  </data>
+  <data name="ColorContrast_RequiresNonTextObjectsPre" xml:space="preserve">
+    <value>Requires a ratio of at least 3:1 (</value>
+  </data>
+  <data name="TextNewForWCAG_2_1" xml:space="preserve">
+    <value>ADD PILL! New for WCAG 2.1</value>
   </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -497,17 +497,8 @@ Accessibility Insights Support Team
   <data name="TextBlockAutomationPropertiesNameInstructions" xml:space="preserve">
     <value>Instructions</value>
   </data>
-  <data name="ColorContrast_HowToTestAuto" xml:space="preserve">
-    <value>Auto-detect an element’s color contrast ratio by hovering over or keyboard focusing on an element in your target application.</value>
-  </data>
   <data name="ColorContrast_Analyzer" xml:space="preserve">
     <value>Analyzer</value>
-  </data>
-  <data name="ColorContrast_HowToTestManualPre" xml:space="preserve">
-    <value>You can manually test the color contrast ratio by selecting colors with the eyedropper</value>
-  </data>
-  <data name="ColorContrast_HowToTestManualPost" xml:space="preserve">
-    <value>button, choosing a color from the drop-down color picker, or entering a hex code value.</value>
   </data>
   <data name="noElementSelected" xml:space="preserve">
     <value>no element selected</value>
@@ -521,8 +512,8 @@ Accessibility Insights Support Team
   <data name="TextBlockTextResult" xml:space="preserve">
     <value>Result</value>
   </data>
-  <data name="TextBlockTextTextSize" xml:space="preserve">
-    <value>Text size</value>
+  <data name="TextBlockTextElement" xml:space="preserve">
+    <value>Element</value>
   </data>
   <data name="TextBlockTextSampleText" xml:space="preserve">
     <value>Sample text</value>
@@ -533,8 +524,8 @@ Accessibility Insights Support Team
   <data name="SetterValuePass" xml:space="preserve">
     <value>Pass</value>
   </data>
-  <data name="TextBlockTextRegular" xml:space="preserve">
-    <value>Regular</value>
+  <data name="TextBlockTextRegularSize" xml:space="preserve">
+    <value>Regular text</value>
   </data>
   <data name="TextBlockTextRequiresRatio" xml:space="preserve">
     <value>(Requires ratio ≥ 4.5)</value>
@@ -545,7 +536,7 @@ Accessibility Insights Support Team
   <data name="largeTextResultAutomationPropertiesName" xml:space="preserve">
     <value>Test result large text</value>
   </data>
-  <data name="ColorContrast_hlHowToTest_Click" xml:space="preserve">
+  <data name="ColorContrast_OpenLinkFailed" xml:space="preserve">
     <value>Failed to open link:
 {0}</value>
   </data>
@@ -1303,15 +1294,6 @@ Accessibility Insights Support Team
   <data name="ExtensionMethods_CopyStringToClipboard_Error_copying_to_clipboard" xml:space="preserve">
     <value>Error copying to clipboard: </value>
   </data>
-  <data name="ColorContrastViewModel_GetBugInformation" xml:space="preserve">
-    <value>Regular requires ratio &gt;= {0}</value>
-  </data>
-  <data name="ColorContrastViewModel_GetBugInformation1" xml:space="preserve">
-    <value>Large (14pt+bold or 18pt) requires ratio &gt;= {0}</value>
-  </data>
-  <data name="ColorContrastViewModel_GetBugInformation_Color_contrast_ratio_is_less_than_required" xml:space="preserve">
-    <value>Color contrast ratio is less than required</value>
-  </data>
   <data name="EventConfigNodeViewModel_ToString_checked" xml:space="preserve">
     <value> checked</value>
   </data>
@@ -1423,14 +1405,11 @@ Accessibility Insights Support Team
   <data name="ColorContrast_Color2" xml:space="preserve">
     <value>Color 2</value>
   </data>
-  <data name="ColorContrast_FontSizes" xml:space="preserve">
-    <value>(14 pt. bold or 18 pt. regular)</value>
-  </data>
   <data name="ColorContrast_Color1" xml:space="preserve">
     <value>Color 1</value>
   </data>
-  <data name="ColorContrast_Large" xml:space="preserve">
-    <value>Large</value>
+  <data name="TextBlockTextLargeSize" xml:space="preserve">
+    <value>Large text (14 pt. bold or 18 pt. regular)</value>
   </data>
   <data name="ColorContrast_OutputAutomationName" xml:space="preserve">
     <value>Ratio is {0}</value>
@@ -1444,8 +1423,8 @@ Accessibility Insights Support Team
   <data name="ColorContrast_Confidence" xml:space="preserve">
     <value>Confidence level</value>
   </data>
-  <data name="ColorContrast_Requires" xml:space="preserve">
-    <value>(Requires ratio ≥ 3.0)</value>
+  <data name="ColorContrast_RequiresRegularSizePre" xml:space="preserve">
+    <value>Requires a ratio of at least 4.5:1 (</value>
   </data>
   <data name="EventConfigTabControl_ckbxAllEvents" xml:space="preserve">
     <value>Listen to All Events</value>
@@ -1578,5 +1557,29 @@ Do you want to change the channel? </value>
   <data name="VersionLinkFormat" xml:space="preserve">
     <value>https://github.com/microsoft/accessibility-insights-windows/releases/tag/v{0}.{1}.{2:0000}.{3:00}</value>
     <comment>{0} - {3} are placeholders for the 4 fields of a Version object</comment>
+  </data>
+  <data name="ColorContrast_IntroLink" xml:space="preserve">
+    <value>Learn more about analyzing color contrast.</value>
+  </data>
+  <data name="ColorContrast_IntroRun" xml:space="preserve">
+    <value>This color contrast analyzer checks for color contrast ratios and measures them against the WCAG AA guidelines.</value>
+  </data>
+  <data name="ColorContrast_RequiresLargeSizePost" xml:space="preserve">
+    <value>)</value>
+  </data>
+  <data name="ColorContrast_RequiresLargeSizePre" xml:space="preserve">
+    <value>Requires a ratio of at least 3:1 (</value>
+  </data>
+  <data name="ColorContrast_RequiresRegularSizePost" xml:space="preserve">
+    <value>)</value>
+  </data>
+  <data name="ColorContrast_TextBlock_NewForWCAG_2_1" xml:space="preserve">
+    <value>New for WCAG 2.1</value>
+  </data>
+  <data name="ColorContrast_TextBlock_WCAG_1_4_11" xml:space="preserve">
+    <value>WCAG 1.4.11</value>
+  </data>
+  <data name="ColorContrast_TextBlock_WCAG_1_4_3" xml:space="preserve">
+    <value>WCAG 1.4.3</value>
   </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1589,6 +1589,6 @@ Do you want to change the channel? </value>
     <value>Requires a ratio of at least 3:1 (</value>
   </data>
   <data name="TextNewForWCAG_2_1" xml:space="preserve">
-    <value>ADD PILL! New for WCAG 2.1</value>
+    <value>New for WCAG 2.1</value>
   </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/ViewModels/ColorContrastViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/ColorContrastViewModel.cs
@@ -19,6 +19,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// </summary>
         const double SMALL_TEXT_THRESHOLD = 4.5;
         const double LARGE_TEXT_THRESHOLD = 3.0;
+        const double NON_TEXT_THRESHOLD = 3.0;
 
         /// <summary>
         /// Constructor
@@ -122,6 +123,17 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             get
             {
                 return Ratio >= LARGE_TEXT_THRESHOLD;
+            }
+        }
+
+        /// <summary>
+        /// Whether the current ratio passes on graphical objects
+        /// </summary>
+        public bool PassNonTextObjects
+        {
+            get
+            {
+                return Ratio >= NON_TEXT_THRESHOLD;
             }
         }
 


### PR DESCRIPTION
#### Describe the change
This adds non-text element support (new for WCAG 2.1) to the color contrast analyzer, while also refactoring the dialog to the latest spec.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

#### Screenshots

##### High Contrast Disabled:
![image](https://user-images.githubusercontent.com/45672944/63624120-44c22180-c5b0-11e9-8cdb-6e58181abb93.png)

##### High Contrast White:
![image](https://user-images.githubusercontent.com/45672944/63623888-b0f05580-c5af-11e9-8e90-db11331270c0.png)

##### High Contrast Black:
![image](https://user-images.githubusercontent.com/45672944/63623855-90280000-c5af-11e9-945d-2aef461acda7.png)

##### High Contrast 1:
![image](https://user-images.githubusercontent.com/45672944/63624048-18a6a080-c5b0-11e9-89a6-9a4d92820908.png)

##### High Contrast 2:
![image](https://user-images.githubusercontent.com/45672944/63624085-2eb46100-c5b0-11e9-9241-1ef34c7f2648.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



