### PR TITLE
Disable the connect button if no text is entered into the edit control

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -59,6 +59,7 @@
             <Button Grid.Column="3" x:Name="btnNext" Padding="8,0" HorizontalAlignment="Left" 
                     Content="{x:Static Properties:Resources.btnNextAutomationPropertiesName}" Click="NextButton_Click"
                     AutomationProperties.Name="{x:Static Properties:Resources.btnNextAutomationPropertiesName}" IsTabStop="True"
+                    IsEnabled="{Binding ElementName=ServerComboBox, Path=Text.Length, Mode=OneWay}"
                     Style="{DynamicResource BtnBlueSquared}" Visibility="{Binding BtnConnectVisibility}" />
             <Button Name="btnDisconnect" Content="{x:Static Properties:Resources.ButtonAutomationPropertiesName}"
                     Click="disconnectButton_Click" Cursor="Hand" Grid.Column="3" HorizontalAlignment="Right" Padding="8,0"


### PR DESCRIPTION
#### Describe the change
Disable the connect button if no text is entered into the edit control

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue#- #643 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes. (issues shown are tracked at #644 
  - [x] Attach any screenshots / GIF's that are applicable.

![DisableConnectButtonWhenTextIsEmpty](https://user-images.githubusercontent.com/45672944/69761403-27a36e80-111c-11ea-8665-185053ea653a.gif)


> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



