### PR TITLE
Bump Newtonsoft.Json.dll from 12.0.2 to 12.0.3

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
@@ -104,7 +104,7 @@
       <HintPath>..\packages\Microsoft.VisualStudio.Services.Client.15.112.1\lib\net45\Microsoft.VisualStudio.Services.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/packages.config
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/packages.config
@@ -17,7 +17,7 @@
   <package id="Microsoft.VisualStudio.Services.InteractiveClient" version="15.112.1" targetFramework="net471" />
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net471" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="System.Collections" version="4.3.0" targetFramework="net471" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/Extensions.GitHubAutoUpdate.csproj
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/Extensions.GitHubAutoUpdate.csproj
@@ -43,7 +43,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/packages.config
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/packages.config
@@ -6,6 +6,6 @@
   <package id="Microsoft.NetCore.Analyzers" version="2.9.7" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.7" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net471" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="Text.Analyzers" version="2.6.4" targetFramework="net471" developmentDependency="true" />
 </packages>

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/Extensions.GitHubAutoUpdateUnitTests.csproj
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/Extensions.GitHubAutoUpdateUnitTests.csproj
@@ -62,7 +62,7 @@
       <HintPath>..\packages\Moq.4.13.1\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/packages.config
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/packages.config
@@ -4,7 +4,7 @@
   <package id="Moq" version="4.13.1" targetFramework="net471" />
   <package id="MSTest.TestAdapter" version="2.0.0" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net471" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net471" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net471" />

--- a/src/AccessibilityInsights.Fakes.Prebuild/Fakes.Prebuild.csproj
+++ b/src/AccessibilityInsights.Fakes.Prebuild/Fakes.Prebuild.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/AccessibilityInsights.Fakes.Prebuild/packages.config
+++ b/src/AccessibilityInsights.Fakes.Prebuild/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/src/AccessibilityInsights.SetupLibrary/SetupLibrary.csproj
+++ b/src/AccessibilityInsights.SetupLibrary/SetupLibrary.csproj
@@ -48,7 +48,7 @@
       <HintPath>..\packages\WiX.3.11.2\tools\Microsoft.Deployment.WindowsInstaller.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/AccessibilityInsights.SetupLibrary/packages.config
+++ b/src/AccessibilityInsights.SetupLibrary/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.NetCore.Analyzers" version="2.9.7" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.7" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net471" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="Text.Analyzers" version="2.6.4" targetFramework="net471" developmentDependency="true" />
   <package id="WiX" version="3.11.2" targetFramework="net471" />
 </packages>

--- a/src/AccessibilityInsights.SetupLibraryUnitTests/SetupLibraryUnitTests.csproj
+++ b/src/AccessibilityInsights.SetupLibraryUnitTests/SetupLibraryUnitTests.csproj
@@ -48,7 +48,7 @@
       <HintPath>..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/AccessibilityInsights.SetupLibraryUnitTests/packages.config
+++ b/src/AccessibilityInsights.SetupLibraryUnitTests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="MSTest.TestAdapter" version="2.0.0" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net471" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
 </packages>

--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -82,7 +82,7 @@
       <HintPath>..\packages\Microsoft.Win32.Registry.4.6.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/AccessibilityInsights.SharedUx/packages.config
+++ b/src/AccessibilityInsights.SharedUx/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.7" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.Win32.Registry" version="4.6.0" targetFramework="net471" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.Drawing.Common" version="4.6.0" targetFramework="net471" />
   <package id="System.Security.AccessControl" version="4.6.0" targetFramework="net471" />

--- a/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
+++ b/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
@@ -105,7 +105,7 @@
       <HintPath>..\AccessibilityInsights.Fakes.Prebuild\FakesAssemblies\mscorlib.4.0.0.0.Fakes.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/AccessibilityInsights.SharedUxTests/packages.config
+++ b/src/AccessibilityInsights.SharedUxTests/packages.config
@@ -6,7 +6,7 @@
   <package id="Moq" version="4.13.1" targetFramework="net471" />
   <package id="MSTest.TestAdapter" version="2.0.0" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net471" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.Drawing.Common" version="4.6.0" targetFramework="net471" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net471" />

--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -86,7 +86,7 @@
       <HintPath>..\packages\Microsoft.Win32.Registry.4.6.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/AccessibilityInsights/packages.config
+++ b/src/AccessibilityInsights/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.7" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.Win32.Registry" version="4.6.0" targetFramework="net471" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.Drawing.Common" version="4.6.0" targetFramework="net471" />
   <package id="System.Security.AccessControl" version="4.6.0" targetFramework="net471" />

--- a/src/UITests/UITests.csproj
+++ b/src/UITests/UITests.csproj
@@ -83,7 +83,7 @@
       <HintPath>..\packages\Microsoft.Win32.Registry.4.6.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SeleniumExtras.PageObjects, Version=3.11.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DotNetSeleniumExtras.PageObjects.3.11.0\lib\net45\SeleniumExtras.PageObjects.dll</HintPath>

--- a/src/UITests/packages.config
+++ b/src/UITests/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.Win32.Registry" version="4.6.0" targetFramework="net471" />
   <package id="MSTest.TestAdapter" version="2.0.0" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net471" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="Selenium.Support" version="3.141.0" targetFramework="net471" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />


### PR DESCRIPTION
#### Describe the change
Bump Newtonsoft.Json.dll from 12.0.2 to 12.0.3. This is the VS-driven version of #631 

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



