### PR TITLE
Display style id correctly

### DIFF
--- a/src/AccessibilityInsights.SharedUx/ViewModels/TextRangeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/TextRangeViewModel.cs
@@ -187,6 +187,11 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                     }
                     break;
                 case TextAttributeType.UIA_StyleIdAttributeId:
+                    if (value is int)
+                    {
+                        list.Add(new TextAttributeViewModel(kv.Key, kv.Value, StyleId.GetInstance().GetNameById(value)));
+                    }
+                    break;
                 case TextAttributeType.UIA_SayAsInterpretAsAttributeId:
                     // VT_I4
                     if (value is int)


### PR DESCRIPTION
#### Describe the change
This is the AIWin-side change of https://github.com/microsoft/axe-windows/issues/265. It ensures that style IDs are properly formatted in the UI. Instead of saying "Unknown(70001)", it will now say "Heading1(70001)". It will only display "Unknown" if the numeric value is not identified in https://github.com/microsoft/axe-windows/blob/master/src/Desktop/Styles/StyleId.cs

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - https://github.com/microsoft/axe-windows/issues/265
- [x] Includes UI changes?
  - [] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Screenshot of dialog displaying "Normal" style--before this change it would say "Unknown(70012)" instead of "Normal(70012)"

![image](https://user-images.githubusercontent.com/45672944/74383604-5d173a00-4da4-11ea-87bb-3a9442131a70.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



