### PR TITLE
Hide patterns tree when no patterns are present

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
@@ -2,11 +2,9 @@
      Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
 <UserControl x:Class="AccessibilityInsights.SharedUx.Controls.PatternInfoControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:converters="clr-namespace:AccessibilityInsights.SharedUx.Converters"
-             xmlns:fabric="clr-namespace:AccessibilityInsights.CommonUxComponents.Controls;assembly=AccessibilityInsights.CommonUxComponents"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:Properties="clr-namespace:AccessibilityInsights.SharedUx.Properties"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="310"
@@ -60,7 +58,7 @@
         </TreeView>
         <Label x:Name="lbNoPattern" Content="{x:Static Properties:Resources.lbNoPatternContent}"
                    Grid.Row="1"
-                   Style="{DynamicResource VarStandardLabel}"
+                   Style="{DynamicResource LblFocusable}"
                    VerticalAlignment="Center"
                    HorizontalAlignment="Center"/>
     </Grid>

--- a/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml.cs
@@ -1,19 +1,19 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Desktop.UIAutomation;
+using AccessibilityInsights.SharedUx.Controls.CustomControls;
+using AccessibilityInsights.SharedUx.Utilities;
+using AccessibilityInsights.SharedUx.ViewModels;
+using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
+using Axe.Windows.Desktop.UIAutomation;
+using Newtonsoft.Json.Bson;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Windows;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
-using Axe.Windows.Core.Bases;
-using AccessibilityInsights.SharedUx.ViewModels;
-using System.Windows.Automation.Peers;
-using AccessibilityInsights.SharedUx.Utilities;
-using AccessibilityInsights.SharedUx.Controls.CustomControls;
-
 using static System.FormattableString;
 
 namespace AccessibilityInsights.SharedUx.Controls
@@ -35,6 +35,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         {
             InitializeComponent();
             PatternType.GetInstance().GetKeyValuePairList().ForEach(kv => ExpStates[kv.Key] = false);
+            HidePatternsTree();
         }
 
         protected override AutomationPeer OnCreateAutomationPeer()
@@ -76,14 +77,26 @@ namespace AccessibilityInsights.SharedUx.Controls
                                    select new PatternViewModel(this.Element, p, this.IsActionAllowed, ExpStates.ContainsKey(p.Id) ? ExpStates[p.Id] : false);
 
                     this.treePatterns.ItemsSource = patterns.ToList();
-                    this.lbNoPattern.Visibility = Visibility.Collapsed;
+                    ShowPatternsTree();
                 }
                 else
                 {
-                    this.lbNoPattern.Visibility = Visibility.Visible;
+                    HidePatternsTree();
                     this.treePatterns.ItemsSource = null;
                 }
             }
+        }
+
+        private void HidePatternsTree()
+        {
+            this.treePatterns.Visibility = Visibility.Collapsed;
+            this.lbNoPattern.Visibility = Visibility.Visible;
+        }
+
+        private void ShowPatternsTree()
+        {
+            this.lbNoPattern.Visibility = Visibility.Collapsed;
+            this.treePatterns.Visibility = Visibility.Visible;
         }
 
         /// <summary>
@@ -98,6 +111,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 this.treePatterns.ItemsSource = null;
             }
             this.Element = null;
+            HidePatternsTree();
         }
 
         private void treePatterns_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -2,14 +2,13 @@
      Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:sys="clr-namespace:System;assembly=mscorlib"
-                    xmlns:fabric="clr-namespace:AccessibilityInsights.CommonUxComponents.Controls;assembly=AccessibilityInsights.CommonUxComponents"
-                    xmlns:controls="clr-namespace:AccessibilityInsights.SharedUx.Controls.CustomControls;assembly=AccessibilityInsights.SharedUx"
-                    xmlns:animations="clr-namespace:AccessibilityInsights.SharedUx.Animations;assembly=AccessibilityInsights.SharedUx"
                     xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:fabric="clr-namespace:AccessibilityInsights.CommonUxComponents.Controls;assembly=AccessibilityInsights.CommonUxComponents"
+                    xmlns:animations="clr-namespace:AccessibilityInsights.SharedUx.Animations;assembly=AccessibilityInsights.SharedUx"
+                    xmlns:colorpickers="clr-namespace:AccessibilityInsights.SharedUx.Controls.ColorPicker;assembly=AccessibilityInsights.SharedUx"
+                    xmlns:controls="clr-namespace:AccessibilityInsights.SharedUx.Controls.CustomControls;assembly=AccessibilityInsights.SharedUx"
                     xmlns:converters="clr-namespace:AccessibilityInsights.SharedUx.Converters;assembly=AccessibilityInsights.SharedUx"
-                    xmlns:cp="clr-namespace:AccessibilityInsights.SharedUx.Controls.ColorPicker;assembly=AccessibilityInsights.SharedUx"
-                    xmlns:colorpickers="clr-namespace:AccessibilityInsights.SharedUx.Controls.ColorPicker;assembly=AccessibilityInsights.SharedUx">
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <converters:TreeNodeToMarginConverter x:Key="nodeMargin"/>
     <Style x:Key="{x:Static SystemParameters.FocusVisualStyleKey}">
         <Setter Property="Control.Template">
@@ -135,6 +134,11 @@
     <Style TargetType="{x:Type Label}" x:Key="LblText">
         <Setter Property="FontSize" Value="11"/>
         <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TextBrush}"/>
+    </Style>
+    <Style TargetType="{x:Type Label}" x:Key="LblFocusable" BasedOn="{StaticResource ResourceKey=VarStandardLabel}">
+        <Setter Property="Focusable" Value="True"/>
+        <Setter Property="KeyboardNavigation.IsTabStop" Value="True"/>
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="TxtTelemetrySettingInfo">
         <Setter Property="FontSize" Value="10"/>


### PR DESCRIPTION
#### Describe the change
Currently, when no patterns are present, we display, "No available pattern..." in place of the patterns tree. For keyboard users, however, focus still goes to the empty tree rather than the text. This PR updates the keyboard nav behavior so that focus goes to the text instead of the empty tree. This is accomplished by a. hiding the tree and b. making the text focusable.

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [-] Does this address an existing issue? If yes, Issue# - 
- [-] Includes UI changes?
  - [-] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [-] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



