### PR TITLE
remove obsolete bits of AutomatedChecksControl.xaml

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -18,7 +18,6 @@
         <Grid Width="Auto" Margin="16,0,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
             <Grid Grid.Row="0" Background="{DynamicResource ResourceKey=LightBackgroundBrush}">
@@ -297,8 +296,8 @@
                     </ListView.GroupStyle>
                 </ListView>
             </Border>
-            <Label Grid.Row="2" Name="lblCongrats" Visibility="Collapsed" Content="{x:Static Properties:Resources.lblCongratsContent}" HorizontalAlignment="Center"  Width="Auto" Style="{StaticResource lblHeader2}" Padding="0,32,0,0" />
-            <TextBlock Grid.Row="2" Name="lblNoFail" Visibility="Collapsed" Text="{x:Static Properties:Resources.lblNoFailText}"  Style="{StaticResource tbHeaderDark}" TextWrapping="Wrap" Width="214" HorizontalAlignment="Center" TextAlignment="Center" Padding="0,49,0,0" />
+            <Label Grid.Row="1" Name="lblCongrats" Visibility="Collapsed" Content="{x:Static Properties:Resources.lblCongratsContent}" HorizontalAlignment="Center"  Width="Auto" Style="{StaticResource lblHeader2}" Padding="0,32,0,0" />
+            <TextBlock Grid.Row="1" Name="lblNoFail" Visibility="Collapsed" Text="{x:Static Properties:Resources.lblNoFailText}"  Style="{StaticResource tbHeaderDark}" TextWrapping="Wrap" Width="214" HorizontalAlignment="Center" TextAlignment="Center" Padding="0,49,0,0" />
         </Grid>
     </ScrollViewer>
 </UserControl>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -15,39 +15,13 @@
         <ResourceDictionary Source="..\..\Resources\Styles.xaml"/>
     </UserControl.Resources>
     <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Disabled" Name="scrollview" SizeChanged="scrollview_SizeChanged">
-        <Grid Width="Auto">
+        <Grid Width="Auto" Margin="16,0,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="16"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-            <Rectangle Fill="{DynamicResource ResourceKey=NoticeBackgroundBrush}" Grid.Row="0" Grid.Column="0" Visibility="Collapsed"/>
-            <Grid Grid.Column="1" Grid.Row="0" Background="{DynamicResource ResourceKey=NoticeBackgroundBrush}" Height="Auto" Visibility="Collapsed">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="8"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="8"/>
-                </Grid.RowDefinitions>
-                <fabric:FabricIconControl GlyphName="Info" Foreground="{DynamicResource ResourceKey=ActiveBlueBrush}" VerticalAlignment="Top" Grid.Column="0" Grid.Row="1"
-                                          GlyphSize="Custom" FontSize="16" Margin="8,2,8,0"/>
-                <TextBlock Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Style="{StaticResource TbFocusable}" KeyboardNavigation.IsTabStop="True">
-                    <Hyperlink FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" TextDecorations="None"
-                               NavigateUri="https://aka.ms/accessibility-insights-announcements" RequestNavigate="Hyperlink_RequestNavigate">
-                        <Run Name="tbLinkText" Text="{x:Static Properties:Resources.RunTextEmailSupport}"/>
-                    </Hyperlink>
-                    <Run Text="{x:Static Properties:Resources.RunTextReceiveEmail}"/>
-                </TextBlock>
-            </Grid>
-            <Rectangle Fill="{DynamicResource ResourceKey=LightBackgroundBrush}" Grid.Column="0" Grid.Row="1"/>
-            <Grid Grid.Row="1" Grid.Column="1" Background="{DynamicResource ResourceKey=LightBackgroundBrush}">
+            <Grid Grid.Row="0" Background="{DynamicResource ResourceKey=LightBackgroundBrush}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="12"/>
                     <RowDefinition Height="28"/>
@@ -85,7 +59,7 @@
                     </TextBlock>
                 </Grid>
             </Grid>
-            <Border Grid.Row="5" Grid.Column="1" BorderBrush="#EAEAEA" BorderThickness="0,1,0,0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+            <Border Grid.Row="1" BorderBrush="#EAEAEA" BorderThickness="0,1,0,0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
                 <ListView AutomationProperties.LabeledBy="{Binding ElementName=lblTitle}" KeyboardNavigation.TabNavigation="Once"
                           Name="lvResults" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderThickness="0"
                           AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.AutomatedChecksResultsListView}">
