### PR TITLE
Update shortcut name for clarity

### DIFF
--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -197,7 +197,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <DirectoryRef Id="ApplicationProgramsFolder">
       <Component Id="ApplicationShortcut" Guid="63DCD2B5-CF57-494B-A81F-748DFDA7E9CF">
         <Shortcut Id="ApplicationStartMenuShortcut"
-           Name="Accessibility Insights"
+           Name="Accessibility Insights for Windows"
            Description="Accessibility Insights for Windows v1.1 (Desktop Accessibility tool)"
            Target="[#FileExe]"
            WorkingDirectory="INSTALLFOLDER"/>


### PR DESCRIPTION
#### Describe the change
Update shortcut name from "Accessibility Insights" to "Accessibility Insights for Windows" to avoid ambiguity if multiple products are installed.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable. In the following screenshot of search results, I pressed the Windows key, then typed in "acc", which the system matched. The current name appears in the top, while the revised name appears in the bottom:

![image](https://user-images.githubusercontent.com/45672944/74550966-2efe3b00-4f07-11ea-88a2-b25e6a40c14b.png)


> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



