### PR TITLE
Improve n-of-m numbering by restructuring tree view walker menu

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -130,7 +130,7 @@
                 <controls:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
                 <Button.ContextMenu>
                     <ContextMenu FlowDirection="LeftToRight" x:Name="cmHierarchySettings">
-                        <MenuItem Header="Tree view" FontWeight="Bold">
+                        <MenuItem Header="Tree view">
                             <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRaw_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName1}">
                                 <MenuItem.Header>

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -129,27 +129,27 @@
                 </Button.ToolTip>
                 <controls:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
                 <Button.ContextMenu>
-                    <ContextMenu FlowDirection="LeftToRight">
-                        <MenuItem Header="Tree view" FontWeight="Bold" IsEnabled="False" IsCheckable="True"/>
-                        <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRaw_Click"
+                    <ContextMenu FlowDirection="LeftToRight" x:Name="cmHierarchySettings">
+                        <MenuItem Header="Tree view" FontWeight="Bold">
+                            <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRaw_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName1}">
-                            <MenuItem.Header>
-                                <RadioButton x:Name="rbRaw" Content="_Raw" Loaded="mniRaw_Loaded" Click="rbRaw_Click" Focusable="False" />
-                            </MenuItem.Header>
-                        </MenuItem>
-                        <MenuItem x:Name="mniControl" IsCheckable="False" Click="mniControl_Click" 
+                                <MenuItem.Header>
+                                    <RadioButton x:Name="rbRaw" Content="_Raw" Loaded="mniRaw_Loaded" Click="rbRaw_Click" Focusable="False" />
+                                </MenuItem.Header>
+                            </MenuItem>
+                            <MenuItem x:Name="mniControl" IsCheckable="False" Click="mniControl_Click" 
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniControlAutomationPropertiesName}">
-                            <MenuItem.Header>
-                                <RadioButton x:Name="rbControl" Content="_Control" Loaded="mniControl_Loaded" Click="rbControl_Click" Focusable="False" />
-                            </MenuItem.Header>
-                        </MenuItem>
-                        <MenuItem x:Name="mniContent" IsCheckable="False" Click="mniContent_Click"
+                                <MenuItem.Header>
+                                    <RadioButton x:Name="rbControl" Content="_Control" Loaded="mniControl_Loaded" Click="rbControl_Click" Focusable="False" />
+                                </MenuItem.Header>
+                            </MenuItem>
+                            <MenuItem x:Name="mniContent" IsCheckable="False" Click="mniContent_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniContentAutomationPropertiesName1}">
-                            <MenuItem.Header>
-                                <RadioButton x:Name="rbContent" Content="Con_tent" Loaded="mniContent_Loaded" Click="rbContent_Click" Focusable="False" />
-                            </MenuItem.Header>
+                                <MenuItem.Header>
+                                    <RadioButton x:Name="rbContent" Content="Con_tent" Loaded="mniContent_Loaded" Click="rbContent_Click" Focusable="False" />
+                                </MenuItem.Header>
+                            </MenuItem>
                         </MenuItem>
-                        <Separator/>
                         <MenuItem Header="Show _Ancestry" x:Name="mniShowAncestry" IsCheckable="True" 
                                   Loaded="mniShowAncestry_Loaded" Click="mniShowAncestry_Click"/>
                         <MenuItem Header="Show _Uncertain results" x:Name="mniShowUncertain" IsCheckable="True" 

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -494,7 +494,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 this.rbRaw.IsChecked = this.ElementContext.Element.TreeWalkerMode == TreeViewMode.Raw;
             }
             var suffix = this.rbRaw.IsChecked.HasValue && this.rbRaw.IsChecked.Value ? "Checked" : "";
-            this.mniRaw.SetValue(AutomationProperties.NameProperty, $"Walk tree in Raw view {suffix}");
+            this.mniRaw.SetValue(AutomationProperties.NameProperty, $"Raw view {suffix}");
         }
 
         /// <summary>
@@ -515,7 +515,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 this.rbContent.IsChecked = this.ElementContext.Element.TreeWalkerMode == TreeViewMode.Content;
             }
             var suffix = this.rbContent.IsChecked.HasValue && this.rbContent.IsChecked.Value ? "Checked" : "";
-            this.mniContent.SetValue(AutomationProperties.NameProperty, $"Walk tree in Content view {suffix}");
+            this.mniContent.SetValue(AutomationProperties.NameProperty, $"Content view {suffix}");
         }
 
         /// <summary>
@@ -536,7 +536,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 this.rbControl.IsChecked = this.ElementContext.Element.TreeWalkerMode == TreeViewMode.Control;
             }
             var suffix = this.rbControl.IsChecked.HasValue && this.rbControl.IsChecked.Value ? "Checked" : "";