@@ -323,9 +297,8 @@
                     </ListView.GroupStyle>
                 </ListView>
             </Border>
-            <Label Grid.Row="6" Grid.Column="1" Name="lblCongrats" Visibility="Collapsed" Content="{x:Static Properties:Resources.lblCongratsContent}" HorizontalAlignment="Center"  Width="Auto" Style="{StaticResource lblHeader2}" Padding="0,32,0,0" />
-            <TextBlock Grid.Row="6" Grid.Column="1" Name="lblNoFail" Visibility="Collapsed" Text="{x:Static Properties:Resources.lblNoFailText}"  Style="{StaticResource tbHeaderDark}" TextWrapping="Wrap" Width="214" HorizontalAlignment="Center" TextAlignment="Center" Padding="0,49,0,0" />
+            <Label Grid.Row="2" Name="lblCongrats" Visibility="Collapsed" Content="{x:Static Properties:Resources.lblCongratsContent}" HorizontalAlignment="Center"  Width="Auto" Style="{StaticResource lblHeader2}" Padding="0,32,0,0" />
+            <TextBlock Grid.Row="2" Name="lblNoFail" Visibility="Collapsed" Text="{x:Static Properties:Resources.lblNoFailText}"  Style="{StaticResource tbHeaderDark}" TextWrapping="Wrap" Width="214" HorizontalAlignment="Center" TextAlignment="Center" Padding="0,49,0,0" />
         </Grid>
     </ScrollViewer>
 </UserControl>
-

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3321,15 +3321,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Join Accessibility Insights Updates and Discussions.
-        /// </summary>
-        public static string RunTextEmailSupport {
-            get {
-                return ResourceManager.GetString("RunTextEmailSupport", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Quickly find accessibility issues with FastPass:.
         /// </summary>
         public static string RunTextFastPass {
@@ -3445,15 +3436,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string RunTextPrivacyStatement {
             get {
                 return ResourceManager.GetString("RunTextPrivacyStatement", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to to receive email announcements..
-        /// </summary>
-        public static string RunTextReceiveEmail {
-            get {
-                return ResourceManager.GetString("RunTextReceiveEmail", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -378,12 +378,6 @@
   <data name="RunTextTabStops" xml:space="preserve">
     <value>Tab Stops</value>
   </data>
-  <data name="RunTextEmailSupport" xml:space="preserve">
-    <value>Join Accessibility Insights Updates and Discussions</value>
-  </data>
-  <data name="RunTextReceiveEmail" xml:space="preserve">
-    <value>to receive email announcements.</value>
-  </data>
   <data name="lblTitleContent" xml:space="preserve">
     <value>AUTOMATED CHECKS</value>
   </data>


### PR DESCRIPTION
#### Describe the change

While looking into 1583836, we found that some of the content from the automated checks component was obsolete; it was permanently collapsed, rather than being removed. This PR removes the obsolete content completely, and cleans up the containing grid layout accordingly. Specifically:

* Removes the always-collapsed `<Rectangle>` and `<Grid>` that used to show an obsolete notification banner
* Removes the corresponding resource strings
* The original used a 2-column grid where the only content of the first column was an empty 16px wide rectangle; replaced the first column and the spacer rectangle with a margin on the grid.
* Removed an unnecessary `<RowDefinition>` from the grid and fixed up the `Grid.Row` references in the children that were pointing to non-existent rows.

This is intended to have no visual or screen reader impact (except that it will improve the screen reader experience for users without .NET 4.8 installed, where the collapsed content would have still been read).

##### Before & after of the "congrats no issues" screen (should be no changes):
![before and after screenshots of "congrats no issues" page showing identical content](https://user-images.githubusercontent.com/376284/64896112-7b311080-d633-11e9-9753-0486853dfcaf.png)

##### Before & after of the "some issues" screen (should be no changes):
![before and after screenshots of results with failures page showing identical content](https://user-images.githubusercontent.com/376284/64896321-3659a980-d634-11e9-9daf-aecceae0e416.png)

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? related to 1583836
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



