### PR TITLE
Call AIWin versions of methods that were removed from Axe.Windows

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/EyedropperWindow.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/EyedropperWindow.xaml.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.Telemetry;
+using AccessibilityInsights.SharedUx.Utilities;
 using Axe.Windows.Actions.Contexts;
-using Axe.Windows.Desktop.Utility;
 using System;
 using System.Windows;
 using System.Windows.Input;
@@ -115,7 +115,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             this.EC = context;
             if (screenshot != null)
             {
-                this.backgroundImageScale = Axe.Windows.Desktop.Utility.ExtensionMethods.GetDPI(
+                this.backgroundImageScale = HelperMethods.GetDPI(
                     (int)System.Windows.Application.Current.MainWindow.Top, 
                     (int)System.Windows.Application.Current.MainWindow.Left);
                 

--- a/src/AccessibilityInsights.SharedUx/Highlighting/ImageHighlighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/ImageHighlighter.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Utilities;
 using Axe.Windows.Core.Bases;
-using Axe.Windows.Desktop.Utility;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -100,7 +100,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
             // if so make sure that dimension is correct to be visible.
             if(el.PlatformObject == null)
             {
-                var dpi = Axe.Windows.Desktop.Utility.ExtensionMethods.GetDPI((int)Application.Current.MainWindow.Top, (int)Application.Current.MainWindow.Left);
+                var dpi = HelperMethods.GetDPI((int)Application.Current.MainWindow.Top, (int)Application.Current.MainWindow.Left);
                 this.WinRect = new Rect()
                 {
                     Y = (int)Application.Current.MainWindow.Top,
@@ -229,7 +229,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
 
             if (WinRect.IsEmpty)
             {
-                var xyDpi = Axe.Windows.Desktop.Utility.ExtensionMethods.GetWPFWindowPositioningDPI();
+                var xyDpi = HelperMethods.GetWPFWindowPositioningDPI();
                 this.HighlightWindow.Top = Dimensions.Top / xyDpi;
                 this.HighlightWindow.Left = Dimensions.Left / xyDpi;
 

--- a/src/AccessibilityInsights.SharedUx/Highlighting/OverlayHighlighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/OverlayHighlighter.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Utilities;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Desktop.Utility;
 using System;
@@ -82,7 +83,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
                 WindowStartupLocation = WindowStartupLocation.Manual
             };
 
-            var xyDpi = Axe.Windows.Desktop.Utility.ExtensionMethods.GetWPFWindowPositioningDPI();
+            var xyDpi = HelperMethods.GetWPFWindowPositioningDPI();
             this.HighlightWindow.Top = Dimensions.Top / xyDpi;
             this.HighlightWindow.Left = Dimensions.Left / xyDpi;
 
@@ -208,7 +209,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
 
             try
             {
-                var xyDpi = Axe.Windows.Desktop.Utility.ExtensionMethods.GetDPI((int)this.HighlightWindow.Left+ (3 * GapWidth), (int)this.HighlightWindow.Top + (3 * GapWidth));
+                var xyDpi = HelperMethods.GetDPI((int)this.HighlightWindow.Left+ (3 * GapWidth), (int)this.HighlightWindow.Top + (3 * GapWidth));
                 var l = (Dimensions.Width / xyDpi- toast.Width) - (GapWidth * 2) ;
                 var t = (Dimensions.Height / xyDpi - toast.Height) - (GapWidth * 2);
                 canvas.Children.Add(toast);

--- a/src/AccessibilityInsights.SharedUx/Highlighting/OverlayHighlighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/OverlayHighlighter.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.Utilities;
 using Axe.Windows.Core.Bases;
-using Axe.Windows.Desktop.Utility;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -52,13 +51,13 @@ namespace AccessibilityInsights.SharedUx.Highlighting
             if (el == null)
                 throw new ArgumentNullException(nameof(el));
 
-            var win = el.GetParentWindow();
+            var win = Axe.Windows.Desktop.Utility.ExtensionMethods.GetParentWindow(el);
             TBCallback = onMouseDown;
             Dimensions = win == null ? el.BoundingRectangle : win.BoundingRectangle;
             Brush = brush;
-            GapWidth = gap;            
+            GapWidth = gap;
         }
-                
+
         /// <summary>
         /// Create and show highlighter window
         /// </summary>

--- a/src/AccessibilityInsights.SharedUx/Utilities/HelperMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/HelperMethods.cs
@@ -88,7 +88,7 @@ namespace AccessibilityInsights.SharedUx.Utilities
         /// <param name="left"></param>
         /// <param name="top"></param>
         /// <returns></returns>
-        private static double GetDPI(int left, int top)
+        internal static double GetDPI(int left, int top)
         {
             NativeMethods.GetDpi(new System.Drawing.Point(left, top), DpiType.Effective, out uint dpiX, out uint dpiY);
 


### PR DESCRIPTION
#### Describe the change
PR #630 moved methods from Axe.Windows into AIWin, but missed a few places where the Axe.Windows versions are still being used. Since these methods don't exist in Axe.Windows 0.3.5, we need to correct these usages before we can use upgrade to Axe.Windows 0.3.5

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



