### PR TITLE
Fix screen reader behavior in AutomatedChecks ListView

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CustomExpander.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CustomExpander.cs
@@ -23,7 +23,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         /// In .NET 4.8 grouped ListViews, the GroupItem's HasKeyboardFocus value is set based on its child expander's
         /// HasKeyboardFocus value, not its own IsFocused value. In our AutomatedChecks use case, this breaks ATs'
         /// readings of the ListView group headers. By setting the child expander's HasKeyboardFocus value here,
-        /// we get the desired value in its parent GroupItem's value, and ATs fuction properly again.
+        /// we get the desired value in its parent GroupItem's value, and ATs function properly again.
         /// </summary>
         override protected bool HasKeyboardFocusCore() => parentGroupItem?.IsFocused ?? base.HasKeyboardFocusCore();
     }

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CustomExpander.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CustomExpander.cs
@@ -1,0 +1,21 @@
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+
+namespace AccessibilityInsights.SharedUx.Controls.CustomControls
+{
+    public class CustomExpander : Expander
+    {
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new CustomExpanderAutomationPeer(this);
+        }
+    }
+    public class CustomExpanderAutomationPeer : ExpanderAutomationPeer
+    {
+        public CustomExpanderAutomationPeer(Expander owner)
+            : base(owner)
+        {
+        }
+        override protected bool HasKeyboardFocusCore() => true;
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CustomExpander.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CustomExpander.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CustomExpander.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CustomExpander.cs
@@ -10,12 +10,19 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
             return new CustomExpanderAutomationPeer(this);
         }
     }
