### PR TITLE
Gate signing only with build variables

### DIFF
--- a/build/delaysign.targets
+++ b/build/delaysign.targets
@@ -7,7 +7,7 @@
   <Import Project="common.targets" />
 
   <Choose>
-    <When Condition=" '$(SignAppForRelease)'=='true' AND '$(Configuration)' == 'SignedRelease'">
+    <When Condition=" '$(SignAppForRelease)'=='true' ">
       <PropertyGroup>
         <DefineConstants>$(DefineConstants);ENABLE_SIGNING;</DefineConstants>
         <SignAssembly>true</SignAssembly>

--- a/build/settings.targets
+++ b/build/settings.targets
@@ -7,7 +7,7 @@
   <Import Project="delaysign.targets" />
 
   <Choose>
-    <When Condition=" '$(SignAppForRelease)'=='true' AND '$(Configuration)' == 'Release'">
+    <When Condition=" '$(SignAppForRelease)'=='true' ">
       <ItemGroup>
         <FilesToSign Include="@(DropSignedFile)">
           <Authenticode>Microsoft400</Authenticode>

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -5,7 +5,7 @@ variables:
   BuildPlatform: 'x86'
   MAICreateNuget: 'true'
   PublicRelease: 'true'
-  SignAppForRelease: 'true'
+  SignAppForRelease: 'false'
   TeamName: 'Accessibility Insights Windows'
   system.debug: 'true' #set to true in case our signed build flakes out again
   FAKES_SUPPORTED: 1
@@ -21,7 +21,6 @@ jobs:
     vmImage: 'windows-2019'
   variables:
     PublicRelease: 'false'
-    SignAppForRelease: 'false'
   steps:
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet 4.3.0'
@@ -79,7 +78,6 @@ jobs:
     vmImage: 'windows-2019'
   variables:
     PublicRelease: 'false'
-    SignAppForRelease: 'false'
   steps:
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet 4.3.0'
@@ -194,6 +192,7 @@ jobs:
   pool: VSEng-MicroBuildVS2019
   variables:
     runCodesignValidationInjection: 'true'
+    SignAppForRelease: 'true'
 
   steps:
   - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -6,8 +6,6 @@ parameters:
 jobs:
 - job: UITests${{ parameters.configuration }}
   displayName: Build and run UI Tests - ${{ parameters.configuration }}
-  variables:
-    SignAppForRelease: 'false'
   condition: succeeded()
   pool:
     vmImage: windows-2019

--- a/src/AccessibilityInsights.sln
+++ b/src/AccessibilityInsights.sln
@@ -471,9 +471,7 @@ Global
 		{7A7C04EA-8279-4D69-959D-E804DD81BC70}.Release|x86.Build.0 = Release|Any CPU
 		{7A7C04EA-8279-4D69-959D-E804DD81BC70}.SignedRelease|Any CPU.ActiveCfg = Release|Any CPU
 		{7A7C04EA-8279-4D69-959D-E804DD81BC70}.SignedRelease|x64.ActiveCfg = Release|Any CPU
-		{7A7C04EA-8279-4D69-959D-E804DD81BC70}.SignedRelease|x64.Build.0 = Release|Any CPU
 		{7A7C04EA-8279-4D69-959D-E804DD81BC70}.SignedRelease|x86.ActiveCfg = Release|Any CPU
-		{7A7C04EA-8279-4D69-959D-E804DD81BC70}.SignedRelease|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
#### Describe the change
PRs #536, #620, and #621 failed to get us digitally and strong name signed. Hopefully this PR will. Here, we stop gating signing based on the Configuration and leave it entirely up to the build variables. We also tweak the variables set in signedbuild.yml to make signing opt-in instead of opt-out. A signed build ran and produced a digitally and strong name signed artifact.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



