### PR TITLE
More dark mode changes

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -95,7 +95,7 @@
                 <Button Click="changeButton_Click" Cursor="Hand" Grid.Row="1" HorizontalAlignment="Right" Margin="0 4px" AutomationProperties.Name="{x:Static Properties:Resources.ButtonAutomationPropertiesNameChangeTeam}" IsTabStop="True" Style="{DynamicResource BtnStandard}">
                     <Button.Template>
                         <ControlTemplate>
-                            <TextBlock Text="{x:Static Properties:Resources.TextBlockTextChange}" TextWrapping="Wrap" Foreground="Blue"/>
+                            <TextBlock Text="{x:Static Properties:Resources.TextBlockTextChange}" TextWrapping="Wrap" Foreground="{DynamicResource ResourceKey=ButtonLinkFGBrush}"/>
                         </ControlTemplate>
                     </Button.Template>
                 </Button>

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -211,7 +211,7 @@
                     <behaviors:KeyboardToolTipButtonBehavior/>
                 </i:Interaction.Behaviors>
                 <Button.Style>
-                    <Style TargetType="Button" BasedOn="{StaticResource BtnStandard}">
+                    <Style TargetType="Button" BasedOn="{StaticResource BtnOnSelectedLine}">
                         <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
                         <Setter Property="Button.ToolTip">
                             <Setter.Value>
@@ -220,7 +220,7 @@
                         </Setter>
                     </Style>
                 </Button.Style>
-                <controls:FabricIconControl GlyphName="TestBeaker" Foreground="{DynamicResource ResourceKey=TreeViewSelectedFGBrush}" Background="{DynamicResource ResourceKey=SelectedBrush}" GlyphSize="Custom" FontSize="14"/>
+                <controls:FabricIconControl GlyphName="TestBeaker" Foreground="{DynamicResource ResourceKey=TreeViewSelectedFGBrush}" Background="{DynamicResource ResourceKey=SelectedBrush}" GlyphSize="Custom" FontSize="14" Padding="1,1,1,1"/>
             </Button>
             <Button x:Name="btnMenu" Grid.Column="1" Margin="0,18,4,0"
                    HorizontalAlignment="Right" VerticalContentAlignment="Center"
@@ -232,12 +232,12 @@
                     <behaviors:DropDownButtonBehavior/>
                     <behaviors:KeyboardToolTipButtonBehavior/>
                 </i:Interaction.Behaviors>
-                <controls:FabricIconControl GlyphName="More" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=TreeViewSelectedFGBrush}" Background="{DynamicResource ResourceKey=SelectedBrush}"/>
+                <controls:FabricIconControl GlyphName="More" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=TreeViewSelectedFGBrush}" Background="{DynamicResource ResourceKey=SelectedBrush}" Padding="2,2,2,2"/>
                 <Button.ToolTip>
                     <ToolTip Content="{x:Static Properties:Resources.SetterValueMoreOptions}"/>
                 </Button.ToolTip>
                 <Button.Style>
-                    <Style TargetType="Button" BasedOn="{StaticResource BtnStandard}">
+                    <Style TargetType="Button" BasedOn="{StaticResource BtnOnSelectedLine}">
                         <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding IsLiveMode}" Value="False">

--- a/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
@@ -94,8 +94,7 @@
                                         <ContextMenu AutomationProperties.Name="{x:Static Properties:Resources.btnSettingAutomationPropertiesName2}">
                                             <MenuItem Header="_Include all properties that have values" x:Name="mniShowCoreProps" IsCheckable="true" 
                                                     Checked="mniShowCoreProps_Checked" Unchecked="mniShowCoreProps_Unchecked" Loaded="mniShowCoreProps_Loaded"/>
-                                            <MenuItem Header="_Configure properties to always show" x:Name="mniIncludeAllProps" Click="mniIncludeAllProps_Click"
-                                                    />
+                                            <MenuItem Header="_Configure properties to always show" x:Name="mniIncludeAllProps" Click="mniIncludeAllProps_Click" />
                                         </ContextMenu>
                                     </Button.ContextMenu>
                                 </Button>

--- a/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
@@ -93,9 +93,9 @@
                                     <Button.ContextMenu>
                                         <ContextMenu AutomationProperties.Name="{x:Static Properties:Resources.btnSettingAutomationPropertiesName2}">
                                             <MenuItem Header="_Include all properties that have values" x:Name="mniShowCoreProps" IsCheckable="true" 
