### PR TITLE
Bump Microsoft.Win32.Registry from 4.6.0 to 4.7.0 (using VS)

### DIFF
--- a/src/AccessibilityInsights.Fakes.Prebuild/app.config
+++ b/src/AccessibilityInsights.Fakes.Prebuild/app.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Win32.Registry" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -78,8 +78,8 @@
     <Reference Include="Microsoft.mshtml, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Microsoft.Win32.Registry, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Win32.Registry.4.6.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Registry.4.7.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -93,11 +93,11 @@
     <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Drawing.Common.4.6.1\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.AccessControl, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.AccessControl.4.6.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    <Reference Include="System.Security.AccessControl, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.4.7.0\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Principal.Windows, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Principal.Windows.4.6.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.7.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/AccessibilityInsights.SharedUx/app.config
+++ b/src/AccessibilityInsights.SharedUx/app.config
@@ -27,7 +27,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Win32.Registry" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/AccessibilityInsights.SharedUx/packages.config
+++ b/src/AccessibilityInsights.SharedUx/packages.config
@@ -7,12 +7,12 @@
   <package id="Microsoft.NetCore.Analyzers" version="2.9.8" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.8" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net471" developmentDependency="true" />
-  <package id="Microsoft.Win32.Registry" version="4.6.0" targetFramework="net471" />
+  <package id="Microsoft.Win32.Registry" version="4.7.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.Drawing.Common" version="4.6.1" targetFramework="net471" />
-  <package id="System.Security.AccessControl" version="4.6.0" targetFramework="net471" />
-  <package id="System.Security.Principal.Windows" version="4.6.0" targetFramework="net471" />
+  <package id="System.Security.AccessControl" version="4.7.0" targetFramework="net471" />
+  <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net471" />
   <package id="System.Windows.Interactivity.WPF" version="2.0.20525" targetFramework="net471" />
   <package id="Text.Analyzers" version="2.6.4" targetFramework="net471" developmentDependency="true" />
 </packages>

--- a/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
+++ b/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
@@ -95,8 +95,8 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Win32.Registry, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Win32.Registry.4.6.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Registry.4.7.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.13.1\lib\net45\Moq.dll</HintPath>
@@ -121,11 +121,11 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.6.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.AccessControl, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.AccessControl.4.6.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    <Reference Include="System.Security.AccessControl, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.4.7.0\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Principal.Windows, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Principal.Windows.4.6.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.7.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.3\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/src/AccessibilityInsights.SharedUxTests/app.config
+++ b/src/AccessibilityInsights.SharedUxTests/app.config
@@ -44,7 +44,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Win32.Registry" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/AccessibilityInsights.SharedUxTests/packages.config
+++ b/src/AccessibilityInsights.SharedUxTests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Axe.Windows" version="0.3.4-prerelease" targetFramework="net471" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net471" />
-  <package id="Microsoft.Win32.Registry" version="4.6.0" targetFramework="net471" />
+  <package id="Microsoft.Win32.Registry" version="4.7.0" targetFramework="net471" />
   <package id="Moq" version="4.13.1" targetFramework="net471" />
   <package id="MSTest.TestAdapter" version="2.0.0" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net471" />
@@ -10,8 +10,8 @@
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.Drawing.Common" version="4.6.1" targetFramework="net471" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net471" />
-  <package id="System.Security.AccessControl" version="4.6.0" targetFramework="net471" />
-  <package id="System.Security.Principal.Windows" version="4.6.0" targetFramework="net471" />
+  <package id="System.Security.AccessControl" version="4.7.0" targetFramework="net471" />
+  <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net471" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net471" />
 </packages>

--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -82,8 +82,8 @@
     <Reference Include="CommandLine, Version=2.6.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
       <HintPath>..\packages\CommandLineParser.2.6.0\lib\net461\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Win32.Registry, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Win32.Registry.4.6.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Registry.4.7.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -95,11 +95,11 @@
     <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Drawing.Common.4.6.1\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.AccessControl, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.AccessControl.4.6.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    <Reference Include="System.Security.AccessControl, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.4.7.0\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Principal.Windows, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Principal.Windows.4.6.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.7.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>

--- a/src/AccessibilityInsights/App.config
+++ b/src/AccessibilityInsights/App.config
@@ -49,7 +49,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Win32.Registry" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/AccessibilityInsights/packages.config
+++ b/src/AccessibilityInsights/packages.config
@@ -8,12 +8,12 @@
   <package id="Microsoft.NetCore.Analyzers" version="2.9.8" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.8" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="net471" developmentDependency="true" />
-  <package id="Microsoft.Win32.Registry" version="4.6.0" targetFramework="net471" />
+  <package id="Microsoft.Win32.Registry" version="4.7.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.Drawing.Common" version="4.6.1" targetFramework="net471" />
-  <package id="System.Security.AccessControl" version="4.6.0" targetFramework="net471" />
-  <package id="System.Security.Principal.Windows" version="4.6.0" targetFramework="net471" />
+  <package id="System.Security.AccessControl" version="4.7.0" targetFramework="net471" />
+  <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net471" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net471" />
   <package id="System.Windows.Interactivity.WPF" version="2.0.20525" targetFramework="net471" />
   <package id="Text.Analyzers" version="2.6.4" targetFramework="net471" developmentDependency="true" />

--- a/src/UITests/UITests.csproj
+++ b/src/UITests/UITests.csproj
@@ -79,8 +79,8 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Win32.Registry, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Win32.Registry.4.6.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Registry.4.7.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -98,11 +98,11 @@
     <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Drawing.Common.4.6.1\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.AccessControl, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.AccessControl.4.6.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    <Reference Include="System.Security.AccessControl, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.4.7.0\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Principal.Windows, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Principal.Windows.4.6.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.7.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="WebDriver, Version=3.141.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/UITests/app.config
+++ b/src/UITests/app.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Win32.Registry" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/UITests/packages.config
+++ b/src/UITests/packages.config
@@ -4,7 +4,7 @@
   <package id="Axe.Windows" version="0.3.4-prerelease" targetFramework="net471" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net471" />
   <package id="DotNetSeleniumExtras.PageObjects" version="3.11.0" targetFramework="net471" />
-  <package id="Microsoft.Win32.Registry" version="4.6.0" targetFramework="net471" />
+  <package id="Microsoft.Win32.Registry" version="4.7.0" targetFramework="net471" />
   <package id="MSTest.TestAdapter" version="2.0.0" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net471" />
@@ -12,6 +12,6 @@
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.Drawing.Common" version="4.6.1" targetFramework="net471" />
-  <package id="System.Security.AccessControl" version="4.6.0" targetFramework="net471" />
-  <package id="System.Security.Principal.Windows" version="4.6.0" targetFramework="net471" />
+  <package id="System.Security.AccessControl" version="4.7.0" targetFramework="net471" />
+  <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
This is the VS-driven version of #658, and supersedes #658, #656, and #662
Bump Microsoft.Win32.Registry from 4.6.0 to 4.7.0 (using VS).
VS also bumped System.Security.AccessControl and System.Security.Principal.Windows to 4.7.0
