### PR TITLE
Update events view for dark mode

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
@@ -69,7 +69,7 @@
                                 <TextBlock Name="tbNode" VerticalAlignment="Center" Text="{Binding Header}" Visibility="{Binding TextVisibility}" Margin="0,0,4,0" FontSize="11" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                                 <Button VerticalAlignment="Center" Visibility="{Binding ButtonVisibility}" Name="btnConfig" Click="btnConfig_Click" IsEnabled="{Binding IsEditEnabled}" Background="Transparent" BorderThickness="0"
                                     AutomationProperties.HelpText="{x:Static Properties:Resources.btnConfigAutomationPropertiesHelpText}">
-                                    <TextBlock TextDecorations="Underline" Foreground="Blue" Text="{Binding ButtonText}" FontSize="11"/>
+                                    <TextBlock TextDecorations="Underline" Foreground="{DynamicResource ResourceKey=ButtonLinkFGBrush}" Text="{Binding ButtonText}" FontSize="11"/>
                                 </Button>
                             </StackPanel>
                         </HierarchicalDataTemplate>

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
@@ -42,7 +42,7 @@
                            AutomationProperties.HelpText="{x:Static Properties:Resources.tbElementAutomationPropertiesHelpText}"/>
             </Grid>
         </Border>
-        <Label Grid.Row="1" FontSize="11" Content="{x:Static Properties:Resources.EventConfigTabControl_SelectEvents}" Margin="8,8,4,4" Padding="0" FontWeight="SemiBold"/>
+        <Label Grid.Row="1" FontSize="11" Content="{x:Static Properties:Resources.EventConfigTabControl_SelectEvents}" Margin="8,8,4,4" Padding="0" FontWeight="SemiBold" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="2">
             <Grid>
                 <Grid.RowDefinitions>
@@ -66,7 +66,7 @@
                      ItemsSource="{Binding Children}">
                             <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                                 <CheckBox VerticalAlignment="Center" Visibility="{Binding TextVisibility}" IsChecked="{Binding IsChecked}" Margin="0,0,4,0" IsEnabled="{Binding IsEditEnabled}" IsTabStop="False" AutomationProperties.LabeledBy="{Binding ElementName=tbNode}"/>
-                                <TextBlock Name="tbNode" VerticalAlignment="Center" Text="{Binding Header}" Visibility="{Binding TextVisibility}" Margin="0,0,4,0" FontSize="11"/>
+                                <TextBlock Name="tbNode" VerticalAlignment="Center" Text="{Binding Header}" Visibility="{Binding TextVisibility}" Margin="0,0,4,0" FontSize="11" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                                 <Button VerticalAlignment="Center" Visibility="{Binding ButtonVisibility}" Name="btnConfig" Click="btnConfig_Click" IsEnabled="{Binding IsEditEnabled}" Background="Transparent" BorderThickness="0"
                                     AutomationProperties.HelpText="{x:Static Properties:Resources.btnConfigAutomationPropertiesHelpText}">
                                     <TextBlock TextDecorations="Underline" Foreground="Blue" Text="{Binding ButtonText}" FontSize="11"/>
@@ -82,7 +82,7 @@
                     </TreeView.ItemContainerStyle>
                 </TreeView>
                 <CheckBox Grid.Row="1" Content="{x:Static Properties:Resources.EventConfigTabControl_ckbxAllEvents}"
-                          Margin="27,2" FontSize="11" Name="ckbxAllEvents"
+                          Margin="27,2" FontSize="11" Name="ckbxAllEvents" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"
                           Checked="ckbxAllEvents_Checked" Unchecked="ckbxAllEvents_Unchecked"
                           FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
             </Grid>

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -44,7 +44,7 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <Label VerticalAlignment="Center" FontSize="15" FontWeight="SemiBold" x:Name="labelEvents" Padding="0" Margin="0" Content="{x:Static Properties:Resources.labelEventsContent}" />
+            <Label VerticalAlignment="Center" FontSize="15" FontWeight="SemiBold" x:Name="labelEvents" Padding="0" Margin="0" Content="{x:Static Properties:Resources.labelEventsContent}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
             <ItemsControl WindowChrome.IsHitTestVisibleInChrome="True" 
                           BorderBrush="{x:Null}"  
                           Grid.Column="1"

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -75,7 +75,7 @@
     <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">1</Thickness>        <!-- (UPDATED) Thickness of border around search panel -->
     <Thickness po:Freeze="True" x:Key="TestModeBorderThickness">0</Thickness>           <!-- (UPDATED) Thickness of border around test mode view -->
 
