### PR TITLE
Refactor ConfigurationManager.GetDefaultInstance

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationManager.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationManager.cs
@@ -164,18 +164,9 @@ namespace AccessibilityInsights.SharedUx.Settings
         /// <returns></returns>
         public static ConfigurationManager GetDefaultInstance(FixedConfigSettingsProvider provider = null)
         {
-            if(sDefaultInstance == null)
+            if (sDefaultInstance == null && provider != null)
             {
-                try
-                {
-                    sDefaultInstance = new ConfigurationManager(provider);
-                }
-#pragma warning disable CA1031 // Do not catch general exception types
-                catch
-                {
-                    // be silent. since it will be ok later once Main window is up.
-                }
-#pragma warning restore CA1031 // Do not catch general exception types
+                sDefaultInstance = new ConfigurationManager(provider);
             }
 
             return sDefaultInstance;

--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationManager.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationManager.cs
@@ -166,7 +166,16 @@ namespace AccessibilityInsights.SharedUx.Settings
         {
             if (sDefaultInstance == null && provider != null)
             {
-                sDefaultInstance = new ConfigurationManager(provider);
+                try
+                {
+                    sDefaultInstance = new ConfigurationManager(provider);
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception e)
+                {
+                    e.ReportException();
+                }
+#pragma warning restore CA1031 // Do not catch general exception types
             }
 
             return sDefaultInstance;


### PR DESCRIPTION
Refactor ConfigurationManager.GetDefaultInstance to prevent NullReferenceException (instead of ignoring it)

#### Describe the change
`ConfigurationManager.GetDefaultInstance` contains some hackiness to allow for the fact that we sometimes ask for the configuration before we can fully answer the question. The old code caught and ate a NullReferenceException during initialization, but the current version of Visual Studio treats this as an unhandled Exception and stops in the debugger. This change prevents the Exception rather than eating it. In the offhand chance that an Exception still occurs, we catch it and log it. It makes no attempt to fix the ugliness inherent to how we're creating the singleton.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #754 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



