### PR TITLE
Fix settings.targets to include keys on SignedRelease

### DIFF
--- a/build/settings.targets
+++ b/build/settings.targets
@@ -7,7 +7,7 @@
   <Import Project="delaysign.targets" />
 
   <Choose>
-    <When Condition=" '$(SignAppForRelease)'=='true' AND '$(Configuration)' == 'Release'">
+    <When Condition=" '$(SignAppForRelease)'=='true' AND '$(Configuration)' == 'SignedRelease'">
       <ItemGroup>
         <FilesToSign Include="@(DropSignedFile)">
           <Authenticode>Microsoft400</Authenticode>


### PR DESCRIPTION
#### Describe the change
In #536- Fix signed build, I claimed to fix our signed build. That may have been true for digital signing, but the PR happened to break strong name signing. The cause: [the conditional here](https://github.com/microsoft/accessibility-insights-windows/blob/3d46005fc1c46861b0975bd5a4594592275a9299/build/settings.targets#L10) wasn't updated to check for the new SignedRelease configuration. A signed build ran without errors related to strong name keys. 

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



