### PR TITLE
Repeat of #720, this time collapsing the ScrollViewer

### DIFF
--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml
@@ -40,30 +40,32 @@
             <controls:HierarchyControl x:Name="ctrlHierarchy"
                                         Grid.Row="1" Visibility="Collapsed"
                                         VerticalAlignment="Stretch"/>
-            <StackPanel Name="spInstructions" Grid.Row="1" KeyboardNavigation.IsTabStop="True">
-                <TextBlock Name="tbInstructions" Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
-                    <Run Text="{x:Static properties:Resources.LiveModeControl_HoverOverElement}"/>
-                    <Run Name="runHkActivate"/><Run Text="."/>
-                    <TextBlock>
-                        <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2075123" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
-                             <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreInspect}"/>
-                        </Hyperlink><Run Text="."/>
+            <ScrollViewer Name ="svInstructions" VerticalScrollBarVisibility="Auto" Grid.Row="1">
+                <StackPanel Name="spInstructions" Grid.Row="1" KeyboardNavigation.IsTabStop="True">
+                    <TextBlock Name="tbInstructions" Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
+                        <Run Text="{x:Static properties:Resources.LiveModeControl_HoverOverElement}"/>
+                        <Run Name="runHkActivate"/><Run Text="."/>
+                        <TextBlock TextWrapping="Wrap">
+                            <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2075123" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
+                                 <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreInspect}"/>
+                            </Hyperlink><Run Text="."/>
+                        </TextBlock>
                     </TextBlock>
-                </TextBlock>
 
-                <TextBlock Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
-                    <Run Text="{x:Static properties:Resources.LiveModeControl_RunAutomatedChecks}"/>
-                    <fabric:FabricIconControl GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" FontStyle="Normal" ShowInControlView="False"/>
-                    <Run Text="{x:Static properties:Resources.LiveModeControl_FocusOnElement}"/>
-                    <Run Name="runHkTest"/><Run Text="."/>
-                    <TextBlock>
-                        <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077027" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
-                             <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreAutomated}" />
-                        </Hyperlink><Run Text="."/>
+                    <TextBlock Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
+                        <Run Text="{x:Static properties:Resources.LiveModeControl_RunAutomatedChecks}"/>
+                        <fabric:FabricIconControl GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" FontStyle="Normal" ShowInControlView="False"/>
+                        <Run Text="{x:Static properties:Resources.LiveModeControl_FocusOnElement}"/>
+                        <Run Name="runHkTest"/><Run Text="."/>
+                        <TextBlock TextWrapping="Wrap">
+                            <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077027" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
+                                 <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreAutomated}" />
+                            </Hyperlink><Run Text="."/>
+                        </TextBlock>
                     </TextBlock>
-                </TextBlock>
 
-            </StackPanel>
+                </StackPanel>
+            </ScrollViewer>
             <controls:DisplayCountControl Grid.RowSpan="2" VerticalAlignment="Center" HorizontalAlignment="Center" x:Name="ccDisplayCount" Visibility="Collapsed"/>
             <GridSplitter x:Name="gsMid"
                             FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
@@ -180,7 +180,7 @@ namespace AccessibilityInsights.Modes
 
                     this.ctrlHierarchy.IsEnabled = false;
                     ctrlHierarchy.Visibility = Visibility.Visible;
-                    spInstructions.Visibility = Visibility.Collapsed;
+                    svInstructions.Visibility = Visibility.Collapsed;
                     await Task.Run(() =>
                     {
                         CaptureAction.SetLiveModeDataContext(ecId, Configuration.TreeViewMode);
@@ -304,7 +304,7 @@ namespace AccessibilityInsights.Modes
         public void Clear()
         {
             ctrlHierarchy.Visibility = Visibility.Collapsed;
-            spInstructions.Visibility = Visibility.Visible;
+            svInstructions.Visibility = Visibility.Visible;
 
             this.SelectedInHierarchyElement = null;
             this.ElementContext = null;


### PR DESCRIPTION
#### Describe the change
Change #720 had a bug that it never collapsed the ScrollViewer, meaning that the transparent ScrollViewer ate all mouse input intended for the hierarchy control. #724 reverted the change from #720. 

This change restores #720, but with 3 additional changes:
1. It names the ScrollViewer as svInstructions
2. Where the code-behind used to collapse spInstructions, it now collapses svInstructions
3. Where the code-behind used to show spInstructions, it now shows svInstructions

The net result is that we get the scrolling as before, and that the hierarchy control gets the mouse input, as intended.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

![PR](https://user-images.githubusercontent.com/45672944/76636336-1bde8b00-6506-11ea-8575-4663b9a7b4a0.gif)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



