### PR TITLE
Fix issues called out in issue #747

### DIFF
--- a/src/AccessibilityInsights.CommonUxComponents/Dialogs/MessageDialog.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Dialogs/MessageDialog.xaml.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
 using System.Windows;
 using System.Windows.Input;
 
@@ -15,6 +16,15 @@ namespace AccessibilityInsights.CommonUxComponents.Dialogs
         public MessageDialog()
         {
             InitializeComponent();
+        }
+
+        /// <summary>
+        /// Invoke MessageDialog.Show on the UI thread.
+        /// </summary>
+        /// <param name="message">The message to display</param>
+        public static void Invoke(string message)
+        {
+            Application.Current.Dispatcher.BeginInvoke(new Action(() => { Show(message); }));
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml.cs
@@ -27,9 +27,10 @@ namespace AccessibilityInsights.Extensions.GitHub
         /// <returns>The extension’s new configuration, serialized</returns>
         public override string OnSave()
         {
-            if (LinkValidator.IsValidGitHubRepoLink(this.tbURL.Text))
+            string trimmedLink = this.tbURL.Text.Trim();
+            if (LinkValidator.IsValidGitHubRepoLink(trimmedLink))
             {
-                this.Config.RepoLink = this.tbURL.Text;
+                this.Config.RepoLink = trimmedLink;
                 canSave = false;
                 UpdateSaveButton();
                 IsConfigured(true);

--- a/src/AccessibilityInsights.Extensions.GitHub/IssueReporter.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/IssueReporter.cs
@@ -71,7 +71,7 @@ namespace AccessibilityInsights.Extensions.GitHub
                 catch (Exception e)
                 {
                     e.ReportException();
-                    MessageDialog.Show(Properties.Resources.InvalidLink);
+                    MessageDialog.Invoke(Properties.Resources.InvalidLink);
                 }
 #pragma warning restore CA1031 // Do not catch general exception types
             }


### PR DESCRIPTION
#### Describe the change
2 items are called out in #747 
1. Leading and trailing spaces from the GitHub link edit control are included in the GitHub link, which leads to an error when we try to launch the browser.
2. When the error occurs, it occurs on a non-UI thread, so the MessageDialog never gets displayed. Net result from the user perspective is that issue filing is broken.

This change does 3 things:
1. It adds MessageDialog.Invoke to invoke the MessageDialog from a non-UI thread. This just wraps MessageDialog.Show, but guarantees that the call is made on the UI thread.
2. It replaces a call to MessageDialog.Show with MessageDialog.Invoke
3. It trims the URL before validating and saving it, so that user changes avoid the originally broken case. This makes no attempt to fix connection strings that are already broken in the saved config, and it means that the Save and Close button will appear if you just add spaces to the beginning or end, even though the saved value doesn't change at all. These seemed like reasonable compromises for a very targeted fix, but I'm happy to entertain options for other ways to address this.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #747
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



