### PR TITLE
hide non-visible controls from control/content planes (like .NET 4.8)

### DIFF
--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
@@ -14,19 +14,10 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
     /// </summary>
     public class CustomControlOverridingAutomationPeer: UserControlAutomationPeer
     {
-        /// <summary>
-        /// Value for custom IsControlElement
-        /// </summary>
         private bool IsControlElem;
 
-        /// <summary>
-        /// Value for custom IsContentElement
-        /// </summary>
         private bool IsContentElem;
 
-        /// <summary>
-        /// String for custom LocalizedControlType
-        /// </summary>
         private string LocalizedControlType;
 
         private AutomationControlType ControlType;
@@ -60,17 +51,9 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
 
         public override object GetPattern(PatternInterface patternInterface) => null;
 
-        /// <summary>
-        /// Use provided value for IsControlElement
-        /// </summary>
-        /// <returns></returns>
-        protected override bool IsControlElementCore() => IsControlElem;
+        protected override bool IsControlElementCore() => this.Owner.IsVisible && IsControlElem;
 
-        /// <summary>
-        /// Use provided value for IsContentElement
-        /// </summary>
-        /// <returns></returns>
-        protected override bool IsContentElementCore() => IsContentElem;
+        protected override bool IsContentElementCore() => this.Owner.IsVisible && IsContentElem;
 
         protected override List<AutomationPeer> GetChildrenCore() => HideChildren ? null : base.GetChildrenCore();
 


### PR DESCRIPTION
#### Describe the change
This updates our `CustomControlOverridingAutomationPeer`'s default behavior to omit controls that are not visible from the content and control planes, similar to the new .NET 4.8 default behavior we recently opted into that does the same thing in the [default `UIElementAutomationPeer` implementation](https://referencesource.microsoft.com/#PresentationCore/Core/CSharp/System/Windows/Automation/Peers/UIElementAutomationPeer.cs,399).

This improves narrator scan mode behavior in a few cases where it was previously reading "invisible" icons; for example, in a "automated checks test results" page showing the "congratulations, no failures" message, this change prevents narrator's scan mode from incorrectly reading the "alert" icon that is only visible when there are failures present.

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? Resolves part of 1583836
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a, no visual change] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



