### PR TITLE
Ensure copied VersionSwitcher files are identical to their source files

### DIFF
--- a/src/AccessibilityInsights.SetupLibrary/VersionSwitcherWrapper.cs
+++ b/src/AccessibilityInsights.SetupLibrary/VersionSwitcherWrapper.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 
 namespace AccessibilityInsights.SetupLibrary
 {
@@ -124,20 +125,7 @@ namespace AccessibilityInsights.SetupLibrary
 
         private static void EnsureFilesAreIdentical(string file1, string file2)
         {
-            byte[] file1Bytes = File.ReadAllBytes(file1);
-            byte[] file2Bytes = File.ReadAllBytes(file2);
-
-            bool matches = file1Bytes.Length == file2Bytes.Length;
-
-            for (int index = 0; matches && index < file1Bytes.Length; index++)
-            {
-                if (file1Bytes[index] != file2Bytes[index])
-                {
-                    matches = false;
-                }
-            }
-
-            if (!matches)
+            if (!File.ReadAllBytes(file1).SequenceEqual(File.ReadAllBytes(file2)))
             {
 #pragma warning disable CA1303 // Do not pass literals as localized parameters
                 throw new IOException("File " + file1 + " does not match " + file2);

--- a/src/AccessibilityInsights.SetupLibrary/VersionSwitcherWrapper.cs
+++ b/src/AccessibilityInsights.SetupLibrary/VersionSwitcherWrapper.cs
@@ -52,7 +52,7 @@ namespace AccessibilityInsights.SetupLibrary
                 string installedFolder = GetInstalledVersionSwitcherFolder();
                 string temporaryFolder = GetTemporaryVersionSwitcherFolder();
                 RemoveFolder(temporaryFolder);
-                RecursiveTreeCopy(installedFolder, temporaryFolder, fileLocks);
+                TreeCopy(installedFolder, temporaryFolder, fileLocks);
                 ProcessStartInfo start = new ProcessStartInfo
                 {
                     FileName = Path.Combine(temporaryFolder, "AccessibilityInsights.VersionSwitcher.exe"),
@@ -118,6 +118,30 @@ namespace AccessibilityInsights.SetupLibrary
                 string destFile = Path.Combine(dest, fileInfo.Name);
                 fileInfo.CopyTo(destFile, true);
                 fileLocks.Add(File.OpenRead(destFile));
+                EnsureFilesAreIdentical(file, destFile);
+            }
+        }
+
+        private static void EnsureFilesAreIdentical(string file1, string file2)
+        {
+            byte[] file1Bytes = File.ReadAllBytes(file1);
+            byte[] file2Bytes = File.ReadAllBytes(file2);
+
+            bool matches = file1Bytes.Length == file2Bytes.Length;
+
+            for (int index = 0; matches && index < file1Bytes.Length; index++)
+            {
+                if (file1Bytes[index] != file2Bytes[index])
+                {
+                    matches = false;
+                }
+            }
+
+            if (!matches)
+            {
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
+                throw new IOException("File " + file1 + " does not match " + file2);
+#pragma warning restore CA1303 // Do not pass literals as localized parameters
             }
         }
 


### PR DESCRIPTION
#### Describe the change
Our existing upgrade code copies the VersionSwitcher app from ProgramFiles to Temp, then executes from Temp. We lock each file against writing immediately after copying it, but there's a tiny time window where a malicious app could theoretically modify the copied file before it is locked. This change waits until after the file is protected against writing, then compares its contents to the source file. There's a potential for a perf hit here, but since both source and destination files are probably still in the disk cache, it should be minimal.

This PR includes one other tiny change. #266 bypassed the method that validates that the source folder exists. This change seemed unintentional since it created an unused method. I noticed this unused method only because of the color coloring when I had this file open in the IDE. I've restored the code path that checks for the existence of the source folder.

Tested by building the MSI with my clock set back a couple of weeks (this creates a version stamp older than what is in Canary), resetting my clock, uninstalling my Canary AIWin installation, then installing the MSI that I built. When AIWin started, it took me through the upgrade process, which successfully upgraded to the official Canary build.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



