### PR TITLE
Improve color contrast on AzureBoards link placeholder text

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -45,7 +45,7 @@
                             <Setter Property="Visibility" Value="Collapsed"/>
                             <Setter Property="VerticalAlignment" Value="Center"/>
                             <Setter Property="Margin" Value="6 0 0 6"/>
-                            <Setter Property="Foreground" Value="SlateGray"/>
+                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TextBrushGray}"/>
                             <Setter Property="FontSize" Value="{DynamicResource StandardTextSize}"/>
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding ElementName=ServerComboBox, Path=Text.Length}" Value="0">


### PR DESCRIPTION
#### Describe the change
Improve color contrast on AzureBoards link placeholder text. The existing code uses a hardcoded value of SlateGray (RGB value of 708090), which is an insufficient color contrast on the default (non-HC) theme, and that fails to become high contrast when HC is enabled. This change replaces the hardcoded color with a color that does a better job at contrast (6E6E6E in non-HC mode, 000000 in HC White, and FFFFFF in other HC modes)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #601 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Screenshot:
![image](https://user-images.githubusercontent.com/45672944/66792001-79b16d00-eeab-11e9-87d2-c605ad04083d.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



