### PR TITLE
Change programmatic order of settings page save button

### DIFF
--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
@@ -40,10 +40,12 @@
                     <Label Content="{x:Static properties:Resources.gdConfigLabelContent}" HorizontalAlignment="Left" Margin="31,20,0,0" VerticalAlignment="Top" FontSize="15" FontWeight="Bold" Padding="0"/>
                 </Grid>
                 <Grid Grid.Row="1">
-                    <DockPanel LastChildFill="False" >
-                        <Button DockPanel.Dock="Bottom" TabIndex="-3" x:Name="btnOk" Content="{x:Static properties:Resources.btnOkContent}" HorizontalAlignment="Left" VerticalAlignment="Top" Width="80" Height="24" Margin="20,20" IsDefault="True" Click="buttonOk_Click" Style="{StaticResource BtnSave}" IsEnabled="False" 
-                                AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsSaveAndCloseButton}"/>
-                        <TabControl Name="tcTabs" DockPanel.Dock="Top" BorderThickness="0,1,0,0" BorderBrush="#FFEAEAEA" Style="{StaticResource tcScrolling}" SelectionChanged="TabControl_SelectionChanged">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <TabControl Name="tcTabs" Grid.Row="0" BorderThickness="0,1,0,0" BorderBrush="#FFEAEAEA" Style="{StaticResource tcScrolling}" SelectionChanged="TabControl_SelectionChanged">
                             <TabItem Header="{x:Static properties:Resources.tcTabsApplicationHeader}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsApplicationTabItem}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiApplication" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Application}">
                                 <controls:ApplicationSettingsControl x:Name="appSettingsCtrl"/>
                             </TabItem>
@@ -54,7 +56,9 @@
                                 <controls:AboutTabControl x:Name="aboutTabCtrl"/>
                             </TabItem>
                         </TabControl>
-                    </DockPanel>
+                        <Button Grid.Row="1" TabIndex="-3" x:Name="btnOk" Content="{x:Static properties:Resources.btnOkContent}" HorizontalAlignment="Left" VerticalAlignment="Top" Width="80" Height="24" Margin="20,20" IsDefault="True" Click="buttonOk_Click" Style="{StaticResource BtnSave}" IsEnabled="False" 
+                                AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsSaveAndCloseButton}"/>
+                    </Grid>
                 </Grid>
             </Grid>
             <Grid DockPanel.Dock="Top"/>


### PR DESCRIPTION
#### Describe the change
Currently, the order of elements on our settings pages causes the Save and close button to appear before the settings tabs programmatically, even though it appears after the tabs visually. For more details, see issue #700- Object navigation in Narrator not in the logical/ visual sequence. This PR changes the programmatic order of the settings page from:
1. Back button
2. Settings text
3. Save and close button 
4. Tab container (and all children)

to:

1. Back button
2. Settings text
3. Tab container (and all children)
4. Save and close button 

This should make the page more logical for AT users. It should have no impact for non-AT users and no impact on tab order.

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue #700 
- [n/a] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



