### PR TITLE
Move decorative images out of control view

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -137,7 +137,7 @@
                          AutomationProperties.Name="{x:Static Properties:Resources.tbTeamProjectSearchAutomationPropertiesName}"
                          FontSize="{DynamicResource StandardTextSize}"/>
                 <fabric:FabricIconControl HorizontalAlignment="Right" Margin="5,0,5,0" 
-                                                  GlyphName="Search" GlyphSize="Custom" FontSize="11" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                                                  GlyphName="Search" GlyphSize="Custom" FontSize="11" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}" ShowInControlView="False"/>
             </Grid>
             <Grid Grid.Row="2" Height="200px" ScrollViewer.VerticalScrollBarVisibility="Auto" Margin="0 12">
                 <TreeView x:Name="serverTreeview" ItemsSource="{Binding Path=projects}" 

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -137,7 +137,7 @@
                          AutomationProperties.Name="{x:Static Properties:Resources.tbTeamProjectSearchAutomationPropertiesName}"
                          FontSize="{DynamicResource StandardTextSize}"/>
                 <fabric:FabricIconControl HorizontalAlignment="Right" Margin="5,0,5,0" 
-                                                  GlyphName="Search" GlyphSize="Custom" FontSize="11" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}" ShowInControlView="False"/>
+                                                  GlyphName="Search" GlyphSize="Custom" FontSize="11" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
             </Grid>
             <Grid Grid.Row="2" Height="200px" ScrollViewer.VerticalScrollBarVisibility="Auto" Margin="0 12">
                 <TreeView x:Name="serverTreeview" ItemsSource="{Binding Path=projects}" 

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml
@@ -41,7 +41,7 @@
         </Grid.RowDefinitions>
         <Border Grid.Row="0" BorderThickness="1" BorderBrush="LightGray">
             <DockPanel>
-                <fabric:FabricIconControl GlyphName="Search" Foreground="{DynamicResource ResourceKey=IconBrush}" FontSize="18" GlyphSize="Custom" Margin="5,0,5,0" DockPanel.Dock="Left" VerticalAlignment="Center" HorizontalAlignment="Center" ShowInControlView="False"/>
+                <fabric:FabricIconControl GlyphName="Search" Foreground="{DynamicResource ResourceKey=IconBrush}" FontSize="18" GlyphSize="Custom" Margin="5,0,5,0" DockPanel.Dock="Left" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                 <TextBox Grid.Column="1" x:Name="textboxSearch" 
                          TextChanged="textboxSearch_TextChanged"
                          ScrollViewer.VerticalScrollBarVisibility="Disabled"

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml
@@ -41,7 +41,7 @@
         </Grid.RowDefinitions>
         <Border Grid.Row="0" BorderThickness="1" BorderBrush="LightGray">
             <DockPanel>
-                <fabric:FabricIconControl GlyphName="Search" Foreground="{DynamicResource ResourceKey=IconBrush}" FontSize="18" GlyphSize="Custom" Margin="5,0,5,0" DockPanel.Dock="Left" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                <fabric:FabricIconControl GlyphName="Search" Foreground="{DynamicResource ResourceKey=IconBrush}" FontSize="18" GlyphSize="Custom" Margin="5,0,5,0" DockPanel.Dock="Left" VerticalAlignment="Center" HorizontalAlignment="Center" ShowInControlView="False"/>
                 <TextBox Grid.Column="1" x:Name="textboxSearch" 
                          TextChanged="textboxSearch_TextChanged"
                          ScrollViewer.VerticalScrollBarVisibility="Disabled"

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -145,7 +145,7 @@
         </Grid>
         <TextBlock Name="tbIntro" Grid.Row="1" Padding="4" TextWrapping="Wrap" Style="{StaticResource TbFocusable}">
             <Run Text="{x:Static Properties:Resources.tbIntroTextSelectEventRecord}"/>
-            <fabric:FabricIconControl GlyphName="CircleFill" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-3" Foreground="#A80000" FontStyle="Normal"/>
+            <fabric:FabricIconControl GlyphName="CircleFill" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-3" Foreground="#A80000" FontStyle="Normal" ShowInControlView="False"/>
             <Run Text="{x:Static Properties:Resources.tbIntroTextStartRecording}"/>
             <Run Name="runHkRecord"/><Run Text="."/>
         </TextBlock>

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -89,7 +89,7 @@
             </Grid.ColumnDefinitions>
             <Border Height="24" Margin="8,5,8,5" Background="{DynamicResource ResourceKey=LightGreyBrush}">
                 <DockPanel>