-                                    Background="{DynamicResource ResourceKey=SecondaryBGBrush}" Checked="mniShowCoreProps_Checked" Unchecked="mniShowCoreProps_Unchecked" Loaded="mniShowCoreProps_Loaded"/>
+                                                    Checked="mniShowCoreProps_Checked" Unchecked="mniShowCoreProps_Unchecked" Loaded="mniShowCoreProps_Loaded"/>
                                             <MenuItem Header="_Configure properties to always show" x:Name="mniIncludeAllProps" Click="mniIncludeAllProps_Click"
-                                    Background="{DynamicResource ResourceKey=SecondaryBGBrush}"/>
+                                                    />
                                         </ContextMenu>
                                     </Button.ContextMenu>
                                 </Button>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -112,11 +112,11 @@
                                 </TextBlock>
                         </StackPanel>
                         <StackPanel Name="spConfidence" Orientation="Vertical" Margin="10,10,0,6" MinWidth="132">
-                            <TextBlock Name="tbConfidenceLabel" Text="{x:Static Properties:Resources.ColorContrast_Confidence}" FontSize="14"/>
+                            <TextBlock Name="tbConfidenceLabel" Text="{x:Static Properties:Resources.ColorContrast_Confidence}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" FontSize="14"/>
                             <TextBlock x:Name="tbConfidence" FontWeight="SemiBold" FontSize="17" HorizontalAlignment="Left"
                                        AutomationProperties.LiveSetting="Polite" VerticalAlignment="Center"
                                        AutomationProperties.Name="{Binding Text, RelativeSource={RelativeSource Self}, StringFormat={x:Static Properties:Resources.ColorContrast_tbConfidenceAutomationName}}"
-                                       KeyboardNavigation.TabIndex="4" Focusable="True">
+                                       KeyboardNavigation.TabIndex="4" Focusable="True" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}">
                             </TextBlock>
                         </StackPanel>
                     </StackPanel>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -11,7 +11,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="WindowBorderTextBrush" Color="#FFFFFF"/>   <!-- (UPDATED) Caption Text -->
     <SolidColorBrush po:Freeze="True" x:Key="StartupInnerBorderBrush" Color="#6D767E"/> <!-- (UPDATED) Inner Border on Startup dialog -->
     <SolidColorBrush po:Freeze="True" x:Key="StartupFGBrush" Color="#FFFFFF"/>          <!-- (UPDATED) Text in Startup dialog -->
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedBrush" Color="#6D767E"/>           <!-- (UPDATED) Selected item highlight in Hierarchy and "How to Fix" view -->
+    <SolidColorBrush po:Freeze="True" x:Key="SelectedBrush" Color="#31383D"/>           <!-- (UPDATED) Selected item highlight in Hierarchy and "How to Fix" view -->
     <SolidColorBrush po:Freeze="True" x:Key="LoadingBrush" Color="#6BADE0"/>            <!-- (UPDATED) Progress ring (dots and text) -->
     <SolidColorBrush po:Freeze="True" x:Key="DisabledOverlayBrush" Color="#FDFDFD"/>    <!-- MainWindow: Overlay for "Tab Stops" ? -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedTabBrush" Color="#6D767E"/>        <!-- (UPDATED) Background brush of selected tab in Tests view -->
@@ -88,7 +88,7 @@
     <SolidColorBrush x:Key="SelectionDropDownListBGBrush" Color="#31383D"/>             <!-- (UPDATED) List background of selection combobox in command bar -->
     <SolidColorBrush po:Freeze="True" x:Key="StartupPrimaryBGBrush" Color="#22272B"/>   <!-- (UPDATED) Startup Primary background brush -->
     <SolidColorBrush po:Freeze="True" x:Key="StartupSecondaryBGBrush" Color="#2B3034"/> <!-- (UPDATED) Startup Secondary background brush -->
