### PR TITLE
Layout.json is being saved in the wrong location. Fix it.

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationManager.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationManager.cs
@@ -55,10 +55,10 @@ namespace AccessibilityInsights.SharedUx.Settings
         {
             try
             {
-                var fp = Path.Combine(SettingsProvider.UserDataFolderPath, LayoutFileName);
+                var fp = Path.Combine(SettingsProvider.ConfigurationFolderPath, LayoutFileName);
                 this.AppLayout.SerializeInJSON(fp);
 
-                fp = Path.Combine(SettingsProvider.ConfigurationFolderPath, SetupLibrary.Constants.AppConfigFileName);
+                fp = Path.Combine(SettingsProvider.ConfigurationFolderPath, Constants.AppConfigFileName);
                 this.AppConfig.SerializeInJSON(fp);
             }
 #pragma warning disable CA1031 // Do not catch general exception types


### PR DESCRIPTION
#### Describe the change
Layout.json is being read from the config files location, but is being written to the data files location. As a result, persisted changes are not honored on the next boot.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #563 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



