### PR TITLE
Fix 'Connect Azure Boards account' padding

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1023,7 +1023,7 @@
                     <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}"
                                         Background="{TemplateBinding Background}"
                                         CornerRadius="{TemplateBinding Border.CornerRadius}">
-                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" TextBlock.Foreground="{TemplateBinding Foreground}"/>
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" TextBlock.Foreground="{TemplateBinding Foreground}"  Margin="{TemplateBinding Padding}"/>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
#### Describe the change
This PR updates the margin/padding link in the btnBlue style to be consistent with btnGrey. Without this change, the padding value is not propagated to the templated ContentPresenter. I looked at other usages of btnBlue and none seemed inadvertently affected (none use padding).

Before:
![before image, poor padding](https://user-images.githubusercontent.com/7775527/70004196-5786b380-151a-11ea-86ea-17b30050e5b8.png)

After:
![after image, better padding](https://user-images.githubusercontent.com/7775527/70004166-43db4d00-151a-11ea-8aab-736be25a4916.png)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



