### PR TITLE
Improve n-of-m numbering by restructuring event config settings menu 

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -117,7 +117,7 @@
                     <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
                     <Button.ContextMenu>
                         <ContextMenu FlowDirection="LeftToRight" Loaded="ContextMenu_Loaded" Unloaded="ContextMenu_Unloaded">
-                            <MenuItem Header="Event recording scope">
+                            <MenuItem Header="{x:Static Properties:Resources.EventRecordControlScopeHeader}">
                                 <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRB_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName}">
                                     <MenuItem.Header>

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -117,26 +117,26 @@
                     <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
                     <Button.ContextMenu>
                         <ContextMenu FlowDirection="LeftToRight" Loaded="ContextMenu_Loaded" Unloaded="ContextMenu_Unloaded">
-                            <MenuItem Header="Event recording scope" FontWeight="Bold" IsEnabled="False" IsCheckable="False"/>
-                            <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRB_Click"
+                            <MenuItem Header="Event recording scope">
+                                <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRB_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName}">
-                                <MenuItem.Header>
-                                    <RadioButton x:Name="radiobuttonScopeSelf" GroupName="groupScope" Content="{x:Static Properties:Resources.mniRawAutomationPropertiesName}" Focusable="False"/>
-                                </MenuItem.Header>
-                            </MenuItem>
-                            <MenuItem x:Name="mniControl" IsCheckable="False" Click="mniRB_Click"
+                                    <MenuItem.Header>
+                                        <RadioButton x:Name="radiobuttonScopeSelf" GroupName="groupScope" Content="{x:Static Properties:Resources.mniRawAutomationPropertiesName}" Focusable="False"/>
+                                    </MenuItem.Header>
+                                </MenuItem>
+                                <MenuItem x:Name="mniControl" IsCheckable="False" Click="mniRB_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.radiobuttonScopeSubtreeContent}">
-                                <MenuItem.Header>
-                                    <RadioButton x:Name="radiobuttonScopeSubtree" GroupName="groupScope" Content="{x:Static Properties:Resources.radiobuttonScopeSubtreeContent}" Focusable="False"/>
-                                </MenuItem.Header>
-                            </MenuItem>
-                            <MenuItem x:Name="mniContent" IsCheckable="False" Click="mniRB_Click"
+                                    <MenuItem.Header>
+                                        <RadioButton x:Name="radiobuttonScopeSubtree" GroupName="groupScope" Content="{x:Static Properties:Resources.radiobuttonScopeSubtreeContent}" Focusable="False"/>
+                                    </MenuItem.Header>
+                                </MenuItem>
+                                <MenuItem x:Name="mniContent" IsCheckable="False" Click="mniRB_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniContentAutomationPropertiesName}">
-                                <MenuItem.Header>
-                                    <RadioButton x:Name="radiobuttonScopeDescendents" GroupName="groupScope" Content="{x:Static Properties:Resources.mniContentAutomationPropertiesName}" Focusable="False"/>
-                                </MenuItem.Header>
+                                    <MenuItem.Header>
+                                        <RadioButton x:Name="radiobuttonScopeDescendents" GroupName="groupScope" Content="{x:Static Properties:Resources.mniContentAutomationPropertiesName}" Focusable="False"/>
+                                    </MenuItem.Header>
+                                </MenuItem>
                             </MenuItem>
-                            <Separator/>
                             <MenuItem Header="Record _AutomationFocusChanged Event" x:Name="mniFocusChanged" IsCheckable="True"/>
                         </ContextMenu>
                     </Button.ContextMenu>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1638,6 +1638,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Event recording scope.
+        /// </summary>
+        public static string EventRecordControlScopeHeader {
+            get {
+                return ResourceManager.GetString("EventRecordControlScopeHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Telemetry was lost! Exceptions were flushed from ReportExceptionBuffer, but the telemetry sink was not open..
         /// </summary>
         public static string ExceptionsLostFromBuffer {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1609,4 +1609,7 @@ Do you want to change the channel? </value>
   <data name="RangeSelectionNotChanged" xml:space="preserve">
     <value>No selected Range or the selected Range is already in the list.</value>
   </data>
+  <data name="EventRecordControlScopeHeader" xml:space="preserve">
+    <value>Event recording scope</value>
+  </data>
 </root>


### PR DESCRIPTION
#### Describe the change

As in #532 - the current structure of the context menu for event recording is not accessible:
- the separator is included in the n-of-m count
- the disabled header menu item is not easily accessible via screen readers
- the n-of-m counts are inaccurate because they include the non-focusable header

This PR introduces a submenu so that the n-of-m counts are correct and the header is more accessible.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 

Screenshot:
![image](https://user-images.githubusercontent.com/7775527/64996559-1aa00e80-d893-11e9-821c-641cf1fe44ca.png)


