### PR TITLE
Bump System.Drawing.Common from 4.6.0 to 4.6.1 (changed via VS)

### DIFF
--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -91,7 +91,7 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Drawing.Common.4.6.0\lib\net461\System.Drawing.Common.dll</HintPath>
+      <HintPath>..\packages\System.Drawing.Common.4.6.1\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.AccessControl, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.4.6.0\lib\net461\System.Security.AccessControl.dll</HintPath>

--- a/src/AccessibilityInsights.SharedUx/packages.config
+++ b/src/AccessibilityInsights.SharedUx/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.Win32.Registry" version="4.6.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
-  <package id="System.Drawing.Common" version="4.6.0" targetFramework="net471" />
+  <package id="System.Drawing.Common" version="4.6.1" targetFramework="net471" />
   <package id="System.Security.AccessControl" version="4.6.0" targetFramework="net471" />
   <package id="System.Security.Principal.Windows" version="4.6.0" targetFramework="net471" />
   <package id="System.Windows.Interactivity.WPF" version="2.0.20525" targetFramework="net471" />

--- a/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
+++ b/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
@@ -116,7 +116,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Drawing.Common.4.6.0\lib\net461\System.Drawing.Common.dll</HintPath>
+      <HintPath>..\packages\System.Drawing.Common.4.6.1\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.6.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>

--- a/src/AccessibilityInsights.SharedUxTests/packages.config
+++ b/src/AccessibilityInsights.SharedUxTests/packages.config
@@ -8,7 +8,7 @@
   <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
-  <package id="System.Drawing.Common" version="4.6.0" targetFramework="net471" />
+  <package id="System.Drawing.Common" version="4.6.1" targetFramework="net471" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net471" />
   <package id="System.Security.AccessControl" version="4.6.0" targetFramework="net471" />
   <package id="System.Security.Principal.Windows" version="4.6.0" targetFramework="net471" />

--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -93,7 +93,7 @@
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Drawing.Common.4.6.0\lib\net461\System.Drawing.Common.dll</HintPath>
+      <HintPath>..\packages\System.Drawing.Common.4.6.1\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.AccessControl, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.4.6.0\lib\net461\System.Security.AccessControl.dll</HintPath>

--- a/src/AccessibilityInsights/packages.config
+++ b/src/AccessibilityInsights/packages.config
@@ -11,7 +11,7 @@
   <package id="Microsoft.Win32.Registry" version="4.6.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
-  <package id="System.Drawing.Common" version="4.6.0" targetFramework="net471" />
+  <package id="System.Drawing.Common" version="4.6.1" targetFramework="net471" />
   <package id="System.Security.AccessControl" version="4.6.0" targetFramework="net471" />
   <package id="System.Security.Principal.Windows" version="4.6.0" targetFramework="net471" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net471" />

--- a/src/UITests/UITests.csproj
+++ b/src/UITests/UITests.csproj
@@ -96,7 +96,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Drawing.Common.4.6.0\lib\net461\System.Drawing.Common.dll</HintPath>
+      <HintPath>..\packages\System.Drawing.Common.4.6.1\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.AccessControl, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.4.6.0\lib\net461\System.Security.AccessControl.dll</HintPath>

--- a/src/UITests/packages.config
+++ b/src/UITests/packages.config
@@ -11,7 +11,7 @@
   <package id="Selenium.Support" version="3.141.0" targetFramework="net471" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
-  <package id="System.Drawing.Common" version="4.6.0" targetFramework="net471" />
+  <package id="System.Drawing.Common" version="4.6.1" targetFramework="net471" />
   <package id="System.Security.AccessControl" version="4.6.0" targetFramework="net471" />
   <package id="System.Security.Principal.Windows" version="4.6.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
#### Describe the change
Bump System.Drawing.Common from 4.6.0 to 4.6.1 (changed via VS). This supersedes #635 

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



