### PR TITLE
Remove ugly code that was needed only temporarily

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Highlighting/OverlayHighlighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/OverlayHighlighter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.Utilities;
 using Axe.Windows.Core.Bases;
+using Axe.Windows.Desktop.Utility;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -51,7 +52,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
             if (el == null)
                 throw new ArgumentNullException(nameof(el));
 
-            var win = Axe.Windows.Desktop.Utility.ExtensionMethods.GetParentWindow(el);
+            var win = el.GetParentWindow();
             TBCallback = onMouseDown;
             Dimensions = win == null ? el.BoundingRectangle : win.BoundingRectangle;
             Brush = brush;


### PR DESCRIPTION
#### Describe the change
To deal with an ambiguity, PR #667 temporarily replaced calling an extension method with calling the fully-qualified method. This was needed only as we moved between Axe.Windows 0.3.4 and Axe.Windows 0.3.5. Now that we've moved to Axe.Windows 0.3.5, we can revert to calling the method as an extension method. This is all syntactic sugar, with no impact to the generated code.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



