### PR TITLE
Fix trusted tester Bug 1584490

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -272,7 +272,7 @@
                         <TextBlock x:Name="smallSampleBold" Text="{x:Static Properties:Resources.smallSampleText}" Grid.Row="0" FontSize="{DynamicResource ConstStandardTextSize}" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"
                            Foreground="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" 
                            Background="{Binding Path=ContrastVM.SecondColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"
-                           FontWeight="Bold" AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_SmallSampleBoldHelpText}" HorizontalAlignment="Left"/>
+                           FontWeight="Bold" AutomationProperties.HelpText="{x:Static Properties:Resources.ColorContrast_SmallSampleBoldHelpText}" HorizontalAlignment="Left"/>
                         <TextBlock x:Name="largeSample" Text="{x:Static Properties:Resources.smallSampleText}" Grid.Row="1" FontSize="18" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"
                            Foreground="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" 
                            Background="{Binding Path=ContrastVM.SecondColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"


### PR DESCRIPTION
#### Describe the change

The help text for the control was accidentally set as the name, making the text "sample small bold text". The tester was concerned the screen reader user would not hear the text as it appears on screen. Now the name is "the quick brown fox" and the help text is "sample small bold text".

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



