### PR TITLE
Simplify automation name in Azure Boards connection dialog

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -37,7 +37,7 @@
             <TextBlock Grid.Row="0" TextWrapping="Wrap" Margin="0 0 0 12px" Text="{x:Static Properties:Resources.ConnectionControl_serverURL}" FontSize="{DynamicResource StandardTextSize}" Grid.ColumnSpan="2"/>
             <Grid Grid.ColumnSpan="2">
                 <ComboBox x:Name ="ServerComboBox" Grid.Row="1" IsEditable="True" Height="30" VerticalContentAlignment="Center" FontSize="{DynamicResource StandardTextSize}"
-                              AutomationProperties.Name="{x:Static Properties:Resources.connectionInstrText}" KeyDown="ServerComboBox_KeyDown">
+                              AutomationProperties.Name="{x:Static Properties:Resources.ServerComboBoxAutomationPropertiesName}" KeyDown="ServerComboBox_KeyDown">
                 </ComboBox>
                 <TextBlock x:Name="accountPlaceholder" Text="{x:Static Properties:Resources.accountPlaceholderText}" IsHitTestVisible="False">
                     <TextBlock.Style>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -37,7 +37,7 @@
             <TextBlock Grid.Row="0" TextWrapping="Wrap" Margin="0 0 0 12px" Text="{x:Static Properties:Resources.ConnectionControl_serverURL}" FontSize="{DynamicResource StandardTextSize}" Grid.ColumnSpan="2"/>
             <Grid Grid.ColumnSpan="2">
                 <ComboBox x:Name ="ServerComboBox" Grid.Row="1" IsEditable="True" Height="30" VerticalContentAlignment="Center" FontSize="{DynamicResource StandardTextSize}"
-                              AutomationProperties.Name="{x:Static Properties:Resources.ServerComboBoxAutomationPropertiesName}" KeyDown="ServerComboBox_KeyDown">
+                              AutomationProperties.Name="{x:Static Properties:Resources.connectionInstrText}" KeyDown="ServerComboBox_KeyDown">
                 </ComboBox>
                 <TextBlock x:Name="accountPlaceholder" Text="{x:Static Properties:Resources.accountPlaceholderText}" IsHitTestVisible="False">
                     <TextBlock.Style>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
@@ -160,15 +160,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enter the full Azure DevOps URL such as https://dev.azure.com/fabrikam.
-        /// </summary>
-        public static string ServerComboBoxAutomationPropertiesName {
-            get {
-                return ResourceManager.GetString("ServerComboBoxAutomationPropertiesName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Team project.
         /// </summary>
         public static string serverTreeviewAutomationPropertiesName {

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
@@ -160,6 +160,15 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enter your desired Azure Boards link.
+        /// </summary>
+        public static string ServerComboBoxAutomationPropertiesName {
+            get {
+                return ResourceManager.GetString("ServerComboBoxAutomationPropertiesName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Team project.
         /// </summary>
         public static string serverTreeviewAutomationPropertiesName {

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -165,4 +165,7 @@
   <data name="CantPopulateProjects" xml:space="preserve">
     <value>Error populating Projects</value>
   </data>
+  <data name="ServerComboBoxAutomationPropertiesName" xml:space="preserve">
+    <value>Enter your desired Azure Boards link</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -120,9 +120,6 @@
   <data name="connectionInstrText" xml:space="preserve">
     <value>Enter desired Azure Boards link</value>
   </data>
-  <data name="ServerComboBoxAutomationPropertiesName" xml:space="preserve">
-    <value>Enter the full Azure DevOps URL such as https://dev.azure.com/fabrikam</value>
-  </data>
   <data name="accountPlaceholderText" xml:space="preserve">
     <value>https://dev.azure.com/fabrikam</value>
   </data>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -120,6 +120,9 @@
   <data name="connectionInstrText" xml:space="preserve">
     <value>Enter desired Azure Boards link</value>
   </data>
+  <data name="ServerComboBoxAutomationPropertiesName" xml:space="preserve">
+    <value>Enter your desired Azure Boards link</value>
+  </data>
   <data name="accountPlaceholderText" xml:space="preserve">
     <value>https://dev.azure.com/fabrikam</value>
   </data>
@@ -164,8 +167,5 @@
   </data>
   <data name="CantPopulateProjects" xml:space="preserve">
     <value>Error populating Projects</value>
-  </data>
-  <data name="ServerComboBoxAutomationPropertiesName" xml:space="preserve">
-    <value>Enter your desired Azure Boards link</value>
   </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3427,15 +3427,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enter the full Azure DevOps URL such as https://dev.azure.com/fabrikam.
-        /// </summary>
-        public static string ServerComboBoxAutomationPropertiesName {
-            get {
-                return ResourceManager.GetString("ServerComboBoxAutomationPropertiesName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Bug {0}.
         /// </summary>
         public static string SetterValueBug {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -336,9 +336,6 @@
   <data name="connectionInstrText" xml:space="preserve">
     <value>To start filing issues, select where you want to file your issues.</value>
   </data>
-  <data name="ServerComboBoxAutomationPropertiesName" xml:space="preserve">
-    <value>Enter the full Azure DevOps URL such as https://dev.azure.com/fabrikam</value>
-  </data>
   <data name="lblIssueFiling" xml:space="preserve">
     <value>Issue Filing</value>
   </data>


### PR DESCRIPTION
#### Describe the change
Using an AT in the Azure Boards Connections dialog is extremely chatty. We use a combobox that currently incorporates the placeholder text into it to make it friendlier. Unfortunately, when NVDA or JAWS read the dialog, it repeats a long string, resulting in too much data to really be usable.

Here's what gets read before this change:
**NVDA**: "Enter the full Azure DevOps URL such as https://dev.azure.com/fabrikam combobox collapsed. Enter the full Azure DevOps URL such as https://dev.azure.com/fabrikam edit. Blank."
**JAWS**: "Enter the full Azure DevOps URL such as https://dev.azure.com/fabrikam combobox. Enter the full Azure DevOps URL such as https://dev.azure.com/fabrikam edit combo. To set the value use the arrow keys or type the value."

We're setting the automation name on the combobox, which then uses the same data as the automation name of the edit control. When the edit box gets the focus, the AT reads both values, hence the repetition. I checked with @guybark, who confirmed that WPF's behavior is consistent with Win32 and WinForms. The screen reader has all of the information that it needs to avoid the repetition, but it repeats anyway.

The "admittedly less than ideal" workaround is just to shorten the automation name. I started with the displayed text ("Enter desired Azure Boards link"), then changed "desired" to "your" to make it sound better and to make it more consistent with the rest of the UI ("Select your Azure Board team", etc.). I'd argue that we also ought to update the visual string, but maybe at a later time.

Here's what gets read after this change:
**NVDA**: "Enter your Azure Boards link combobox collapsed. Enter your Azure Boards link edit. Blank."
**JAWS**: "Enter your Azure Boards link combobox. Enter your Azure Boards link edit combo. To set the value use the arrow keys or type the value."

Note that the placeholder text is not read, so AT users will no longer have that prompt to help guide their experience. I've discussed this with @RobGallo and @adarshrema, and they agree that while it's non-ideal, it's a reasonable compromise. 

One tiny cleanup is included here--the ServerComboBoxAutomationPropertiesName string was defined in both SharedUx and AzureDevOps projects, and of course I changed the wrong one on my first try. Since the one in SharedUx is unused, I went ahead and removed it to prevent further confusion. There may be other similar artifacts in SharedUx, but I didn't go looking for them.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #707 
- [ ] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



