### PR TITLE
Hide tab stop highlighter asyncronously on dispatcher to fix rendering

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
@@ -27,6 +27,7 @@ using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Media;
+using System.Windows.Threading;
 
 namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 {
@@ -96,7 +97,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         {
             get
             {
-                lock(this)
+                lock (this)
                 {
                     tabStopCount++;
                     return tabStopCount;
@@ -503,7 +504,10 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         {
             this.IsTabOpen = false;
             this.StopRecordEvents();
-            ClearOverlayDriver.GetDefaultInstance().Hide();
+
+            // if we don't run this on dispatcher like this, we get rendering issues in the parent
+            // tab control in TestModeControl on hide.
+            Dispatcher.BeginInvoke(new Action(ClearOverlayDriver.GetDefaultInstance().Hide));
         }
 
         /// Automated Checks mode is shown


### PR DESCRIPTION
#### Describe the change
Per issue #543- Text on the automated checks overlaps with text from tabstops, we were seeing some unfortunate drawing behavior in our test mode tab control. I was able to narrow down the offending code to our call to hide the tab stop highlighter. I was able to alleviate the issue by putting that highlighter call in a `Dispatcher.BeginInvoke` call. I did not go deeper into the cause, considering that it is outside of our control how WPF draws the tab control.

Before:
![image](https://user-images.githubusercontent.com/4615491/65628533-7438c500-df86-11e9-81e7-3c9ffd7e167c.png)

After:
![image](https://user-images.githubusercontent.com/4615491/65628773-fde89280-df86-11e9-83f2-72754d80a423.png)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue#543
- [-] Includes UI changes?
  - [-] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



