### PR TITLE
Fix high contrast regression

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -99,4 +99,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="#000000"/>    <!-- (UPDATED) Foreground color of selected tab stop rows -->
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="#B2B3B5"/>    <!-- (UPDATED) Background color of selected tab stop rows -->
     <SolidColorBrush po:Freeze="True" x:Key="TSRowHoverBGBrush" Color="#31383D"/>       <!-- (UPDATED) Hover color of selected tab stop rows -->
+    <SolidColorBrush po:Freeze="True" x:Key="IconHoverFGBrush" Color="#FFFFFF"/>        <!-- (UPDATED) Foreground of icons on mouse hover -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -100,4 +100,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="#B2B3B5"/>    <!-- (UPDATED) Background color of selected tab stop rows -->
     <SolidColorBrush po:Freeze="True" x:Key="TSRowHoverBGBrush" Color="#31383D"/>       <!-- (UPDATED) Hover color of selected tab stop rows -->
     <SolidColorBrush po:Freeze="True" x:Key="IconHoverFGBrush" Color="#FFFFFF"/>        <!-- (UPDATED) Foreground of icons on mouse hover -->
+    <SolidColorBrush po:Freeze="True" x:Key="CommandBarBGBrush" Color="#2B3034"/>       <!-- (UPDATED) Background of command bar -->
+    <SolidColorBrush po:Freeze="True" x:Key="CommandBarFGBrush" Color="#FFFFFF"/>       <!-- (UPDATED) Foreground of command bar -->
+    <SolidColorBrush po:Freeze="True" x:Key="FocusBorderBrush" Color="#FFFFFF"/>        <!-- (UPDATED) Border color to track keyboard focus -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -82,4 +82,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="IconHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -83,4 +83,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="IconHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="CommandBarBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="CommandBarFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="FocusBorderBrush" Color="{x:Static SystemColors.WindowFrameColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -99,4 +99,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="#EFF6FC"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowHoverBGBrush" Color="#F4F4F4"/>
+    <SolidColorBrush po:Freeze="True" x:Key="IconHoverFGBrush" Color="#000000"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -100,4 +100,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="#EFF6FC"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowHoverBGBrush" Color="#F4F4F4"/>
     <SolidColorBrush po:Freeze="True" x:Key="IconHoverFGBrush" Color="#000000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="CommandBarBGBrush" Color="#F4F4F4"/>
+    <SolidColorBrush po:Freeze="True" x:Key="CommandBarFGBrush" Color="#000000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="FocusBorderBrush" Color="#000000"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1473,4 +1473,14 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <Style TargetType="fabric:FabricIconControl" x:Key="hoverAwareFabricIcon">
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=IconHoverFGBrush}"/>
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -16,7 +16,7 @@
             <Setter.Value>
                 <ControlTemplate>
                     <Border BorderThickness="2" Margin="-2"
-                      BorderBrush="{DynamicResource ResourceKey=IconBrush}"
+                      BorderBrush="{DynamicResource ResourceKey=FocusBorderBrush}"
                       SnapsToDevicePixels="true"/>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -289,13 +289,13 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
-                        <DockPanel Height="Auto" Background="{DynamicResource ResourceKey=WindowBorderBrush}">
-                            <StackPanel DockPanel.Dock="Left" x:Name="spCommandBar" Grid.Row="0" Background="{DynamicResource ResourceKey=WindowBorderBrush}"
+                        <DockPanel Height="Auto" Background="{DynamicResource ResourceKey=CommandBarBGBrush}">
+                            <StackPanel DockPanel.Dock="Left" x:Name="spCommandBar" Grid.Row="0" Background="{DynamicResource ResourceKey=CommandBarBGBrush}"
                                     WindowChrome.IsHitTestVisibleInChrome="True" Focusable="True" GotKeyboardFocus="spCommandBar_GotKeyboardFocus"
                                     Orientation="Horizontal" KeyboardNavigation.DirectionalNavigation="Cycle"
                                     Height="28" KeyboardNavigation.TabNavigation="Once"
                                     HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                                <TextBlock x:Name="tbComboboxLabel" FontSize="{StaticResource ConstStandardTextSize}" Text="{x:Static properties:Resources.tbComboboxLabelText}" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="8,0" Foreground="{DynamicResource ResourceKey=WindowBorderTextBrush}"/>
