### PR TITLE
Opt into accessibility features available in .NET framework 4.8

### DIFF
--- a/src/AccessibilityInsights/App.config
+++ b/src/AccessibilityInsights/App.config
@@ -9,6 +9,7 @@
       <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
   </startup>
   <runtime>
+    <AppContextSwitchOverrides value="Switch.UseLegacyAccessibilityFeatures=false;Switch.UseLegacyAccessibilityFeatures.2=false;Switch.UseLegacyAccessibilityFeatures.3=false;Switch.UseLegacyToolTipDisplay=false" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/src/UITests/LiveMode.cs
+++ b/src/UITests/LiveMode.cs
@@ -37,7 +37,7 @@ namespace UITests
 
         private void ValidateResultsInUIATree()
         {
-            driver.TestMode.ResultsInUIATree.ValidateResults(false, 2, 11);
+            driver.TestMode.ResultsInUIATree.ValidateResults(2, 11);
             driver.TestMode.ResultsInUIATree.SwitchToDetailsTab();
             driver.TestMode.ResultsInUIATree.ValidateDetails("SynchronizedInputPattern", "Name, Property does not exist", 1, 10);
             driver.TestMode.ResultsInUIATree.ValidateTree("pane 'Desktop 1'", 16);

--- a/src/UITests/LoadTestFile.cs
+++ b/src/UITests/LoadTestFile.cs
@@ -40,7 +40,7 @@ namespace UITests
 
         private void ValidateFirstSelectedElement()
         {
-            driver.TestMode.ResultsInUIATree.ValidateResults(false, 2, 28);
+            driver.TestMode.ResultsInUIATree.ValidateResults(2, 28);
             driver.TestMode.ResultsInUIATree.SwitchToDetailsTab();
             driver.TestMode.ResultsInUIATree.ValidateDetails("InvokePattern", "Name, Ok", 3, 10);
             driver.TestMode.ResultsInUIATree.ValidateTree("pane 'Desktop 1' has failed test results in descendants.", 16);
@@ -50,7 +50,7 @@ namespace UITests
         {
             driver.TestMode.ResultsInUIATree.ValidateDetails("LegacyIAccessiblePattern", "Name, Desktop 1", 10, 10);
             driver.TestMode.ResultsInUIATree.SwitchToResultsTab();
-            driver.TestMode.ResultsInUIATree.ValidateResults(true, 0, 0);
+            driver.TestMode.ResultsInUIATree.ValidateResults(0, 0);
         }
 
         private void ValidateResultsInUIATree()

--- a/src/UITests/UILibrary/TestMode.cs
+++ b/src/UITests/UILibrary/TestMode.cs
@@ -112,7 +112,7 @@ namespace UITests.UILibrary
             Assert.AreEqual(firstNodeText, nodes.First().Text);
         }
 
-        public void ValidateResults(bool isFixFollowingTextNull, int failedResultsCount, int allResultsCount)
+        public void ValidateResults(int failedResultsCount, int allResultsCount)
         {
             var resultsList = Session.FindElementByAccessibilityId(AutomationIDs.ScannerResultsDetailsListView);
             var resultsFailedOnly = resultsList.FindElementsByClassName("ListViewItem");
@@ -123,9 +123,6 @@ namespace UITests.UILibrary
             }
 
             var resultsAll = resultsList.FindElementsByClassName("ListViewItem");
-            var fixFollowTb = Session.FindElementByAccessibilityId(AutomationIDs.ScannerResultsFixFollowingTextBox);
-
-            Assert.AreEqual(isFixFollowingTextNull, string.IsNullOrEmpty(fixFollowTb.Text));
             Assert.AreEqual(failedResultsCount, resultsFailedOnly.Count);
             Assert.AreEqual(allResultsCount, resultsAll.Count);
         }

--- a/src/UITests/UILibrary/TestMode.cs
+++ b/src/UITests/UILibrary/TestMode.cs
@@ -120,6 +120,8 @@ namespace UITests.UILibrary
             if (allResultsCount > 0)
             {
                 Session.FindElementByAccessibilityId(AutomationIDs.ScannerResultsShowAllButton).Click();
+                var fixFollowTb = Session.FindElementByAccessibilityId(AutomationIDs.ScannerResultsFixFollowingTextBox);
+                Assert.IsFalse(string.IsNullOrEmpty(fixFollowTb.Text));
             }
 
             var resultsAll = resultsList.FindElementsByClassName("ListViewItem");


### PR DESCRIPTION
This PR opts into accessibility features as described by these [docs](https://docs.microsoft.com/en-us/dotnet/framework/whats-new/whats-new-in-accessibility#accessibility-switches):

> You can configure your app to opt into accessibility features if it targets .NET Framework 4.7 or an earlier version but is running on .NET Framework 4.7.1 or later.

This results in some of the following improvements if the app is running on a machine with .NET framework 4.8 installed:

- > In .NET Framework 4.7.2 and earlier versions, tooltips display only when the user hovers the mouse cursor over a control. In .NET Framework 4.8, tooltips also display on keyboard focus, as well as via a keyboard shortcut.
- > Windows 10 introduced two new UIAutomation properties, SizeOfSet and PositionInSet, which are used by applications to describe the count of items in a set. UIAutomation client applications such as screen readers can then query an application for these properties and announce an accurate representation of the application’s UI...In addition, items in ItemsControl instances provide a value for these properties automatically without additional action from the developer.

The switch also removes some UI elements from the control view if they are not visible. One of our UI tests depended on this behavior to check some text so I have removed that line for now.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



