### PR TITLE
Give interactive elements in the color chooser unique names

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml
@@ -17,7 +17,7 @@
     <Grid>
         <StackPanel Orientation="Horizontal" Grid.Row="0">
             <Button x:Name="colorPicker" Style="{StaticResource BtnStandard}" Width="32" Height="32" BorderBrush="Transparent"
-                Click="colorPicker_Click" AutomationProperties.Name="{x:Static Properties:Resources.colorPickerAutomationPropertiesName}">
+                Click="colorPicker_Click" AutomationProperties.Name="{Binding Path=ColorPickerName, StringFormat='{x:Static Properties:Resources.colorPickerAutomationPropertiesName}'}">
                 <fabric:FabricIconControl GlyphName="Eyedropper" GlyphSize="Default" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
             </Button>
             <ComboBox Name="cbColorPicker" DropDownOpened="Popup_Opened" Width="120" Style="{StaticResource tgbtnColorPicker}" AutomationProperties.Name="{Binding Path=ColorPickerName, StringFormat='{x:Static Properties:Resources.cbColorPickerAutomationPropertiesName}'}">
@@ -28,7 +28,7 @@
             <TextBox x:Name="colorTb" Width="100px" Height="32" BorderBrush="{DynamicResource ResourceKey=BorderBrush}" FontSize="17"
                     Text="{Binding StoredColor, Converter={converters:ColorStringConverter}, FallbackValue=#FFFFFF}"
                     VerticalContentAlignment="Center" TextAlignment="Center"
-                    AutomationProperties.Name="{x:Static Properties:Resources.colorTbAutomationPropertiesName}" IsTabStop="True" Focusable="True"
+                    AutomationProperties.Name="{Binding Path=ColorPickerName, StringFormat='{x:Static Properties:Resources.colorTbAutomationPropertiesName}'}" IsTabStop="True" Focusable="True"
                     PreviewTextInput="colorTb_PreviewTextInput">
             </TextBox>
         </StackPanel>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1186,7 +1186,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Eyedropper.
+        ///   Looks up a localized string similar to {0} eyedropper.
         /// </summary>
         public static string colorPickerAutomationPropertiesName {
             get {
@@ -1213,7 +1213,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to hex code.
+        ///   Looks up a localized string similar to {0} hex code.
         /// </summary>
         public static string colorTbAutomationPropertiesName {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -626,10 +626,10 @@ Accessibility Insights Support Team
     <value>Color chooser</value>
   </data>
   <data name="colorPickerAutomationPropertiesName" xml:space="preserve">
-    <value>Eyedropper</value>
+    <value>{0} eyedropper</value>
   </data>
   <data name="colorTbAutomationPropertiesName" xml:space="preserve">
-    <value>hex code</value>
+    <value>{0} hex code</value>
   </data>
   <data name="cbColorPickerAutomationPropertiesName" xml:space="preserve">
     <value>{0} color picker</value>


### PR DESCRIPTION
#### Describe the change
The two color choosers in our color contrast analyzer mode each have 3 interactive elements--eyedropper button, color picker combo box, and hex code text box. Previously, only the combo box automation name included reference to whether the box was for color 1 or color 2. With this PR, all 3 elements will include color 1 or 2 in their automation names. 

![image](https://user-images.githubusercontent.com/4615491/63707970-1038aa80-c7e8-11e9-81a2-f05be5843ffa.png)

#### PR checklist

- [-] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [-] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



