### PR TITLE
Enable dark mode by default

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationConstants.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationConstants.cs
@@ -37,8 +37,8 @@ namespace AccessibilityInsights.SharedUx.Settings
         private const string keyAppVersion = "AppVersion";
         private const string keyCoreProperties = "CoreProperties";
         private const string keyCoreTPAttributes = "CoreTPAttributes";
+        private const string keyDisableDarkMode = "DisableDarkMode";
         private const string keyDisableTestsInSnapMode = "DisableTestsInSnapMode";
-        private const string keyEnableDarkMode = "EnableDarkMode";
         private const string keyEnableTelemetry = "EnableTelemetry";
         private const string keyEventRecordPath = "EventRecordPath";
         public const string keyFontSize = "FontSize";

--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
@@ -423,12 +423,12 @@ namespace AccessibilityInsights.SharedUx.Settings
         }
 
         /// <summary>
-        /// If true, dark mode will be enabled
+        /// If true, dark mode will be disabled
         /// </summary>
-        public bool EnableDarkMode
+        public bool DisableDarkMode
         {
-            get => GetDataValue<bool>(keyEnableDarkMode);
-            set => SetDataValue<bool>(keyEnableDarkMode, value);
+            get => GetDataValue<bool>(keyDisableDarkMode);
+            set => SetDataValue<bool>(keyDisableDarkMode, value);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUxTests/Resources/ConfigSettings.json
+++ b/src/AccessibilityInsights.SharedUxTests/Resources/ConfigSettings.json
@@ -14,8 +14,8 @@
         30101
     ],
     "CoreTPAttributes": [],
+    "DisableDarkMode": true,
     "DisableTestsInSnapMode": false,
-    "EnableDarkMode": true,
     "EnableTelemetry": false,
     "EventRecordPath": "C:\\blah\\AccessibilityInsightsEventFiles",
     "FontSize": "Small",

--- a/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
@@ -97,7 +97,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
                 config.CoreProperties.ToArray());
             ConfirmEnumerablesMatchExpectations(new int[] { }, config.CoreTPAttributes.ToArray());
             Assert.IsFalse(config.DisableTestsInSnapMode);
-            Assert.IsFalse(config.EnableDarkMode);
+            Assert.IsFalse(config.DisableDarkMode);
             Assert.IsTrue(config.EnableTelemetry);
             Assert.IsTrue(config.EventRecordPath.Equals(testProvider.UserDataFolderPath));
             Assert.AreEqual(FontSize.Standard, config.FontSize);
@@ -147,7 +147,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
             ConfigurationModel config = ConfigurationModel.LoadFromJSON(@"..\..\Resources\ConfigSettings.json", testProvider);
 
             ConfirmOverrideConfigMatchesExpectation(config,
-                enableDarkMode: true,
+                disableDarkMode: true,
                 issueReporterSerializedConfigs: @"{""27f21dff-2fb3-4833-be55-25787fce3e17"":""hello world""}",
                 selectedIssueReporter: new Guid("{27f21dff-2fb3-4833-be55-25787fce3e17}"),
                 releaseChannel: ReleaseChannel.Canary
@@ -161,7 +161,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
 
         private static void ConfirmOverrideConfigMatchesExpectation(ConfigurationModel config,
             Guid? selectedIssueReporter = null, string issueReporterSerializedConfigs = null,
-            ReleaseChannel? releaseChannel = null, bool enableDarkMode = false)
+            ReleaseChannel? releaseChannel = null, bool disableDarkMode = false)
         {
             Assert.IsFalse(config.AlwaysOnTop);
             Assert.AreEqual("1.1.", config.AppVersion.Substring(0, 4));
@@ -172,7 +172,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
                 config.CoreProperties.ToArray());
             ConfirmEnumerablesMatchExpectations( new int[] { }, config.CoreTPAttributes.ToArray());
             Assert.IsFalse(config.DisableTestsInSnapMode);
-            Assert.AreEqual(config.EnableDarkMode, enableDarkMode);
+            Assert.AreEqual(config.DisableDarkMode, disableDarkMode);
             Assert.IsFalse(config.EnableTelemetry);
             Assert.AreEqual(@"C:\blah\AccessibilityInsightsEventFiles", config.EventRecordPath);
             Assert.AreEqual(FontSize.Small, config.FontSize);

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -231,7 +231,7 @@ namespace AccessibilityInsights
                 // Due to initialization order, config will be null the first time this is called
                 ConfigurationModel config = ConfigurationManager.GetDefaultInstance()?.AppConfig;
 
-                theme = (config != null && config.EnableDarkMode && NativeMethods.IsDarkModeEnabled())
+                theme = (config != null && !config.DisableDarkMode && NativeMethods.IsDarkModeEnabled())
                     ? App.Theme.Dark
                     : App.Theme.Light;
             }


### PR DESCRIPTION
#### Describe the change
We've recently made changes to enable dark mode, but kept the behavior behind a flag that could only be set by manually editing Configuration.json. We now think they're ready to be enabled by default, but we'll keep a config flag to disable them if problems arise.

To disable dark mode in just Accessibility Insights for Windows:

1. Exit Accessibility Insights for Windows
2. Edit %localappdata%\AccessibilityInsights\V1\Configurations\Configuration.json
3. Insert the following line somewhere in the middle of the file: 
    "DisableDarkMode": true,
4. Save the updated file
5. Start Accessibility Insights for Windows


#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



