### PR TITLE
Add Axe-Windows version to About tab

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -24,7 +24,9 @@
                 <Run Text="{Binding Path=VersionInfoLabel, Mode=OneWay}" />
             </Hyperlink>
         </TextBlock>
-        <Label x:Name="lbUIAccess" Padding="0" FontSize="14" Margin="0,5,0,0" Content="{Binding Path=UIAccessStatus, Mode=OneWay}" />
+        <Label Content="{Binding Path=AxeVersion}" ContentStringFormat="{x:Static Properties:Resources.AboutTabControl_AxeVersionFormat}"
+               Style="{StaticResource lblDark}" Margin="0,5,0,0"/>
+        <Label Style="{StaticResource lblDark}" Margin="0,5,0,0" Content="{Binding Path=UIAccessStatus, Mode=OneWay}" />
         <TextBlock Padding="0" FontSize="14" Margin="0,32,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlHelp" AutomationProperties.Name="{x:Static Properties:Resources.hlHelpName}" 
                        Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 

--- a/src/AccessibilityInsights.SharedUx/Misc/VersionTools.cs
+++ b/src/AccessibilityInsights.SharedUx/Misc/VersionTools.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Actions;
+using Axe.Windows.Core.Misc;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -18,6 +18,6 @@ namespace AccessibilityInsights.SharedUx.Misc
             return fileVersion;
         }
 
-        public static string GetAxeVersion() => FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(CaptureAction)).Location).FileVersion;
+        public static string GetAxeVersion() => PackageInfo.InformationalVersion;
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Misc/VersionTools.cs
+++ b/src/AccessibilityInsights.SharedUx/Misc/VersionTools.cs
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Axe.Windows.Actions;
+using System.Diagnostics;
+using System.Reflection;
 
 namespace AccessibilityInsights.SharedUx.Misc
 {
@@ -11,8 +14,10 @@ namespace AccessibilityInsights.SharedUx.Misc
         /// <returns>The file version string (as formatted in the file resources)</returns>
         public static string GetAppVersion()
         {
-            string fileVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly().Location).FileVersion;
+            string fileVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
             return fileVersion;
         }
+
+        public static string GetAxeVersion() => FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(CaptureAction)).Location).FileVersion;
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Built with Axe-Windows v{0}.
+        ///   Looks up a localized string similar to Built with Axe-Windows {0}.
         /// </summary>
         public static string AboutTabControl_AxeVersionFormat {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Built with Axe-Windows v{0}.
+        /// </summary>
+        public static string AboutTabControl_AxeVersionFormat {
+            get {
+                return ResourceManager.GetString("AboutTabControl_AxeVersionFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to passed value is not supported type..
         /// </summary>
         public static string ActionViewModelConverter_Convert_passed_value_is_not_supported_type {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Built with Axe-Windows {0}.
+        ///   Looks up a localized string similar to Built with Axe.Windows {0}.
         /// </summary>
         public static string AboutTabControl_AxeVersionFormat {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1577,7 +1577,7 @@ Do you want to change the channel? </value>
     <value>Graphical objects and UI components</value>
   </data>
   <data name="AboutTabControl_AxeVersionFormat" xml:space="preserve">
-    <value>Built with Axe-Windows v{0}</value>
+    <value>Built with Axe-Windows {0}</value>
   </data>
   <data name="ColorContrast_RequiresNonTextObjectsPost" xml:space="preserve">
     <value>)</value>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1576,6 +1576,9 @@ Do you want to change the channel? </value>
   <data name="ColorContrast_NonTextObjectsText" xml:space="preserve">
     <value>Graphical objects and UI components</value>
   </data>
+  <data name="AboutTabControl_AxeVersionFormat" xml:space="preserve">
+    <value>Built with Axe-Windows v{0}</value>
+  </data>
   <data name="ColorContrast_RequiresNonTextObjectsPost" xml:space="preserve">
     <value>)</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1577,7 +1577,7 @@ Do you want to change the channel? </value>
     <value>Graphical objects and UI components</value>
   </data>
   <data name="AboutTabControl_AxeVersionFormat" xml:space="preserve">
-    <value>Built with Axe-Windows {0}</value>
+    <value>Built with Axe.Windows {0}</value>
   </data>
   <data name="ColorContrast_RequiresNonTextObjectsPost" xml:space="preserve">
     <value>)</value>

--- a/src/AccessibilityInsights.SharedUx/ViewModels/AboutTabViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/AboutTabViewModel.cs
@@ -56,6 +56,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         public string VersionInfoLabel => string.Format(CultureInfo.InvariantCulture,
             Properties.Resources.VersionLinkContentFormat, VersionTools.GetAppVersion());
 
+        public string AxeVersion => VersionTools.GetAxeVersion();
 #pragma warning restore CA1822
     }
 }


### PR DESCRIPTION
#### Describe the change
This PR adds the text, "Built with Axe-Windows v\<axe version>" to the about tab. It is another step towards achieving the mocked state in [Feature Request] What's new content hasn't been updated since initial release #299.

![image](https://user-images.githubusercontent.com/4615491/65265528-06902300-dac6-11e9-955d-a5fa372ebe07.png)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue#299
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



