### PR TITLE
Color contrast more dark mode

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml
@@ -27,6 +27,7 @@
             </ComboBox>
             <TextBox x:Name="colorTb" Width="100px" Height="32" BorderBrush="{DynamicResource ResourceKey=BorderBrush}" FontSize="17"
                     Text="{Binding StoredColor, Converter={converters:ColorStringConverter}, FallbackValue=#FFFFFF}"
+                    Background="{DynamicResource ResourceKey=PrimaryBGBrush}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" CaretBrush="{DynamicResource ResourceKey=PrimaryFGBrush}"
                     VerticalContentAlignment="Center" TextAlignment="Center"
                     AutomationProperties.Name="{Binding Path=ColorPickerName, StringFormat='{x:Static Properties:Resources.colorTbAutomationPropertiesName}'}" IsTabStop="True" Focusable="True"
                     PreviewTextInput="colorTb_PreviewTextInput">

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -103,9 +103,9 @@
                         VerticalAlignment="Top" Height="110" Width="200">
                     <StackPanel Background="{DynamicResource ResourceKey=CCABackgroundBrush}">
                         <StackPanel Orientation="Vertical" Margin="10,6,0,0" MinWidth="132">
-                            <TextBlock Text="{x:Static Properties:Resources.ColorContrast_Ratio}" FontSize="14"/>
+                            <TextBlock Text="{x:Static Properties:Resources.ColorContrast_Ratio}" FontSize="14" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                             <TextBlock x:Name="output" FontWeight="SemiBold" FontSize="17" HorizontalAlignment="Left"
-                               AutomationProperties.LiveSetting="Polite" VerticalAlignment="Center"
+                               AutomationProperties.LiveSetting="Polite" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"
                                AutomationProperties.Name="{Binding Text, RelativeSource={RelativeSource Self}, StringFormat={x:Static Properties:Resources.ColorContrast_OutputAutomationName}}"
                                KeyboardNavigation.TabIndex="3" Focusable="True"
                                Text="{Binding Path=ContrastVM.FormattedRatio, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}">

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -61,8 +61,8 @@
     <SolidColorBrush po:Freeze="True" x:Key="SnapshotBtnBGBrush" Color="#0C5186"/>      <!-- Background of Snapshot button (non-hover) -->
     <SolidColorBrush po:Freeze="True" x:Key="SnapshotBtnHoverBrush" Color="#0E78C8"/>   <!-- Background of Snapshot button (hover) -->
     <SolidColorBrush po:Freeze="True" x:Key="BtnBrderBrush" Color="{x:Static SystemColors.ControlDarkColor}"/>  <!-- Borders of buttons ? -->
-    <SolidColorBrush po:Freeze="True" x:Key="CCABackgroundBrush" Color="#F8F8F8"/>      <!-- Background of Color Contrast preview -->
-    <SolidColorBrush po:Freeze="True" x:Key="CCABorderBrush" Color="#7a7a7a"/>          <!-- Border of Color Contrast preview -->
+    <SolidColorBrush po:Freeze="True" x:Key="CCABackgroundBrush" Color="#2B3034"/>      <!-- (UPDATED) Background of Color Contrast preview -->
+    <SolidColorBrush po:Freeze="True" x:Key="CCABorderBrush" Color="#7a7a7a"/>          <!-- (UPDATED) Border of Color Contrast preview -->
     <SolidColorBrush x:Key="HLbrushRed" Color="#CD4A45"/>                               <!-- (UPDATED) Color of FAILED color contrast icon, hierarchy highlighter -->
     <SolidColorBrush x:Key="HLbrushGreen" Color="#55A362"/>                             <!-- (UPDATED) Color of PASSED color contrast icon -->
     <SolidColorBrush x:Key="HLbrushPurple" Color="#A45EF4"/>                            <!-- Color of glimpse shown in tab stops list -->

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -62,7 +62,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="SnapshotBtnHoverBrush" Color="#0E78C8"/>   <!-- Background of Snapshot button (hover) -->
     <SolidColorBrush po:Freeze="True" x:Key="BtnBrderBrush" Color="{x:Static SystemColors.ControlDarkColor}"/>  <!-- Borders of buttons ? -->
     <SolidColorBrush po:Freeze="True" x:Key="CCABackgroundBrush" Color="#2B3034"/>      <!-- (UPDATED) Background of Color Contrast preview -->
-    <SolidColorBrush po:Freeze="True" x:Key="CCABorderBrush" Color="#7a7a7a"/>          <!-- (UPDATED) Border of Color Contrast preview -->
+    <SolidColorBrush po:Freeze="True" x:Key="CCABorderBrush" Color="#7a7a7a"/>          <!-- Border of Color Contrast preview -->
     <SolidColorBrush x:Key="HLbrushRed" Color="#CD4A45"/>                               <!-- (UPDATED) Color of FAILED color contrast icon, hierarchy highlighter -->
     <SolidColorBrush x:Key="HLbrushGreen" Color="#55A362"/>                             <!-- (UPDATED) Color of PASSED color contrast icon -->
     <SolidColorBrush x:Key="HLbrushPurple" Color="#A45EF4"/>                            <!-- Color of glimpse shown in tab stops list -->


### PR DESCRIPTION
#### Describe the change
Early feedback from the dark mode feature pointed out that we'd overlooked both the color edits and the Ratio control in Color Contrast. This fixes both.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Before the change (shows both light and dark mode):
![image](https://user-images.githubusercontent.com/45672944/77209022-6b9af480-6aba-11ea-87c2-75778fc2859c.png)

After the change (shows both light and dark mode):
![image](https://user-images.githubusercontent.com/45672944/77209032-6fc71200-6aba-11ea-9dd9-831d3f9dde2a.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