-    <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedFGBrush" Color="#000000"/> <!-- (UPDATED) Selected text color in TreeView -->
+    <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedFGBrush" Color="#FFFFFF"/> <!-- (UPDATED) Selected text color in TreeView -->
     <SolidColorBrush po:Freeze="True" x:Key="ActionsButtonHoverBGBrush" Color="#6D767E"/>    <!-- (UPDATED NEEDS UI REVIEW) Background Hover for "Actions" button in Patterns pane -->
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="#000000"/>     <!-- (UPDATED) Foreground of column headers in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="#6D767E"/>     <!-- (UPDATED) Background of column headers in data grid (list of properties) -->

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -92,7 +92,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="ActionsButtonHoverBGBrush" Color="#6D767E"/>    <!-- (UPDATED NEEDS UI REVIEW) Background Hover for "Actions" button in Patterns pane -->
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="#000000"/>     <!-- (UPDATED) Foreground of column headers in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="#6D767E"/>     <!-- (UPDATED) Background of column headers in data grid (list of properties) -->
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="#000000"/>      <!-- (UPDATED) Foreground of selected row in a data grid (list of properties) -->
+    <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground of selected row in a data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedTabFGBrush" Color="#000000"/>      <!-- (UPDATED) Foreground brush of selected tab in Tests view -->
     <SolidColorBrush po:Freeze="True" x:Key="TabHorizontalBorderBrush" Color="Transparent"/>    <!-- (UPDATED) Horizontal Border between tab items in test mode -->
     <SolidColorBrush po:Freeze="True" x:Key="ACRowHoverBGBrush" Color="#2B3034"/>       <!-- (UPDATED) Hover background color of automated checks rows -->

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -99,4 +99,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="#000000"/>    <!-- (UPDATED) Foreground color of selected tab stop rows -->
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="#B2B3B5"/>    <!-- (UPDATED) Background color of selected tab stop rows -->
     <SolidColorBrush po:Freeze="True" x:Key="TSRowHoverBGBrush" Color="#31383D"/>       <!-- (UPDATED) Hover color of selected tab stop rows -->
