### PR TITLE
Improve highlighter contrast in HC modes

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Highlighting/Win32SnapshotButton.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/Win32SnapshotButton.cs
@@ -66,7 +66,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
             this.BackgroundBrush = System.Drawing.Color.FromArgb(brush.Color.A, brush.Color.R, brush.Color.G, brush.Color.B);
             brush = Application.Current.Resources["SnapshotBtnHoverBrush"] as SolidColorBrush;
             this.HoveredBackgroundBrush = System.Drawing.Color.FromArgb(brush.Color.A, brush.Color.R, brush.Color.G, brush.Color.B);
-            brush = Application.Current.Resources["WhiteTextBrush"] as SolidColorBrush;
+            brush = Application.Current.Resources["SnapshotBtnFGBrush"] as SolidColorBrush;
             this.FontBrush = System.Drawing.Color.FromArgb(brush.Color.A, brush.Color.R, brush.Color.G, brush.Color.B);
 
             beakerIconCollection = new Dictionary<double, Bitmap>();

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -31,7 +31,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="BubbleBGBrush" Color="#696C6F"/>           <!-- (UPDATED) Used ONLY for "New for WCAG 2.1" bubble -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedTextBrush" Color="#FFFFFF"/>       <!-- (UPDATED) Generic selected text color (used everywhere) -->
     <SolidColorBrush po:Freeze="True" x:Key="IconBrush" Color="#FFFFFF"/>               <!-- (UPDATED) Used for fabric icons, some (incorrect?) borders -->
-    <SolidColorBrush po:Freeze="True" x:Key="WhiteTextBrush" Color="#FFFFFF"/>          <!-- Text color (normal) for snapshot button and video player -->
+    <SolidColorBrush po:Freeze="True" x:Key="WhiteTextBrush" Color="#FFFFFF"/>          <!-- Text color (normal) for video player -->
     <SolidColorBrush po:Freeze="True" x:Key="WhiteTextHoverBrush" Color="#FFFFFF"/>     <!-- Text color (hover) for snapshot button and video player -->
     <SolidColorBrush po:Freeze="True" x:Key="BorderBrush" Color="#C7C7C7"/>             <!-- Generic light border (used everywhere) -->
     <SolidColorBrush po:Freeze="True" x:Key="LightIconBrush" Color="#EAEAEA"/>          <!-- Used to draw the icons on the nav bar -->
@@ -102,5 +102,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="IconHoverFGBrush" Color="#FFFFFF"/>        <!-- (UPDATED) Foreground of icons on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="CommandBarBGBrush" Color="#2B3034"/>       <!-- (UPDATED) Background of command bar -->
     <SolidColorBrush po:Freeze="True" x:Key="CommandBarFGBrush" Color="#FFFFFF"/>       <!-- (UPDATED) Foreground of command bar -->
-    <SolidColorBrush po:Freeze="True" x:Key="FocusBorderBrush" Color="#FFFFFF"/>        <!-- (UPDATED) Border color to track keyboard focus -->
+    <SolidColorBrush po:Freeze="True" x:Key="FocusBorderBrush" Color="#FFFFFF"/>        <!-- (UPDATED) Border of keyboard focus tracker -->
+    <SolidColorBrush po:Freeze="True" x:Key="SnapshotBtnFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground of snapshot button -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -42,13 +42,13 @@
     <SolidColorBrush po:Freeze="True" x:Key="BtnBrderBrush" Color="{x:Static SystemColors.ControlDarkColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ToggleSliderBlueBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="LoadingBrush" Color="{x:Static SystemColors.HighlightColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="SnapshotBtnBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="SnapshotBtnBGBrush" Color="{x:Static SystemColors.HotTrackColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SnapshotBtnHoverBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="WhiteTextBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="HLbrushRed" Color="#CC0000"/>
     <SolidColorBrush po:Freeze="True" x:Key="HLbrushGreen" Color="#107c10"/>
     <SolidColorBrush po:Freeze="True" x:Key="HLbrushPurple" Color="#A45EF4"/>
-    <SolidColorBrush po:Freeze="True" x:Key="HLDefaultBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="HLDefaultBrush" Color="{x:Static SystemColors.HotTrackColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="HLGreenTextBrush" Color="#00FF00 "/>
     <SolidColorBrush po:Freeze="True" x:Key="HLTextBrush" Color="#FFFF00 "/>
     <SolidColorBrush po:Freeze="True" x:Key="BorderBrush" Color="{x:Static SystemColors.InactiveBorderColor}" />

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -86,4 +86,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="CommandBarBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="CommandBarFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="FocusBorderBrush" Color="{x:Static SystemColors.WindowFrameColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="SnapshotBtnFGBrush" Color="{x:Static SystemColors.MenuBarColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -103,4 +103,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="CommandBarBGBrush" Color="#F4F4F4"/>
     <SolidColorBrush po:Freeze="True" x:Key="CommandBarFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="FocusBorderBrush" Color="#000000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="SnapshotBtnFGBrush" Color="#FFFFFF"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights/App.xaml.cs
+++ b/src/AccessibilityInsights/App.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.Enums;
+using AccessibilityInsights.SharedUx.Highlighting;
 using System;
 using System.Collections.Generic;
 using System.Windows;
@@ -85,6 +86,7 @@ namespace AccessibilityInsights
             Resources.MergedDictionaries.Remove(this.themeResourceDictionaty);
             this.themeResourceDictionaty = new ResourceDictionary() { Source = Brushes[theme] };
             Resources.MergedDictionaries.Add(this.themeResourceDictionaty);
+            HollowHighlightDriver.ClearAllHighlighters();
 
             // give the window a border if in high contrast mode
             if (theme == Theme.HighContrast)


### PR DESCRIPTION
#### Describe the change
Highlighter and snapshot button contrast is a little odd in high contrast modes. It's something of an inexact science, since it depends on the pixels around the element being highlighted, but this change makes it a little better. We use the system-defined "Hot tracking color", which is defined [here](https://docs.microsoft.com/en-us/dotnet/api/system.windows.systemcolors.hottrackcolor?view=netframework-4.8) as "The color used to designate a hot-tracked item".

The Snapshot button background is drawn in the same color, and the snapshot button icon is drawn in a system color that is always black in HC Black themes, and white in the HC White theme.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 1661682. Note that the bug is fairly vague, but the bug has been interpreted in triage as referring to the highlighter color in HC modes.
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Light and dark mode haven't changed, and we've made no attempt to respect HC settings in the tooltip. These screen grabs are all taken using calc.exe:
![image](https://user-images.githubusercontent.com/45672944/78948906-bcc95300-7a7e-11ea-8c22-75038dc619a6.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