-            this.mniControl.SetValue(AutomationProperties.NameProperty, $"Walk tree in Control view {suffix}");
+            this.mniControl.SetValue(AutomationProperties.NameProperty, $"Control view {suffix}");
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -131,6 +131,12 @@ namespace AccessibilityInsights.SharedUx.Controls
                 }
 
                 UpdateButtonVisibility();
+
+                cmHierarchySettings.Items.Remove(mniShowUncertain);
+                if (this.IsLiveMode == false)
+                {
+                    cmHierarchySettings.Items.Add(mniShowUncertain);
+                }
             }
         }
 
@@ -489,7 +495,6 @@ namespace AccessibilityInsights.SharedUx.Controls
             }
             var suffix = this.rbRaw.IsChecked.HasValue && this.rbRaw.IsChecked.Value ? "Checked" : "";
             this.mniRaw.SetValue(AutomationProperties.NameProperty, $"Walk tree in Raw view {suffix}");
-            SetFocusOnHierarchyTree();
         }
 
         /// <summary>
@@ -511,7 +516,6 @@ namespace AccessibilityInsights.SharedUx.Controls
             }
             var suffix = this.rbContent.IsChecked.HasValue && this.rbContent.IsChecked.Value ? "Checked" : "";
             this.mniContent.SetValue(AutomationProperties.NameProperty, $"Walk tree in Content view {suffix}");
-            SetFocusOnHierarchyTree();
         }
 
         /// <summary>
@@ -533,7 +537,6 @@ namespace AccessibilityInsights.SharedUx.Controls
             }
             var suffix = this.rbControl.IsChecked.HasValue && this.rbControl.IsChecked.Value ? "Checked" : "";
             this.mniControl.SetValue(AutomationProperties.NameProperty, $"Walk tree in Control view {suffix}");
-            SetFocusOnHierarchyTree();
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -132,7 +132,13 @@ namespace AccessibilityInsights.SharedUx.Controls
 
                 UpdateButtonVisibility();
 
-                cmHierarchySettings.Items.Remove(mniShowUncertain);
+                // We remove and re-add the "show uncertain" item from the visual tree
+                // in order to ensure n-of-m information is read correctly
+                // by screen readers via the SizeOfSet and PositionInSet properties.
+                if (cmHierarchySettings.Items.Contains(mniShowUncertain))
+                {
+                    cmHierarchySettings.Items.Remove(mniShowUncertain);
+                }
                 if (this.IsLiveMode == false)
                 {
                     cmHierarchySettings.Items.Add(mniShowUncertain);

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2959,7 +2959,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Walk tree in Content view.
+        ///   Looks up a localized string similar to Content view.
         /// </summary>
         public static string mniContentAutomationPropertiesName1 {
             get {
@@ -2968,7 +2968,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Walk tree in Control view.
+        ///   Looks up a localized string similar to Control view.
         /// </summary>
         public static string mniControlAutomationPropertiesName {
             get {
@@ -3004,7 +3004,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Walk tree in Raw view.
+        ///   Looks up a localized string similar to Raw view.
         /// </summary>
         public static string mniRawAutomationPropertiesName1 {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -785,13 +785,13 @@ Accessibility Insights Support Team
     <value>UI Automation Tree Settings</value>
   </data>
   <data name="mniRawAutomationPropertiesName1" xml:space="preserve">
-    <value>Walk tree in Raw view</value>
+    <value>Raw view</value>
   </data>
   <data name="mniControlAutomationPropertiesName" xml:space="preserve">
-    <value>Walk tree in Control view</value>
+    <value>Control view</value>
   </data>
   <data name="mniContentAutomationPropertiesName1" xml:space="preserve">
-    <value>Walk tree in Content view</value>
+    <value>Content view</value>
   </data>
   <data name="btnTestElementAutomationPropertiesName" xml:space="preserve">
     <value>Test this element</value>


### PR DESCRIPTION
#### Describe the change
The SizeOfSet and PositionInSet properties of the tree view menu items were incorrect (2 of 7, 3 of 7, etc) for the following reasons:
- We used a non-actionable menu item as a visual header
- Separators are included in the SizeOfSet count for menu items
- Hidden menu items are included in the SizeOfSet count for menu items

We are unable to override the SizeOfSet or PositionInSet properties unless we explicitly target .NET framework 4.8. In the meantime, this PR restructures the menu to improve accessibility. Now the SizeOfSet and PositionInSet properties are as expected and the visual-only header and separator have gone away.

**before**
!["before" screenshot of menu](https://user-images.githubusercontent.com/7775527/64741995-78a5ae00-d4af-11e9-96fa-fc143ae73391.png)

**after**
!["after" screenshot of menu](https://user-images.githubusercontent.com/7775527/64741882-0765fb00-d4af-11e9-9de8-4f5a6fa18068.png)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
-- It looks like both in production and this PR, we flag popups created by context menus because they have no name. We may want to look into this in more detail to see if axe-windows needs to be updated
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



