### PR TITLE
Add Octokit version as an overridable variable

### DIFF
--- a/tools/scripts/ValidateReleaseInfo.ps1
+++ b/tools/scripts/ValidateReleaseInfo.ps1
@@ -74,8 +74,15 @@ function ValidateChannelInfo($channel)
 	return $isCurrentVersionValid -and $isMinimumVersionValid -and $isVersionRelationshipValid -and $isInstallerUrlValid -and $isReleaseNotesUrlValid
 }
 
+# Determine our octokit version
+$octokitVersion = $Env:OctokitVersion
+if ($octokitVersion -eq $null)
+{
+	$octokitVersion = '0.33.0'
+}
+
 # Load the octokit dll
-Add-Type -Path ((Get-Location).Path + '\Octokit.0.33.0\lib\net45\Octokit.dll')
+Add-Type -Path ((Get-Location).Path + '\Octokit.' + $($octokitVersion) + '\lib\net45\Octokit.dll')
 
 # Get a new client with an appropriate product header value
 $productHeader = [Octokit.ProductHeaderValue]::new("AIWindows-ReleaseInfoValidation")


### PR DESCRIPTION
#### Describe the change
Update ValidateReleaseInfo.ps1 with an environment variable to control the release of Octokit to use when validating the releases. This variable can be updated by changing the build definition.

This is the code-side fix for #545. The other changes are all in build definitions (already in place and validated)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



