### PR TITLE
Move fabric icons into control view

### DIFF
--- a/src/AccessibilityInsights.CommonUxComponents/CommonUxComponents.csproj
+++ b/src/AccessibilityInsights.CommonUxComponents/CommonUxComponents.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="$(TEMP)\A11yInsightsVersionInfo.cs" />
     <Compile Include="Controls\CustomControlOverridingAutomationPeer.cs" />
+    <Compile Include="Controls\CommonAutomationPeerCreator.cs" />
     <Compile Include="Controls\PlaceholderTextBox.xaml.cs">
       <DependentUpon>PlaceholderTextBox.xaml</DependentUpon>
     </Compile>

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.using System.Windows.Automation.Peers;
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
@@ -18,7 +18,7 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
                 owner,
                 localizedControl: "icon",
                 isContentElement: false,
-                isControlElement: false,
+                isControlElement: true,
                 hideChildren: true,
                 controlType: AutomationControlType.Image);
         }

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Automation.Peers;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 
 namespace AccessibilityInsights.CommonUxComponents.Controls

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
@@ -7,7 +7,7 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
 {
     class CommonAutomationPeerCreator
     {
-        public static AutomationPeer CreateIconAutomationPeer(UserControl owner)
+        public static AutomationPeer CreateControlViewIconAutomationPeer(UserControl owner)
         {
             return new CustomControlOverridingAutomationPeer(
                 owner,

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
@@ -1,0 +1,24 @@
+﻿using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+
+namespace AccessibilityInsights.CommonUxComponents.Controls
+{
+    class CommonAutomationPeerCreator
+    {
+        /// <summary>
+        /// Returns a peer for a decorative icon (hide children, raw tree only)
+        /// </summary>
+        /// <param name="owner"></param>
+        /// <returns></returns>
+        public static AutomationPeer CreateIconAutomationPeer(UserControl owner)
+        {
+            return new CustomControlOverridingAutomationPeer(
+                owner,
+                localizedControl: "icon",
+                isContentElement: false,
+                isControlElement: false,
+                hideChildren: true,
+                controlType: AutomationControlType.Image);
+        }
+    }
+}

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.using System.Windows.Automation.Peers;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 
 namespace AccessibilityInsights.CommonUxComponents.Controls

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
@@ -7,11 +7,6 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
 {
     class CommonAutomationPeerCreator
     {
-        /// <summary>
-        /// Returns a peer for a decorative icon (hide children, raw tree only)
-        /// </summary>
-        /// <param name="owner"></param>
-        /// <returns></returns>
         public static AutomationPeer CreateIconAutomationPeer(UserControl owner)
         {
             return new CustomControlOverridingAutomationPeer(

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
@@ -37,7 +37,8 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
 
         public AutomationOrientation AutomationOrientation { get; set; }
 
-        public CustomControlOverridingAutomationPeer(UserControl owner,
+        public CustomControlOverridingAutomationPeer(
+            UserControl owner,
             string localizedControl, 
             bool isControlElement = true, 
             bool isContentElement = false, 

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Collections.Generic;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 
@@ -26,19 +27,33 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
         /// </summary>
         private string LocalizedControlType;
 
+        private AutomationControlType ControlType;
+
+        /// <summary>
+        /// Whether to hide all children automation peers
+        /// </summary>
+        private bool HideChildren;
+
         public AutomationOrientation AutomationOrientation { get; set; }
 
-        public CustomControlOverridingAutomationPeer(UserControl owner,string localizedcontrol, bool isControlElement=true, bool isContentElement=false)
+        public CustomControlOverridingAutomationPeer(UserControl owner,string localizedControl, bool isControlElement=true, bool isContentElement=false, bool hideChildren=false, AutomationControlType controlType=AutomationControlType.Custom)
         : base(owner)
         {
-            this.LocalizedControlType = localizedcontrol;
+            this.LocalizedControlType = localizedControl;
             this.IsControlElem = isControlElement;
             this.IsContentElem = isContentElement;
+            this.HideChildren = hideChildren;
+            this.ControlType = controlType;
         }
 
         protected override string GetLocalizedControlTypeCore()
         {
             return LocalizedControlType;
+        }
+
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return ControlType;
         }
 
         public override object GetPattern(PatternInterface patternInterface)
@@ -62,6 +77,11 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
         protected override bool IsContentElementCore()
         {
             return IsContentElem;
+        }
+
+        protected override List<AutomationPeer> GetChildrenCore()
+        {
+            return HideChildren ? null : base.GetChildrenCore();
         }
 
         protected override AutomationOrientation GetOrientationCore() => AutomationOrientation;

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
 using System.Collections.Generic;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
@@ -39,6 +40,10 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
         public CustomControlOverridingAutomationPeer(UserControl owner,string localizedControl, bool isControlElement=true, bool isContentElement=false, bool hideChildren=false, AutomationControlType controlType=AutomationControlType.Custom)
         : base(owner)
         {
+            if (isContentElement && !isControlElement)
+            {
+                throw new ArgumentException("The content tree is a subset of the control tree");
+            }
             this.LocalizedControlType = localizedControl;
             this.IsControlElem = isControlElement;
             this.IsContentElem = isContentElement;

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
@@ -30,9 +30,6 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
 
         private AutomationControlType ControlType;
 
-        /// <summary>
-        /// Whether to hide all children automation peers
-        /// </summary>
         private bool HideChildren;
 
         public AutomationOrientation AutomationOrientation { get; set; }

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
@@ -37,7 +37,12 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
 
         public AutomationOrientation AutomationOrientation { get; set; }
 
-        public CustomControlOverridingAutomationPeer(UserControl owner,string localizedControl, bool isControlElement=true, bool isContentElement=false, bool hideChildren=false, AutomationControlType controlType=AutomationControlType.Custom)
+        public CustomControlOverridingAutomationPeer(UserControl owner,
+            string localizedControl, 
+            bool isControlElement = true, 
+            bool isContentElement = false, 
+            bool hideChildren = false, 
+            AutomationControlType controlType = AutomationControlType.Custom)
         : base(owner)
         {
             if (isContentElement && !isControlElement)
@@ -51,43 +56,24 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
             this.ControlType = controlType;
         }
 
-        protected override string GetLocalizedControlTypeCore()
-        {
-            return LocalizedControlType;
-        }
+        protected override string GetLocalizedControlTypeCore() => LocalizedControlType;
+        protected override AutomationControlType GetAutomationControlTypeCore() => ControlType;
 
-        protected override AutomationControlType GetAutomationControlTypeCore()
-        {
-            return ControlType;
-        }
-
-        public override object GetPattern(PatternInterface patternInterface)
-        {
-            return null;
-        }
+        public override object GetPattern(PatternInterface patternInterface) => null;
 
         /// <summary>
         /// Use provided value for IsControlElement
         /// </summary>
         /// <returns></returns>
-        protected override bool IsControlElementCore()
-        {
-            return IsControlElem;
-        }
+        protected override bool IsControlElementCore() => IsControlElem;
 
         /// <summary>
         /// Use provided value for IsContentElement
         /// </summary>
         /// <returns></returns>
-        protected override bool IsContentElementCore()
-        {
-            return IsContentElem;
-        }
+        protected override bool IsContentElementCore() => IsContentElem;
 
-        protected override List<AutomationPeer> GetChildrenCore()
-        {
-            return HideChildren ? null : base.GetChildrenCore();
-        }
+        protected override List<AutomationPeer> GetChildrenCore() => HideChildren ? null : base.GetChildrenCore();
 
         protected override AutomationOrientation GetOrientationCore() => AutomationOrientation;
     }

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/DualFabricIconControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/DualFabricIconControl.xaml.cs
@@ -186,6 +186,6 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
             this.fabicnBack.GlyphSize = GlyphContext.Custom;
         }
 
-        protected override AutomationPeer OnCreateAutomationPeer() => CommonAutomationPeerCreator.CreateIconAutomationPeer(this);
+        protected override AutomationPeer OnCreateAutomationPeer() => CommonAutomationPeerCreator.CreateControlViewIconAutomationPeer(this);
     }
 }

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/DualFabricIconControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/DualFabricIconControl.xaml.cs
@@ -187,12 +187,9 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
         }
 
         /// <summary>
-        /// Set LocalizedControlType and mark as raw
+        /// Expose automation properties similar to decorative image
         /// </summary>
         /// <returns></returns>
-        protected override AutomationPeer OnCreateAutomationPeer()
-        {
-            return new CustomControlOverridingAutomationPeer(this, "icon", false);
-        }
+        protected override AutomationPeer OnCreateAutomationPeer() => CommonAutomationPeerCreator.CreateIconAutomationPeer(this);
     }
 }

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/DualFabricIconControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/DualFabricIconControl.xaml.cs
@@ -186,10 +186,6 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
             this.fabicnBack.GlyphSize = GlyphContext.Custom;
         }
 
-        /// <summary>
-        /// Expose automation properties similar to decorative image
-        /// </summary>
-        /// <returns></returns>
         protected override AutomationPeer OnCreateAutomationPeer() => CommonAutomationPeerCreator.CreateIconAutomationPeer(this);
     }
 }

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/FabricIconControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/FabricIconControl.xaml.cs
@@ -150,19 +150,10 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
         #endregion
 
         /// <summary>
