### PR TITLE
Add checks for existence of .NET Core runtime 3.0 or higher

### DIFF
--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -25,6 +25,18 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <WixVariable Id="WixUIBannerBmp" Value="Resources\WixDialogBanner.png" />
     <WixVariable Id="WixUILicenseRtf" Value="..\AccessibilityInsights\bin\Release\eula.rtf" />
 
+    <Property Id="NETCORERUNTIMEFOUNDX86">
+      <DirectorySearch Id="NetCoreDirectoryFoundx86" Path="[ProgramFilesFolder]dotnet" >
+        <FileSearch Name="dotnet.exe" MinVersion="3.0"/>
+      </DirectorySearch>
+    </Property>
+
+    <Property Id="NETCORERUNTIMEFOUNDX64">
+      <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ProgramFiles64Folder]dotnet" >
+        <FileSearch Name="dotnet.exe" MinVersion="3.0"/>
+      </DirectorySearch>
+    </Property>
+
     <MediaTemplate EmbedCab="yes" />
 
     <Feature Id="ProductFeature" Title="Accessibility Insights for Windows" Level="1">
@@ -40,6 +52,10 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <PropertyRef Id="NETFRAMEWORK45" />
     <Condition Message="[ProductName] requires .NET Framework 4.7.1 or later.">
       <![CDATA[Installed OR (NETFRAMEWORK45 AND NETFRAMEWORK45 >= "#461308")]]>
+    </Condition>
+
+    <Condition Message="[ProductName] requires .NET Core Runtime 3.0 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core">
+      <![CDATA[Installed OR NETCORERUNTIMEFOUNDX64 OR NETCORERUNTIMEFOUNDX86]]>
     </Condition>
 
     <Directory Id="TARGETDIR" Name="SourceDir">


### PR DESCRIPTION
#### Describe the change
The latest version of Axe.Windows requires the .NET Core 3.0 runtime, which isn't pre-installed on older versions of Windows. This change adds a check for the presence and version of the .NET core runtime and blocks installation if an appropriate version isn't found. It uses the same check that we use for the Axe.Windows CLI (see https://github.com/microsoft/axe-windows/pull/308 for reference). The text of the blocking message reads "Accessibility Insights for Windows v1.1 requires .NET Core Runtime 3.0 or newer. Please visit https://dotnet.microsoft.com/download/dotnet-core". Once the user clicks the OK button, they're taken to the existing final dialog that explains that installation was unsuccessful.

We should make a point of calling out this dependency in the release notes when this goes to production, since someone using AIWin on an older Windows installation will probably encounter failures during upgrade.

#### PR checklist

- [] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

![image](https://user-images.githubusercontent.com/45672944/74958832-644ed100-53be-11ea-9c90-07a6e78591fc.png)


> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



