### PR TITLE
Don't run CG on PR builds

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -12,7 +12,7 @@ jobs:
   parameters:
     configuration: release
     checkLicenseHeaders: true
-    runComponentGovernance: true
+    runComponentGovernance: $[in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')]
 
 - template: build-and-unit-tests.yml
   parameters:


### PR DESCRIPTION
#### Describe the change
This PR disables CG on PR builds. It will still run on all of our other builds.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