-        /// Set LocalizedControlType and mark as raw
+        /// Expose automation properties similar to decorative image
         /// </summary>
         /// <returns></returns>
-        protected override AutomationPeer OnCreateAutomationPeer()
-        {
-            return new CustomControlOverridingAutomationPeer(
-                owner: this, 
-                localizedControl: "icon",
-                isContentElement: true,
-                isControlElement: false,
-                hideChildren: true,
-                controlType: AutomationControlType.Image);
-        }
+        protected override AutomationPeer OnCreateAutomationPeer() => CommonAutomationPeerCreator.CreateIconAutomationPeer(this);
     }
 
     #region Icon Values

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/FabricIconControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/FabricIconControl.xaml.cs
@@ -155,7 +155,13 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
         /// <returns></returns>
         protected override AutomationPeer OnCreateAutomationPeer()
         {
-            return new CustomControlOverridingAutomationPeer(this, "icon", false);
+            return new CustomControlOverridingAutomationPeer(
+                owner: this, 
+                localizedControl: "icon",
+                isContentElement: true,
+                isControlElement: false,
+                hideChildren: true,
+                controlType: AutomationControlType.Image);
         }
     }
 

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/FabricIconControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/FabricIconControl.xaml.cs
@@ -149,10 +149,6 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
 
         #endregion
 
