### PR TITLE
Ensure that tabs are displayed (at the expense of a broken button)

### DIFF
--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -272,7 +272,7 @@
                 <controls:NamedPane x:Name="ctrlNamedCommandbar"
                                     KeyboardNavigation.DirectionalNavigation="Contained"
                                     KeyboardNavigation.TabNavigation="Cycle"
-                                    Grid.Row="1" Grid.RowSpan="2" Height="Auto" Panel.ZIndex="2"
+                                    Grid.Row="1" Grid.RowSpan="2" Height="Auto"
                                     BorderThickness="0" Visibility="Collapsed"
                                     AutomationProperties.Name="{x:Static properties:Resources.ctrlNamedCommandbarAutomationPropertiesName}">
                     <controls:NamedPane.InputBindings>

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml
@@ -12,7 +12,7 @@
              xmlns:Util="clr-namespace:AccessibilityInsights.SharedUx.Utilities;assembly=AccessibilityInsights.SharedUx"
              mc:Ignorable="d" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SnapshotModeControl}"
              AutomationProperties.Name="{x:Static properties:Resources.SnapshotModeControlAutomationPropertiesName}" Height="600" Width="600">
-    <Grid Panel.ZIndex="3">
+    <Grid Panel.ZIndex="1">
         <Grid.RowDefinitions>
             <RowDefinition Height="34"/>
             <RowDefinition Height="*"/>

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml
@@ -12,7 +12,7 @@
              xmlns:Util="clr-namespace:AccessibilityInsights.SharedUx.Utilities;assembly=AccessibilityInsights.SharedUx"
              mc:Ignorable="d" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SnapshotModeControl}"
              AutomationProperties.Name="{x:Static properties:Resources.SnapshotModeControlAutomationPropertiesName}" Height="600" Width="600">
-    <Grid Panel.ZIndex="1">
+    <Grid Panel.ZIndex="3">
         <Grid.RowDefinitions>
             <RowDefinition Height="34"/>
             <RowDefinition Height="*"/>


### PR DESCRIPTION
#### Describe the change
#719 introduced a regression by changing the ZIndex of the breadcrumbs to be "above" the tab control that displays the properties and HowToFix information. This was done to fix a breadcrumb button breaking. As a result, the tabs are not being displayed correctly. This change reverts the ZIndex change because it's better to have the broken breadcrumb than to not have the tabs.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

With the ZIndex change:
![image](https://user-images.githubusercontent.com/45672944/76475414-fe050f00-63bb-11ea-8815-d11367e5893f.png)

With the ZIndex change reverted
![image](https://user-images.githubusercontent.com/45672944/76475319-b1213880-63bb-11ea-82c0-a1d5e53177a7.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