-    <SolidColorBrush x:Key="EventStartBrush" Color="#A80000"/>                          <!-- Color of "start recording" button in events -->
+    <SolidColorBrush x:Key="EventStartBrush" Color="#CD4A45"/>                          <!-- (UPDATED) Color of "start recording" button in events -->
     <SolidColorBrush x:Key="WarningBrush" Color="#D67F3C"/>                             <!-- (UPDATED) Color of "warning" icon in results -->
     <SolidColorBrush x:Key="SearchAndIconForegroundBrush" Color="#FFFFFF"/>             <!-- (UPDATED) Color of various icons -->
     <SolidColorBrush x:Key="SearchPlaceholderFGBrush" Color="#B2B3B5"/>                 <!-- (UPDATED) Color of placeholder text in search box -->

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -53,7 +53,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="DataGridBGBrush" Color="#444C52"/>         <!-- (UPDATED) Background of data grid items (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="#6D767E"/> <!-- (UPDATED) Background of selected item in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkFGBrush" Color="#6BADE0"/>       <!-- (UPDATED) Text color for links -->
-    <SolidColorBrush po:Freeze="True" x:Key="DataGridBorderBrush" Color="#FFFFFF"/>     <!-- Brush for border of data grid -->
+    <SolidColorBrush po:Freeze="True" x:Key="DataGridBorderBrush" Color="Transparent"/> <!-- (UPDATED) Brush for border of data grid (event view) -->
     <SolidColorBrush po:Freeze="True" x:Key="TabBGBrush" Color="#B3B3B3"/>              <!-- Foreground color in tab (search bar?) -->
     <SolidColorBrush po:Freeze="True" x:Key="ExpBorderBrush" Color="#6D767E"/>          <!-- (UPDATED) Border color on expandos -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedInspectTabBrush" Color="#22272B"/> <!-- (UPDATED) Background color of selected tab (Details, HowToFix) -->

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -931,7 +931,8 @@
         </Setter>
     </Style>
     <Style TargetType="{x:Type DataGridColumnHeader}" x:Key="dgchStyle">
-        <Setter Property="Background" Value="{DynamicResource ResourceKey=DataGridBGBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource ResourceKey=ColumnHeaderBGBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ColumnHeaderFGBrush}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="FontSize" Value="{DynamicResource ResourceKey=SmallTextBlockSize}"/>
         <Setter Property="Padding" Value="4,0"/>
@@ -944,11 +945,14 @@
     <Style TargetType="{x:Type DataGridRow}" x:Key="dgrStyle">
         <Setter Property="Focusable" Value="True"/>
         <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
+        <Setter Property="Background" Value="Transparent"/>
     </Style>
     <Style x:Key="DataGridTextCellStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="Padding" Value="4,0"/>
         <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource ResourceKey=DataGridBGGrush}"/>
     </Style>
     <Style TargetType="{x:Type DataGridCell}" x:Key="dgcStyle">
         <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>


### PR DESCRIPTION
#### Describe the change
Update colors used in events view to properly handle dark mode

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

In the following screenshots, the current Canary build is shown in the top, with the revised build in the bottom.

Light mode, selecting events to record--UI should be basically the same
![image](https://user-images.githubusercontent.com/45672944/76554875-d9f50c80-6453-11ea-9654-3fde6c11605d.png)

Dark mode, selecting events to record--UI should fix contrast issues in current code:
![image](https://user-images.githubusercontent.com/45672944/76554942-f98c3500-6453-11ea-800f-e7a91ea6ca20.png)

Light mode, showing recorded events--UI should be basically the same:
![image](https://user-images.githubusercontent.com/45672944/76555084-33f5d200-6454-11ea-94b4-2efd6731138d.png)

Dark mode, showing recorded events--UI should fix contrast issues in current code:
![image](https://user-images.githubusercontent.com/45672944/76555151-5851ae80-6454-11ea-9187-e181b10829d5.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



