### PR TITLE
Bump System.Runtime.CompilerServices.Unsafe from 4.6.0 to 4.7.0 (using VS)

### DIFF
--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/Extensions.GitHubAutoUpdateUnitTests.csproj
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/Extensions.GitHubAutoUpdateUnitTests.csproj
@@ -68,8 +68,8 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.6.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.3\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/app.config
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/packages.config
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/packages.config
@@ -5,7 +5,7 @@
   <package id="MSTest.TestAdapter" version="2.0.0" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net471" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net471" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net471" />
 </packages>

--- a/src/AccessibilityInsights.Extensions.GitHubUnitTests/Extensions.GitHubUnitTests.csproj
+++ b/src/AccessibilityInsights.Extensions.GitHubUnitTests/Extensions.GitHubUnitTests.csproj
@@ -58,8 +58,8 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.6.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.3\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/src/AccessibilityInsights.Extensions.GitHubUnitTests/app.config
+++ b/src/AccessibilityInsights.Extensions.GitHubUnitTests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/AccessibilityInsights.Extensions.GitHubUnitTests/packages.config
+++ b/src/AccessibilityInsights.Extensions.GitHubUnitTests/packages.config
@@ -4,6 +4,6 @@
   <package id="Moq" version="4.13.1" targetFramework="net471" />
   <package id="MSTest.TestAdapter" version="2.0.0" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net471" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net471" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net471" />
 </packages>

--- a/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
+++ b/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
@@ -118,8 +118,8 @@
     <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Drawing.Common.4.6.1\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.6.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.AccessControl, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.4.6.0\lib\net461\System.Security.AccessControl.dll</HintPath>

--- a/src/AccessibilityInsights.SharedUxTests/app.config
+++ b/src/AccessibilityInsights.SharedUxTests/app.config
@@ -48,7 +48,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/AccessibilityInsights.SharedUxTests/packages.config
+++ b/src/AccessibilityInsights.SharedUxTests/packages.config
@@ -9,7 +9,7 @@
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.Drawing.Common" version="4.6.1" targetFramework="net471" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net471" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.0" targetFramework="net471" />
   <package id="System.Security.AccessControl" version="4.6.0" targetFramework="net471" />
   <package id="System.Security.Principal.Windows" version="4.6.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net471" />


### PR DESCRIPTION
#### Describe the change
This is the VS-driven version of #660 
