### PR TITLE
Make UITests rerun even in case of 100% failure

### DIFF
--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -42,6 +42,8 @@ jobs:
       runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
       testFiltercriteria: 'TestCategory=Integration&TestCategory!=LiveMode'
       rerunFailedTests: true
+      rerunType: basedOnTestFailureCount
+      rerunFailedTestCasesMaxLimit: 100 # Rerun even if all UI tests fail on a given run (much larger than count of tests)
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Stop - WinAppDriver'


### PR DESCRIPTION
#### Describe the change
In a recent build, 3 of our 5 UITests failed, but no UITests were rerun. This was surprising since the retry flag was set to true. After digging into the docs at https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/vstest?view=azure-devops, we learned that the default behavior for rerunning is to disable rerun if the failure rate exceeds 30% of the tests. We had a 60% failure rate (3 of 5), so no rerun occurred. That's not what we wanted.

This changes the rerun failure rate to be based on the count of failures (not the percentage), and it sets the "don't rerun any tests" threshold to a value larger than our count of tests. The intent is that even if 100% of our UITests failed on the first try, we still want to rerun the failed tests.

Validation build has been queued: https://dev.azure.com/mseng/1ES/_build/results?buildId=10716189&view=results. I'll cancel the build once the UITests succeed.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



