### PR TITLE
Update NuGet version in remote builds from 4.3 to 5.x

### DIFF
--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -24,8 +24,8 @@ jobs:
 
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'
-      inputs:
-        versionSpec: '5.x'
+    inputs:
+      versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -22,8 +22,10 @@ jobs:
         filePath: tools\scripts\verification.scripts\LicenseHeaderVerification.ps1
         arguments: '-target  $(Build.Repository.LocalPath) -licenseHeaderPath tools\scripts\verification.scripts\LicenseHeader.txt -extensions *.xaml,*.xml,*.cs,*.ps1 -addIfAbsent $false'
 
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.3.0'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet 5.x'
+      inputs:
+        versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/build/build-without-fakes.yml
+++ b/build/build-without-fakes.yml
@@ -6,8 +6,10 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.3.0'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet 5.x'
+      inputs:
+        versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/build/build-without-fakes.yml
+++ b/build/build-without-fakes.yml
@@ -8,8 +8,8 @@ jobs:
   steps:
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'
-      inputs:
-        versionSpec: '5.x'
+    inputs:
+      versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -18,8 +18,10 @@ jobs:
   variables:
     PublicRelease: 'false'
   steps:
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.3.0'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet 5.x'
+      inputs:
+        versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
@@ -75,8 +77,10 @@ jobs:
   variables:
     PublicRelease: 'false'
   steps:
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.3.0'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet 5.x'
+      inputs:
+        versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
@@ -199,8 +203,10 @@ jobs:
     inputs:
       signType: real
 
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.3.0'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet 5.x'
+      inputs:
+        versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -20,8 +20,8 @@ jobs:
   steps:
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'
-      inputs:
-        versionSpec: '5.x'
+    inputs:
+      versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
@@ -79,8 +79,8 @@ jobs:
   steps:
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'
-      inputs:
-        versionSpec: '5.x'
+    inputs:
+      versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
@@ -205,8 +205,8 @@ jobs:
 
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'
-      inputs:
-        versionSpec: '5.x'
+    inputs:
+      versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -12,8 +12,8 @@ jobs:
   steps:
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'
-      inputs:
-        versionSpec: '5.x'
+    inputs:
+      versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -10,8 +10,10 @@ jobs:
   pool:
     vmImage: windows-2019
   steps:
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.3.0'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet 5.x'
+      inputs:
+        versionSpec: '5.x'
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'


### PR DESCRIPTION
#### Describe the change
Currently, our remote builds run using Visual Studio 2019 (16.0). Our remote NuGet restores, however, use a [deprecated NuGet install task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/prev-versions/nuget-installer-0?view=azure-devops) that installs NuGet 4.3, which is associated with Visual Studio 2017. This combination has caused recent build issues. This PR updates the build to use the current version of the NuGet install task and specifies the use of NuGet version 5.x, which corresponds with VS2019. A successful run of the signed build (or at least the NuGet related parts) can be [found here](https://dev.azure.com/mseng/1ES/_build/results?buildId=11746468&view=results).

This PR does not attempt to update our csproj files to reference VS 2019.

#### PR checklist

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



