### PR TITLE
Add private versions of Axe.Windows methods that aren't used by Axe.Windows

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/GlobalEyedropperWindow.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/GlobalEyedropperWindow.xaml.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Desktop.Utility;
 using AccessibilityInsights.SharedUx.Utilities;
 using AccessibilityInsights.SharedUx.ViewModels;
 using AccessibilityInsights.Win32;

--- a/src/AccessibilityInsights.SharedUx/Highlighting/Win32SnapshotButton.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/Win32SnapshotButton.cs
@@ -3,7 +3,6 @@
 using AccessibilityInsights.CommonUxComponents.Utilities;
 using AccessibilityInsights.SharedUx.Utilities;
 using AccessibilityInsights.Win32;
-using Axe.Windows.Desktop.Utility;
 using System;
 using System.Collections.Generic;
 using System.Drawing;

--- a/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
@@ -267,7 +267,7 @@ namespace AccessibilityInsights.SharedUx.Utilities
             }
         }
 
-        public static System.Windows.Media.Color ToMediaColor(this System.Drawing.Color color)
+        internal static System.Windows.Media.Color ToMediaColor(this System.Drawing.Color color)
         {
             return System.Windows.Media.Color.FromArgb(color.A, color.R, color.G, color.B);
         }
@@ -277,7 +277,7 @@ namespace AccessibilityInsights.SharedUx.Utilities
         /// </summary>
         /// <param name="bitmap"></param>
         /// <returns></returns>
