### PR TITLE
Use gray text for the GitHub issue filing placeholder text

### DIFF
--- a/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml
+++ b/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml
@@ -11,19 +11,33 @@
     xmlns:controls="clr-namespace:AccessibilityInsights.CommonUxComponents.Controls;assembly=AccessibilityInsights.CommonUxComponents"
     mc:Ignorable="d"
     IsVisibleChanged="IssueConfigurationControl_IsVisibleChanged">
+    <UserControl.Resources>
+        <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
+    </UserControl.Resources>
     <Grid HorizontalAlignment="Left" VerticalAlignment="Top">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-        <TextBlock x:Name="connectionInstr" Grid.Row="0" Text="{x:Static Properties:Resources.tbURLPlaceHolder}" TextWrapping="Wrap" Margin="0 9px"  FontSize="{DynamicResource StandardTextSize}" />
+        <TextBlock x:Name="connectionInstr" Grid.Row="0" Text="{x:Static Properties:Resources.tbURLPlaceHolder}" TextWrapping="Wrap" Margin="0 9px"  FontSize="{DynamicResource StandardTextSize}" Foreground="{DynamicResource ResourceKey=TextBrush}"/>
         <Grid Grid.Row="1" >
             <controls:PlaceholderTextBox
                 Width="294px" Height="32px" VerticalContentAlignment="Center" x:Name="tbURL" Margin="5"
                 AutomationProperties.Name="{x:Static Properties:Resources.tbURLPlaceHolder}" 
                 FontSize="{DynamicResource StandardTextSize}"
                 AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.IssueConfigurationUrlTextBox}"
-                Placeholder="{x:Static Properties:Resources.PlaceHolder}"/>
+                BorderThickness="1"
+                Placeholder="{x:Static Properties:Resources.PlaceHolder}">
+                <controls:PlaceholderTextBox.Style>
+                    <Style TargetType="{x:Type controls:PlaceholderTextBox}" BasedOn="{StaticResource ResourceKey=PlaceholderTextBox}">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Text, ElementName=tbURL}" Value="">
+                                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TextBrushGray}"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </controls:PlaceholderTextBox.Style>
+            </controls:PlaceholderTextBox>
         </Grid>
     </Grid>
 </src:IssueConfigurationControl>

--- a/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
@@ -35,7 +35,17 @@
                                     AutomationProperties.HelpText="{x:Static Properties:Resources.PropertyInfoControl_textboxSearch}"
                                     Height="24" HorizontalAlignment="Stretch"
                                     VerticalContentAlignment="Center" BorderThickness="0"
-                                    Background="Transparent" Placeholder="{x:Static Properties:Resources.tbSearchText}"/>
+                                    Background="Transparent" Placeholder="{x:Static Properties:Resources.tbSearchText}">
+                            <controls:PlaceholderTextBox.Style>
+                                <Style TargetType="{x:Type controls:PlaceholderTextBox}" BasedOn="{StaticResource ResourceKey=PlaceholderTextBox}">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Text, ElementName=textboxSearch}" Value="">
+                                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=DarkGreyTextBrush}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </controls:PlaceholderTextBox.Style>
+                        </controls:PlaceholderTextBox>
                     </DockPanel>                        
                 </Border>
                 <customcontrols:CustomListView

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1429,7 +1429,6 @@
                                    Text="{TemplateBinding Property=Placeholder}" Margin="2,0">
                             <TextBlock.Style>
                                 <Style TargetType="TextBlock">
-                                    <Setter Property="Foreground" Value="{DynamicResource ResourceKey=DarkGreyTextBrush}"/>
                                     <Setter Property="Visibility" Value="Collapsed"/>
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding Path=Text, RelativeSource={RelativeSource Mode=TemplatedParent}}" Value="">


### PR DESCRIPTION
#### Describe the change
Use gray text for the GitHub issue filing placeholder text. 

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - #546 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

There are 2 other places where PlaceholderTextBox is used. One is the Search control in the Hierarchy view, and the other is the Search control in the Details view. These controls retain their existing colors, since they render on a different background color. The changes take a somewhat naive approach, since it should be theoretically possible to have just 1 style to handle multiple colors, but my attempts to do were unsuccessful. Maybe John can suggest a better style option later on.

Screenshot: Key difference to observe is between the leftmost and rightmost portions of the top row of the screenshot. All others are intentionally unchanged.
![image](https://user-images.githubusercontent.com/45672944/66789858-4fa77d00-eea2-11e9-8e6b-77a044bcea1d.png)


> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



