### PR TITLE
Remove XAML elements that are no longer used, but are showing up with screen readers

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -71,19 +71,11 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <Image Grid.Column="0" x:Name="imgAvatar" Width="40" Height="40"
-                       Source="{Binding Path=Avatar, TargetNullValue={x:Null}, Mode=OneWay}">
-                <Image.Clip>
-                    <EllipseGeometry Center="20,20" RadiusX="20" RadiusY="20" />
-                </Image.Clip>
-            </Image>
             <Grid Grid.Column="1" Margin="12px 0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <TextBlock x:Name="displayNameField" Grid.Row="0" Text="{Binding Path=DisplayName}" FontSize="{DynamicResource StandardTextSize}"/>
-                <TextBlock x:Name="emailField" Grid.Row="1" Text="{Binding Path=Email}" FontSize="{DynamicResource StandardTextSize}"/>
             </Grid>
         </Grid>
         <Grid x:Name="teamSelectedGrid" Visibility="{Binding TeamSelectedGridVisibility}" Grid.Row="4" Margin="0px 0px 24px 12px">


### PR DESCRIPTION
#### Describe the change
Fix issue #644: The XAML has objects that are no longer used (and never shown), but they're still being detected by screen readers. This change simply removes them from the XAML. AIWin reports no problems with the modified dialog.

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #644
- [ ] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



