### PR TITLE
Hide fabric icons when used in toggle button

### DIFF
--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CommonAutomationPeerCreator.cs
@@ -7,13 +7,13 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
 {
     class CommonAutomationPeerCreator
     {
-        public static AutomationPeer CreateControlViewIconAutomationPeer(UserControl owner)
+        public static AutomationPeer CreateIconAutomationPeer(UserControl owner, bool showInControlView)
         {
             return new CustomControlOverridingAutomationPeer(
                 owner,
                 localizedControl: "icon",
                 isContentElement: false,
-                isControlElement: true,
+                isControlElement: showInControlView,
                 hideChildren: true,
                 controlType: AutomationControlType.Image);
         }

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/DualFabricIconControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/DualFabricIconControl.xaml.cs
@@ -176,6 +176,20 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
 
         #endregion
 
+        #region ShowInControlView (Dependency Property)
+
+        public static readonly DependencyProperty ShowInControlViewProperty =
+            DependencyProperty.Register("ShowInControlView", typeof(bool), typeof(DualFabricIconControl), new PropertyMetadata(true));
+
+        public bool ShowInControlView
+        {
+            get { return (bool)GetValue(ShowInControlViewProperty); }
+
+            set { SetValue(ShowInControlViewProperty, value); }
+        }
+
+        #endregion
+
         /// <summary>
         /// Constructor with default size
         /// </summary>
@@ -186,6 +200,6 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
             this.fabicnBack.GlyphSize = GlyphContext.Custom;
         }
 
-        protected override AutomationPeer OnCreateAutomationPeer() => CommonAutomationPeerCreator.CreateControlViewIconAutomationPeer(this);
+        protected override AutomationPeer OnCreateAutomationPeer() => CommonAutomationPeerCreator.CreateIconAutomationPeer(this, ShowInControlView);
     }
 }

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/FabricIconControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/FabricIconControl.xaml.cs
@@ -149,7 +149,22 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
 
         #endregion
 
-        protected override AutomationPeer OnCreateAutomationPeer() => CommonAutomationPeerCreator.CreateControlViewIconAutomationPeer(this);
+
+        #region ShowInControlView (Dependency Property)
+
+        public static readonly DependencyProperty ShowInControlViewProperty =
+            DependencyProperty.Register("ShowInControlView", typeof(bool), typeof(FabricIconControl), new PropertyMetadata(true));
+
+        public bool ShowInControlView
+        {
+            get { return (bool)GetValue(ShowInControlViewProperty); }
+
+            set { SetValue(ShowInControlViewProperty, value); }
+        }
+
+        #endregion
+
+        protected override AutomationPeer OnCreateAutomationPeer() => CommonAutomationPeerCreator.CreateIconAutomationPeer(this, ShowInControlView);
     }
 
     #region Icon Values

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1093,16 +1093,16 @@
                                 <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <fabric:FabricIconControl x:Name="fbiBorder" GlyphName="ToggleBorder" GlyphSize="Custom" FontSize="26" VerticalAlignment="Center" Margin="0,-10" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
-                            <fabric:FabricIconControl x:Name="fbiFilled" GlyphName="ToggleFilled" GlyphSize="Custom" FontSize="26" VerticalAlignment="Center" Margin="0,-10" Foreground="{DynamicResource ResourceKey=ToggleSliderBlueBrush}"/>
-                            <fabric:FabricIconControl x:Name="fbiFilledHover" GlyphName="ToggleFilled" GlyphSize="Custom" FontSize="26" Visibility="Collapsed" VerticalAlignment="Center" Margin="0,-10" Foreground="Wheat" Opacity=".3"/>
+                            <fabric:FabricIconControl x:Name="fbiBorder" ShowInControlView="False" GlyphName="ToggleBorder" GlyphSize="Custom" FontSize="26" VerticalAlignment="Center" Margin="0,-10" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                            <fabric:FabricIconControl x:Name="fbiFilled" ShowInControlView="False" GlyphName="ToggleFilled" GlyphSize="Custom" FontSize="26" VerticalAlignment="Center" Margin="0,-10" Foreground="{DynamicResource ResourceKey=ToggleSliderBlueBrush}"/>
+                            <fabric:FabricIconControl x:Name="fbiFilledHover" ShowInControlView="False" GlyphName="ToggleFilled" GlyphSize="Custom" FontSize="26" Visibility="Collapsed" VerticalAlignment="Center" Margin="0,-10" Foreground="Wheat" Opacity=".3"/>
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition x:Name="colLeftSide" Width="0"/>
                                     <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition x:Name="colRightSide" Width="*"/>
                                 </Grid.ColumnDefinitions>
-                                <fabric:FabricIconControl Grid.Column="1" x:Name="fbiThumb" GlyphName="ToggleThumb" GlyphSize="Custom" FontSize="6" Foreground="{DynamicResource ResourceKey=IconBrush}" Margin="3,8,3,0"/>
+                                <fabric:FabricIconControl Grid.Column="1" x:Name="fbiThumb" ShowInControlView="False" GlyphName="ToggleThumb" GlyphSize="Custom" FontSize="6" Foreground="{DynamicResource ResourceKey=IconBrush}" Margin="3,8,3,0"/>
                             </Grid>
                             <Label x:Name="lblState" Padding="4,0,0,0" FontSize="11" VerticalAlignment="Center" Grid.Column="1"/>
                         </Grid>


### PR DESCRIPTION
#### Describe the change

This PR removes extraneous icons from scan mode in Narrator by removing them from the control view when used inside a toggle button.

Screenshot below of the UIA tree, which now only shows Button in the control view and not its four icon children:

**before**
![image](https://user-images.githubusercontent.com/7775527/64744097-4a2bd100-d4b7-11e9-93ee-e0adfe2a1e46.png)

**after**
![image](https://user-images.githubusercontent.com/7775527/64744050-194b9c00-d4b7-11e9-8fea-eb4bab45c0f2.png)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