+                                <TextBlock x:Name="tbComboboxLabel" FontSize="{StaticResource ConstStandardTextSize}" Text="{x:Static properties:Resources.tbComboboxLabelText}" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="8,0" Foreground="{DynamicResource ResourceKey=CommandBarFGBrush}"/>
                                 <ComboBox x:Name="cbSelectionScope" AutomationProperties.Name="{x:Static properties:Resources.cbSelectionScopeAutomationPropertiesName}" Width="92" 
                                     HorizontalAlignment="Left" VerticalContentAlignment="Center"
                                     FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" FontSize="{StaticResource ConstStandardTextSize}"

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -171,11 +171,11 @@
                             </Grid>
                         </Button>
                         <Button Width="40" Height="40"
-                                    x:Name="btnConfig" Grid.Row="1"
-                                    AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinSettingsButton}"
-                                    AutomationProperties.Name="{x:Static properties:Resources.btnConfigAutomationPropertiesName}"
-                                    AutomationProperties.HelpText="{x:Static properties:Resources.btnConfigAutomationPropertiesHelpText}"
-                                    Style="{StaticResource btnLeftNav}" Click="onbtnConfigClicked">
+                                x:Name="btnConfig" Grid.Row="1"
+                                AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinSettingsButton}"
+                                AutomationProperties.Name="{x:Static properties:Resources.btnConfigAutomationPropertiesName}"
+                                AutomationProperties.HelpText="{x:Static properties:Resources.btnConfigAutomationPropertiesHelpText}"
+                                Style="{StaticResource btnLeftNav}" Click="onbtnConfigClicked">
                             <Button.ToolTip>
                                 <ToolTip>
                                     <Run Text="{x:Static properties:Resources.btnConfigToolTip}" />
@@ -223,10 +223,10 @@
                                 Name="txtBlkTitleBar" >
                         </TextBlock>
                         <ItemsControl WindowChrome.IsHitTestVisibleInChrome="True"
-                                        BorderBrush="{x:Null}" Background="Transparent"
-                                        Height="Auto" Width="Auto" 
-                                        HorizontalContentAlignment="Right" VerticalContentAlignment="Top" HorizontalAlignment="Right" VerticalAlignment="Stretch" 
-                                        Margin="0,0,-1,0" KeyboardNavigation.TabNavigation="Once" IsTabStop="False" TabIndex="0">
+                                BorderBrush="{x:Null}" Background="Transparent"
+                                Height="Auto" Width="Auto" 
+                                HorizontalContentAlignment="Right" VerticalContentAlignment="Top" HorizontalAlignment="Right" VerticalAlignment="Stretch" 
+                                Margin="0,0,-1,0" KeyboardNavigation.TabNavigation="Once" IsTabStop="False" TabIndex="0">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Horizontal" />
@@ -270,11 +270,11 @@
                     </Grid>
                 </Border>
                 <controls:NamedPane x:Name="ctrlNamedCommandbar"
-                                    KeyboardNavigation.DirectionalNavigation="Contained"
-                                    KeyboardNavigation.TabNavigation="Cycle"
-                                    Grid.Row="1" Grid.RowSpan="2" Height="Auto"
-                                    BorderThickness="0" Visibility="Collapsed"
-                                    AutomationProperties.Name="{x:Static properties:Resources.ctrlNamedCommandbarAutomationPropertiesName}">
+                        KeyboardNavigation.DirectionalNavigation="Contained"
+                        KeyboardNavigation.TabNavigation="Cycle"
+                        Grid.Row="1" Grid.RowSpan="2" Height="Auto"
+                        BorderThickness="0" Visibility="Collapsed"
+                        AutomationProperties.Name="{x:Static properties:Resources.ctrlNamedCommandbarAutomationPropertiesName}">
                     <controls:NamedPane.InputBindings>
                         <KeyBinding Command="{x:Static local:MainWindow.F6Command}"
                             CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=FrameworkElement}}"
@@ -291,15 +291,15 @@
                         </Grid.RowDefinitions>
                         <DockPanel Height="Auto" Background="{DynamicResource ResourceKey=WindowBorderBrush}">
                             <StackPanel DockPanel.Dock="Left" x:Name="spCommandBar" Grid.Row="0" Background="{DynamicResource ResourceKey=WindowBorderBrush}"
