### PR TITLE
Fix color contrast mode background color for high contrast themes

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -52,7 +52,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="HLGreenTextBrush" Color="#00FF00 "/>
     <SolidColorBrush po:Freeze="True" x:Key="HLTextBrush" Color="#FFFF00 "/>
     <SolidColorBrush po:Freeze="True" x:Key="BorderBrush" Color="{x:Static SystemColors.InactiveBorderColor}" />
-    <SolidColorBrush po:Freeze="True" x:Key="CCABackgroundBrush" Color="{x:Static SystemColors.ControlDarkColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="CCABorderBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
     <Thickness po:Freeze="True" x:Key="BtnBrdrThickness">1</Thickness>
 </ResourceDictionary>


### PR DESCRIPTION
#### Describe the change
A recent issue (#675) pointed out that a certain control in the color contrast mode had poor color contrast while using high contrast themes. This PR addresses this issue by removing the specific color we set for that control's background in HC modes. This allows the background to revert to the control's default, which offers proper contrast.

Before and after (before on the left):
Normal (no change):
![image](https://user-images.githubusercontent.com/4615491/71834196-7caf9a00-3063-11ea-963b-3d9388de866f.png)
HC Black:
![image](https://user-images.githubusercontent.com/4615491/71834102-3e19df80-3063-11ea-8aab-43dfe9cf0c43.png)
HC White:
![image](https://user-images.githubusercontent.com/4615491/71834135-51c54600-3063-11ea-9ae0-669edd41ee5e.png)

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue #675
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



