### PR TITLE
Update hotkey dialog to have TextBox + block saving tab key

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
@@ -5,14 +5,13 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:AccessibilityInsights.SharedUx.Dialogs"
         xmlns:Properties="clr-namespace:AccessibilityInsights.SharedUx.Properties"
         mc:Ignorable="d"
         ResizeMode="NoResize"
         Title="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}" Height="162" Width="319" 
         KeyDown="Window_KeyDown" KeyUp="Window_KeyUp" 
         WindowStartupLocation="CenterOwner"
-        ShowInTaskbar="False" Topmost="True"
+        ShowInTaskbar="False" Topmost="True" FocusManager.FocusedElement="{Binding ElementName=tbHotkey}"
         AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.SettingsHotkeyGrabDialog}">
     <Window.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
@@ -28,19 +27,20 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Label Content="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}" HorizontalAlignment="Left" Margin="8,8,0,0" Grid.Row="0" VerticalAlignment="Top" Style="{StaticResource LblH5}" Padding="0"/>
-        <TextBlock HorizontalAlignment="Left" Margin="8,10,0,0" TextWrapping="Wrap" 
+        <TextBlock HorizontalAlignment="Left" Margin="8,10,0,0" TextWrapping="Wrap" Name="tbInstructions"
                    VerticalAlignment="Top" Width="303" Grid.Row="1" Style="{StaticResource TxtBlkText}">
-            <Run Text="{x:Static Properties:Resources.RunTextToChangeKeyBoard}" />
+            <Run Text="{x:Static Properties:Resources.RunTextToChangeKeyBoard}"/>
         </TextBlock>
-        <Grid Grid.Row="2" Margin="8,10,0,0">
-            <Rectangle HorizontalAlignment="Left" Fill="#F4F4F4" VerticalAlignment="Top" Height="24" Width="300" StrokeThickness="0"/>
-            <StackPanel Orientation="Horizontal">
-                <Label Name="lbModifiers" Content="" Margin="30,0,0,0"  HorizontalAlignment="Left" Height="23" VerticalAlignment="Top" Width="103" HorizontalContentAlignment="Right" Style="{StaticResource LblText}"/>
-                <Label x:Name="lbPlus" Content="+" HorizontalAlignment="Center" Height="23"  VerticalAlignment="Top" Width="18" Style="{StaticResource LblText}" />
-                <Label x:Name="lbKey" Content="" Margin="20,0,0,0" HorizontalAlignment="Right" Height="23"  VerticalAlignment="Top" Width="50" Style="{StaticResource LblText}"/>
-            </StackPanel>
-        </Grid>
-        <TextBlock HorizontalAlignment="Left" Margin="8,10,0,0" TextWrapping="Wrap" 
-                   VerticalAlignment="Top" Width="303" Grid.Row="3" Style="{StaticResource TxtBlkText}" Text="{x:Static Properties:Resources.TextBlockTextPressEscabeToCancel}" />
+        <TextBox Grid.Row="2" Margin="0,10" Name="tbHotkey"  
+                 Height="24" Width="300" HorizontalContentAlignment="Center"
+                 VerticalContentAlignment="Center" Style="{StaticResource StandardTextBox}"
+                 AutomationProperties.Name="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}"
+                 AutomationProperties.HelpText="{x:Static Properties:Resources.RunTextToChangeKeyBoard}"
+                 KeyDown="Window_KeyDown" KeyUp="Window_KeyUp" 
+                 PreviewTextInput="TbHotkey_PreviewTextInput" ContextMenu="{x:Null}"
+                 CommandManager.PreviewExecuted="TbHotkey_PreviewExecuted"/>
+        <TextBlock HorizontalAlignment="Left" Margin="8,0" TextWrapping="Wrap" 
+                   VerticalAlignment="Top" Width="303" Grid.Row="3" Style="{StaticResource TxtBlkText}"
+                   Text="{x:Static Properties:Resources.TextBlockTextPressEscabeToCancel}" />
     </Grid>
 </Window>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
@@ -27,7 +27,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Label Content="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}" HorizontalAlignment="Left" Margin="8,8,0,0" Grid.Row="0" VerticalAlignment="Top" Style="{StaticResource LblH5}" Padding="0"/>
-        <TextBlock HorizontalAlignment="Left" Margin="8,10,0,0" TextWrapping="Wrap" Name="tbInstructions"
+        <TextBlock HorizontalAlignment="Left" Margin="8,10,0,0" TextWrapping="Wrap"
                    VerticalAlignment="Top" Width="303" Grid.Row="1" Style="{StaticResource TxtBlkText}">
             <Run Text="{x:Static Properties:Resources.RunTextToChangeKeyBoard}"/>
         </TextBlock>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
@@ -27,10 +27,6 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Label Content="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}" HorizontalAlignment="Left" Margin="8,8,0,0" Grid.Row="0" VerticalAlignment="Top" Style="{StaticResource LblH5}" Padding="0"/>
-        <TextBlock HorizontalAlignment="Left" Margin="8,10,0,0" TextWrapping="Wrap"
-                   VerticalAlignment="Top" Width="303" Grid.Row="1" Style="{StaticResource TxtBlkText}">
-            <Run Text="{x:Static Properties:Resources.RunTextToChangeKeyBoard}"/>
-        </TextBlock>
         <TextBox Grid.Row="2" Margin="0,10" Name="tbHotkey"  
                  Height="24" Width="300" HorizontalContentAlignment="Center"
                  VerticalContentAlignment="Center" Style="{StaticResource StandardTextBox}"