-                    <controls:FabricIconControl DockPanel.Dock="Left" Margin="5,0,5,0" GlyphName="Search" FontSize="{StaticResource ConstStandardTextSize}" GlyphSize="Custom" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                    <controls:FabricIconControl DockPanel.Dock="Left" Margin="5,0,5,0" GlyphName="Search" FontSize="{StaticResource ConstStandardTextSize}" GlyphSize="Custom" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}" ShowInControlView="False"/>
                     <controls:PlaceholderTextBox x:Name="textboxSearch" TextChanged="textboxSearch_TextChanged"
                         AutomationProperties.Name="{x:Static Properties:Resources.HierarchyControl_textboxSearchAutomationName}"
                         Height="24" HorizontalAlignment="Stretch" VerticalContentAlignment="Center"

--- a/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
@@ -29,7 +29,7 @@
                 </Grid.ColumnDefinitions>
                 <Border Background="#14000000" x:Name="dpFilter" Grid.Row="0" HorizontalAlignment="Stretch" BorderBrush="LightGray" BorderThickness="0" Height="24" Margin="0,0,0,5">
                     <DockPanel>
-                        <controls:FabricIconControl GlyphName="Search" GlyphSize="Custom" FontSize="18" Margin="5,0,5,0" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="#333333"/>
+                        <controls:FabricIconControl GlyphName="Search" GlyphSize="Custom" FontSize="18" Margin="5,0,5,0" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="#333333" ShowInControlView="False"/>
                         <controls:PlaceholderTextBox x:Name="textboxSearch" TextChanged="textboxSearch_TextChanged"
                                     AutomationProperties.Name="{x:Static Properties:Resources.tbSearchText}" 
                                     AutomationProperties.HelpText="{x:Static Properties:Resources.PropertyInfoControl_textboxSearch}"

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
@@ -162,7 +162,7 @@
                     <ColumnDefinition Width="50"/>
                     <ColumnDefinition Width="130"/>
                 </Grid.ColumnDefinitions>
-                <controls:FabricIconControl Grid.Column="0" Height="16" Width="16" GlyphName="KeyboardClassic" GlyphSize="Default" Foreground="{DynamicResource ResourceKey=IconBrush}" AutomationProperties.Name="{x:Static Properties:Resources.ApplicationSettingsControl_KeyboardIconAutomationName}"/>
+                <controls:FabricIconControl Grid.Column="0" Height="16" Width="16" GlyphName="KeyboardClassic" GlyphSize="Default" Foreground="{DynamicResource ResourceKey=IconBrush}" AutomationProperties.Name="{x:Static Properties:Resources.ApplicationSettingsControl_KeyboardIconAutomationName}" ShowInControlView="False"/>
                 <Label Name="lblFocusLabel" Grid.Column="1" Content="{x:Static Properties:Resources.lblFocusLabelContent}" Margin="8,0,0,0" Padding="0" Style="{StaticResource LblText}" VerticalAlignment="Center"/>
                 <ToggleButton Grid.Column="2" Style="{StaticResource tgbSlider}" Name="tgbtnKeyboard" AutomationProperties.LabeledBy="{Binding ElementName=lblFocusLabel}" IsChecked="{Binding SelectionByFocus}"/>
             </Grid>
@@ -173,7 +173,7 @@
                     <ColumnDefinition Width="50"/>
                     <ColumnDefinition Width="130"/>
                 </Grid.ColumnDefinitions>
-                <controls:FabricIconControl Grid.Column="0" Height="16" Width="16" GlyphName="F12DevTools" GlyphSize="Default" Foreground="{DynamicResource ResourceKey=IconBrush}" AutomationProperties.Name="{x:Static Properties:Resources.ApplicationSettingsControl_MouseIconAutomationName}"/>
+                <controls:FabricIconControl Grid.Column="0" Height="16" Width="16" GlyphName="F12DevTools" GlyphSize="Default" Foreground="{DynamicResource ResourceKey=IconBrush}" AutomationProperties.Name="{x:Static Properties:Resources.ApplicationSettingsControl_MouseIconAutomationName}" ShowInControlView="False"/>
                 <Label Name="lblMouseLabel" Grid.Column="1" Margin="8,0,0,0" Content="{x:Static Properties:Resources.lblMouseLabelContent}"  RenderTransformOrigin="0.877,0.538" Padding="0" Style="{StaticResource LblText}" VerticalAlignment="Center"/>
                 <ToggleButton Grid.Column="2" Style="{StaticResource tgbSlider}" Name="tgbtnMouse" AutomationProperties.LabeledBy="{Binding ElementName=lblMouseLabel}" IsChecked="{Binding SelectionByMouse}"/>
                 <StackPanel Grid.Column="3" Margin="30,0,0,0" Orientation="Horizontal">

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -40,7 +40,7 @@
                         AutomationProperties.Name="{Binding ElementName=tbViewResults,Path=Text}"
                         AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.AutomatedChecksUIATreeButton}">
                     <StackPanel Orientation="Horizontal">
