### PR TITLE
Stop publishing symbols from build

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -273,21 +273,6 @@ jobs:
       rerunFailedTests: true
       testFiltercriteria: 'TestCategory!=NoStrongName'
 
-  - task: PublishSymbols@1
-    displayName: 'Index Sources'
-    inputs:
-      SearchPattern: '**\bin\**\*.pdb'
-    continueOnError: true
-
-  - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
-    displayName: 'Publish Symbols'
-    inputs:
-      symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
-      requestName: 'CollectionId/$(System.CollectionId)/ProjectId/$(System.TeamProjectId)/BuildId/$(Build.BuildId)'
-      sourcePath: '$(Build.ArtifactStagingDirectory)'
-      detailedLog: true
-      usePat: false
-
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 


### PR DESCRIPTION
#### Describe the change
This PR removes the symbol publishing tasks from our signed build. We don't use them or need them, so we are removing them.

#### PR checklist

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



