### PR TITLE
Issue #544: Don't cut off "File Issue" text in standard font size

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -7,6 +7,7 @@ using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.SharedUx.FileIssue;
 using AccessibilityInsights.SharedUx.Settings;
 using AccessibilityInsights.SharedUx.Telemetry;
+using AccessibilityInsights.SharedUx.Utilities;
 using AccessibilityInsights.SharedUx.ViewModels;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Results;
@@ -33,11 +34,6 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// Keeps track of if we should automatically set lv column widths
         /// </summary>
         public bool HasUserResizedLvHeader { get; set; } = false;
-
-        /// <summary>
-        /// Fixed width for bug column
-        /// </summary>
-        const int BugColumnWidth = 80;
 
         /// <summary>
         /// Constructor
@@ -413,7 +409,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             }
             if ((header.Content as string) == Properties.Resources.ScannerResultControl_Thumb_DragDelta_Issue)
             {
-                header.Column.Width = BugColumnWidth;
+                header.Column.Width = HelperMethods.FileIssueColumnWidth;
             }
         }
     }

--- a/src/AccessibilityInsights.SharedUx/Utilities/HelperMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/HelperMethods.cs
@@ -51,6 +51,21 @@ namespace AccessibilityInsights.SharedUx.Utilities
         }
 
         /// <summary>
+        /// Get a "File Issue" column width that is appropriate for the currently configured font size
+        /// </summary>
+        public static double FileIssueColumnWidth
+        {
+            get
+            {
+                switch (ConfigurationManager.GetDefaultInstance().AppConfig.FontSize)
+                {
+                    case Enums.FontSize.Small: return 80.0;
+                    default: return 90.0;
+                }
+            }
+        }
+
+        /// <summary>
         /// Provides bindable property for ProgressRingControls
         /// </summary>
         public static bool PlayScanningSound => ConfigurationManager.GetDefaultInstance().AppConfig.PlayScanningSound;

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -58,7 +58,7 @@ namespace AccessibilityInsights
         /// <summary>
         /// The width of the Bug column in the data grid (0 if bug filing isn't available)
         /// </summary>
-        public static double BugColumnWidth => HelperMethods.GeneralFileBugVisibility == Visibility.Visible ? 80 : 0;
+        public static double BugColumnWidth => HelperMethods.GeneralFileBugVisibility == Visibility.Visible ? HelperMethods.FileIssueColumnWidth : 0;
 
         /// <summary>
         /// Internal bool to ignore or allow updating logic


### PR DESCRIPTION
#### Describe the change
Make the "File Issue" column width responsive to the configured font size.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - #544 
- [ ] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

![image](https://user-images.githubusercontent.com/45672944/65000439-77ee8c80-d8a0-11e9-93db-7b0f3eda3901.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



