### PR TITLE
Add "Accessibility Insights for Windows" tag to bugs filed by AI-Win

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/IssueTemplates/IssueColorContrast.json
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/IssueTemplates/IssueColorContrast.json
@@ -1,4 +1,4 @@
 ﻿{
   "Title": "@[RuleSource]@: (@[ProcessName]@/@[Glimpse]@) @[RuleDescription]@",
-  "Tags": "A11y;Accessibility;@[RuleSource]@"
+  "Tags": "Accessibility Insights For Windows;A11y;Accessibility;@[RuleSource]@"
 }

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/IssueTemplates/IssueNoFailures.json
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/IssueTemplates/IssueNoFailures.json
@@ -1,4 +1,4 @@
 ﻿{
   "Title": "(@[ProcessName]@/@[Glimpse]@) has an accessibility issue that needs investigation",
-  "Tags": "A11y;Accessibility"
+  "Tags": "Accessibility Insights For Windows;A11y;Accessibility"
 }

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/IssueTemplates/IssueSingleFailure.json
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/IssueTemplates/IssueSingleFailure.json
@@ -1,4 +1,4 @@
 ﻿{
   "Title": "@[RuleSource]@: (@[ProcessName]@/@[Glimpse]@) @[RuleDescription]@",
-  "Tags": "A11y;Accessibility;@[RuleSource]@"
+  "Tags": "Accessibility Insights For Windows;A11y;Accessibility;@[RuleSource]@"
 }


### PR DESCRIPTION
#### Describe the change

This PR adds the "Accessibility Insights for Windows" tag to any ADO bugs filed by our tool.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #520
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



