### PR TITLE
Update TextBox event handling

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
@@ -9,8 +9,7 @@
         mc:Ignorable="d"
         ResizeMode="NoResize"
         Title="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}" Height="162" Width="319" 
-        KeyDown="TextBox_KeyDown" KeyUp="TextBox_KeyUp" 
-        WindowStartupLocation="CenterOwner"
+        KeyUp="WindowAndTextBox_KeyUp" WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False" FocusManager.FocusedElement="{Binding ElementName=tbHotkey}"
         AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.SettingsHotkeyGrabDialog}">
     <Window.Resources>
@@ -32,7 +31,7 @@
                  VerticalContentAlignment="Center" Style="{StaticResource StandardTextBox}"
                  AutomationProperties.Name="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}"
                  AutomationProperties.HelpText="{x:Static Properties:Resources.RunTextToChangeKeyBoard}"
-                 KeyDown="TextBox_KeyDown" KeyUp="TextBox_KeyUp" 
+                 KeyDown="TextBox_KeyDown" KeyUp="WindowAndTextBox_KeyUp"
                  PreviewTextInput="TbHotkey_PreviewTextInput" ContextMenu="{x:Null}"
                  CommandManager.PreviewExecuted="TbHotkey_PreviewExecuted"/>
         <TextBlock HorizontalAlignment="Left" Margin="8,10,0,0" TextWrapping="Wrap"

--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
@@ -9,7 +9,7 @@
         mc:Ignorable="d"
         ResizeMode="NoResize"
         Title="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}" Height="162" Width="319" 
-        KeyDown="Window_KeyDown" KeyUp="Window_KeyUp" 
+        KeyDown="TextBox_KeyDown" KeyUp="TextBox_KeyUp" 
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False" FocusManager.FocusedElement="{Binding ElementName=tbHotkey}"
         AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.SettingsHotkeyGrabDialog}">
@@ -32,7 +32,7 @@
                  VerticalContentAlignment="Center" Style="{StaticResource StandardTextBox}"
                  AutomationProperties.Name="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}"
                  AutomationProperties.HelpText="{x:Static Properties:Resources.RunTextToChangeKeyBoard}"
-                 KeyDown="Window_KeyDown" KeyUp="Window_KeyUp" 
+                 KeyDown="TextBox_KeyDown" KeyUp="TextBox_KeyUp" 
                  PreviewTextInput="TbHotkey_PreviewTextInput" ContextMenu="{x:Null}"
                  CommandManager.PreviewExecuted="TbHotkey_PreviewExecuted"/>
         <TextBlock HorizontalAlignment="Left" Margin="8,10,0,0" TextWrapping="Wrap"

--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
@@ -115,7 +115,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
 
         private void TbHotkey_PreviewExecuted(object sender, ExecutedRoutedEventArgs e)
         {
-            if (e.Command == ApplicationCommands.Paste)
+            if (e.Command == ApplicationCommands.Paste || e.Command == ApplicationCommands.Cut || e.Command == ApplicationCommands.Delete)
             {
                 e.Handled = true;
             }

--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
@@ -102,7 +102,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             return str;
         }
 
-        private void TextBox_KeyUp(object sender, KeyEventArgs e)
+        private void WindowAndTextBox_KeyUp(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.Escape)
             {

--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml.cs
@@ -34,7 +34,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Window_KeyDown(object sender, KeyEventArgs e)
+        private void TextBox_KeyDown(object sender, KeyEventArgs e)
         {
             Key tempKey = (e.Key == Key.System ? e.SystemKey : e.Key);
 
@@ -102,7 +102,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             return str;
         }
 
-        private void Window_KeyUp(object sender, KeyEventArgs e)
+        private void TextBox_KeyUp(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.Escape)
             {


### PR DESCRIPTION
#### Describe the change
Picking up two minor changes pointed out by @dbjorge but missed in #552. Two event handler methods were switched from a window to a textbox, but their names still referenced the window. This PR renames them accordingly. It also prevents the Cut and Delete commands from being executed on the textbox, since it is not meant to be directly edited.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [-] Does this address an existing issue? If yes, Issue# - 
- [-] Includes UI changes?
  - [-] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [-] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



