### PR TITLE
Slightly darken "TextBrushGray" color

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -28,7 +28,7 @@
         <GradientStop Color="#000000" Offset="0.5"/>
     </LinearGradientBrush>
     <SolidColorBrush po:Freeze="True" x:Key="TextBrush" Color="#000000"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TextBrushGray" Color="#737373"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TextBrushGray" Color="#6E6E6E"/>
     <SolidColorBrush po:Freeze="True" x:Key="TextBrushDark" Color="#1A1A1A"/>
     <SolidColorBrush po:Freeze="True" x:Key="WindowTextBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedTextBrush" Color="#000000"/>


### PR DESCRIPTION
#### Describe the change

This PR changes TextBrushGray from #737373 to #6E6E6E. This changes the contrast ratio > 5:1. From Chelsea: 

> If we brought the secondary text in Accessibility Insights for Windows to #6E6E6E, that would bring the ratio up to 5.09:1. If that's not a high enough bump, let me know and I'll tweak the color some more

Screenshot below with before on left and after on right.
![image](https://user-images.githubusercontent.com/7775527/64742844-7db82c80-d4b2-11e9-8cb0-13416322959e.png)


#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