-        public static BitmapSource ConvertToSource(this Bitmap bitmap)
+        internal static BitmapSource ConvertToSource(this Bitmap bitmap)
         {
             if (bitmap == null) throw new ArgumentNullException(nameof(bitmap));
 

--- a/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
@@ -28,6 +28,9 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using static System.FormattableString;
 
+using MediaColor = System.Windows.Media.Color;
+using WindowsPoint = System.Windows.Point;
+
 namespace AccessibilityInsights.SharedUx.Utilities
 {
     /// <summary>
@@ -185,9 +188,9 @@ namespace AccessibilityInsights.SharedUx.Utilities
         /// </summary>
         /// <param name="window"></param>
         /// <returns></returns>
-        public static System.Windows.Point GetTopLeftPoint(this Window window)
+        public static WindowsPoint GetTopLeftPoint(this Window window)
         {
-            System.Windows.Point topLeft = new System.Windows.Point();
+            WindowsPoint topLeft = new WindowsPoint();
             // .Top & .Left are not updated when window is maximized, so need to 
             //  recover the position of the window in this case
             var left = typeof(Window).GetField("_actualLeft", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
@@ -267,9 +270,9 @@ namespace AccessibilityInsights.SharedUx.Utilities
             }
         }
 
-        internal static System.Windows.Media.Color ToMediaColor(this System.Drawing.Color color)
+        internal static MediaColor ToMediaColor(this System.Drawing.Color color)
         {
-            return System.Windows.Media.Color.FromArgb(color.A, color.R, color.G, color.B);
+            return MediaColor.FromArgb(color.A, color.R, color.G, color.B);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
@@ -6,6 +6,7 @@ using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.SharedUx.Properties;
 using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.SharedUx.ViewModels;
+using AccessibilityInsights.Win32;
 using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
@@ -13,6 +14,7 @@ using Axe.Windows.Core.Results;
 using Axe.Windows.Desktop.Utility;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -21,7 +23,9 @@ using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Interop;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using static System.FormattableString;
 
 namespace AccessibilityInsights.SharedUx.Utilities
@@ -181,9 +185,9 @@ namespace AccessibilityInsights.SharedUx.Utilities
         /// </summary>
         /// <param name="window"></param>
         /// <returns></returns>
-        public static Point GetTopLeftPoint(this Window window)
+        public static System.Windows.Point GetTopLeftPoint(this Window window)
         {
-            Point topLeft = new Point();
+            System.Windows.Point topLeft = new System.Windows.Point();
             // .Top & .Left are not updated when window is maximized, so need to 
             //  recover the position of the window in this case
             var left = typeof(Window).GetField("_actualLeft", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
@@ -263,9 +267,24 @@ namespace AccessibilityInsights.SharedUx.Utilities
             }
         }
 
-        public static Color ToMediaColor(this System.Drawing.Color color)
+        public static System.Windows.Media.Color ToMediaColor(this System.Drawing.Color color)
         {
-            return Color.FromArgb(color.A, color.R, color.G, color.B);
+            return System.Windows.Media.Color.FromArgb(color.A, color.R, color.G, color.B);
+        }
+
+        /// <summary>
+        /// Gets source for bitmap
+        /// </summary>
+        /// <param name="bitmap"></param>
+        /// <returns></returns>
+        public static BitmapSource ConvertToSource(this Bitmap bitmap)
+        {
+            if (bitmap == null) throw new ArgumentNullException(nameof(bitmap));
+
+            var hbmp = bitmap.GetHbitmap();
+            var result = Imaging.CreateBitmapSourceFromHBitmap(hbmp, IntPtr.Zero, Int32Rect.Empty, BitmapSizeOptions.FromEmptyOptions());
+            NativeMethods.DeleteObject(hbmp);
+            return result;
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Utilities/HelperMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/HelperMethods.cs
@@ -77,7 +77,7 @@ namespace AccessibilityInsights.SharedUx.Utilities
         /// </summary>
         /// <param name="rc"></param>
         /// <returns></returns>
-        public static double GetDPI(this Rectangle rc)
+        internal static double GetDPI(this Rectangle rc)
         {
             return GetDPI(rc.Left, rc.Top);
         }
@@ -88,7 +88,7 @@ namespace AccessibilityInsights.SharedUx.Utilities
         /// <param name="left"></param>
         /// <param name="top"></param>
         /// <returns></returns>
-        public static double GetDPI(int left, int top)
+        private static double GetDPI(int left, int top)
         {
             NativeMethods.GetDpi(new System.Drawing.Point(left, top), DpiType.Effective, out uint dpiX, out uint dpiY);
 
@@ -111,7 +111,7 @@ namespace AccessibilityInsights.SharedUx.Utilities
         /// when setting Window.Left / Window.Top before calling show()
         /// </summary>
         /// <returns></returns>
-        public static double GetWPFWindowPositioningDPI()
+        internal static double GetWPFWindowPositioningDPI()
         {
             return new Rectangle().GetDPI();
         }

--- a/src/AccessibilityInsights.SharedUx/Utilities/HelperMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/HelperMethods.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.FileIssue;
 using AccessibilityInsights.SharedUx.Settings;
+using AccessibilityInsights.Win32;
 using Axe.Windows.Actions;
 using Axe.Windows.Actions.Contexts;
 using System;
+using System.Drawing;
 using System.Windows;
 
 namespace AccessibilityInsights.SharedUx.Utilities
@@ -69,5 +71,49 @@ namespace AccessibilityInsights.SharedUx.Utilities
         /// Provides bindable property for ProgressRingControls
         /// </summary>
         public static bool PlayScanningSound => ConfigurationManager.GetDefaultInstance().AppConfig.PlayScanningSound;
+
+        /// <summary>
+        /// Get DPI
+        /// </summary>
+        /// <param name="rc"></param>
+        /// <returns></returns>
+        public static double GetDPI(this Rectangle rc)
+        {
+            return GetDPI(rc.Left, rc.Top);
+        }
+
+        /// <summary>
+        /// Get DPI with left/top
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="top"></param>
+        /// <returns></returns>
+        public static double GetDPI(int left, int top)
+        {
+            NativeMethods.GetDpi(new System.Drawing.Point(left, top), DpiType.Effective, out uint dpiX, out uint dpiY);
+
+            return GetDPIRate(dpiX);
+        }
+
+        /// <summary>
+        /// turn raw DPI value to DPI rate
+        /// </summary>
+        /// <param name="dpiX"></param>
+        /// <returns></returns>
+        private static double GetDPIRate(uint dpi)
+        {
+            return dpi / 96.0; // 96 is 100% scale. 
+        }
+
+        /// <summary>
+        /// Gets the DPI that WPF seems to use internally
+        /// when positioning windows; scale by this DPI 
+        /// when setting Window.Left / Window.Top before calling show()
+        /// </summary>
+        /// <returns></returns>
+        public static double GetWPFWindowPositioningDPI()
+        {
+            return new Rectangle().GetDPI();
+        }
     }
 }

--- a/src/AccessibilityInsights.Win32/NativeMethods.cs
+++ b/src/AccessibilityInsights.Win32/NativeMethods.cs
@@ -21,7 +21,7 @@ namespace AccessibilityInsights.Win32
 
         //https://msdn.microsoft.com/en-us/library/windows/desktop/dn280510(v=vs.85).aspx
         [DllImport("Shcore.dll")]
-        internal static extern IntPtr GetDpiForMonitor([In]IntPtr hmonitor, [In]DpiType dpiType, [Out]out uint dpiX, [Out]out uint dpiY);
+        internal static extern uint GetDpiForMonitor([In]IntPtr hmonitor, [In]DpiType dpiType, [Out]out uint dpiX, [Out]out uint dpiY);
 
         [DllImport("Gdi32.dll", CharSet = CharSet.Auto, SetLastError = true, ExactSpelling = true)]
         internal static extern IntPtr CreateCompatibleDC(IntPtr hDC);

--- a/src/AccessibilityInsights.Win32/NativeMethods.cs
+++ b/src/AccessibilityInsights.Win32/NativeMethods.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
+using System.Drawing;
 using System.Runtime.InteropServices;
 
 namespace AccessibilityInsights.Win32
@@ -11,6 +12,17 @@ namespace AccessibilityInsights.Win32
     /// </summary>
     internal static partial class NativeMethods
     {
+        [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true, ExactSpelling = true)]
+        internal static extern uint GetDeviceCaps(IntPtr hDC, int nIndex);
+
+        //https://msdn.microsoft.com/en-us/library/windows/desktop/dd145062(v=vs.85).aspx
+        [DllImport("User32.dll")]
+        internal static extern IntPtr MonitorFromPoint([In]Point pt, [In]uint dwFlags);
+
+        //https://msdn.microsoft.com/en-us/library/windows/desktop/dn280510(v=vs.85).aspx
+        [DllImport("Shcore.dll")]
+        internal static extern IntPtr GetDpiForMonitor([In]IntPtr hmonitor, [In]DpiType dpiType, [Out]out uint dpiX, [Out]out uint dpiY);
+
         [DllImport("Gdi32.dll", CharSet = CharSet.Auto, SetLastError = true, ExactSpelling = true)]
         internal static extern IntPtr CreateCompatibleDC(IntPtr hDC);
 

--- a/src/AccessibilityInsights.Win32/Win32Enums.cs
+++ b/src/AccessibilityInsights.Win32/Win32Enums.cs
@@ -446,5 +446,31 @@ namespace AccessibilityInsights.Win32
         UntrustedRoot = 0x800B0109                  // CERT_E_UNTRUSTEDROOT - A certification chain processed correctly but terminated in a root certificate that is not trusted by the trust provider.
     }
 
+    /// <summary>
+    /// https://msdn.microsoft.com/en-us/library/windows/desktop/dn280511(v=vs.85).aspx
+    /// </summary>
+    public enum DpiType
+    {
+        Effective = 0,
+        Angular = 1,
+        Raw = 2,
+    }
+
+    /// <summary>
+    /// Device Cap
+    /// https://docs.microsoft.com/en-us/windows/desktop/api/wingdi/nf-wingdi-getdevicecaps
+    /// </summary>
+    public enum DeviceCap
+    {
+        /// <summary>
+        /// Logical pixels inch in X
+        /// </summary>
+        LOGPIXELSX = 88,
+        /// <summary>
+        /// Logical pixels inch in Y
+        /// </summary>
+        LOGPIXELSY = 90
+    }
+
 #pragma warning restore CA1712 // Do not prefix enum values with type name
 }

--- a/src/AccessibilityInsights.Win32/Win32Helper.cs
+++ b/src/AccessibilityInsights.Win32/Win32Helper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.Win32;
 using System;
+using System.Drawing;
 using System.Threading;
 
 namespace AccessibilityInsights.Win32
@@ -107,6 +108,39 @@ namespace AccessibilityInsights.Win32
             const string valueName = "Release";
 
             return (int?)Registry.GetValue(keyName, valueName, null);
+        }
+
+        /// <summary>
+        /// Check whether the current Windows is Windows 7 or not. 
+        /// </summary>
+        /// <returns></returns>
+        internal static bool IsWindows7()
+        {
+            return Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor == 1;
+        }
+
+        /// <summary>
+        /// Get DPI value from pointer
+        /// </summary>
+        /// <param name="point"></param>
+        /// <param name="dpiType"></param>
+        /// <param name="dpiX"></param>
+        /// <param name="dpiY"></param>
+        internal static void GetDpi(Point point, DpiType dpiType, out uint dpiX, out uint dpiY)
+        {
+            var mon = NativeMethods.MonitorFromPoint(point, 2/*MONITOR_DEFAULTTONEAREST*/);
+            if (IsWindows7())
+            {
+                Graphics g = Graphics.FromHwnd(IntPtr.Zero);
+                IntPtr desktop = g.GetHdc();
+
+                dpiX = NativeMethods.GetDeviceCaps(desktop, (int)DeviceCap.LOGPIXELSX);
+                dpiY = NativeMethods.GetDeviceCaps(desktop, (int)DeviceCap.LOGPIXELSY);
+            }
+            else
+            {
+                NativeMethods.GetDpiForMonitor(mon, dpiType, out dpiX, out dpiY);
+            }
         }
     }
 }