-                            WindowChrome.IsHitTestVisibleInChrome="True" Focusable="True" GotKeyboardFocus="spCommandBar_GotKeyboardFocus"
-                            Orientation="Horizontal" KeyboardNavigation.DirectionalNavigation="Cycle"
-                            Height="28" KeyboardNavigation.TabNavigation="Once"
-                            HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                                    WindowChrome.IsHitTestVisibleInChrome="True" Focusable="True" GotKeyboardFocus="spCommandBar_GotKeyboardFocus"
+                                    Orientation="Horizontal" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                    Height="28" KeyboardNavigation.TabNavigation="Once"
+                                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                                 <TextBlock x:Name="tbComboboxLabel" FontSize="{StaticResource ConstStandardTextSize}" Text="{x:Static properties:Resources.tbComboboxLabelText}" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="8,0" Foreground="{DynamicResource ResourceKey=WindowBorderTextBrush}"/>
                                 <ComboBox x:Name="cbSelectionScope" AutomationProperties.Name="{x:Static properties:Resources.cbSelectionScopeAutomationPropertiesName}" Width="92" 
-                                      HorizontalAlignment="Left" VerticalContentAlignment="Center"
-                                      FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" FontSize="{StaticResource ConstStandardTextSize}"
-                                      SelectionChanged="ComboBox_SelectionChanged" PreviewKeyDown="processComboBox_PreviewKeyDown">
+                                    HorizontalAlignment="Left" VerticalContentAlignment="Center"
+                                    FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" FontSize="{StaticResource ConstStandardTextSize}"
+                                    SelectionChanged="ComboBox_SelectionChanged" PreviewKeyDown="processComboBox_PreviewKeyDown">
                                     <ComboBoxItem x:Name="cbiElement" Content="{x:Static properties:Resources.cbiElementContent}" AutomationProperties.Name="{x:Static properties:Resources.cbiElementAutomationPropertiesName}" IsSelected="True"/>
                                     <ComboBoxItem x:Name="cbiEntireApp" Content="{x:Static properties:Resources.cbiEntireAppContent}" AutomationProperties.Name="{x:Static properties:Resources.cbiEntireAppAutomationPropertiesName}"/>
                                 </ComboBox>
@@ -335,7 +335,7 @@
                                             </Style.Triggers>
                                         </Style>
                                     </Button.Style>
-                                    <fabric:FabricIconControl Height="16" Width="16" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=WindowBorderTextBrush}" GlyphSize="Default">
+                                    <fabric:FabricIconControl Height="16" Width="16" VerticalAlignment="Center" HorizontalAlignment="Center" GlyphSize="Default">
                                         <fabric:FabricIconControl.Style>
                                             <Style TargetType="fabric:FabricIconControl">
                                                 <Style.Triggers>
@@ -345,15 +345,21 @@
                                                     <DataTrigger Binding="{Binding Path=vmHilighter.State, Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:MainWindow}}" Value="Off">
                                                         <Setter Property="GlyphName" Value="UnSetColor"/>
                                                     </DataTrigger>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=IconHoverFGBrush}"/>
+                                                    </Trigger>
+                                                    <Trigger Property="IsMouseOver" Value="False">
+                                                        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                                                    </Trigger>
                                                 </Style.Triggers>
                                             </Style>
                                         </fabric:FabricIconControl.Style>
                                     </fabric:FabricIconControl>
                                 </Button>
                                 <Button x:Name="btnRefresh"
-                                    Style="{StaticResource BtnNoAutoHelpText}"
-                                    VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="16,0,0,0"
-                                    AutomationProperties.Name="{x:Static properties:Resources.btnRefreshAutomationPropertiesName}" Click="btnRefresh_Click">
+                                        Style="{StaticResource BtnNoAutoHelpText}"
+                                        VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="16,0,0,0"
+                                        AutomationProperties.Name="{x:Static properties:Resources.btnRefreshAutomationPropertiesName}" Click="btnRefresh_Click">
                                     <Button.ToolTip>
                                         <ToolTip>
                                             <Run Text="{x:Static properties:Resources.btnRefreshToolTip}"/>
@@ -362,12 +368,12 @@
                                     <i:Interaction.Behaviors>
                                         <behaviors:KeyboardToolTipButtonBehavior/>
                                     </i:Interaction.Behaviors>