+
     public class CustomExpanderAutomationPeer : ExpanderAutomationPeer
     {
-        public CustomExpanderAutomationPeer(Expander owner)
-            : base(owner)
-        {
-        }
-        override protected bool HasKeyboardFocusCore() => true;
+        GroupItem parentGroupItem;
+
+        public CustomExpanderAutomationPeer(Expander owner) : base(owner) => parentGroupItem = owner?.TemplatedParent as GroupItem;
+
+        /// <summary>
+        /// In .NET 4.8 grouped ListViews, the GroupItem's HasKeyboardFocus value is set based on its child expander's
+        /// HasKeyboardFocus value, not its own IsFocused value. In our AutomatedChecks use case, this breaks ATs'
+        /// readings of the ListView group headers. By setting the child expander's HasKeyboardFocus value here,
+        /// we get the desired value in its parent GroupItem's value, and ATs fuction properly again.
+        /// </summary>
+        override protected bool HasKeyboardFocusCore() => parentGroupItem?.IsFocused ?? base.HasKeyboardFocusCore();
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -201,7 +201,7 @@
                                 <Setter Property="IsEnabled" Value="{Binding Path=ScreenshotAvailable, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}"/>
                             </Style.Setters>
                         </Style>
-                        <Style TargetType="{x:Type Expander}">
+                        <Style TargetType="{x:Type local:CustomExpander}">
                             <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
                             <Setter Property="Background" Value="Transparent"/>
                             <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
@@ -265,9 +265,9 @@
                                     <Setter Property="Template">
                                         <Setter.Value>
                                             <ControlTemplate>
-                                                <Expander IsExpanded="False" KeyboardNavigation.DirectionalNavigation="Local" 
+                                                <local:CustomExpander IsExpanded="False" KeyboardNavigation.DirectionalNavigation="Local" 
                                                           RequestBringIntoView="Expander_RequestBringIntoView" Collapsed="Expander_Collapsed">
-                                                    <Expander.Header>
+                                                    <local:CustomExpander.Header>
                                                         <StackPanel Focusable="False" Orientation="Horizontal" Height="20">
                                                             <Label Content="{Binding Path=Items[0].Description}" Style="{StaticResource lblRowStyle}" VerticalAlignment="Center" />
                                                             <Label Margin="4,0,0,0" Padding="0" Style="{StaticResource lblLink}" 
@@ -284,9 +284,9 @@
                                                             <Label Content="{Binding ItemCount}" Style="{StaticResource lblRowStyle}" VerticalAlignment="Center" />
                                                             <Label Content=")" Style="{StaticResource lblRowStyle}"  VerticalAlignment="Center" />
                                                         </StackPanel>
-                                                    </Expander.Header>
+                                                    </local:CustomExpander.Header>
                                                     <ItemsPresenter/>
-                                                </Expander>
+                                                </local:CustomExpander>
                                             </ControlTemplate>
                                         </Setter.Value>
                                     </Setter>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -99,7 +99,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         /// <summary>
         /// Gets/sets fastpass highlighter visibility, updating as necessary 
         /// </summary>
-#pragma warning disable CA1822 
+#pragma warning disable CA1822
         public bool HighlightVisibility
 #pragma warning restore CA1822
         {
@@ -151,7 +151,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 this.gdFailures.Focus();
                 var count = results.Where(r => r.RuleResult.Status == Axe.Windows.Core.Results.ScanStatus.Fail).Count();
 
-                switch(count)
+                switch (count)
                 {
                     case 0:
                         this.runFailures.Text = Properties.Resources.AutomatedChecksControl_SetRuleResults_No_failure_was;
@@ -160,7 +160,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                         this.runFailures.Text = Properties.Resources.AutomatedChecksControl_SetRuleResults_1_failure_was;
                         break;
                     default:
-                        this.runFailures.Text = String.Format(CultureInfo.InvariantCulture,Properties.Resources.AutomatedChecksControl_SetRuleResults_0_failures_were, results.Count);
+                        this.runFailures.Text = String.Format(CultureInfo.InvariantCulture, Properties.Resources.AutomatedChecksControl_SetRuleResults_0_failures_were, results.Count);
                         break;
                 }
 
@@ -458,7 +458,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                     DependencyObject child = VisualTreeHelper.GetChild(element, i);
                     if (child != null && child is T)
                     {
-                        yield return (T) child;
+                        yield return (T)child;
                     }
                     foreach (T descendant in FindChildren<T>(child))
                     {
@@ -562,7 +562,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 {
                     if (selectedElementIndex + 1 < elements.Count)
                     {
-                        ((UIElement) elements.ElementAt(selectedElementIndex + 1)).Focus();
+                        ((UIElement)elements.ElementAt(selectedElementIndex + 1)).Focus();
                     }
                 }
                 else if (selectedElementIndex - 1 >= 0)
@@ -595,7 +595,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                     }
                     else
                     {
-                        (GetParentElem<GroupItem>(sender as DependencyObject) as UIElement).Focus();
+                        (GetParentElem<Expander>(sender as DependencyObject) as UIElement).Focus();
                     }
                 }
                 e.Handled = true;
@@ -647,7 +647,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             for (int x = 0; x < VisualTreeHelper.GetChildrenCount(root); x++)
             {
                 DependencyObject child = VisualTreeHelper.GetChild(root, x);
-                CheckAllBoxes(child,check);
+                CheckAllBoxes(child, check);
             }
         }
 