--- a/src/AccessibilityInsights.Win32/Win32Helper.cs
+++ b/src/AccessibilityInsights.Win32/Win32Helper.cs
@@ -120,7 +120,7 @@ namespace AccessibilityInsights.Win32
         }
 
         /// <summary>
-        /// Get DPI value from pointer
+        /// Get DPI value from point
         /// </summary>
         /// <param name="point"></param>
         /// <param name="dpiType"></param>
@@ -128,6 +128,9 @@ namespace AccessibilityInsights.Win32
         /// <param name="dpiY"></param>
         internal static void GetDpi(Point point, DpiType dpiType, out uint dpiX, out uint dpiY)
         {
+            const uint defaultDpi = 96;
+            const uint S_OK = 0;
+
             var mon = NativeMethods.MonitorFromPoint(point, 2/*MONITOR_DEFAULTTONEAREST*/);
             if (IsWindows7())
             {
@@ -139,7 +142,17 @@ namespace AccessibilityInsights.Win32
             }
             else
             {
-                NativeMethods.GetDpiForMonitor(mon, dpiType, out dpiX, out dpiY);
+                uint localDpiX, localDpiY;
+                if (NativeMethods.GetDpiForMonitor(mon, dpiType, out localDpiX, out localDpiY) == S_OK)
+                {
+                    dpiX = localDpiX;
+                    dpiY = localDpiY;
+                }
+                else
+                {
+                    dpiX = defaultDpi;
+                    dpiY = defaultDpi;
+                }
             }
         }
     }


### PR DESCRIPTION
#### Describe the change
We identified some Axe.Windows methods that are used only in AIWin. We're adding these methods to AIWin and removing them from Axe.Windows. This is the complement of https://github.com/microsoft/axe-windows/pull/214

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



