### PR TITLE
Stop hotkeys from acting while settings pane is open

### DIFF
--- a/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKey.cs
+++ b/src/AccessibilityInsights.SharedUx/KeyboardHelpers/HotKey.cs
@@ -20,7 +20,7 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
         public Keys Key { get; internal set; }
         public HotkeyModifier Modifier { get; internal set; }
 
-        public Action Action { get; set; }
+        public Action Action { get; private set; }
 
         public uint ErrorCode { get; private set; }
 
@@ -32,7 +32,7 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
         {
             this.ErrorCode = 0;
 
-            if(NativeMethods.RegisterHotKey(hWnd, Id, (int)this.Modifier, Key.GetHashCode()) == false)
+            if (NativeMethods.RegisterHotKey(hWnd, Id, (int)this.Modifier, Key.GetHashCode()) == false)
             {
                 ErrorCode = NativeMethods.GetLastError();
                 return false;
@@ -49,7 +49,7 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
         {
             this.ErrorCode = 0;
 
-            if(NativeMethods.UnregisterHotKey(hWnd, Id) == false)
+            if (NativeMethods.UnregisterHotKey(hWnd, Id) == false)
             {
                 ErrorCode = NativeMethods.GetLastError();
                 return false;
@@ -109,7 +109,7 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
         private static HotkeyModifier GetModifier(string mods)
         {
             var fms = from m in mods.Split(',')
-                     select $"MOD_{m.Trim().ToUpperInvariant()}";
+                      select $"MOD_{m.Trim().ToUpperInvariant()}";
 
             HotkeyModifier result = HotkeyModifier.MOD_NoModifier;
 
@@ -135,6 +135,17 @@ namespace AccessibilityInsights.SharedUx.KeyboardHelpers
             }
 
             return result;
+        }
+
+        public void SetConditionalAction(Action action, Func<bool> condition)
+        {
+            Action = () =>
+            {
+                if (condition == null || condition())
+                {
+                    action();
+                }
+            };
         }
     }
 }

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -191,7 +191,7 @@ namespace AccessibilityInsights
             {
                 if (this.HotkeyHandler.Exist(hk) == false)
                 {
-                    hk.Action = action;
+                    hk.SetConditionalAction(action, () => !ctrlConfigurationMode.IsVisible);
 
                     this.HotkeyHandler.RegisterHotKey(hk);
                 }


### PR DESCRIPTION
#### Describe the change
Currently, hotkeys attempt to function at all times and states in ai-win. This includes while the user is trying to change their hotkeys. This PR stops hotkeys from acting when the settings pane is open to avoid potentially confusing or difficult scenarios. We currently only have one hotkey which could possibly be useful in settings, the show/hide window hotkey. In my opinion, the purpose of this hotkey relates to actually testing and inspecting apps, not changing one's settings. I feel comfortable disabling it here. If anyone disagrees with that (or the change as a whole), feel free to voice those concerns.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [-] Does this address an existing issue? If yes, Issue# - 
- [-] Includes UI changes?
  - [-] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [-] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



