### PR TITLE
Collapse the "Update later" button when it will be permanently disabled

### DIFF
--- a/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml
+++ b/src/AccessibilityInsights/Dialogs/UpdateDialog.xaml
@@ -33,7 +33,7 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <fabric:FabricIconControl Grid.Column="0" VerticalAlignment="Center" Margin="8px 4px 4px 0" GlyphName="Info" GlyphSize="Small" Foreground="{DynamicResource ResourceKey=IconBrush}"></fabric:FabricIconControl>
-                <TextBlock x:Name="txtUpdateNotice" Grid.Column="1" Margin="0 0 24px 0" LineHeight="15px" FontSize="11px" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"></TextBlock>
+                <TextBlock x:Name="txtUpdateNotice" Grid.Column="1" Margin="0 0 24px 0" LineHeight="15px" FontSize="11px" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" Text="{x:Static properties:Resources.MainWindow_ShowUpgradeDialog_An_update_is_available}"></TextBlock>
             </Grid>
             <Button x:Name="btnUpdateNow" Click="UpdateNow_Click" Grid.Column="1" Style="{StaticResource BtnBlueSharpSquared}">
                 <TextBlock Text="{x:Static properties:Resources.btnUpdateNowText}" Margin="8px" LineHeight="15px"  FontSize="11px" FontWeight="SemiBold" VerticalAlignment="Center"></TextBlock>

--- a/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/AutoUpdate.cs
@@ -95,8 +95,11 @@ namespace AccessibilityInsights
         private UpdateDialog CreateUpgradeDialog(Uri releaseNotesUri, AutoUpdateOption updateOption)
         {
             UpdateDialog dialog = new UpdateDialog(releaseNotesUri);
-            dialog.btnUpdateLater.IsEnabled = (updateOption != AutoUpdateOption.RequiredUpgrade);
-            dialog.txtUpdateNotice.Text = (updateOption == AutoUpdateOption.RequiredUpgrade) ? Properties.Resources.MainWindow_ShowUpgradeDialog_An_update_is_required : Properties.Resources.MainWindow_ShowUpgradeDialog_An_update_is_available;
+            if (updateOption == AutoUpdateOption.RequiredUpgrade)
+            {
+                dialog.btnUpdateLater.Visibility = Visibility.Collapsed;
+                dialog.txtUpdateNotice.Text = Properties.Resources.MainWindow_ShowUpgradeDialog_An_update_is_required;
+            }
 
             // center horizontally - does not work when maximized on secondary screen
             Point topLeft = this.WindowState == WindowState.Maximized ?


### PR DESCRIPTION
#### Describe the change
The Update dialog currently disables the "Update later" button when a mandatory update takes place. Usability studies consistently show that permanently disabled buttons are confusing to users, and that it's preferable to simply remove the permanently disabled button. 

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Screenshot is below. The "optional update" (the top image) experience is unchanged. In the old "required update" case (the middle image), the "Later" button is diabled. In the "required update" (the bottom image), the "Later"button gets collapsed.

![image](https://user-images.githubusercontent.com/45672944/76784984-d920eb00-6771-11ea-8f5e-80a589aa591d.png)


> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



