### PR TITLE
Scroll Live Mode Instructions

### DIFF
--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml
@@ -40,30 +40,32 @@
             <controls:HierarchyControl x:Name="ctrlHierarchy"
                                         Grid.Row="1" Visibility="Collapsed"
                                         VerticalAlignment="Stretch"/>
-            <StackPanel Name="spInstructions" Grid.Row="1" KeyboardNavigation.IsTabStop="True">
-                <TextBlock Name="tbInstructions" Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
-                    <Run Text="{x:Static properties:Resources.LiveModeControl_HoverOverElement}"/>
-                    <Run Name="runHkActivate"/><Run Text="."/>
-                    <TextBlock>
-                        <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2075123" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
-                             <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreInspect}"/>
-                        </Hyperlink><Run Text="."/>
+            <ScrollViewer VerticalScrollBarVisibility="Auto" Grid.Row="1">
+                <StackPanel Name="spInstructions" Grid.Row="1" KeyboardNavigation.IsTabStop="True">
+                    <TextBlock Name="tbInstructions" Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
+                        <Run Text="{x:Static properties:Resources.LiveModeControl_HoverOverElement}"/>
+                        <Run Name="runHkActivate"/><Run Text="."/>
+                        <TextBlock TextWrapping="Wrap">
+                            <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2075123" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
+                                 <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreInspect}"/>
+                            </Hyperlink><Run Text="."/>
+                        </TextBlock>
                     </TextBlock>
-                </TextBlock>
 
-                <TextBlock Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
-                    <Run Text="{x:Static properties:Resources.LiveModeControl_RunAutomatedChecks}"/>
-                    <fabric:FabricIconControl GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" FontStyle="Normal" ShowInControlView="False"/>
-                    <Run Text="{x:Static properties:Resources.LiveModeControl_FocusOnElement}"/>
-                    <Run Name="runHkTest"/><Run Text="."/>
-                    <TextBlock>
-                        <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077027" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
-                             <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreAutomated}" />
-                        </Hyperlink><Run Text="."/>
+                    <TextBlock Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
+                        <Run Text="{x:Static properties:Resources.LiveModeControl_RunAutomatedChecks}"/>
+                        <fabric:FabricIconControl GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" FontStyle="Normal" ShowInControlView="False"/>
+                        <Run Text="{x:Static properties:Resources.LiveModeControl_FocusOnElement}"/>
+                        <Run Name="runHkTest"/><Run Text="."/>
+                        <TextBlock TextWrapping="Wrap">
+                            <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077027" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
+                                 <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreAutomated}" />
+                            </Hyperlink><Run Text="."/>
+                        </TextBlock>
                     </TextBlock>
-                </TextBlock>
 
-            </StackPanel>
+                </StackPanel>
+            </ScrollViewer>
             <controls:DisplayCountControl Grid.RowSpan="2" VerticalAlignment="Center" HorizontalAlignment="Center" x:Name="ccDisplayCount" Visibility="Collapsed"/>
             <GridSplitter x:Name="gsMid"
                             FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"


### PR DESCRIPTION
#### Describe the change
Live mode instructions support limited horizontal scroll (the links won't word wrap) but no vertical scroll. This adds a ScrollViewer around the StackPanel to get the vertical scroll, and sets the word wrap on the links so that they work better.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Video is in 2 parts--first part is using the mouse, second part is using the keyboard. Mouse cursor is inaccurately recorded in the video (bug in LiceCap)

![ScrollableInstructions](https://user-images.githubusercontent.com/45672944/76463697-1582ce80-63a1-11ea-84c8-e9e92a7f20c8.gif)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