-                                    <fabric:FabricIconControl GlyphName="Refresh" FontSize="16" Foreground="{DynamicResource ResourceKey=WindowBorderTextBrush}"/>
+                                    <fabric:FabricIconControl GlyphName="Refresh" FontSize="16" Style="{StaticResource hoverAwareFabricIcon}"/>
                                 </Button>
                                 <Button x:Name="btnSave"
-                                    Style="{StaticResource BtnNoAutoHelpText}"
-                                    VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
-                                    AutomationProperties.Name="{x:Static properties:Resources.btnSaveAutomationPropertiesName}" Click="btnSave_Click">
+                                        Style="{StaticResource BtnNoAutoHelpText}"
+                                        VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
+                                        AutomationProperties.Name="{x:Static properties:Resources.btnSaveAutomationPropertiesName}" Click="btnSave_Click">
                                     <Button.ToolTip>
                                         <ToolTip>
                                             <Run Text="{x:Static properties:Resources.btnSaveAutomationPropertiesName}" />
@@ -376,13 +382,13 @@
                                     <i:Interaction.Behaviors>
                                         <behaviors:KeyboardToolTipButtonBehavior/>
                                     </i:Interaction.Behaviors>
-                                    <fabric:FabricIconControl GlyphName="Save" FontSize="16" Foreground="{DynamicResource ResourceKey=WindowBorderTextBrush}"/>
+                                    <fabric:FabricIconControl GlyphName="Save" FontSize="16" Style="{StaticResource hoverAwareFabricIcon}"/>
                                 </Button>
                                 <Button x:Name="btnPause"
-                                VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
-                                Click="btnPause_Click"
-                                AutomationProperties.Name="{x:Static properties:Resources.btnPauseAutomationPropertiesNameOn}"
-                                AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinPauseButton}" >
+                                        VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
+                                        Click="btnPause_Click"
+                                        AutomationProperties.Name="{x:Static properties:Resources.btnPauseAutomationPropertiesNameOn}"
+                                        AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinPauseButton}" >
                                     <i:Interaction.Behaviors>
                                         <behaviors:KeyboardToolTipButtonBehavior/>
                                     </i:Interaction.Behaviors>
@@ -411,7 +417,7 @@
                                             </Style.Triggers>
                                         </Style>
                                     </Button.Style>
-                                    <fabric:FabricIconControl Height="16" Width="16" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=WindowBorderTextBrush}" GlyphSize="Default">
+                                    <fabric:FabricIconControl Height="16" Width="16" VerticalAlignment="Center" HorizontalAlignment="Center" GlyphSize="Default">
                                         <fabric:FabricIconControl.Style>
                                             <Style TargetType="fabric:FabricIconControl">
                                                 <Style.Triggers>
@@ -421,15 +427,21 @@
                                                     <DataTrigger Binding="{Binding Path=vmLiveModePauseResume.State, Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:MainWindow}}" Value="Off">
                                                         <Setter Property="GlyphName" Value="Play"/>
                                                     </DataTrigger>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=IconHoverFGBrush}"/>
+                                                    </Trigger>
+                                                    <Trigger Property="IsMouseOver" Value="False">
+                                                        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                                                    </Trigger>
                                                 </Style.Triggers>
                                             </Style>
                                         </fabric:FabricIconControl.Style>
                                     </fabric:FabricIconControl>
                                 </Button>
                                 <Button x:Name="btnTimer"
-                            Style="{StaticResource BtnNoAutoHelpText}"
-                            VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
-                            AutomationProperties.Name="{x:Static properties:Resources.btnTimerAutomationPropertiesName}">
+                                        Style="{StaticResource BtnNoAutoHelpText}"
+                                        VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
+                                        AutomationProperties.Name="{x:Static properties:Resources.btnTimerAutomationPropertiesName}">
                                     <Button.ToolTip>
                                         <ToolTip>
                                             <Run Text="{x:Static properties:Resources.btnTimerAutomationPropertiesName}" />
@@ -439,7 +451,7 @@
                                         <behaviors:DropDownButtonBehavior/>
                                         <behaviors:KeyboardToolTipButtonBehavior/>
                                     </i:Interaction.Behaviors>
