### PR TITLE
Change AutomationName and ToolTip for tabstops (i) icon link

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml
@@ -45,8 +45,8 @@
             <TextBlock Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,0,0,10">
                 <Run FontWeight="SemiBold" FontSize="{DynamicResource ConstXLTextSize}" Text="{x:Static Properties:Resources.RunTextTabStops}" />
                 <Hyperlink TextDecorations="{x:Null}" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"
-                           ToolTip="{x:Static Properties:Resources.RunTextTabStops}"
-                           AutomationProperties.Name="{x:Static Properties:Resources.RunTextHowToTest}"
+                           ToolTip="{x:Static Properties:Resources.RunTextGuidance}"
+                           AutomationProperties.Name="{x:Static Properties:Resources.RunTextGuidance}" AutomationProperties.HelpText=" "
                            NavigateUri="https://go.microsoft.com/fwlink/?linkid=2080645" RequestNavigate="Hyperlink_RequestNavigate">
                     <fabric:FabricIconControl GlyphName="Info" GlyphSize="Custom" FontSize="17" Margin="8,0,0,-3" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
                 </Hyperlink>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3225,6 +3225,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Guidance.
+        /// </summary>
+        public static string RunTextGuidance {
+            get {
+                return ResourceManager.GetString("RunTextGuidance", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to By opting into telemetry, you.
         /// </summary>
         public static string RunTextHelpCommunity1 {
@@ -3250,15 +3259,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string RunTextHelpCommunity3 {
             get {
                 return ResourceManager.GetString("RunTextHelpCommunity3", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to How to test.
-        /// </summary>
-        public static string RunTextHowToTest {
-            get {
-                return ResourceManager.GetString("RunTextHowToTest", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -426,8 +426,8 @@
   <data name="ColorContrastAutomationPropertiesName" xml:space="preserve">
     <value>Color contrast analyzer</value>
   </data>
-  <data name="RunTextHowToTest" xml:space="preserve">
-    <value>How to test</value>
+  <data name="RunTextGuidance" xml:space="preserve">
+    <value>Guidance</value>
   </data>
   <data name="firstChooserAutomationPropertiesName" xml:space="preserve">
     <value>first color</value>


### PR DESCRIPTION
#### Describe the change
Currently, for the (i) icon link, the AutomationName is "How to test" and the ToolTip is "Tab Stops". This PR updates both of those to be "Guidance", in line with AI-Web.

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.
![image](https://user-images.githubusercontent.com/4615491/73313535-5bfcdf00-41e0-11ea-91dc-98d0caacd93e.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