+    <SolidColorBrush po:Freeze="True" x:Key="FastPassLabelFGBrush" Color="#FFFFFF"/>    <!-- (UPDATED) Foreground brush of "FastPass" label and icon -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -46,7 +46,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="SettingsTabBgBrush" Color="Transparent"/>  <!-- Keep Transparent in dark -->
     <SolidColorBrush po:Freeze="True" x:Key="ActionsButtonBGBrush" Color="#444C52"/>    <!-- (UPDATED) Background for "Actions" button in Patterns pane -->
     <SolidColorBrush po:Freeze="True" x:Key="SecondaryBGBrush" Color="#2B3034"/>        <!-- (UPDATED) Secondary background brush (not u-->
-    <SolidColorBrush po:Freeze="True" x:Key="GreyBackgroundBrush" Color="#EAEAEA"/>     <!-- Horizontal rules in color contrast, borders of ADO's "disconnect" button -->
+    <SolidColorBrush po:Freeze="True" x:Key="GreyBackgroundBrush" Color="#EAEAEA"/>     <!-- Horizontal rules in color contrast -->
     <SolidColorBrush po:Freeze="True" x:Key="ActiveModeBrush" Color="#FFFFFF"/>         <!-- Color of "active" marker in nav bar -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledBrush" Color="#656E75"/>     <!-- (UPDATED) Background of disabled button (example: Later button in update dialog on mandatory update) -->
     <SolidColorBrush po:Freeze="True" x:Key="PrimaryBGBrush" Color="#22272B"/>          <!-- (UPDATED) Primary background brush (not in startup mode) -->
@@ -99,5 +99,8 @@
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="#000000"/>    <!-- (UPDATED) Foreground color of selected tab stop rows -->
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="#B2B3B5"/>    <!-- (UPDATED) Background color of selected tab stop rows -->
     <SolidColorBrush po:Freeze="True" x:Key="TSRowHoverBGBrush" Color="#31383D"/>       <!-- (UPDATED) Hover color of selected tab stop rows -->
-    <SolidColorBrush po:Freeze="True" x:Key="FastPassLabelFGBrush" Color="#FFFFFF"/>    <!-- (UPDATED) Foreground brush of "FastPass" label and icon -->
+    <SolidColorBrush po:Freeze="True" x:Key="FastPassLabelFGBrush" Color="#FFFFFF"/>    <!-- (UPDATED) Foreground of "FastPass" label and icon -->
+    <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGBrush" Color="#EAEAEA"/>       <!-- (UPDATED) Background of "BtnGreySquared" buttons -->
+    <SolidColorBrush po:Freeze="True" x:Key="GreyButtonFGBrush" Color="#000000"/>       <!-- (UPDATED) Foreground of "BtnGreySquared" buttons -->
+    <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGHoverBrush" Color="#B2B3B5"/>  <!-- (UPDATED) Background of "BtnGreySquared" buttons on hover -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -108,4 +108,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGBrush" Color="#EAEAEA"/>       <!-- (UPDATED) Background of "BtnGreySquared" buttons -->
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonFGBrush" Color="#000000"/>       <!-- (UPDATED) Foreground of "BtnGreySquared" buttons -->
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGHoverBrush" Color="#B2B3B5"/>  <!-- (UPDATED) Background of "BtnGreySquared" buttons on hover -->
+    <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedHoverBrush" Color="#FFFFFF"/>   <!-- (UPDATED) Hover of "BtnOnSelectedLine" buttons -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -90,4 +90,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="FastPassLabelFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedHoverBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -83,4 +83,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="FastPassLabelFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="GreyButtonFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -82,4 +82,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="FastPassLabelFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -100,4 +100,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="#EFF6FC"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowHoverBGBrush" Color="#F4F4F4"/>
     <SolidColorBrush po:Freeze="True" x:Key="FastPassLabelFGBrush" Color="#6E6E6E"/>
+    <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGBrush" Color="#EAEAEA"/>
+    <SolidColorBrush po:Freeze="True" x:Key="GreyButtonFGBrush" Color="#000000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGHoverBrush" Color="#CCCCCC"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -108,4 +108,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGBrush" Color="#EAEAEA"/>
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGHoverBrush" Color="#CCCCCC"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedHoverBrush" Color="#BEE6Fd"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -99,4 +99,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="#EFF6FC"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowHoverBGBrush" Color="#F4F4F4"/>
+    <SolidColorBrush po:Freeze="True" x:Key="FastPassLabelFGBrush" Color="#6E6E6E"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1079,8 +1079,8 @@
         <Setter Property="Border.CornerRadius" Value="0"/>
     </Style>
     <Style TargetType="{x:Type Button}" x:Key="BtnGreySquared">
-        <Setter Property="Background" Value="{DynamicResource ResourceKey=GreyBackgroundBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource ResourceKey=GreyButtonBGBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=GreyButtonFGBrush}"/>
         <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
         <Setter Property="FontSize" Value="{DynamicResource ResourceKey=StandardTextSize}"/>
         <Setter Property="BorderThickness" Value="{DynamicResource ResourceKey=BtnBrdrThickness}"/>
@@ -1098,7 +1098,7 @@
         </Setter>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="{DynamicResource ResourceKey=ActionsButtonBGBrush}"/>
+                <Setter Property="Background" Value="{DynamicResource ResourceKey=GreyButtonBGHoverBrush}"/>
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -88,6 +88,22 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <Style TargetType="{x:Type Button}" x:Key="BtnOnSelectedLine" BasedOn="{StaticResource BtnStandard}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+                        <ContentPresenter RecognizesAccessKey="True" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Margin="{TemplateBinding Padding}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource ResourceKey=TreeViewSelectedHoverBrush}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
     <!--BtnNoAutoHelpText has " " HelpText to prevent the button's ToolTip content from being used as HelpText-->
     <Style TargetType="{x:Type Button}" x:Key="BtnNoAutoHelpText" BasedOn="{StaticResource BtnStandard}">
         <Setter Property="AutomationProperties.HelpText" Value=" "/>

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
@@ -46,13 +46,13 @@
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
                         <TabControl Name="tcTabs" Grid.Row="0" BorderThickness="0,1,0,0" BorderBrush="{DynamicResource ResourceKey=TabBorderBrush}" Style="{StaticResource tcScrolling}" SelectionChanged="TabControl_SelectionChanged">
-                            <TabItem Header="{x:Static properties:Resources.tcTabsApplicationHeader}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsApplicationTabItem}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiApplication" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Application}">
+                            <TabItem Header="{x:Static properties:Resources.tcTabsApplicationHeader}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsApplicationTabItem}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiApplication" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Application}">
                                 <controls:ApplicationSettingsControl x:Name="appSettingsCtrl"/>
                             </TabItem>
-                            <TabItem Header="{x:Static properties:Resources.tcTabsConnectionHeader}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsConnectionTabItem}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiConnection" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Connection}">
+                            <TabItem Header="{x:Static properties:Resources.tcTabsConnectionHeader}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsConnectionTabItem}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Name="tbiConnection" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.Connection}">
                                 <controls:ConnectionControl x:Name="connectionCtrl"/>
                             </TabItem>