-                                    <fabric:FabricIconControl GlyphName="Timer" FontSize="16" Foreground="{DynamicResource ResourceKey=WindowBorderTextBrush}"/>
+                                    <fabric:FabricIconControl GlyphName="Timer" FontSize="16" Style="{StaticResource hoverAwareFabricIcon}"/>
                                     <Button.ContextMenu>
                                         <ContextMenu>
                                             <MenuItem Name="miTimer" AutomationProperties.Name="{x:Static properties:Resources.miTimerAutomationPropertiesName}" Click="btnTimer_Click">
@@ -447,7 +459,7 @@
                                                     <TextBlock Name="tbTimer">
                                                     <Run Text="{x:Static properties:Resources.tbTimerText1}"/>
                                                     <TextBox TextChanged="tbxTimer_TextChanged" Name="tbxTimer" PreviewTextInput="tbxTimer_PreviewTextInput" Text="5" MaxLength="2" FontSize="11" Width="16" Margin="2,-4" 
-                                                             AutomationProperties.LabeledBy="{Binding RelativeSource={RelativeSource AncestorType={x:Type TextBlock}}}"/>                                                    
+                                                             AutomationProperties.LabeledBy="{Binding RelativeSource={RelativeSource AncestorType={x:Type TextBlock}}}"/>
                                                     <Run Text="{x:Static properties:Resources.tbTimerText2}"/>
                                                     </TextBlock>
                                                 </MenuItem.Header>
@@ -456,9 +468,9 @@
                                     </Button.ContextMenu>
                                 </Button>
                                 <Button x:Name="btnLoad"
-                                Style="{StaticResource BtnNoAutoHelpText}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinLoadButton}"
-                                VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
-                                AutomationProperties.Name="{x:Static properties:Resources.btnLoadAutomationPropertiesName}" Click="btnLoad_Click">
+                                        Style="{StaticResource BtnNoAutoHelpText}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinLoadButton}"
+                                        VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
+                                        AutomationProperties.Name="{x:Static properties:Resources.btnLoadAutomationPropertiesName}" Click="btnLoad_Click">
                                     <Button.ToolTip>
                                         <ToolTip>
                                             <Run Text="{x:Static properties:Resources.btnLoadAutomationPropertiesName}" />
@@ -467,7 +479,7 @@
                                     <i:Interaction.Behaviors>
                                         <behaviors:KeyboardToolTipButtonBehavior/>
                                     </i:Interaction.Behaviors>
-                                    <fabric:FabricIconControl GlyphName="OpenFolderHorizontal" FontSize="16" Foreground="{DynamicResource ResourceKey=WindowBorderTextBrush}"/>
+                                    <fabric:FabricIconControl GlyphName="OpenFolderHorizontal" FontSize="16" Style="{StaticResource hoverAwareFabricIcon}"/>
                                 </Button>
                             </StackPanel>
                             <Label DockPanel.Dock="Right" Padding="8,0" Name="lblVersion" HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Row="0" FontSize="{StaticResource ConstStandardTextSize}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>


### PR DESCRIPTION
#### Describe the change
Issue #756 calls out a regression that (as a result of the dark mode changes) several icons disappear in HC White mode. This change creates 4 new colors in the palette and leverages these color to ensure that HC modes (especially HC White) are working properly. It restore pre-dark mode parity, plus it fixes the fact that command bar icons were kind of broken on mouse hover in HC White mode. There are still some mouse hover issues in HC White mode, but those will get fixed in a separate PR.

Also, #756 only called out issues in Live mode. This also fixes a couple of icons in Test mode that had the same problem (no screenshots for these)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ x Does this address an existing issue? If yes, Issue# - #756 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Production (before dark mode changes):
![image](https://user-images.githubusercontent.com/45672944/78931755-41a27580-7a5b-11ea-964e-9d5077d9176e.png)

Canary (with dark mode changes):
![image](https://user-images.githubusercontent.com/45672944/78931828-5e3ead80-7a5b-11ea-9474-df882b3706ee.png)

Version with these changes:
![image](https://user-images.githubusercontent.com/45672944/78935103-f25f4380-7a60-11ea-84a1-1579092a85d8.png)

Things to note:
- Light and dark remain unchanged
- Command bar backgrounds are back to what they are in Production
- Icons in non-hover HC White are visible again (same as Production)
- Icons in hover HC White have sufficient contrast (fixes an issue in Production)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



