### PR TITLE
Set dummy HelpText value on some buttons

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -70,6 +70,10 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <!--BtnNoAutoHelpText has " " HelpText to prevent the button's ToolTip content from being used as HelpText-->
+    <Style TargetType="{x:Type Button}" x:Key="BtnNoAutoHelpText" BasedOn="{StaticResource BtnStandard}">
+        <Setter Property="AutomationProperties.HelpText" Value=" "/>
+    </Style>
     <Style TargetType="{x:Type Button}" x:Key="BtnNoDisabledBackground" BasedOn="{StaticResource BtnStandard}">
         <Setter Property="Template">
             <Setter.Value>
@@ -566,7 +570,9 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <!--btnLeftNav has " " HelpText to prevent the button's ToolTip content from being used as HelpText-->
     <Style x:Key="btnLeftNav" TargetType="{x:Type Button}">
+        <Setter Property="AutomationProperties.HelpText" Value=" "/>
         <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
         <Setter Property="Background" Value="{DynamicResource ResourceKey=ButtonBackgroundBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource ResourceKey=ButtonBackgroundBrush}"/>

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -309,7 +309,7 @@
                                     <behaviors:KeyboardToolTipButtonBehavior/>
                                 </i:Interaction.Behaviors>
                                 <Button.Style>
-                                    <Style TargetType="Button" BasedOn="{StaticResource BtnStandard}">
+                                    <Style TargetType="Button" BasedOn="{StaticResource BtnNoAutoHelpText}">
                                         <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding Path=vmHilighter.State, Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:MainWindow}}" Value="On">
@@ -349,7 +349,7 @@
                                 </fabric:FabricIconControl>
                             </Button>
                             <Button x:Name="btnRefresh"
-                                    Style="{StaticResource BtnStandard}"
+                                    Style="{StaticResource BtnNoAutoHelpText}"
                                     VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="16,0,0,0"
                                     AutomationProperties.Name="{x:Static properties:Resources.btnRefreshAutomationPropertiesName}" Click="btnRefresh_Click">
                                 <Button.ToolTip>
@@ -363,7 +363,7 @@
                                 <fabric:FabricIconControl GlyphName="Refresh" FontSize="16" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
                             </Button>
                             <Button x:Name="btnSave"
-                                    Style="{StaticResource BtnStandard}"
+                                    Style="{StaticResource BtnNoAutoHelpText}" AutomationProperties.HelpText=""
                                     VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
                                     AutomationProperties.Name="{x:Static properties:Resources.btnSaveAutomationPropertiesName}" Click="btnSave_Click">
                                 <Button.ToolTip>
@@ -380,12 +380,12 @@
                                 VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
                                 Click="btnPause_Click"
                                 AutomationProperties.Name="{x:Static properties:Resources.btnPauseAutomationPropertiesNameOn}"
-                                AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinPauseButton}">
+                                AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinPauseButton}" >
                                 <i:Interaction.Behaviors>
                                     <behaviors:KeyboardToolTipButtonBehavior/>
                                 </i:Interaction.Behaviors>
                                 <Button.Style>
-                                    <Style TargetType="Button" BasedOn="{StaticResource BtnStandard}">
+                                    <Style TargetType="Button" BasedOn="{StaticResource BtnNoAutoHelpText}">
                                         <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding Path=vmLiveModePauseResume.State, Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:MainWindow}}" Value="On">
@@ -425,7 +425,7 @@
                                 </fabric:FabricIconControl>
                             </Button>
                             <Button x:Name="btnTimer"
-                            Style="{StaticResource BtnStandard}"
+                            Style="{StaticResource BtnNoAutoHelpText}"
                             VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
                             AutomationProperties.Name="{x:Static properties:Resources.btnTimerAutomationPropertiesName}">
                                 <Button.ToolTip>
@@ -454,7 +454,7 @@
                                 </Button.ContextMenu>
                             </Button>
                             <Button x:Name="btnLoad"
-                                Style="{StaticResource BtnStandard}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinLoadButton}"
+                                Style="{StaticResource BtnNoAutoHelpText}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinLoadButton}"
                                 VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
                                 AutomationProperties.Name="{x:Static properties:Resources.btnLoadAutomationPropertiesName}" Click="btnLoad_Click">
                                 <Button.ToolTip>

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -363,7 +363,7 @@
                                 <fabric:FabricIconControl GlyphName="Refresh" FontSize="16" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
                             </Button>
                             <Button x:Name="btnSave"
-                                    Style="{StaticResource BtnNoAutoHelpText}" AutomationProperties.HelpText=""
+                                    Style="{StaticResource BtnNoAutoHelpText}"
                                     VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
                                     AutomationProperties.Name="{x:Static properties:Resources.btnSaveAutomationPropertiesName}" Click="btnSave_Click">
                                 <Button.ToolTip>

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
@@ -25,7 +25,7 @@
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <Grid Grid.Row="0" >
-                    <Button x:Name="btnClose" Margin="12,24,20,14" Width="15" Height="15" Click="Button_Click" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" VerticalAlignment="Top" HorizontalAlignment="Left" IsCancel="True" IsTabStop="True" AutomationProperties.Name="{x:Static properties:Resources.gdConfigBtnCloseAutomationPropertiesName}" KeyboardNavigation.TabIndex="-2" Style="{StaticResource BtnStandard}">
+                    <Button x:Name="btnClose" Margin="12,24,20,14" Width="15" Height="15" Click="Button_Click" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" VerticalAlignment="Top" HorizontalAlignment="Left" IsCancel="True" IsTabStop="True" AutomationProperties.Name="{x:Static properties:Resources.gdConfigBtnCloseAutomationPropertiesName}" KeyboardNavigation.TabIndex="-2" Style="{StaticResource BtnNoAutoHelpText}">
                         <Grid>
                             <AccessText Text="_x" Opacity="0"/>
                             <fabric:FabricIconControl GlyphName="ChromeBack" GlyphSize="Custom" FontSize="11" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=DarkGreyTextBrush}"/>


### PR DESCRIPTION
#### Describe the change
According to [the docs](https://docs.microsoft.com/en-us/dotnet/api/system.windows.automation.automationproperties.helptext?view=netframework-4.8), AutomationProperties.HelpText is generally the same text that is provided in the tooltip for the control. WPF takes this to heart and automatically sets a button's helptext to its tooltip value. Frustratingly, if the tooltip is set as a text-containing control such as a `Run`, the helptext is set to be that control's class name. For ai-win's icon buttons, the tooltip's content is roughly the same as the AutomationProperties.Name's content. To avoid repetitive screen reader output, we don't want to set the helptext with the tooltip at all (much less with the tooltip's class name). This PR sets dummy (blank space) values to the helptext in the situations where we want to stop the default tooltip-as-helptext behavior. 

#### Before:
![image](https://user-images.githubusercontent.com/4615491/64291879-03216700-cf1e-11e9-9103-c59593a15954.png)
#### After:
![image](https://user-images.githubusercontent.com/4615491/64292038-4d0a4d00-cf1e-11e9-84f5-0a1c0c012750.png)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



