### PR TITLE
Update CredScan to V2

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -105,6 +105,7 @@ jobs:
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
     displayName: 'Run CredScan'
     inputs:
+      toolMajorVersion: V2
       verboseOutput: true
       debugMode: false
 


### PR DESCRIPTION
#### Describe the change
CredScan V1 is on the road to deprecation and we're starting to receive warnings during build. The recommended change is to use CredScan V2. As outlined in https://www.1eswiki.com/wiki/CredScan_Azure_DevOps_Build_Task, this involves setting the toolMajorVerion input to V2. Validation build is at https://dev.azure.com/mseng/1ES/_build/results?buildId=11457821&view=results. Compare the CredScan results (in the ComplianceDebug job) to previous results, and you'll note that we're no longer getting the warning. This is a tool-only change that doesn't touch any code.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



