### PR TITLE
Remove text that only shows up in JAWS

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -34,7 +34,6 @@
                 <ColumnDefinition Width="8"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <TextBlock Grid.Row="0" TextWrapping="Wrap" Margin="0 0 0 12px" Text="{x:Static Properties:Resources.ConnectionControl_serverURL}" FontSize="{DynamicResource StandardTextSize}" Grid.ColumnSpan="2"/>
             <Grid Grid.ColumnSpan="2">
                 <ComboBox x:Name ="ServerComboBox" Grid.Row="1" IsEditable="True" Height="30" VerticalContentAlignment="Center" FontSize="{DynamicResource StandardTextSize}"
                               AutomationProperties.Name="{x:Static Properties:Resources.ServerComboBoxAutomationPropertiesName}" KeyDown="ServerComboBox_KeyDown">

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
@@ -142,15 +142,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Server URL.
-        /// </summary>
-        public static string ConnectionControl_serverURL {
-            get {
-                return ResourceManager.GetString("ConnectionControl_serverURL", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Enter desired Azure Boards link.
         /// </summary>
         public static string connectionInstrText {

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -153,9 +153,6 @@
   <data name="ConnectionControl_selectTeam" xml:space="preserve">
     <value>Select your Azure Boards team</value>
   </data>
-  <data name="ConnectionControl_serverURL" xml:space="preserve">
-    <value>Server URL</value>
-  </data>
   <data name="There_was_an_error_identifying_the_created_issue_This_may_occur_if_the_ID_used_to_create_the_issue_is_removed_from_its_Azure_DevOps_description_Attachments_have_not_been_uploaded" xml:space="preserve">
     <value>There was an error identifying the created issue. This may occur if the ID used to create the issue is removed from its Azure DevOps description. Attachments have not been uploaded.</value>
   </data>


### PR DESCRIPTION
#### Describe the change
The "Server URL" text only manifests in JAWS, and adds no value. Removing it. I didn't try to update the rest of the grid, since it's autosized and an empty grid row will have 0 height.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



