### PR TITLE
Fully remove CCA confidence level text when not applicable

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -100,41 +100,28 @@
                                />
                     </StackPanel>
                 </Grid>
-                <Grid Grid.Row="3" Grid.Column="1" Margin="0,16,0,0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" MinWidth="240"/>
-                        <ColumnDefinition Width="1*"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <Border Margin="20,27,20,0" BorderThickness="2" BorderBrush="{DynamicResource ResourceKey=CCABorderBrush}">
-                        <StackPanel Background="{DynamicResource ResourceKey=CCABackgroundBrush}">
-                            <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Vertical" Margin="10,6,0,0" MinWidth="132">
-                                <TextBlock Text="{x:Static Properties:Resources.ColorContrast_Ratio}" FontSize="14"/>
-                                <DockPanel>
-                                    <TextBlock x:Name="output" FontWeight="SemiBold" FontSize="17" HorizontalAlignment="Left"
+                <Border Margin="20,43,20,0" Grid.Row="3" Grid.Column="1" BorderThickness="2" BorderBrush="{DynamicResource ResourceKey=CCABorderBrush}"
+                        VerticalAlignment="Top" Height="110" Width="200">
+                    <StackPanel Background="{DynamicResource ResourceKey=CCABackgroundBrush}">
+                        <StackPanel Orientation="Vertical" Margin="10,6,0,0" MinWidth="132">
+                            <TextBlock Text="{x:Static Properties:Resources.ColorContrast_Ratio}" FontSize="14"/>
+                            <TextBlock x:Name="output" FontWeight="SemiBold" FontSize="17" HorizontalAlignment="Left"
                                AutomationProperties.LiveSetting="Polite" VerticalAlignment="Center"
                                AutomationProperties.Name="{Binding Text, RelativeSource={RelativeSource Self}, StringFormat={x:Static Properties:Resources.ColorContrast_OutputAutomationName}}"
                                KeyboardNavigation.TabIndex="3" Focusable="True"
                                Text="{Binding Path=ContrastVM.FormattedRatio, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}">
-                                    </TextBlock>
-                                </DockPanel>
-                            </StackPanel>
-                            <StackPanel Name="spConfidence" Grid.Row="1" Grid.Column="0" Orientation="Vertical" Margin="10,10,0,6" MinWidth="132">
-                                <TextBlock Text="{x:Static Properties:Resources.ColorContrast_Confidence}" FontSize="14"/>
-                                <DockPanel>
-                                    <TextBlock x:Name="tbConfidence" FontWeight="SemiBold" FontSize="17" HorizontalAlignment="Left"
-                           AutomationProperties.LiveSetting="Polite" VerticalAlignment="Center"
-                           AutomationProperties.Name="{Binding Text, RelativeSource={RelativeSource Self}, StringFormat={x:Static Properties:Resources.ColorContrast_tbConfidenceAutomationName}}"
-                           KeyboardNavigation.TabIndex="4" Focusable="True">
-                                    </TextBlock>
-                                </DockPanel>
-                            </StackPanel>
+                                </TextBlock>
                         </StackPanel>
-                    </Border>
-                </Grid>
+                        <StackPanel Name="spConfidence" Orientation="Vertical" Margin="10,10,0,6" MinWidth="132">
+                            <TextBlock Name="tbConfidenceLabel" Text="{x:Static Properties:Resources.ColorContrast_Confidence}" FontSize="14"/>
+                            <TextBlock x:Name="tbConfidence" FontWeight="SemiBold" FontSize="17" HorizontalAlignment="Left"
+                                       AutomationProperties.LiveSetting="Polite" VerticalAlignment="Center"
+                                       AutomationProperties.Name="{Binding Text, RelativeSource={RelativeSource Self}, StringFormat={x:Static Properties:Resources.ColorContrast_tbConfidenceAutomationName}}"
+                                       KeyboardNavigation.TabIndex="4" Focusable="True">
+                            </TextBlock>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
                 <Grid Grid.Row="4" Margin="0,12,115,0" Grid.ColumnSpan="2">
                     <Grid.Resources>
                         <Style TargetType="{x:Type TextBlock}">

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Actions.Contexts;
 using AccessibilityInsights.CommonUxComponents.Controls;
 using AccessibilityInsights.CommonUxComponents.Dialogs;
-using Axe.Windows.Desktop.ColorContrastAnalyzer;
-using Axe.Windows.Desktop.Utility;
 using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Interfaces;
 using AccessibilityInsights.SharedUx.Settings;
 using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.SharedUx.Utilities;
 using AccessibilityInsights.SharedUx.ViewModels;
+using Axe.Windows.Actions.Contexts;
+using Axe.Windows.Desktop.ColorContrastAnalyzer;
+using Axe.Windows.Desktop.Utility;
 using System;
 using System.Diagnostics;
 using System.Drawing;
@@ -271,19 +271,18 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             ICCAMode CCAMode = Application.Current.MainWindow as ICCAMode;
 
             // Watson crashes suggest that this will be null sometimes
-            if (CCAMode!=null)
+            if (CCAMode != null)
             {
                 CCAMode.HandleToggleStatusChanged(isEnabled);
             }
 
+            spConfidence.Children.Clear();
+            tbConfidence.Text = "";
+
             if (isEnabled)
             {
-                spConfidence.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                spConfidence.Visibility = Visibility.Hidden;
-                tbConfidence.Text = "";
+                spConfidence.Children.Add(tbConfidenceLabel);
+                spConfidence.Children.Add(tbConfidence);
             }
         }
 
@@ -301,7 +300,8 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             return this.tgbtnAutoDetect.IsChecked.Value;
         }
 
-        public void ActivateProgressRing(){
+        public void ActivateProgressRing()
+        {
             this.ctrlProgressRing.Activate();
         }
 


### PR DESCRIPTION
#### Describe the change
Currently, we visually hide the confidence text in CCA mode when auto-detect is disabled. However, the text remains in the UI Automation tree. This PR updates that behavior to fully remove the confidence text, both visually and from the UIA tree. Some XAML cleanup is done while in the neighborhood. There should be no visual impact from this PR.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [-] Does this address an existing issue? If yes, Issue# - 
- [-] Includes UI changes?
  - [-] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [-] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