-        /// <summary>
-        /// Expose automation properties similar to decorative image
-        /// </summary>
-        /// <returns></returns>
         protected override AutomationPeer OnCreateAutomationPeer() => CommonAutomationPeerCreator.CreateIconAutomationPeer(this);
     }
 

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/FabricIconControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/FabricIconControl.xaml.cs
@@ -149,7 +149,7 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
 
         #endregion
 
-        protected override AutomationPeer OnCreateAutomationPeer() => CommonAutomationPeerCreator.CreateIconAutomationPeer(this);
+        protected override AutomationPeer OnCreateAutomationPeer() => CommonAutomationPeerCreator.CreateControlViewIconAutomationPeer(this);
     }
 
     #region Icon Values

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -107,7 +107,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Focus select icon.
+        ///   Looks up a localized string similar to Focus selection.
         /// </summary>
         public static string ApplicationSettingsControl_KeyboardIconAutomationName {
             get {
@@ -116,7 +116,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Mouse select icon.
+        ///   Looks up a localized string similar to Mouse selection.
         /// </summary>
         public static string ApplicationSettingsControl_MouseIconAutomationName {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1340,10 +1340,10 @@ Accessibility Insights Support Team
     <value>Select Highlighter Mode</value>
   </data>
   <data name="ApplicationSettingsControl_KeyboardIconAutomationName" xml:space="preserve">
-    <value>Focus select icon</value>
+    <value>Focus selection</value>
   </data>
   <data name="ApplicationSettingsControl_MouseIconAutomationName" xml:space="preserve">
-    <value>Mouse select icon</value>
+    <value>Mouse selection</value>
   </data>
   <data name="ColorPickerControlAutomationName" xml:space="preserve">
     <value>Color Picker</value>


### PR DESCRIPTION
#### Describe the change

This change updates the UIA properties of our fabric icons across the app. After this change the icons should appear in the control view, have the control type "Image", the localized control type "icon", and have no children. Because the control type is now "image", the icons will show up in scan mode. This also means that a screen reader will say "search icon" instead of just "search" - beforehand, the text child of the icon (implementation detail) would show up in scan mode but not the icon itself. This PR improves the representation so that the text child is not shown and instead the user is presented with an icon.

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