-                        <fabric:FabricIconControl GlyphName="DOM" FontSize="14" Foreground="{DynamicResource ResourceKey=ActiveBlueBrush}" Margin="0,0,4,0"/>
+                        <fabric:FabricIconControl GlyphName="DOM" FontSize="14" Foreground="{DynamicResource ResourceKey=ActiveBlueBrush}" Margin="0,0,4,0" ShowInControlView="False"/>
                         <TextBlock Name="tbViewResults" Text="{x:Static Properties:Resources.tbViewResultsText}" Style="{StaticResource tbLink}" Focusable="False"/>
                     </StackPanel>
                 </Button>
@@ -125,7 +125,7 @@
                                 <GridViewColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Orientation="Horizontal" MinWidth="200">
-                                            <fabric:FabricIconControl GlyphName="LadybugSolid" GlyphSize="Custom" FontSize="15" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=ButtonBlueBGBrush}" Margin="0,0,4,0" Visibility="{Binding Path=FileBugVisibility}"/>
+                                            <fabric:FabricIconControl GlyphName="LadybugSolid" GlyphSize="Custom" FontSize="15" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=ButtonBlueBGBrush}" Margin="0,0,4,0" Visibility="{Binding Path=FileBugVisibility}" ShowInControlView="False"/>
                                             <Button Visibility="{Binding FileBugVisibility}" VerticalAlignment="Center" Tag="{Binding}"
                                                 Style="{StaticResource btnLink}" Name="btnFileBug" Click="btnFileBug_Click"
                                                 Content="{Binding IssueDisplayText, TargetNullValue='{x:Static Properties:Resources.btnFileIssueContent}'}"

--- a/src/AccessibilityInsights.SharedUx/Controls/WhatsNew/WhatsNewControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/WhatsNew/WhatsNewControl.xaml
@@ -31,7 +31,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <fabric:FabricIconControl VerticalAlignment="Center" GlyphName="SearchAndApps" GlyphSize="Custom" FontSize="18" Foreground="{DynamicResource ResourceKey=IconBrush}" Grid.Column="1" Grid.Row="0"/>
+            <fabric:FabricIconControl VerticalAlignment="Center" GlyphName="SearchAndApps" GlyphSize="Custom" FontSize="18" Foreground="{DynamicResource ResourceKey=IconBrush}" Grid.Column="1" Grid.Row="0" ShowInControlView="False"/>
             <TextBlock Style="{StaticResource TbFocusable}" Margin="0,12" Grid.Column="2" Grid.Row="0">
                 <Run FontWeight="SemiBold" Text="{x:Static Properties:Resources.RunTextInspectMode}"/>
                 <Run Text="{x:Static Properties:Resources.RunTextInspectLiveUIATree}"/>
@@ -47,7 +47,7 @@
                 </TextBlock>
             </TextBlock>
 
-            <fabric:FabricIconControl VerticalAlignment="Center" GlyphName="Rocket" GlyphSize="Custom" FontSize="18" Foreground="{DynamicResource ResourceKey=IconBrush}" Grid.Column="1" Grid.Row="1"/>
+            <fabric:FabricIconControl VerticalAlignment="Center" GlyphName="Rocket" GlyphSize="Custom" FontSize="18" Foreground="{DynamicResource ResourceKey=IconBrush}" Grid.Column="1" Grid.Row="1" ShowInControlView="False"/>
             <TextBlock Margin="0,12"  Grid.Column="2" Grid.Row="1" Style="{StaticResource TbFocusable}" TextWrapping="Wrap">
                 <Run Name="tbFastPass" FontWeight="SemiBold" Text="{x:Static Properties:Resources.RunTextFastPass}"/>
                 <Run Name="tbFastPassInfo" Text="{x:Static Properties:Resources.tbFastPassInfoText}"/>
@@ -69,7 +69,7 @@
                 </AutomationProperties.Name>
             </TextBlock>
 
-            <fabric:FabricIconControl VerticalAlignment="Center" GlyphName="LadybugSolid" GlyphSize="Custom" FontSize="18" Foreground="{DynamicResource ResourceKey=IconBrush}" Grid.Column="1" Grid.Row="2"/>
+            <fabric:FabricIconControl VerticalAlignment="Center" GlyphName="LadybugSolid" GlyphSize="Custom" FontSize="18" Foreground="{DynamicResource ResourceKey=IconBrush}" Grid.Column="1" Grid.Row="2" ShowInControlView="False"/>
             <TextBlock Style="{StaticResource TbFocusable}" Margin="0,12" Grid.Column="2" Grid.Row="2">
                 <Run FontWeight="SemiBold" Text="{x:Static Properties:Resources.RunTextFileBugs}"/>
                 <Run Text="{x:Static Properties:Resources.RunTextLogBugsIn}"/>
