### PR TITLE
fix: enable Narrator to read the element description in the inspect details pane

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
@@ -37,34 +37,31 @@
                             Key="V"
                             Modifiers="Alt"/>
             </TabItem.InputBindings>
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Border Margin="-1,0" Grid.Row="0" Grid.Column="0" BorderBrush="#A6A6A6" BorderThickness="0,0,0,1" >
-                    <Grid Margin="8,10">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="30"/>
-                        </Grid.RowDefinitions>
-                        <TextBlock 
-                           x:Name="tbElement" 
-                           VerticalAlignment="Center" 
-                           FontSize="{StaticResource ConstXXLTextSize}"
-                           FontWeight="Bold" 
-                           TextWrapping="Wrap"
-                           TextTrimming="CharacterEllipsis"
-                           Height="30"
-                           AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.InspectTabsElementTextBlock}"/>
-                    </Grid>
-                </Border>
-                <Grid Grid.Row="1" Name="gdTab">
+            <!--
+                This unnamed NamedPane is a workaround for a Narrator compat issue; without some sort of UIAutomation-included
+                wrapper around the tab content, Narrator doesn't include tbElement in reading order.
+            -->
+            <controls:NamedPane>
+                <Grid Name="gdTab">
                     <Grid.RowDefinitions>
+                        <RowDefinition x:Name="rowElementDescription" Height="Auto" MinHeight="30"/>
                         <RowDefinition x:Name="rowProperties" Height="7*" MinHeight="80"/>
                         <RowDefinition x:Name="rowPatterns" Height="3*" MinHeight="80"/>
                         <RowDefinition x:Name="rowEvents" Height="3*" MinHeight="80"/>
                     </Grid.RowDefinitions>
-                    <Expander Grid.Row="0" IsExpanded="True" Style="{StaticResource expAccordion}"  AutomationProperties.Name="{x:Static Properties:Resources.ExpanderAutomationPropertiesNameProps}">
+                    <Border Margin="-1,0" Grid.Row="0" Grid.Column="0" BorderBrush="#A6A6A6" BorderThickness="0,0,0,1" >
+                        <TextBlock 
+                            x:Name="tbElement" 
+                            VerticalAlignment="Center" 
+                            FontSize="{StaticResource ConstXXLTextSize}"
+                            FontWeight="Bold" 
+                            TextWrapping="Wrap"
+                            TextTrimming="CharacterEllipsis"
+                            Height="30"
+                            Margin="8,10"
+                            AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.InspectTabsElementTextBlock}"/>
+                    </Border>
+                    <Expander Grid.Row="1" IsExpanded="True" Style="{StaticResource expAccordion}"  AutomationProperties.Name="{x:Static Properties:Resources.ExpanderAutomationPropertiesNameProps}">
                         <i:Interaction.Behaviors>
                             <behaviors:ExpanderBehavior/>
                         </i:Interaction.Behaviors>
@@ -105,11 +102,11 @@
                         </Grid>
                     </Expander>
                     <GridSplitter x:Name="gsProperties"
-                                  Grid.Row="0" Style="{StaticResource gsStyle}"
-                                  ResizeBehavior="CurrentAndNext"
-                                  AutomationProperties.Name="{x:Static Properties:Resources.gsPropertiesAutomationPropertiesName1}"
-                                  Grid.ColumnSpan="2"/>
-                    <Expander Grid.Row="1" IsExpanded="True" Style="{StaticResource expAccordion}">
+                                    Grid.Row="1" Style="{StaticResource gsStyle}"
+                                    ResizeBehavior="CurrentAndNext"
+                                    AutomationProperties.Name="{x:Static Properties:Resources.gsPropertiesAutomationPropertiesName1}"
+                                    Grid.ColumnSpan="2"/>
+                    <Expander Grid.Row="2" IsExpanded="True" Style="{StaticResource expAccordion}">
                         <i:Interaction.Behaviors>
                             <behaviors:ExpanderBehavior/>
                         </i:Interaction.Behaviors>
@@ -121,11 +118,11 @@
                         </Grid>
                     </Expander>
                     <GridSplitter x:Name="gsEvents"
-                                  Grid.Row="1" Style="{StaticResource gsStyle}"
-                                  ResizeBehavior="CurrentAndNext"
-                                  AutomationProperties.Name="{x:Static Properties:Resources.gsEventsAutomationPropertiesName1}"
-                                  Grid.ColumnSpan="2"/>
-                    <Expander Name="expEvents" Grid.Row="2" IsExpanded="True" Style="{StaticResource expAccordion}">
+                                    Grid.Row="2" Style="{StaticResource gsStyle}"
+                                    ResizeBehavior="CurrentAndNext"
+                                    AutomationProperties.Name="{x:Static Properties:Resources.gsEventsAutomationPropertiesName1}"
+                                    Grid.ColumnSpan="2"/>
+                    <Expander Name="expEvents" Grid.Row="3" IsExpanded="True" Style="{StaticResource expAccordion}">
                         <i:Interaction.Behaviors>
                             <behaviors:ExpanderBehavior/>
                         </i:Interaction.Behaviors>
@@ -134,14 +131,13 @@
                         </Expander.Header>
                         <Grid x:Name="gridEvents" VerticalAlignment="Stretch" Grid.ColumnSpan="2">
                             <controls:EventDetailControl x:Name="ctrlEventMessage"
-                                                       Grid.Row="0"    Margin="8"                                                   
-                                                       Grid.ColumnSpan="2"
-                                                       />
+                                                        Grid.Row="0"    Margin="8"                                                   
+                                                        Grid.ColumnSpan="2"
+                                                        />
                         </Grid>
                     </Expander>
-                    
                 </Grid>
-            </Grid>
+            </controls:NamedPane>
         </TabItem>
         <TabItem Name="tabHowToFix" BorderThickness="1" Style="{StaticResource tbiInspectTabs}">
             <TabItem.Header>


### PR DESCRIPTION
#### Describe the change

This change fixes an issue where narrator wasn't including the `tbElement` text (the text description of the element above the properties in the inspect details pane) in reading order. It does so by:

* Collapsing the original nested grid structure of the details tabitem content into a flatter grid
* Wrapping that flatter grid in an unnamed container which appears in the UIAutomation tree (I used an unnamed NamedPane, but if there's a more appropriate control for this someone has a suggestion for, I'd be happy to use it)

Both of these changes were required to get the component to appear in reading order in Narrator. It's not clear to my why.

There is no visual change. I'm struggling to verify the change in NVDA/JAWS since I can't get either to read the text content in question in either production or a local build, will get help from Rob to figure out what I'm missing about their usage :)

![side-by-side screenshots of insiders build and build with change, with no apparent differences](https://user-images.githubusercontent.com/376284/64731551-505d8580-d496-11e9-973f-9991c5fc16d1.png)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# 1583849
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



