### PR TITLE
Add telemetry of installed .NET Framework version

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
@@ -37,5 +37,6 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         ReleaseChannel,
         ReleaseChannelConsidered,
         IssueReporter,
+        InstalledDotNetFrameworkVersion,
     }
 }

--- a/src/AccessibilityInsights.Win32/Win32Helper.cs
+++ b/src/AccessibilityInsights.Win32/Win32Helper.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Microsoft.Win32;
 using System;
 using System.Threading;
 
@@ -93,6 +94,19 @@ namespace AccessibilityInsights.Win32
             const int SPI_GETSCREENREADER = 0x0046;  // Defined in winuser.h
             bool success = NativeMethods.SystemParametersInfo(SPI_GETSCREENREADER, 0, out bool active, 0);
             return success && active;
+        }
+
+        /// <summary>
+        /// Extract the installed .NET Framework version from the registry. Based on information found at
+        /// https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
+        /// </summary>
+        /// <returns>The integral version if it's available, null if not</returns>
+        internal static int? GetInstalledDotNetFrameworkVersion()
+        {
+            const string keyName = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\";
+            const string valueName = "Release";
+
+            return (int?)Registry.GetValue(keyName, valueName, null);
         }
     }
 }

--- a/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
+++ b/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
@@ -111,10 +111,16 @@ namespace AccessibilityInsights.Misc
 
         public static TelemetryEvent ForMainWindowStartup()
         {
+            int? rawDotNetFrameworkVersion = NativeMethods.GetInstalledDotNetFrameworkVersion();
+            string formattedDotNetFrameworkVersion = rawDotNetFrameworkVersion.HasValue ?
+                rawDotNetFrameworkVersion.Value.ToString(CultureInfo.InvariantCulture) :
+                "unknown";
+
             return new TelemetryEvent(TelemetryAction.Mainwindow_Startup,
                 new Dictionary<TelemetryProperty, string>
                 {
                     { TelemetryProperty.UIAccessEnabled, NativeMethods.IsRunningWithUIAccess().ToString(CultureInfo.InvariantCulture) },
+                    { TelemetryProperty.InstalledDotNetFrameworkVersion, formattedDotNetFrameworkVersion }
                 });
         }
     }


### PR DESCRIPTION
#### Describe the change
Add a telemetry property to allow us to better understand what .NET Framework version is installed. This is to enable us to better evaluate how users will be impacted by potential future adoptions of newer versions of the .NET framework.

The lack of unit tests for the new code is intentional. We don't want to add any more Fake-based tests, and there's little return in testing the behavior of .NET's Registry.GetValue method. Testing was ensuring that the return value is correct for my dev machine, as well as confirming that `GetInstalledDotNetFrameworkVersion` returns null if the value doesn't exist in the registry.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



