### PR TITLE
Update dialog: Better support in dark mode

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -48,7 +48,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="SecondaryBGBrush" Color="#2B3034"/>        <!-- (UPDATED) Secondary background brush (not u-->
     <SolidColorBrush po:Freeze="True" x:Key="GreyBackgroundBrush" Color="#EAEAEA"/>     <!-- Horizontal rules in color contrast, borders of ADO's "disconnect" button -->
     <SolidColorBrush po:Freeze="True" x:Key="ActiveModeBrush" Color="#FFFFFF"/>         <!-- Color of "active" marker in nav bar -->
-    <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledBrush" Color="#A6A6A6"/>     <!-- Background of disabled button (but I can't find any examples) -->
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledBrush" Color="#656E75"/>     <!-- (UPDATED) Background of disabled button (example: Later button in update dialog on mandatory update) -->
     <SolidColorBrush po:Freeze="True" x:Key="PrimaryBGBrush" Color="#22272B"/>          <!-- (UPDATED) Primary background brush (not in startup mode) -->
     <SolidColorBrush po:Freeze="True" x:Key="DataGridBGBrush" Color="#444C52"/>         <!-- (UPDATED) Background of data grid items (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="#6D767E"/> <!-- (UPDATED) Background of selected item in data grid (list of properties) -->

--- a/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml
+++ b/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml
@@ -33,16 +33,16 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <fabric:FabricIconControl Grid.Column="0" VerticalAlignment="Center" Margin="8px 4px 4px 0" GlyphName="Info" GlyphSize="Small" Foreground="{DynamicResource ResourceKey=IconBrush}"></fabric:FabricIconControl>
-                <TextBlock x:Name="txtUpdateNotice" Grid.Column="1" Margin="0 0 24px 0" LineHeight="15px" FontSize="11px" VerticalAlignment="Center"></TextBlock>
+                <TextBlock x:Name="txtUpdateNotice" Grid.Column="1" Margin="0 0 24px 0" LineHeight="15px" FontSize="11px" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"></TextBlock>
             </Grid>
             <Button x:Name="btnUpdateNow" Click="UpdateNow_Click" Grid.Column="1" Style="{StaticResource BtnBlueSharpSquared}">
                 <TextBlock Text="{x:Static properties:Resources.btnUpdateNowText}" Margin="8px" LineHeight="15px"  FontSize="11px" FontWeight="SemiBold" VerticalAlignment="Center"></TextBlock>
             </Button>
             <Button x:Name="btnUpdateLater" Click="UpdateLater_Click" Grid.Column="2" Style="{StaticResource BtnBlueSharpSquared}">
-                <TextBlock Text="{x:Static properties:Resources.btnUpdateLaterText}" Margin="8px" LineHeight="15px" FontSize="11px" FontWeight="SemiBold" Foreground="{DynamicResource ResourceKey=BlueButtonFGBrush}" VerticalAlignment="Center"></TextBlock>
+                <TextBlock Text="{x:Static properties:Resources.btnUpdateLaterText}" Margin="8px" LineHeight="15px" FontSize="11px" FontWeight="SemiBold" VerticalAlignment="Center"></TextBlock>
             </Button>
             <Button x:Name="btnReleaseNotes" Click="ReleaseNotes_Click" Grid.Column="3" Style="{StaticResource BtnBlueSharpSquared}">
-                <TextBlock Text="{x:Static properties:Resources.btnReleaseNotesText}" Margin="8px" LineHeight="15px" FontSize="11px" FontWeight="SemiBold" Foreground="{DynamicResource ResourceKey=BlueButtonFGBrush}" VerticalAlignment="Center"></TextBlock>
+                <TextBlock Text="{x:Static properties:Resources.btnReleaseNotesText}" Margin="8px" LineHeight="15px" FontSize="11px" FontWeight="SemiBold" VerticalAlignment="Center"></TextBlock>
             </Button>
         </Grid>
     </Border>


### PR DESCRIPTION
#### Describe the change
The update dialog doesn't work well in dark mode

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Update dialog showing a mandatory update in light mode (current is on top, revised is on the bottom--note how the current version makes the disabled "Later" button disappear completely, even though it's still in the UIA tree. I checked with @jalkire, and the "disappearing text" seems wrong to him. I checked with @ferBonnin about color contrast requirements for disabled text, and she confirmed that disabled buttons have no contrast requirement, so the current changes will be OK. She mentioned that we might want to simply remove the permanently disabled button as a usability improvement. I'll bring this up with @adarshrema, and if he approves the removal, that will be a separate PR. 

![image](https://user-images.githubusercontent.com/45672944/76674824-8b896000-6570-11ea-9a7e-ab7c6b28c0dd.png)


Update dialog showing a mandatory update in dark mode (current is on the top, revised is on the bottom):

![image](https://user-images.githubusercontent.com/45672944/76674757-eec6c280-656f-11ea-8a1c-40fd946bb59e.png)


> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