@@ -39,6 +35,10 @@
                  KeyDown="Window_KeyDown" KeyUp="Window_KeyUp" 
                  PreviewTextInput="TbHotkey_PreviewTextInput" ContextMenu="{x:Null}"
                  CommandManager.PreviewExecuted="TbHotkey_PreviewExecuted"/>
+        <TextBlock HorizontalAlignment="Left" Margin="8,10,0,0" TextWrapping="Wrap"
+                   VerticalAlignment="Top" Width="303" Grid.Row="1" Style="{StaticResource TxtBlkText}">
+            <Run Text="{x:Static Properties:Resources.RunTextToChangeKeyBoard}"/>
+        </TextBlock>
         <TextBlock HorizontalAlignment="Left" Margin="8,0" TextWrapping="Wrap" 
                    VerticalAlignment="Top" Width="303" Grid.Row="3" Style="{StaticResource TxtBlkText}"
                    Text="{x:Static Properties:Resources.TextBlockTextPressEscabeToCancel}" />

--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
@@ -11,7 +11,7 @@
         Title="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}" Height="162" Width="319" 
         KeyDown="Window_KeyDown" KeyUp="Window_KeyUp" 
         WindowStartupLocation="CenterOwner"
-        ShowInTaskbar="False" Topmost="True" FocusManager.FocusedElement="{Binding ElementName=tbHotkey}"
+        ShowInTaskbar="False" FocusManager.FocusedElement="{Binding ElementName=tbHotkey}"
         AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.SettingsHotkeyGrabDialog}">
     <Window.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
@@ -24,6 +24,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         public HotkeyGrabDialog(Button tb)
         {
             ButtonParent = tb;
+            Topmost = Application.Current.MainWindow.Topmost;
             InitializeComponent();
         }
 

--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
@@ -12,14 +12,8 @@ namespace AccessibilityInsights.SharedUx.Dialogs
     /// </summary>
     public partial class HotkeyGrabDialog : Window
     {
-        /// <summary>
-        /// Modifier key
-        /// </summary>
         ModifierKeys ModKey;
 
-        /// <summary>
-        /// Selected non-modifier key
-        /// </summary>
         Key SelectedKey;
 
         /// <summary>
@@ -27,14 +21,10 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         /// </summary>
         Button ButtonParent;
 
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="tb">Button which triggered dialog</param>
         public HotkeyGrabDialog(Button tb)
         {
             ButtonParent = tb;
-            InitializeComponent();            
+            InitializeComponent();
         }
 
         /// <summary>
@@ -50,6 +40,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             switch (tempKey)
             {
                 case Key.Escape:
+                case Key.Tab:
                     return;
                 case Key.LeftAlt:
                 case Key.RightAlt:
@@ -72,22 +63,16 @@ namespace AccessibilityInsights.SharedUx.Dialogs
                     break;
             }
 
-            if (ModKey != ModifierKeys.None)
-            {
-                this.lbModifiers.Content = GetCleanModifierString();
-            }
+            UpdateHotkeyText();
 
-            if (SelectedKey != Key.None)
-            {
-                this.lbKey.Content = GetCleanKeyString();
-            }
-
-            if(ModKey != ModifierKeys.None && SelectedKey != Key.None)
+            if (ModKey != ModifierKeys.None && SelectedKey != Key.None)
             {
                 ButtonParent.Content = string.Format(CultureInfo.InvariantCulture, "{0} + {1}", GetCleanModifierString(), GetCleanKeyString());
                 this.Close();
             }
         }
+
+        private void UpdateHotkeyText() => tbHotkey.Text = $"{GetCleanModifierString()} + {GetCleanKeyString()}";
 
         /// <summary>
         /// Get the string to represent ModKeys. This string removes any spaces that get
@@ -101,12 +86,11 @@ namespace AccessibilityInsights.SharedUx.Dialogs
 
             return ModKey.ToString().Replace(" ", "");
         }
-        /// <summary>
-        /// Get clean key string for display
-        /// </summary>
-        /// <returns></returns>
+
         private string GetCleanKeyString()
         {
+            if (SelectedKey == Key.None) return string.Empty;
+
             var str = SelectedKey.ToString();
 
             if (SelectedKey >= Key.D0 && SelectedKey <= Key.D9)
@@ -117,18 +101,23 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             return str;
         }
 
-        /// <summary>
-        /// Handles key up. Closes window on esc.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
         private void Window_KeyUp(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.Escape)
             {
                 e.Handled = true;
                 this.Close();
-            } 
+            }
+        }
+
+        private void TbHotkey_PreviewTextInput(object sender, TextCompositionEventArgs e) => e.Handled = true;
+
+        private void TbHotkey_PreviewExecuted(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (e.Command == ApplicationCommands.Paste)
+            {
+                e.Handled = true;
+            }
         }
     }
 }


### PR DESCRIPTION
#### Describe the change
We were seeing a few accessibility/usability issues with the set hotkey dialog. This PR makes two key changes:
1. A TextBox is added to display the new hotkey selection. What is displayed does not change. The key purpose of the TextBox is to provide an actual focusable element on the window, which there previously was not.
2. The Tab key can no longer be added to a shortcut.

Minor visual impact. We could make it look the same, but then the TextBox would not look like a TextBox, which seems bad to me.
Before:
![image](https://user-images.githubusercontent.com/4615491/65059606-263f1400-d92b-11e9-9890-29b01a06d25c.png)
After:
![image](https://user-images.githubusercontent.com/4615491/65059562-132c4400-d92b-11e9-8ec2-18064b220ae6.png)


#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



