### PR TITLE
Fix typo in github placeholder

### DIFF
--- a/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace AccessibilityInsights.Extensions.GitHub.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -106,7 +106,7 @@ namespace AccessibilityInsights.Extensions.GitHub.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ^{0}/+{1}/+{2}.
+        ///   Looks up a localized string similar to ^{0}/+{1}/+{2}$.
         /// </summary>
         public static string LinkPatttern {
             get {
@@ -141,7 +141,7 @@ namespace AccessibilityInsights.Extensions.GitHub.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https//github.com/owner/repo.
+        ///   Looks up a localized string similar to https://github.com/owner/repo.
         /// </summary>
         public static string PlaceHolder {
             get {

--- a/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.resx
@@ -138,7 +138,7 @@
     <value>({0}/{1}) has an accessibility issue that needs investigation</value>
   </data>
   <data name="PlaceHolder" xml:space="preserve">
-    <value>https//github.com/owner/repo</value>
+    <value>https://github.com/owner/repo</value>
   </data>
   <data name="SingleFailureIssueBody" xml:space="preserve">
     <value>The following accessibility issue needs investigation.


### PR DESCRIPTION
#### Describe the change
Our GitHub URL placeholder was missing a colon. This PR fixes the typo

![image](https://user-images.githubusercontent.com/7775527/65170006-9ec1d580-d9fc-11e9-8e56-56a59d5511b4.png)



