### PR TITLE
Create insider release for v1.1.0990.01

### DIFF
--- a/Channels/Insider/release_info.json
+++ b/Channels/Insider/release_info.json
@@ -1,8 +1,8 @@
 {
   "default": {
-    "current_version": "1.1.0988.01",
-    "minimum_version": "1.1.0988.01",
-    "installer_url": "https://www.github.com/Microsoft/accessibility-insights-windows/releases/download/v1.1.0988.01/AccessibilityInsights.msi",
+    "current_version": "1.1.0990.01",
+    "minimum_version": "1.1.0990.01",
+    "installer_url": "https://www.github.com/Microsoft/accessibility-insights-windows/releases/download/v1.1.0990.01/AccessibilityInsights.msi",
     "release_notes_url": "https://www.github.com/Microsoft/accessibility-insights-windows/blob/Control/Channels/Insider/release_notes.md"
   }
 }

--- a/Channels/Insider/release_notes.md
+++ b/Channels/Insider/release_notes.md
@@ -1,8 +1,10 @@
-## September 16, 2019 Insider Release ([v1.1.0988.01](https://github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.0988.01))
 
-Welcome to the September 16, 2019 Insider release of Accessibility Insights for Windows.
 
-Installation Link: https://github.com/microsoft/accessibility-insights-windows/releases/download/v1.1.0988.01/AccessibilityInsights.msi
+## September [INSERT DATE], 2019 Insider Release ([v1.1.0990.01](https://github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.0990.01))
+
+Welcome to the September [INSERT DATE], 2019 Insider release of Accessibility Insights for Windows.
+
+Installation Link: https://github.com/microsoft/accessibility-insights-windows/releases/download/v1.1.0990.01/AccessibilityInsights.msi
 
 Documentation Link: https://accessibilityinsights.io/docs/en/windows/overview
 
@@ -21,6 +23,7 @@ We have added functionality to the Color Contrast Analyzer feature in Accessibil
 - We have fixed several issues to make the app more usable for screen reader users.
 - We have updated to Axe.Windows 0.3.4 [#529](https://github.com/microsoft/accessibility-insights-windows/pull/529)
 - We have fixed the issue that caused "Prerelease Build" to display incorrectly in the version bar [#450](https://github.com/microsoft/accessibility-insights-windows/pull/450)
+- We have fixed the "File issue" button column width so it scales appropriately with font size [#551](https://github.com/microsoft/accessibility-insights-windows/pull/551)
 
 #### Rule Updates
 

--- a/Channels/Insider/release_notes.md
+++ b/Channels/Insider/release_notes.md
@@ -1,8 +1,8 @@
 
 
-## September [INSERT DATE], 2019 Insider Release ([v1.1.0990.01](https://github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.0990.01))
+## September 18, 2019 Insider Release ([v1.1.0990.01](https://github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.0990.01))
 
-Welcome to the September [INSERT DATE], 2019 Insider release of Accessibility Insights for Windows.
+Welcome to the September 18, 2019 Insider release of Accessibility Insights for Windows.
 
 Installation Link: https://github.com/microsoft/accessibility-insights-windows/releases/download/v1.1.0990.01/AccessibilityInsights.msi
 

--- a/build/prbuild-Control.yml
+++ b/build/prbuild-Control.yml
@@ -11,7 +11,7 @@ jobs:
     displayName: 'NuGet - Octokit install'
     inputs:
       command: custom
-      arguments: 'install OctoKit -source "https://api.nuget.org/v3/index.json"'  
+      arguments: 'install -version $(OctokitVersion) OctoKit -source "https://api.nuget.org/v3/index.json"'
     
   - task: PowerShell@2
     displayName: 'Validate release_info.json Files'


### PR DESCRIPTION
This creates an insider release for v1.1.0990.01 (likely canary from the morning of the 18th).

See the updated release notes here: https://github.com/microsoft/accessibility-insights-windows/blob/67c726e791838a7d13954916180e2b96bc84c878/Channels/Insider/release_notes.md

This release contains primarily accessibility fixes. We'd like to be able to push these to prod alongside the existing WCAG 2.1 color contrast changes in flight.