### PR TITLE
Add toggle pattern to list view

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ListViewWithGroupItem.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ListViewWithGroupItem.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Utilities;
+using System.Collections.Generic;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Controls;
+
+namespace AccessibilityInsights.SharedUx.Controls.CustomControls
+{
+    /// <summary>
+    /// Automation peer for a grouped list view with group items that 
+    /// support the toggle patter via checkboxes in the expander
+    /// </summary>
+    public class ListViewWithGroupItem : ListView
+    {
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new BasicPeerWithGroupItemToggled(this);
+        }
+    }
+
+    public class BasicPeerWithGroupItemToggled : ListViewAutomationPeer
+    {
+        public BasicPeerWithGroupItemToggled(ListView owner) : base(owner)
+        {
+        }
+
+        protected override List<AutomationPeer> GetChildrenCore()
+        {
+            var list = new List<AutomationPeer>();
+            var existingPeers = base.GetChildrenCore();
+            if (existingPeers != null)
+            {
+                foreach (var child in existingPeers)
+                {
+                    if (child is GroupItemAutomationPeer)
+                    {
+                        var groupItemUIElement = (child as GroupItemAutomationPeer).Owner as GroupItem;
+                        list.Add(new GroupItemWithTogglePatternPeer(groupItemUIElement));
+                    }
+                    else
+                    {
+                        list.Add(child);
+                    }
+                }
+            }
+            return list;
+        }
+    }
+
+    public class GroupItemWithTogglePatternPeer : GroupItemAutomationPeer
+    {
+        public GroupItemWithTogglePatternPeer(GroupItem owner) : base(owner)
+        {
+        }
+
+        public override object GetPattern(PatternInterface patternInterface)
+        {
+            if (patternInterface == PatternInterface.Toggle)
+            {
+                var cb = HelperMethods.GetFirstChildElement<CheckBox>(Owner) as CheckBox;
+                AutomationPeer checkboxPeer = UIElementAutomationPeer.CreatePeerForElement(cb);
+                if (checkboxPeer != null && checkboxPeer is IToggleProvider)
+                {
+                    return (IToggleProvider)checkboxPeer;
+                }
+            }
+            return base.GetPattern(patternInterface);
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -59,10 +59,10 @@
                 </Grid>
             </Grid>
             <Border Grid.Row="1" BorderBrush="#EAEAEA" BorderThickness="0,1,0,0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
-                <ListView AutomationProperties.LabeledBy="{Binding ElementName=lblTitle}" KeyboardNavigation.TabNavigation="Once"
-                          Name="lvResults" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderThickness="0"
+                <local:ListViewWithGroupItem AutomationProperties.LabeledBy="{Binding ElementName=lblTitle}" KeyboardNavigation.TabNavigation="Once"
+                          x:Name="lvResults" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderThickness="0"
                           AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.AutomatedChecksResultsListView}">
-                    <ListView.View>
+                    <local:ListViewWithGroupItem.View>
                         <local:CustomGridView x:Name="gv">
                             <GridViewColumn Width="26" DisplayMemberBinding="{x:Null}">
                                 <local:CustomGridViewColumnHeader Style="{StaticResource gvchAutomatedChecks}" Margin="-5,0,0,0" AutomationProperties.Name="{x:Static Properties:Resources.localCustomGridViewColumnHeaderAutomationPropertiesName}" MinWidth="28" MaxWidth="28" Tag="false" Focusable="True">
@@ -155,8 +155,8 @@
                                 </GridViewColumn.CellTemplate>
                             </GridViewColumn>
                         </local:CustomGridView>
-                    </ListView.View>
-                    <ListView.ItemContainerStyle>
+                    </local:ListViewWithGroupItem.View>
+                    <local:ListViewWithGroupItem.ItemContainerStyle>
                         <Style TargetType="{x:Type ListViewItem}">
                             <Style.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
@@ -194,8 +194,8 @@
                                 </Setter.Value>
                             </Setter>
                         </Style>
-                    </ListView.ItemContainerStyle>
-                    <ListView.Resources>
+                    </local:ListViewWithGroupItem.ItemContainerStyle>
+                    <local:ListViewWithGroupItem.Resources>
                         <Style TargetType="CheckBox">
                             <Style.Setters>
                                 <Setter Property="IsEnabled" Value="{Binding Path=ScreenshotAvailable, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}"/>
@@ -242,8 +242,8 @@
                             <Setter Property="BorderBrush" Value="#EAEAEA"/>
                             <Setter Property="Margin" Value="0,-1,-1,0"/>
                         </Style>
-                    </ListView.Resources>
-                    <ListView.GroupStyle>
+                    </local:ListViewWithGroupItem.Resources>
+                    <local:ListViewWithGroupItem.GroupStyle>
                         <GroupStyle>
                             <GroupStyle.ContainerStyle>
                                 <Style TargetType="{x:Type GroupItem}">
@@ -293,8 +293,8 @@
                                 </Style>
                             </GroupStyle.ContainerStyle>
                         </GroupStyle>
-                    </ListView.GroupStyle>
-                </ListView>
+                    </local:ListViewWithGroupItem.GroupStyle>
+                </local:ListViewWithGroupItem>
             </Border>
             <Label Grid.Row="1" Name="lblCongrats" Visibility="Collapsed" Content="{x:Static Properties:Resources.lblCongratsContent}" HorizontalAlignment="Center"  Width="Auto" Style="{StaticResource lblHeader2}" Padding="0,32,0,0" />
             <TextBlock Grid.Row="1" Name="lblNoFail" Visibility="Collapsed" Text="{x:Static Properties:Resources.lblNoFailText}"  Style="{StaticResource tbHeaderDark}" TextWrapping="Wrap" Width="214" HorizontalAlignment="Center" TextAlignment="Center" Padding="0,49,0,0" />

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -444,60 +444,6 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         }
 
         /// <summary>
