### PR TITLE
Collapse User Info controls when we have no data

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -71,7 +71,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <Image Grid.Column="0" x:Name="imgAvatar" Width="40" Height="40"
+            <Image Grid.Column="0" x:Name="imgAvatar" Width="40" Height="40" Visibility="{Binding AvatarVisibility}"
                        Source="{Binding Path=Avatar, TargetNullValue={x:Null}, Mode=OneWay}">
                 <Image.Clip>
                     <EllipseGeometry Center="20,20" RadiusX="20" RadiusY="20" />
@@ -82,8 +82,8 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <TextBlock x:Name="displayNameField" Grid.Row="0" Text="{Binding Path=DisplayName}" FontSize="{DynamicResource StandardTextSize}"/>
-                <TextBlock x:Name="emailField" Grid.Row="1" Text="{Binding Path=Email}" FontSize="{DynamicResource StandardTextSize}"/>
+                <TextBlock x:Name="displayNameField" Grid.Row="0" Text="{Binding Path=DisplayName}" FontSize="{DynamicResource StandardTextSize}" Visibility="{Binding DisplayNameVisibility}"/>
+                <TextBlock x:Name="emailField" Grid.Row="1" Text="{Binding Path=Email}" FontSize="{DynamicResource StandardTextSize}" Visibility="{Binding EmailVisibility}"/>
             </Grid>
         </Grid>
         <Grid x:Name="teamSelectedGrid" Visibility="{Binding TeamSelectedGridVisibility}" Grid.Row="4" Margin="0px 0px 24px 12px">

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Models/ConfigurationViewModel.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Models/ConfigurationViewModel.cs
@@ -23,6 +23,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Models
             {
                 avatar = value;
                 OnPropertyChanged(nameof(Avatar));
+                OnPropertyChanged(nameof(AvatarVisibility));
             }
         }
 
@@ -35,6 +36,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Models
             {
                 displayName = value;
                 OnPropertyChanged(nameof(DisplayName));
+                OnPropertyChanged(nameof(DisplayNameVisibility));
             }
         }
 
@@ -48,6 +50,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Models
             {
                 email = value;
                 OnPropertyChanged(nameof(Email));
+                OnPropertyChanged(nameof(EmailVisibility));
             }
         }
 
@@ -64,6 +67,9 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Models
                 OnPropertyChanged(nameof(BtnDisconnectVisibility));
                 OnPropertyChanged(nameof(IsSelectTeamGridEnabled));
                 OnPropertyChanged(nameof(SelectTeamGridVisibility));
+                OnPropertyChanged(nameof(AvatarVisibility));
+                OnPropertyChanged(nameof(DisplayNameVisibility));
+                OnPropertyChanged(nameof(EmailVisibility));
             }
         }
 
@@ -104,6 +110,30 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Models
             get
             {
                 return State == ControlState.EditingServer;
+            }
+        }
+
+        public Visibility AvatarVisibility
+        {
+            get
+            {
+                return (Avatar == null || Avatar.Length == 0) ? Visibility.Collapsed : Visibility.Visible;
+            }
+        }
+
+        public Visibility DisplayNameVisibility
+        {
+            get
+            {
+                return (DisplayName == null || DisplayName.Length == 0) ? Visibility.Collapsed : Visibility.Visible;
+            }
+        }
+
+        public Visibility EmailVisibility
+        {
+            get
+            {
+                return (Email == null || Email.Length == 0) ? Visibility.Collapsed : Visibility.Visible;
             }
         }
     }

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Models/ConfigurationViewModel.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Models/ConfigurationViewModel.cs
@@ -67,9 +67,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Models
                 OnPropertyChanged(nameof(BtnDisconnectVisibility));
                 OnPropertyChanged(nameof(IsSelectTeamGridEnabled));
                 OnPropertyChanged(nameof(SelectTeamGridVisibility));
-                OnPropertyChanged(nameof(AvatarVisibility));
-                OnPropertyChanged(nameof(DisplayNameVisibility));
-                OnPropertyChanged(nameof(EmailVisibility));
             }
         }
 

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Models/ConfigurationViewModel.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Models/ConfigurationViewModel.cs
@@ -114,7 +114,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Models
         {
             get
             {
-                return (Avatar == null || Avatar.Length == 0) ? Visibility.Collapsed : Visibility.Visible;
+                return (avatar == null || avatar.Length == 0) ? Visibility.Collapsed : Visibility.Visible;
             }
         }
 
@@ -122,7 +122,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Models
         {
             get
             {
-                return (DisplayName == null || DisplayName.Length == 0) ? Visibility.Collapsed : Visibility.Visible;
+                return string.IsNullOrEmpty(displayName) ? Visibility.Collapsed : Visibility.Visible;
             }
         }
 
@@ -130,7 +130,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Models
         {
             get
             {
-                return (Email == null || Email.Length == 0) ? Visibility.Collapsed : Visibility.Visible;
+                return string.IsNullOrEmpty(email) ? Visibility.Collapsed : Visibility.Visible;
             }
         }
     }


### PR DESCRIPTION
#### Describe the change
Fix issue #644: The empty user into controls are showing up for screen readers even when they contain no data. This change simply adds visibility properties to collapse each element if no data is available. Ran AIWin on the control with no validated user and it comes out clean.

Having a property for each control might be overkill, since all three properties should be populated together, but I opted for an approach that could handle any combination of properties from the server.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #644 
- [ ] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