@@ -85,7 +85,7 @@
                 </TextBlock>
             </TextBlock>
 
-            <fabric:FabricIconControl VerticalAlignment="Center" GlyphName="Color" GlyphSize="Custom" FontSize="18" Foreground="{DynamicResource ResourceKey=IconBrush}" Grid.Column="1" Grid.Row="3"/>
+            <fabric:FabricIconControl VerticalAlignment="Center" GlyphName="Color" GlyphSize="Custom" FontSize="18" Foreground="{DynamicResource ResourceKey=IconBrush}" Grid.Column="1" Grid.Row="3" ShowInControlView="False"/>
             <TextBlock Margin="0,12"  Grid.Column="2" Grid.Row="3" Style="{StaticResource TbFocusable}" TextWrapping="Wrap">
                 <Run Name="tbColorContrast" FontWeight="SemiBold" Text="{x:Static Properties:Resources.RunTextColorContrast}"/>
                 <Run Text="{x:Static Properties:Resources.RunTextManualColorTest}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1050,7 +1050,7 @@
                                 <ColumnDefinition Width="24"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <fabric:FabricIconControl x:Name="fbIcn" VerticalAlignment="Center" Grid.Column="0" GlyphSize="Small" GlyphName="{Binding Tag, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
+                            <fabric:FabricIconControl x:Name="fbIcn" VerticalAlignment="Center" Grid.Column="0" GlyphSize="Small" GlyphName="{Binding Tag, RelativeSource={RelativeSource Mode=TemplatedParent}}" ShowInControlView="False"/>
                             <ContentPresenter VerticalAlignment="Center" Grid.Column="1" ContentSource="Header" RecognizesAccessKey="True" />
                         </Grid>
                     </Border>

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml
@@ -53,7 +53,7 @@
 
                 <TextBlock Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
                     <Run Text="{x:Static properties:Resources.LiveModeControl_RunAutomatedChecks}"/>
-                    <fabric:FabricIconControl GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal"/>
+                    <fabric:FabricIconControl GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal" ShowInControlView="False"/>
                     <Run Text="{x:Static properties:Resources.LiveModeControl_FocusOnElement}"/>
                     <Run Name="runHkTest"/><Run Text="."/>
                     <TextBlock>

--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml
@@ -32,7 +32,7 @@
                                 <ColumnDefinition Width="4"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <fabric:FabricIconControl Grid.Column="0" GlyphName="Rocket" GlyphSize="Custom" FontSize="14" VerticalAlignment="Center" Margin="0,4,0,2" Foreground="#333333"/>
+                            <fabric:FabricIconControl Grid.Column="0" GlyphName="Rocket" GlyphSize="Custom" FontSize="14" VerticalAlignment="Center" Margin="0,4,0,2" Foreground="#333333" ShowInControlView="False"/>
                             <Label Name="lblFastpass" Grid.Column="2" Content="{x:Static properties:Resources.tabControlLabelContent}" Style="{StaticResource lblXLHeader}" VerticalAlignment="Top"/>
                         </Grid>
                     </TabItem.Header>
@@ -58,9 +58,9 @@
             </Grid.RowDefinitions>
             <TextBlock Grid.Row="0" x:Name="tbSelectElement" Style="{StaticResource TbFocusableCenter}" MinWidth="40">
                 <Run Text="{x:Static properties:Resources.TestModeControl_RunAutomatedChecks}"/>
-                <fabric:FabricIconControl GlyphName="SearchAndApps" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-3" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal"/>
+                <fabric:FabricIconControl GlyphName="SearchAndApps" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-3" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal" ShowInControlView="False"/>
                 <Run Text="{x:Static properties:Resources.TestModeControl_HoverAndTest}"/>
-                <fabric:FabricIconControl GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal"/>
+                <fabric:FabricIconControl GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal" ShowInControlView="False"/>
                 <Run Text="{x:Static properties:Resources.LiveModeControl_FocusOnElement}"/>
                 <Run Name="runHotkey"/><Run Text="."/>
                 <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077027" RequestNavigate="Hyperlink_RequestNavigate"


### PR DESCRIPTION
In this PR, decorative images are moved out of the UIA control view. This will prevent these images from showing up in Narrator's scan mode. For our purposes, a decorative image adds no additional information than adjacent text.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