-                            <TabItem Header="{x:Static properties:Resources.tcTabsAboutHeader}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsAboutTabItem}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.About}">
+                            <TabItem Header="{x:Static properties:Resources.tcTabsAboutHeader}" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SettingsAboutTabItem}" Style="{StaticResource ResourceKey=tbiSettingsTab}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" Tag="{x:Static Member=local:ConfigurationModeControl+SettingModes.About}">
                                 <controls:AboutTabControl x:Name="aboutTabCtrl"/>
                             </TabItem>
                         </TabControl>

--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml
@@ -32,8 +32,8 @@
                                 <ColumnDefinition Width="4"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <fabric:FabricIconControl Grid.Column="0" GlyphName="Rocket" GlyphSize="Custom" FontSize="14" VerticalAlignment="Center" Margin="0,4,0,2" Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}" ShowInControlView="False" Background="Transparent"/>
-                            <Label Name="lblFastpass" Grid.Column="2" Content="{x:Static properties:Resources.tabControlLabelContent}" Style="{StaticResource lblXLHeader}" VerticalAlignment="Top" Background="Transparent"/>
+                            <fabric:FabricIconControl Grid.Column="0" GlyphName="Rocket" GlyphSize="Custom" FontSize="14" VerticalAlignment="Center" Margin="0,4,0,2" Foreground="{DynamicResource ResourceKey=FastPassLabelFGBrush}" ShowInControlView="False" Background="Transparent"/>
+                            <Label Name="lblFastpass" Grid.Column="2" Content="{x:Static properties:Resources.tabControlLabelContent}" Style="{StaticResource lblXLHeader}" VerticalAlignment="Top" Foreground="{DynamicResource ResourceKey=FastPassLabelFGBrush}" Background="Transparent"/>
                         </Grid>
                     </TabItem.Header>
                 </TabItem>


### PR DESCRIPTION
#### Describe the change
This provides more fixes to dark modes, and fixes a high contrast issue that was discovered along the way.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Problem 1: Captions in the "Test Results view" didn't respect dark mode. Current behavior is on top, updated behavior on the bottom (ignore scale difference):
![image](https://user-images.githubusercontent.com/45672944/79286497-a9026000-7e75-11ea-8ccc-5cf547107fd4.png)

Problem 2: "Disconnect Azure Boards account" button needed a different foreground color. Current behavior is on top, updated behavior on the bottom (ignore scale difference):
![image](https://user-images.githubusercontent.com/45672944/79286555-d64f0e00-7e75-11ea-93f7-06e1d21ba4dd.png)

Problem 3: Non-selected tabs in the settings dialog needed a different foreground color. Current behavior is on top, updated behavior on the bottom (ignore scale difference):
![image](https://user-images.githubusercontent.com/45672944/79286600-f979bd80-7e75-11ea-98b9-70654ab6eeaf.png)

Problem 4: "FastPass" text and icon need to stand out more in dark mode. Current behavior is on top, updated behavior on the bottom (ignore scale difference):
![image](https://user-images.githubusercontent.com/45672944/79286645-1d3d0380-7e76-11ea-9449-558627dffa3e.png)

Problem 5: "Selected team" and "Change" have insufficient contrast in ADO connection dialog. Current behavior is on top, updated behavior on the bottom (ignore scale difference):
![image](https://user-images.githubusercontent.com/45672944/79286729-583f3700-7e76-11ea-9a10-cc7a717230d5.png)

Problem 6: Confidence level text in automated color contrast result needs to stand out more in dark mode. Current behavior is on top, updated behavior on the bottom (ignore scale difference):
![image](https://user-images.githubusercontent.com/45672944/79287257-131c0480-7e78-11ea-8017-4ada61723bfb.png)

Problem 7: Menu to select properties to display needs higher contrast in dark mode. Current behavior is on top, updated behavior on the bottom (ignore scale difference):
![image](https://user-images.githubusercontent.com/45672944/79286866-c71c9000-7e76-11ea-8ffa-0dd161150716.png)

Problem 8: "Test element" and "More options" buttons in hierarchy view have a hover border with insufficient contrast in dark mode, and no border at all in any HC mode (because the background and the highlight are the same color). Current behavior is on the left, updated behavior is on the right. An eagle-eyed observer might notice that the light mode border is narrower than it used to be. This is an effect of separating the border a bit from the beaker icon. The images show only the "Test element" icon but the "More options" all follow the same visual pattern. From the top, we have Light mode, Dark mode, HC 1, HC 2, HC Black, and HC White:
![image](https://user-images.githubusercontent.com/45672944/79287007-41e5ab00-7e77-11ea-8403-a31f63bdbc1e.png)


> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



