### PR TITLE
Don't show welcome screen when opening loaded file

### DIFF
--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -173,7 +173,6 @@ namespace AccessibilityInsights
 
             this.Topmost = ConfigurationManager.GetDefaultInstance().AppConfig.AlwaysOnTop;
 
-
             UpdateMainWindowLayout();
 
             this.TreeNavigator = new TreeNavigator(this);

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -108,7 +108,7 @@ namespace AccessibilityInsights
         {
             get
             {
-                return string.Format(CultureInfo.InvariantCulture, Properties.Resources.MainWindow_AutomationPropertiesName_0_1_2, Properties.Resources.btnCCAAutomationPropertiesName , this.CurrentPage.ToString(), Properties.Resources.ModeIsEnabled);
+                return string.Format(CultureInfo.InvariantCulture, Properties.Resources.MainWindow_AutomationPropertiesName_0_1_2, Properties.Resources.btnCCAAutomationPropertiesName, this.CurrentPage.ToString(), Properties.Resources.ModeIsEnabled);
             }
         }
 
@@ -172,7 +172,7 @@ namespace AccessibilityInsights
             InitializeComponent();
 
             this.Topmost = ConfigurationManager.GetDefaultInstance().AppConfig.AlwaysOnTop;
-            
+
 
             UpdateMainWindowLayout();
 
@@ -310,7 +310,7 @@ namespace AccessibilityInsights
             // update version string. 
             UpdateVersionString();
 
-            StartStartMode();
+            Initialize();
 
             HandleFileAssociationOpenRequest();
         }

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -59,7 +59,7 @@ namespace AccessibilityInsights
             InitAccessKeyRule();
             InitHighlighter();
 
-            if (ConfigurationManager.GetDefaultInstance().AppConfig.NeedToShowWelcomeScreen())
+            if (ConfigurationManager.GetDefaultInstance().AppConfig.NeedToShowWelcomeScreen() && CommandLineSettings.FileToOpen == null)
             {
                 InitStartMode();
             }

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -29,18 +29,22 @@ namespace AccessibilityInsights
         public HotKeyHandler HotkeyHandler { get; private set; }
         readonly TreeNavigator TreeNavigator = null;
 
-        /// <summary>
-        /// Start Start Mode
-        /// </summary>
-        /// <returns></returns>
-        void StartStartMode()
+        void InitStartMode()
         {
             this.CurrentPage = AppPage.Start;
+            PageTracker.TrackPage(this.CurrentPage, null);
+            this.gdModes.Visibility = Visibility.Visible;
+            this.btnPause.Visibility = Visibility.Visible;
+            ctrlDialogContainer.ShowDialog(new StartUpModeControl()).ContinueWith(BackToSelectingOnDispatcher, TaskScheduler.Current);
+            ShowTelemetryDialog();
+            CheckForUpdates();
+        }
+
+        private void Initialize()
+        {
             this.ctrlCurMode = ctrlLiveMode;
             this.ctrlCurMode.ShowControl();
-            PageTracker.TrackPage(this.CurrentPage, null);
 
-            /// Make sure that title and Name property are set with same value. 
             UpdateTitleString();
 
             this.hWnd = new WindowInteropHelper(this).Handle;
@@ -54,16 +58,10 @@ namespace AccessibilityInsights
             InitTimerAutoSnap();
             InitAccessKeyRule();
             InitHighlighter();
-            this.gdModes.Visibility = Visibility.Visible;
-            this.btnPause.Visibility = Visibility.Visible;
-            /// Set UI appropriately if showing startup screen
+
             if (ConfigurationManager.GetDefaultInstance().AppConfig.NeedToShowWelcomeScreen())
             {
-                ctrlDialogContainer.ShowDialog(new StartUpModeControl()).ContinueWith(BackToSelectingOnDispatcher, TaskScheduler.Current);
-                //show telemetry dialog
-                ShowTelemetryDialog();
-                // make sure that we show update. 
-                CheckForUpdates();
+                InitStartMode();
             }
             else
             {
@@ -71,7 +69,6 @@ namespace AccessibilityInsights
                 // make sure that we disable selector before showing update
                 // otherwise, UI could be in weird state (Main window is gray out but still show selection and update dialog is disappearing)
                 DisableElementSelector();
-                //show telemetry dialog
                 ShowTelemetryDialog();
                 CheckForUpdates();
                 EnableElementSelector();


### PR DESCRIPTION
#### Describe the change
To address #608- [BUG] Opening file by file association is broken if welcome dialog is shown, this PR stops showing the startup/welcome screen when loading a file directly on launch. This makes more sense to me than our old behavior (which I would describe as unintentional), which was that the welcome screen would show over the loaded data. If others disagree, we can revert to that behavior instead.
![no-startup](https://user-images.githubusercontent.com/4615491/67337437-e47e2c00-f4db-11e9-907e-f3e06cd4a876.gif)


#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue #608 
- [-] Includes UI changes?
  - [-] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



