### PR TITLE
Port IsVisibleLocation from Axe.Windows to AIWin

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Highlighting/TextRangeHilighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/TextRangeHilighter.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.Enums;
-using Axe.Windows.Desktop.Utility;
+using AccessibilityInsights.SharedUx.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Drawing;

--- a/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
@@ -289,5 +289,19 @@ namespace AccessibilityInsights.SharedUx.Utilities
             NativeMethods.DeleteObject(hbmp);
             return result;
         }
+
+        /// <summary>
+        /// Check whether p is fully visible based on current screen size
+        /// </summary>
+        /// <param name="p"></param>
+        /// <param name="c"></param>
+        /// <param name="margin"></param>
+        /// <returns></returns>
+        internal static bool IsVisibleLocation(this Rectangle p)
+        {
+            return (from s in System.Windows.Forms.Screen.AllScreens
+                    where s.Bounds.Contains(p)
+                    select s).Any();
+        }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
@@ -293,10 +293,6 @@ namespace AccessibilityInsights.SharedUx.Utilities
         /// <summary>
         /// Check whether p is fully visible based on current screen size
         /// </summary>
-        /// <param name="p"></param>
-        /// <param name="c"></param>
-        /// <param name="margin"></param>
-        /// <returns></returns>
         internal static bool IsVisibleLocation(this Rectangle p)
         {
             return (from s in System.Windows.Forms.Screen.AllScreens


### PR DESCRIPTION
#### Describe the change
The IsVisibleLocation extension method in Axe.Windows is used only by AIWin, so we want to migrate it into AIWin. This change adds it to AIWin. A separate change (as part of the port) will remove it from Axe.Windows.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



