### PR TITLE
Enable retry when running UITests

### DIFF
--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -41,6 +41,7 @@ jobs:
       configuration: ${{ parameters.configuration }}
       runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
       testFiltercriteria: 'TestCategory=Integration&TestCategory!=LiveMode'
+      rerunFailedTests: true
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Stop - WinAppDriver'


### PR DESCRIPTION
#### Describe the change
We've been seeing some UITests failures that seem to be timeout-related. We'll try for a more permanent fix, but this will allow each test 3 attempts to succeed. Deterministic failures will still cause the test task to fail (and break the build)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



