### PR TITLE
Fix breadcrumb button (HitTest was impacted by transparent background)

### DIFF
--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml
@@ -15,7 +15,7 @@
     <UserControl.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
     </UserControl.Resources>
-    <Grid Background="Transparent">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="34"/>
             <RowDefinition Height="*"/>


### PR DESCRIPTION
#### Describe the change
#719 and #721 left a broken button in the breadcrumbs. Cause is that the transparent background of the grid is causing the HitTest of the button to fail, so it no longer worked with the mouse. Fix is to remove the transparent background on the grid (a change that was in #719) to restore the breadcrumb behavior. Colors are still correct in both light and dark mode.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Screenshots with mouse over breadcrumb.
Before (no underline on mouse over, clicking does nothing):
![image](https://user-images.githubusercontent.com/45672944/76536290-5e866180-6439-11ea-81ae-b8836dbae410.png)

After (underline on mouse over, clicking returns to live mode):
![image](https://user-images.githubusercontent.com/45672944/76536376-837ad480-6439-11ea-9719-aaedf6d8fe5e.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