-        /// Finds all controls of the given type under the given object
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="element"></param>
-        /// <returns></returns>
-        public IEnumerable<T> FindChildren<T>(DependencyObject element) where T : DependencyObject
-        {
-            if (element != null)
-            {
-                for (int i = 0; i < VisualTreeHelper.GetChildrenCount(element); i++)
-                {
-                    DependencyObject child = VisualTreeHelper.GetChild(element, i);
-                    if (child != null && child is T)
-                    {
-                        yield return (T) child;
-                    }
-                    foreach (T descendant in FindChildren<T>(child))
-                    {
-                        yield return descendant;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Get child element of specified type
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="element"></param>
-        /// <returns></returns>
-        public DependencyObject GetFirstChildElement<T>(DependencyObject element)
-        {
-            if (element == null)
-            {
-                return null;
-            }
-
-            if (element is T)
-            {
-                return element as DependencyObject;
-            }
-
-            for (int x = 0; x < VisualTreeHelper.GetChildrenCount(element); x++)
-            {
-                DependencyObject child = VisualTreeHelper.GetChild(element, x);
-                var b = GetFirstChildElement<T>(child);
-
-                if (b != null)
-                    return b;
-            }
-            return null;
-        }
-
-        /// <summary>
         /// Finds object up parent hierarchy of specified type
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -540,13 +486,13 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             {
                 if (e.Key == Key.Right)
                 {
-                    var vb = GetFirstChildElement<CheckBox>(sender as DependencyObject) as CheckBox;
+                    var vb = HelperMethods.GetFirstChildElement<CheckBox>(sender as DependencyObject) as CheckBox;
                     vb.Focus();
                 }
                 else
                 {
                     var parent = GetParentElem<Expander>(sender as DependencyObject) as Expander;
-                    var vb = GetFirstChildElement<Label>(parent as DependencyObject) as Label;
+                    var vb = HelperMethods.GetFirstChildElement<Label>(parent as DependencyObject) as Label;
                     vb.Focus();
                 }
                 e.Handled = true;
@@ -554,8 +500,8 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             else if ((e.Key == Key.Right || e.Key == Key.Left) && (Keyboard.FocusedElement is CheckBox || Keyboard.FocusedElement is Button))
             {
                 var elements = new List<DependencyObject>();
-                elements.Add(GetFirstChildElement<CheckBox>(sender as DependencyObject));
-                elements.AddRange(FindChildren<Button>(sender as DependencyObject));
+                elements.Add(HelperMethods.GetFirstChildElement<CheckBox>(sender as DependencyObject));
+                elements.AddRange(HelperMethods.FindChildren<Button>(sender as DependencyObject));
                 int selectedElementIndex = elements.FindIndex(b => b.Equals(Keyboard.FocusedElement));
 
                 if (e.Key == Key.Right)
@@ -602,7 +548,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             }
             else if (e.Key == Key.Return && Keyboard.FocusedElement is ListViewItem)
             {
-                var btn = GetFirstChildElement<Button>(sender as DependencyObject) as Button;
+                var btn = HelperMethods.GetFirstChildElement<Button>(sender as DependencyObject) as Button;
                 ButtonElem_Click(btn, e);
             }
         }
@@ -696,7 +642,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         {
             var exp = sender as Expander;
             var lst = exp.DataContext as CollectionViewGroup;
-            var cb = GetFirstChildElement<CheckBox>(exp) as CheckBox;
+            var cb = HelperMethods.GetFirstChildElement<CheckBox>(exp) as CheckBox;
             SetItemsChecked(lst.Items, cb.IsChecked.Value);
             exp.SizeChanged -= Exp_Checked;
         }
@@ -711,7 +657,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
             var lvi = sender as ListViewItem;
             var exp = GetParentElem<Expander>(lvi) as Expander;
-            var cb = GetFirstChildElement<CheckBox>(exp) as CheckBox;
+            var cb = HelperMethods.GetFirstChildElement<CheckBox>(exp) as CheckBox;
             var srvm = lvi.DataContext as RuleResultViewModel;
 
             // ElementContext can be null when app is closed.
@@ -803,7 +749,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             {
                 var lvi = sender as ListViewItem;
                 var exp = GetParentElem<Expander>(lvi) as Expander;
-                var cb = GetFirstChildElement<CheckBox>(exp) as CheckBox;
+                var cb = HelperMethods.GetFirstChildElement<CheckBox>(exp) as CheckBox;
                 var itm = lvi.DataContext as RuleResultViewModel;
                 if (!SelectedItems.Contains(itm))
                 {
@@ -863,8 +809,8 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             }
 
             var gi = sender as GroupItem;
-            var sp = GetFirstChildElement<StackPanel>(gi) as StackPanel;
-            var urlLink = FindChildren<Label>(sp).FirstOrDefault(obj => obj.Content is Hyperlink).Content as Hyperlink;
+            var sp = HelperMethods.GetFirstChildElement<StackPanel>(gi) as StackPanel;
+            var urlLink = HelperMethods.FindChildren<Label>(sp).FirstOrDefault(obj => obj.Content is Hyperlink).Content as Hyperlink;
             var exp = GetParentElem<Expander>(sp) as Expander;
 
             if (e.Key == Key.Right)
@@ -894,7 +840,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             }
             else if (e.Key == Key.Space && Keyboard.FocusedElement == sender)
             {
-                var cb = GetFirstChildElement<CheckBox>(exp) as CheckBox;
+                var cb = HelperMethods.GetFirstChildElement<CheckBox>(exp) as CheckBox;
                 cb.IsChecked = !cb.IsChecked ?? false;
                 CheckBox_Click(cb, null);
                 e.Handled = true;
@@ -914,7 +860,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 }
                 else
                 {
-                    ListViewItem firstResult = GetFirstChildElement<ListViewItem>(exp) as ListViewItem;
+                    ListViewItem firstResult = HelperMethods.GetFirstChildElement<ListViewItem>(exp) as ListViewItem;
                     firstResult.Focus();
                 }
                 e.Handled = true;

--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -333,6 +333,7 @@
       <DependentUpon>CustomGridViewColumn.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\CustomControls\CustomListView.cs" />
+    <Compile Include="Controls\CustomControls\ListViewWithGroupItem.cs" />
     <Compile Include="Controls\PrivacyLearnMore.xaml.cs">
       <DependentUpon>PrivacyLearnMore.xaml</DependentUpon>
     </Compile>

--- a/src/AccessibilityInsights.SharedUx/Utilities/HelperMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/HelperMethods.cs
@@ -5,7 +5,9 @@ using AccessibilityInsights.SharedUx.Settings;
 using Axe.Windows.Actions;
 using Axe.Windows.Actions.Contexts;
 using System;
+using System.Collections.Generic;
 using System.Windows;
+using System.Windows.Media;
 
 namespace AccessibilityInsights.SharedUx.Utilities
 {
@@ -69,5 +71,59 @@ namespace AccessibilityInsights.SharedUx.Utilities
         /// Provides bindable property for ProgressRingControls
         /// </summary>
         public static bool PlayScanningSound => ConfigurationManager.GetDefaultInstance().AppConfig.PlayScanningSound;
+
+        /// <summary>
+        /// Finds all controls of the given type under the given object
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="element"></param>
+        /// <returns></returns>
+        public static IEnumerable<T> FindChildren<T>(DependencyObject element) where T : DependencyObject
+        {
+            if (element != null)
+            {
+                for (int i = 0; i < VisualTreeHelper.GetChildrenCount(element); i++)
+                {
+                    DependencyObject child = VisualTreeHelper.GetChild(element, i);
+                    if (child != null && child is T)
+                    {
+                        yield return (T)child;
+                    }
+                    foreach (T descendant in FindChildren<T>(child))
+                    {
+                        yield return descendant;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get child element of specified type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="element"></param>
+        /// <returns></returns>
+        public static DependencyObject GetFirstChildElement<T>(DependencyObject element)
+        {
+            if (element == null)
+            {
+                return null;
+            }
+
+            if (element is T)
+            {
+                return element as DependencyObject;
+            }
+
+            for (int x = 0; x < VisualTreeHelper.GetChildrenCount(element); x++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(element, x);
+                var b = GetFirstChildElement<T>(child);
+
+                if (b != null)
+                    return b;
+            }
+            return null;
+        }
     }
 }


### PR DESCRIPTION
#### Describe the change

This work-in-progress PR adds the Toggle pattern to grouped items in our automated checks listview. The toggle pattern is provided by the child checkbox. However, focus changes to the group item aren't picked up by UIA - need to understand what's going on.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



