### PR TITLE
Eat ArgumentNullException where we already eat NullReferenceException

### DIFF
--- a/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml.cs
@@ -361,9 +361,13 @@ namespace AccessibilityInsights.SharedUx.ActionViews
             {
                 MarkElement(((A11yElement)this.cbElements.SelectedItem));
             }
-            catch(NullReferenceException ex)
+            catch (NullReferenceException e)
             {
-                ex.ReportException();
+                e.ReportException();
+            }
+            catch (ArgumentNullException e)
+            {
+                e.ReportException();
             }
         }
 

--- a/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml.cs
@@ -361,13 +361,13 @@ namespace AccessibilityInsights.SharedUx.ActionViews
             {
                 MarkElement(((A11yElement)this.cbElements.SelectedItem));
             }
-            catch (NullReferenceException e)
+            catch (NullReferenceException ex)
             {
-                e.ReportException();
+                ex.ReportException();
             }
-            catch (ArgumentNullException e)
+            catch (ArgumentNullException ex)
             {
-                e.ReportException();
+                ex.ReportException();
             }
         }
 

--- a/src/AccessibilityInsights.SharedUx/Dialogs/EyedropperWindow.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/EyedropperWindow.xaml.cs
@@ -231,6 +231,10 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             {
                 e.ReportException();
             }
+            catch (ArgumentNullException e)
+            {
+                e.ReportException();
+            }
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Highlighting/OverlayHighlighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/OverlayHighlighter.cs
@@ -151,6 +151,10 @@ namespace AccessibilityInsights.SharedUx.Highlighting
             {
                 // TODO : Report this?
             }
+            catch (ArgumentNullException)
+            {
+                // TODO : Report this?
+            }
         }
 
 
@@ -194,6 +198,10 @@ namespace AccessibilityInsights.SharedUx.Highlighting
                 // TODO : Report this?
             }
             catch (NullReferenceException)
+            {
+                // TODO : Report this?
+            }
+            catch (ArgumentNullException)
             {
                 // TODO : Report this?
             }


### PR DESCRIPTION
#### Describe the change
There are a few places in the code that explicitly catch `NullReferenceException`, presumably based on observation of previous behavior that we can't directly control. Null parameter checks were recently added to several Axe.Windows methods, meaning that they now throw `ArgumentNullException` instead of `NullReferenceException`. The underlying fact that the data is null hasn't changed, but the changed Exception type is leaving the `ArgumentNullException` uncaught, and the app crashes as a result.

This change identifies all places where we silently ignore `NullReferenceException` and treats `ArgumentNullException` in exactly the same way. It's not pretty, but it's intended to prevent the crash in the same way that we used to prevent it. We've begun conversations on options of notifiying the user that something unexpected occurred, but there's no clear time frame on when we'll have a design, much less implementation.

Note: This doesn't change `ClearOverlayDriver.BringMainWindowsOfPOIElementToFront`, since that code already handles `ArgumentException` (a base class for `ArgumentNullException`).


#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