@@ -660,7 +660,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         private bool SetItemsChecked(IReadOnlyCollection<Object> lst, bool check)
         {
             var ret = true;
-            foreach(RuleResultViewModel itm in lst.AsParallel())
+            foreach (RuleResultViewModel itm in lst.AsParallel())
             {
                 if (check && !SelectedItems.Contains(itm))
                 {
@@ -722,7 +722,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
             SelectedItems.Remove(srvm);
             var groupitem = GetParentElem<GroupItem>(exp) as GroupItem;
-            var dc =  cb.DataContext as CollectionViewGroup;
+            var dc = cb.DataContext as CollectionViewGroup;
             var itms = dc.Items;
             var any = itms.Intersect(SelectedItems).Any();
             if (any)

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -99,7 +99,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         /// <summary>
         /// Gets/sets fastpass highlighter visibility, updating as necessary 
         /// </summary>
-#pragma warning disable CA1822
+#pragma warning disable CA1822 
         public bool HighlightVisibility
 #pragma warning restore CA1822
         {
@@ -151,7 +151,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 this.gdFailures.Focus();
                 var count = results.Where(r => r.RuleResult.Status == Axe.Windows.Core.Results.ScanStatus.Fail).Count();
 
-                switch (count)
+                switch(count)
                 {
                     case 0:
                         this.runFailures.Text = Properties.Resources.AutomatedChecksControl_SetRuleResults_No_failure_was;
@@ -160,7 +160,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                         this.runFailures.Text = Properties.Resources.AutomatedChecksControl_SetRuleResults_1_failure_was;
                         break;
                     default:
-                        this.runFailures.Text = String.Format(CultureInfo.InvariantCulture, Properties.Resources.AutomatedChecksControl_SetRuleResults_0_failures_were, results.Count);
+                        this.runFailures.Text = String.Format(CultureInfo.InvariantCulture,Properties.Resources.AutomatedChecksControl_SetRuleResults_0_failures_were, results.Count);
                         break;
                 }
 
@@ -458,7 +458,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                     DependencyObject child = VisualTreeHelper.GetChild(element, i);
                     if (child != null && child is T)
                     {
-                        yield return (T)child;
+                        yield return (T) child;
                     }
                     foreach (T descendant in FindChildren<T>(child))
                     {
@@ -562,7 +562,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 {
                     if (selectedElementIndex + 1 < elements.Count)
                     {
-                        ((UIElement)elements.ElementAt(selectedElementIndex + 1)).Focus();
+                        ((UIElement) elements.ElementAt(selectedElementIndex + 1)).Focus();
                     }
                 }
                 else if (selectedElementIndex - 1 >= 0)
@@ -595,7 +595,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                     }
                     else
                     {
-                        (GetParentElem<Expander>(sender as DependencyObject) as UIElement).Focus();
+                        (GetParentElem<GroupItem>(sender as DependencyObject) as UIElement).Focus();
                     }
                 }
                 e.Handled = true;
@@ -647,7 +647,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             for (int x = 0; x < VisualTreeHelper.GetChildrenCount(root); x++)
             {
                 DependencyObject child = VisualTreeHelper.GetChild(root, x);
-                CheckAllBoxes(child, check);
+                CheckAllBoxes(child,check);
             }
         }
 
@@ -660,7 +660,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         private bool SetItemsChecked(IReadOnlyCollection<Object> lst, bool check)
         {
             var ret = true;
-            foreach (RuleResultViewModel itm in lst.AsParallel())
+            foreach(RuleResultViewModel itm in lst.AsParallel())
             {
                 if (check && !SelectedItems.Contains(itm))
                 {
@@ -722,7 +722,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
             SelectedItems.Remove(srvm);
             var groupitem = GetParentElem<GroupItem>(exp) as GroupItem;
-            var dc = cb.DataContext as CollectionViewGroup;
+            var dc =  cb.DataContext as CollectionViewGroup;
             var itms = dc.Items;
             var any = itms.Intersect(SelectedItems).Any();
             if (any)

--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -329,6 +329,7 @@
       <DependentUpon>ChannelConfigControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\CustomControls\CustomDataGrid.cs" />
+    <Compile Include="Controls\CustomControls\CustomExpander.cs" />
     <Compile Include="Controls\CustomControls\CustomGridViewColumn.xaml.cs">
       <DependentUpon>CustomGridViewColumn.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
#### Describe the change
A recent change to enable .NET 4.8 accessibility features had an unintended side effect of breaking our Automated Checks `ListView`'s screen reader user behavior. Specifically, once a group item had been expanded at least once, screen readers would no longer speak upon that item receiving keyboard focus. Per @karanbirsingh's investigation, this appeared to be caused by a change to the `GroupItemAutomationPeer` which made its `HasKeyboardFocus` UIA property set based on its child expander's `HasKeyboardFocus` property. Because of our customization, that expander never receives keyboard focus. This PR addresses the problem by overriding the child expander's `AutomationPeer` and setting its `HasKeyboardFocus` value based on its parent GroupItem's `IsFocused` value. This does not impact non-.NET-4.8 users because it the previous `GroupItemAutomationPeer` is not dependent upon the expander's automation peer in this way.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [-] Does this address an existing issue? If yes, Issue# - 
- [-] Includes UI changes?
  - [-] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [-] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



