### PR TITLE
Update the welcome screen

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -15,7 +15,7 @@
     <dialogs:ContainedDialog.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
     </dialogs:ContainedDialog.Resources>
-    <Border MaxHeight="460" MaxWidth="620" VerticalAlignment="Center"
+    <Border MaxHeight="460" MaxWidth="613" VerticalAlignment="Center"
             Background="{DynamicResource ResourceKey=StartupPrimaryBGBrush}"
             BorderThickness="{DynamicResource ResourceKey=BtnBrdrThickness}"
             BorderBrush="{DynamicResource ResourceKey=PrimaryFGBrush}">
@@ -31,7 +31,7 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="13"/>
                 <ColumnDefinition Width="290"/>
-                <ColumnDefinition Width="13"/>
+                <ColumnDefinition Width="6"/>
                 <ColumnDefinition Width="290"/>
                 <ColumnDefinition Width="13"/>
             </Grid.ColumnDefinitions>
@@ -43,7 +43,7 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="14"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="1" Grid.ColumnSpan="3" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" Padding="0"
+                <TextBlock Grid.Column="1" Grid.ColumnSpan="3" FontSize="10" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" Padding="0"
                             FontWeight="Light" VerticalAlignment="Center" TextAlignment="Center" Margin="12">
                     <Run Text="{x:Static properties:Resources.WelcomeToAccessibilityInsightsForWindowsLabelContent}" FontSize="18"/>
                     <LineBreak/>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -15,7 +15,7 @@
     <dialogs:ContainedDialog.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
     </dialogs:ContainedDialog.Resources>
-    <Border MaxHeight="700" MaxWidth="700" VerticalAlignment="Center"
+    <Border MaxHeight="700" MaxWidth="728" VerticalAlignment="Center"
             Background="{DynamicResource ResourceKey=StartupPrimaryBGBrush}"
             BorderThickness="{DynamicResource ResourceKey=BtnBrdrThickness}"
             BorderBrush="{DynamicResource ResourceKey=PrimaryFGBrush}">
@@ -29,11 +29,11 @@
                 <RowDefinition Height="12"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="32"/>
-                <ColumnDefinition Width="300"/>
-                <ColumnDefinition Width="6"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="18"/>
+                <ColumnDefinition Width="16"/>
+                <ColumnDefinition Width="340"/>
+                <ColumnDefinition Width="16"/>
+                <ColumnDefinition Width="340"/>
+                <ColumnDefinition Width="16"/>
             </Grid.ColumnDefinitions>
             <Border Grid.Column="1" Grid.Row="2" Background="{DynamicResource ResourceKey=StartupSecondaryBGBrush}" BorderBrush="{DynamicResource ResourceKey=StartupInnerBorderBrush}" BorderThickness="1">
                 <Grid>
@@ -47,7 +47,7 @@
                         <Run Text="{x:Static properties:Resources.tbVideoText1}"/>
                     </TextBlock>
                     <TextBlock x:Name="videoDescription" Grid.Row="1" FontSize="12" Style="{StaticResource TbFocusable}" Padding="16,10" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" TextWrapping="Wrap" Text="{x:Static properties:Resources.tbVideoText2}"/>
-                    <Button Style="{StaticResource BtnStandard}" Cursor="Hand" Grid.Row="2" Width="240" Height="121" BorderThickness="0" Name="btnVideo" Click="btnVideo_Click" AutomationProperties.LabeledBy="{Binding ElementName=videoDescription}" VerticalAlignment="Top">
+                    <Button Style="{StaticResource BtnStandard}" Cursor="Hand" Grid.Row="2" Width="240" Height="121" BorderThickness="0" Name="btnVideo" Click="btnVideo_Click" AutomationProperties.LabeledBy="{Binding ElementName=videoDescription}" VerticalAlignment="Top" Margin="10">
                         <Grid>
                             <Image Width="240" Height="135" Source="../Resources/video_thumb.png" AutomationProperties.Name="{x:Static properties:Resources.imageVideoAutomationPropertiesName}"/>
                             <Border Opacity=".40" Name="bdOverlay">
@@ -67,7 +67,7 @@
                         </Grid>
                     </Button>
                     <TextBlock Grid.Column="1" Grid.Row="3" Grid.ColumnSpan="3" TextWrapping="Wrap" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" Padding="0"
-                           FontWeight="Light" VerticalAlignment="Center" TextAlignment="Left" Margin="12,20,12,12">
+                           FontWeight="Light" VerticalAlignment="Center" TextAlignment="Left" Margin="12,12,12,12">
                         <Hyperlink x:Name="hlHelp" TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077919"
                                     AutomationProperties.Name="{x:Static properties:Resources.StartupModeControl_moreGuidanceText}" Style="{StaticResource hLink}">
                             <Run Text="{x:Static properties:Resources.StartupModeControl_moreGuidanceText}" FontSize="12" FontWeight="Light"/>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -43,7 +43,7 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="14"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="1" Grid.ColumnSpan="3" FontSize="10" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" Padding="0"
+                <TextBlock Grid.Column="1" Grid.ColumnSpan="3" FontSize="4" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" Padding="0"
                             FontWeight="Light" VerticalAlignment="Center" TextAlignment="Center" Margin="12">
                     <Run Text="{x:Static properties:Resources.WelcomeToAccessibilityInsightsForWindowsLabelContent}" FontSize="18"/>
                     <LineBreak/>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -15,7 +15,7 @@
     <dialogs:ContainedDialog.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
     </dialogs:ContainedDialog.Resources>
-    <Border MaxHeight="700" MaxWidth="700" VerticalAlignment="Center"
+    <Border MaxHeight="460" MaxWidth="620" VerticalAlignment="Center"
             Background="{DynamicResource ResourceKey=StartupPrimaryBGBrush}"
             BorderThickness="{DynamicResource ResourceKey=BtnBrdrThickness}"
             BorderBrush="{DynamicResource ResourceKey=PrimaryFGBrush}">
@@ -24,15 +24,15 @@
                 <RowDefinition Height="8"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="12"/>
+                <RowDefinition Height="8"/>
                 <RowDefinition Height="48"/>
-                <RowDefinition Height="12"/>
+                <RowDefinition Height="8"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="13"/>
-                <ColumnDefinition Width="330"/>
+                <ColumnDefinition Width="290"/>
                 <ColumnDefinition Width="13"/>
-                <ColumnDefinition Width="330"/>
+                <ColumnDefinition Width="290"/>
                 <ColumnDefinition Width="13"/>
             </Grid.ColumnDefinitions>
             <Border Grid.Column="1" Grid.Row="2" Background="{DynamicResource ResourceKey=StartupSecondaryBGBrush}" BorderBrush="{DynamicResource ResourceKey=StartupInnerBorderBrush}" BorderThickness="1">
@@ -89,10 +89,10 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="32"/>
-                        <RowDefinition Height="24"/>
+                        <RowDefinition Height="20"/>
                         <RowDefinition Height="32"/>
-                        <RowDefinition Height="24"/>
-                        <RowDefinition Height="48"/>
+                        <RowDefinition Height="10"/>
+                        <RowDefinition Height="54"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <TextBlock Style="{StaticResource TbFocusable}" Grid.ColumnSpan="8" Padding="16,10,16,0" FontSize="20" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" FontWeight="Light">
@@ -101,13 +101,13 @@
                     <TextBlock Grid.Row="1" Style="{StaticResource TbFocusable}" Grid.ColumnSpan="8" Padding="16,10,16,0" FontSize="12" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" FontWeight="Light">
                         <Run Text="{x:Static properties:Resources.StartupModeControl_shortcutsDescription}"/>
                     </TextBlock>
-                    <TextBlock Grid.Row="2" Grid.ColumnSpan="8" Padding="16,10" TextWrapping="Wrap">
+                    <TextBlock Grid.Row="2" Grid.ColumnSpan="8" Padding="16,6,0,10" TextWrapping="Wrap">
                         <Hyperlink TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2073853"
                                    AutomationProperties.Name="{Binding ElementName=shortcutsDescTxt, Path=Text}" Style="{StaticResource hLink}">
                             <Run x:Name="shortcutsDescTxt" Text="{x:Static properties:Resources.StartupModeControl_shortcutsLinkLabel}" FontSize="12" FontWeight="Light"/>
                         </Hyperlink>  
                     </TextBlock>
-                    <Border Grid.Row="3" Grid.Column="1" Style="{StaticResource BrdrKey}">
+                    <Border Grid.Row="3" Grid.Column="1" Style="{StaticResource BrdrKey}" VerticalAlignment="Center">
                         <Label Name="lblEventHk" Style="{StaticResource LblKey}" Content="Shift + F6" Padding="3,6">
                             <AutomationProperties.Name>
                                 <MultiBinding StringFormat="{}{0} {1}">
@@ -117,8 +117,8 @@
                             </AutomationProperties.Name>
                         </Label>
                     </Border>
-                    <TextBlock Name="txtEventHk" Style="{StaticResource TbBaseWrap}" Grid.Row="3" Grid.Column="3" Text="{x:Static properties:Resources.toggleEventText}" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
-                    <Border Grid.Row="5" Grid.Column="1" Style="{StaticResource BrdrKey}">
+                    <TextBlock Name="txtEventHk" Style="{StaticResource TbBaseWrap}" Grid.Row="3" Grid.Column="3" Text="{x:Static properties:Resources.toggleEventText}" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
+                    <Border Grid.Row="5" Grid.Column="1" Style="{StaticResource BrdrKey}" VerticalAlignment="Center">
                         <Label Name="lblTestHk" Style="{StaticResource LblKey}" Content="Shift + F8" Padding="3,6">
                             <AutomationProperties.Name>
                                 <MultiBinding StringFormat="{}{0} {1}">
@@ -128,8 +128,8 @@
                             </AutomationProperties.Name>
                         </Label>
                     </Border>
-                    <TextBlock Name="txtTesttHk" Style="{StaticResource TbBaseWrap}" Grid.Row="5" Grid.Column="3" Text="{x:Static properties:Resources.runSelectedTestText}" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
-                    <Border Grid.Row="7" Grid.Column="1" Style="{StaticResource BrdrKey}" Height="32" VerticalAlignment="Top">
+                    <TextBlock Name="txtTesttHk" Style="{StaticResource TbBaseWrap}" Grid.Row="5" Grid.Column="3" Text="{x:Static properties:Resources.runSelectedTestText}" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
+                    <Border Grid.Row="7" Grid.Column="1" Style="{StaticResource BrdrKey}" Height="32" VerticalAlignment="Center">
                         <Label Name="lblActivateHk" Style="{StaticResource LblKey}" Content="Shift + F9" Padding="3,6">
                             <AutomationProperties.Name>
                                 <MultiBinding StringFormat="{}{0} {1}">
@@ -139,7 +139,7 @@
                             </AutomationProperties.Name>
                         </Label>
                     </Border>
-                    <TextBlock Name="txtActivateHk" Grid.Row="7" Grid.Column="3" Style="{StaticResource TbBaseWrap}" Text="{x:Static properties:Resources.minmizeOrActivateWindowText}" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
+                    <TextBlock Name="txtActivateHk" Grid.Row="7" Grid.Column="3" Style="{StaticResource TbBaseWrap}" Text="{x:Static properties:Resources.minmizeOrActivateWindowText}" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
                 </Grid>
             </Border>
             <Grid Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="5">
@@ -158,8 +158,8 @@
                     <LineBreak/>
                     <LineBreak/>
                     <Hyperlink x:Name="hlVersion" TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="{Binding Path=AppVersionUri, Mode=OneWay}"
-                                AutomationProperties.Name="{x:Static properties:Resources.hlVersion}" Style="{StaticResource hLink}">
-                        <Run Text="{Binding Path=VersionInfoLabel, Mode=OneWay}" FontSize="12" FontWeight="Light"/>
+                                AutomationProperties.Name="{Binding Path=VersionInfoLabel, Mode=OneWay}" Style="{StaticResource hLink}">
+                        <Run Text="{Binding Path=VersionInfoLabel, Mode=OneWay}" FontSize="12"/>
                     </Hyperlink>
                 </TextBlock>
             </Grid>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -108,7 +108,7 @@
                         </Hyperlink>  
                     </TextBlock>
                     <Border Grid.Row="3" Grid.Column="1" Style="{StaticResource BrdrKey}">
-                        <Label Name="lblEventHk" Style="{StaticResource LblKey}" Content="Shift + F6" Padding="3,1">
+                        <Label Name="lblEventHk" Style="{StaticResource LblKey}" Content="Shift + F6" Padding="3,6">
                             <AutomationProperties.Name>
                                 <MultiBinding StringFormat="{}{0} {1}">
                                     <Binding RelativeSource="{RelativeSource Self}" Path="Content"/>
@@ -119,7 +119,7 @@
                     </Border>
                     <TextBlock Name="txtEventHk" Style="{StaticResource TbBaseWrap}" Grid.Row="3" Grid.Column="3" Text="{x:Static properties:Resources.toggleEventText}" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
                     <Border Grid.Row="5" Grid.Column="1" Style="{StaticResource BrdrKey}">
-                        <Label Name="lblTestHk" Style="{StaticResource LblKey}" Content="Shift + F8" Padding="3,1">
+                        <Label Name="lblTestHk" Style="{StaticResource LblKey}" Content="Shift + F8" Padding="3,6">
                             <AutomationProperties.Name>
                                 <MultiBinding StringFormat="{}{0} {1}">
                                     <Binding RelativeSource="{RelativeSource Self}" Path="Content"/>
@@ -130,7 +130,7 @@
                     </Border>
                     <TextBlock Name="txtTesttHk" Style="{StaticResource TbBaseWrap}" Grid.Row="5" Grid.Column="3" Text="{x:Static properties:Resources.runSelectedTestText}" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
                     <Border Grid.Row="7" Grid.Column="1" Style="{StaticResource BrdrKey}" Height="32" VerticalAlignment="Top">
-                        <Label Name="lblActivateHk" Style="{StaticResource LblKey}" Content="Shift + F9" Padding="3,1">
+                        <Label Name="lblActivateHk" Style="{StaticResource LblKey}" Content="Shift + F9" Padding="3,6">
                             <AutomationProperties.Name>
                                 <MultiBinding StringFormat="{}{0} {1}">
                                     <Binding RelativeSource="{RelativeSource Self}" Path="Content"/>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -143,6 +143,12 @@
                     <Run Text="{x:Static properties:Resources.WelcomeToAccessibilityInsightsForWindowsLabelContent}" FontSize="18"/>
                     <LineBreak/>
                     <Run Text="{x:Static properties:Resources.LabelContentAccessibilityInsightsForWindows}" FontSize="24"/>
+                    <LineBreak/>
+                    <LineBreak/>
+                    <Hyperlink x:Name="hlVersion" TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="{Binding Path=AppVersionUri, Mode=OneWay}"
+                                AutomationProperties.Name="{x:Static properties:Resources.hlVersion}" Style="{StaticResource hLink}">
+                        <Run Text="{Binding Path=VersionInfoLabel, Mode=OneWay}" FontSize="12" FontWeight="Light"/>
+                    </Hyperlink>
                 </TextBlock>
             </Grid>
                 <CheckBox Grid.Column="1" Grid.Row="4" Content="{x:Static properties:Resources.ckbxShowContent}" Name="ckbxShow" FontSize="12" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -67,7 +67,7 @@
                         </Grid>
                     </Button>
                     <TextBlock Grid.Column="1" Grid.Row="3" Grid.ColumnSpan="3" TextWrapping="Wrap" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" Padding="0"
-                           FontWeight="Light" VerticalAlignment="Center" TextAlignment="Left" Margin="12,12,12,12">
+                           FontWeight="Light" VerticalAlignment="Center" TextAlignment="Left" Margin="12,17,12,12">
                         <Hyperlink x:Name="hlHelp" TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077919"
                                     AutomationProperties.Name="{x:Static properties:Resources.StartupModeControl_moreGuidanceText}" Style="{StaticResource hLink}">
                             <Run Text="{x:Static properties:Resources.StartupModeControl_moreGuidanceText}" FontSize="12" FontWeight="Light"/>
@@ -98,14 +98,8 @@
                     <TextBlock Style="{StaticResource TbFocusable}" Grid.ColumnSpan="8" Padding="16,10,16,0" FontSize="20" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" FontWeight="Light">
                         <Run Text="{x:Static properties:Resources.StartupModeControl_shortcutsTitle}"/>
                     </TextBlock>
-                    <TextBlock Grid.Row="1" Style="{StaticResource TbFocusable}" Grid.ColumnSpan="8" Padding="16,10,16,0" FontSize="12" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" FontWeight="Light">
+                    <TextBlock Grid.Row="1" Style="{StaticResource TbFocusable}" Grid.ColumnSpan="8" Padding="16,10,16,15" FontSize="12" Foreground="{DynamicResource ResourceKey=StartupFGBrush}">
                         <Run Text="{x:Static properties:Resources.StartupModeControl_shortcutsDescription}"/>
-                    </TextBlock>
-                    <TextBlock Grid.Row="2" Grid.ColumnSpan="8" Padding="16,6,0,10" TextWrapping="Wrap">
-                        <Hyperlink TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2073853"
-                                   AutomationProperties.Name="{Binding ElementName=shortcutsDescTxt, Path=Text}" Style="{StaticResource hLink}">
-                            <Run x:Name="shortcutsDescTxt" Text="{x:Static properties:Resources.StartupModeControl_shortcutsLinkLabel}" FontSize="12" FontWeight="Light"/>
-                        </Hyperlink>  
                     </TextBlock>
                     <Border Grid.Row="3" Grid.Column="1" Style="{StaticResource BrdrKey}" VerticalAlignment="Center">
                         <Label Name="lblEventHk" Style="{StaticResource LblKey}" Content="Shift + F6" Padding="3,6">
@@ -140,6 +134,12 @@
                         </Label>
                     </Border>
                     <TextBlock Name="txtActivateHk" Grid.Row="7" Grid.Column="3" Style="{StaticResource TbBaseWrap}" Text="{x:Static properties:Resources.minmizeOrActivateWindowText}" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
+                    <TextBlock Grid.Row="8" Grid.ColumnSpan="8" Padding="16,4,0,10" TextWrapping="Wrap">
+                        <Hyperlink TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2073853"
+                                   AutomationProperties.Name="{Binding ElementName=shortcutsDescTxt, Path=Text}" Style="{StaticResource hLink}">
+                            <Run x:Name="shortcutsDescTxt" Text="{x:Static properties:Resources.StartupModeControl_shortcutsLinkLabel}" FontSize="12" FontWeight="Light"/>
+                        </Hyperlink>
+                    </TextBlock>
                 </Grid>
             </Border>
             <Grid Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="5">

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -15,7 +15,7 @@
     <dialogs:ContainedDialog.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
     </dialogs:ContainedDialog.Resources>
-    <Border MaxHeight="700" MaxWidth="728" VerticalAlignment="Center"
+    <Border MaxHeight="700" MaxWidth="700" VerticalAlignment="Center"
             Background="{DynamicResource ResourceKey=StartupPrimaryBGBrush}"
             BorderThickness="{DynamicResource ResourceKey=BtnBrdrThickness}"
             BorderBrush="{DynamicResource ResourceKey=PrimaryFGBrush}">
@@ -29,11 +29,11 @@
                 <RowDefinition Height="12"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="16"/>
-                <ColumnDefinition Width="340"/>
-                <ColumnDefinition Width="16"/>
-                <ColumnDefinition Width="340"/>
-                <ColumnDefinition Width="16"/>
+                <ColumnDefinition Width="13"/>
+                <ColumnDefinition Width="330"/>
+                <ColumnDefinition Width="13"/>
+                <ColumnDefinition Width="330"/>
+                <ColumnDefinition Width="13"/>
             </Grid.ColumnDefinitions>
             <Border Grid.Column="1" Grid.Row="2" Background="{DynamicResource ResourceKey=StartupSecondaryBGBrush}" BorderBrush="{DynamicResource ResourceKey=StartupInnerBorderBrush}" BorderThickness="1">
                 <Grid>
@@ -43,7 +43,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
-                    <TextBlock Name="tbVideo" FontSize="22" Padding="16,10,16,0" FontWeight="Light" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" Style="{StaticResource TbFocusable}" TextWrapping="Wrap">
+                    <TextBlock Name="tbVideo" FontSize="20" Padding="16,10,16,0" FontWeight="Light" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" Style="{StaticResource TbFocusable}" TextWrapping="Wrap">
                         <Run Text="{x:Static properties:Resources.tbVideoText1}"/>
                     </TextBlock>
                     <TextBlock x:Name="videoDescription" Grid.Row="1" FontSize="12" Style="{StaticResource TbFocusable}" Padding="16,10" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" TextWrapping="Wrap" Text="{x:Static properties:Resources.tbVideoText2}"/>
@@ -95,7 +95,7 @@
                         <RowDefinition Height="48"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    <TextBlock Style="{StaticResource TbFocusable}" Grid.ColumnSpan="8" Padding="16,10,16,0" FontSize="22" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" FontWeight="Light">
+                    <TextBlock Style="{StaticResource TbFocusable}" Grid.ColumnSpan="8" Padding="16,10,16,0" FontSize="20" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" FontWeight="Light">
                         <Run Text="{x:Static properties:Resources.StartupModeControl_shortcutsTitle}"/>
                     </TextBlock>
                     <TextBlock Grid.Row="1" Style="{StaticResource TbFocusable}" Grid.ColumnSpan="8" Padding="16,10,16,0" FontSize="12" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" FontWeight="Light">

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -35,6 +35,27 @@
                 <ColumnDefinition Width="290"/>
                 <ColumnDefinition Width="13"/>
             </Grid.ColumnDefinitions>
+            <Grid Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="5">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="14"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="14"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="1" Grid.ColumnSpan="3" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" Padding="0"
+                            FontWeight="Light" VerticalAlignment="Center" TextAlignment="Center" Margin="12">
+                    <Run Text="{x:Static properties:Resources.WelcomeToAccessibilityInsightsForWindowsLabelContent}" FontSize="18"/>
+                    <LineBreak/>
+                    <Run Text="{x:Static properties:Resources.LabelContentAccessibilityInsightsForWindows}" FontSize="24"/>
+                    <LineBreak/>
+                    <LineBreak/>
+                    <Hyperlink x:Name="hlVersion" TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="{Binding Path=AppVersionUri, Mode=OneWay}"
+                                AutomationProperties.Name="{Binding Path=VersionInfoLabel, Mode=OneWay}" Style="{StaticResource hLink}">
+                        <Run Text="{Binding Path=VersionInfoLabel, Mode=OneWay}" FontSize="12"/>
+                    </Hyperlink>
+                </TextBlock>
+            </Grid>
             <Border Grid.Column="1" Grid.Row="2" Background="{DynamicResource ResourceKey=StartupSecondaryBGBrush}" BorderBrush="{DynamicResource ResourceKey=StartupInnerBorderBrush}" BorderThickness="1">
                 <Grid>
                     <Grid.RowDefinitions>
@@ -142,27 +163,6 @@
                     </TextBlock>
                 </Grid>
             </Border>
-            <Grid Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="5">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="14"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="14"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="1" Grid.ColumnSpan="3" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" Padding="0"
-                           FontWeight="Light" VerticalAlignment="Center" TextAlignment="Center" Margin="12">
-                    <Run Text="{x:Static properties:Resources.WelcomeToAccessibilityInsightsForWindowsLabelContent}" FontSize="18"/>
-                    <LineBreak/>
-                    <Run Text="{x:Static properties:Resources.LabelContentAccessibilityInsightsForWindows}" FontSize="24"/>
-                    <LineBreak/>
-                    <LineBreak/>
-                    <Hyperlink x:Name="hlVersion" TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="{Binding Path=AppVersionUri, Mode=OneWay}"
-                                AutomationProperties.Name="{Binding Path=VersionInfoLabel, Mode=OneWay}" Style="{StaticResource hLink}">
-                        <Run Text="{Binding Path=VersionInfoLabel, Mode=OneWay}" FontSize="12"/>
-                    </Hyperlink>
-                </TextBlock>
-            </Grid>
             <CheckBox Grid.Column="1" Grid.Row="4" Content="{x:Static properties:Resources.ckbxShowContent}" Name="ckbxShow" FontSize="12" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"
                         FontWeight="SemiBold" Style="{StaticResource CkbxRightSide}" VerticalAlignment="Center" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" IsChecked="True"/>
             <Button Grid.Column="3" Grid.Row="4" x:Name="btnExit" Click="btnExit_Click" UseLayoutRounding="True" AutomationProperties.AutomationId="{x:Static properties:AutomationIDs.StartUpModeExitButton}"

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -87,6 +87,7 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="32"/>
                         <RowDefinition Height="24"/>
                         <RowDefinition Height="32"/>
@@ -95,15 +96,18 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <TextBlock Style="{StaticResource TbFocusable}" Grid.ColumnSpan="8" Padding="16,10,16,0" FontSize="22" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" FontWeight="Light">
-                        <Run Text="{x:Static properties:Resources.shortcutsTitle}"/>
+                        <Run Text="{x:Static properties:Resources.StartupModeControl_shortcutsTitle}"/>
                     </TextBlock>
-                    <TextBlock Grid.Row="1" Grid.ColumnSpan="8" Padding="16,10" TextWrapping="Wrap">
+                    <TextBlock Grid.Row="1" Style="{StaticResource TbFocusable}" Grid.ColumnSpan="8" Padding="16,10,16,0" FontSize="12" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" FontWeight="Light">
+                        <Run Text="{x:Static properties:Resources.StartupModeControl_shortcutsDescription}"/>
+                    </TextBlock>
+                    <TextBlock Grid.Row="2" Grid.ColumnSpan="8" Padding="16,10" TextWrapping="Wrap">
                         <Hyperlink TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2073853"
                                    AutomationProperties.Name="{Binding ElementName=shortcutsDescTxt, Path=Text}" Style="{StaticResource hLink}">
-                            <Run x:Name="shortcutsDescTxt" Text="{x:Static properties:Resources.shortcutsDescription}" FontSize="12" FontWeight="Light"/>
+                            <Run x:Name="shortcutsDescTxt" Text="{x:Static properties:Resources.StartupModeControl_shortcutsLinkLabel}" FontSize="12" FontWeight="Light"/>
                         </Hyperlink>  
                     </TextBlock>
-                    <Border Grid.Row="2" Grid.Column="1" Style="{StaticResource BrdrKey}">
+                    <Border Grid.Row="3" Grid.Column="1" Style="{StaticResource BrdrKey}">
                         <Label Name="lblEventHk" Style="{StaticResource LblKey}" Content="Shift + F6" Padding="3,1">
                             <AutomationProperties.Name>
                                 <MultiBinding StringFormat="{}{0} {1}">
@@ -113,8 +117,8 @@
                             </AutomationProperties.Name>
                         </Label>
                     </Border>
-                    <TextBlock Name="txtEventHk" Style="{StaticResource TbBaseWrap}" Grid.Row="2" Grid.Column="3" Text="{x:Static properties:Resources.toggleEventText}" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
-                    <Border Grid.Row="4" Grid.Column="1" Style="{StaticResource BrdrKey}">
+                    <TextBlock Name="txtEventHk" Style="{StaticResource TbBaseWrap}" Grid.Row="3" Grid.Column="3" Text="{x:Static properties:Resources.toggleEventText}" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
+                    <Border Grid.Row="5" Grid.Column="1" Style="{StaticResource BrdrKey}">
                         <Label Name="lblTestHk" Style="{StaticResource LblKey}" Content="Shift + F8" Padding="3,1">
                             <AutomationProperties.Name>
                                 <MultiBinding StringFormat="{}{0} {1}">
@@ -124,8 +128,8 @@
                             </AutomationProperties.Name>
                         </Label>
                     </Border>
-                    <TextBlock Name="txtTesttHk" Style="{StaticResource TbBaseWrap}" Grid.Row="4" Grid.Column="3" Text="{x:Static properties:Resources.runSelectedTestText}" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
-                    <Border Grid.Row="6" Grid.Column="1" Style="{StaticResource BrdrKey}" Height="32" VerticalAlignment="Top">
+                    <TextBlock Name="txtTesttHk" Style="{StaticResource TbBaseWrap}" Grid.Row="5" Grid.Column="3" Text="{x:Static properties:Resources.runSelectedTestText}" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
+                    <Border Grid.Row="7" Grid.Column="1" Style="{StaticResource BrdrKey}" Height="32" VerticalAlignment="Top">
                         <Label Name="lblActivateHk" Style="{StaticResource LblKey}" Content="Shift + F9" Padding="3,1">
                             <AutomationProperties.Name>
                                 <MultiBinding StringFormat="{}{0} {1}">
@@ -135,7 +139,7 @@
                             </AutomationProperties.Name>
                         </Label>
                     </Border>
-                    <TextBlock Name="txtActivateHk" Grid.Row="6" Grid.Column="3" Style="{StaticResource TbBaseWrap}" Text="{x:Static properties:Resources.minmizeOrActivateWindowText}" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
+                    <TextBlock Name="txtActivateHk" Grid.Row="7" Grid.Column="3" Style="{StaticResource TbBaseWrap}" Text="{x:Static properties:Resources.minmizeOrActivateWindowText}" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
                 </Grid>
             </Border>
             <Grid Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="5">

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -163,10 +163,10 @@
                     </Hyperlink>
                 </TextBlock>
             </Grid>
-                <CheckBox Grid.Column="1" Grid.Row="4" Content="{x:Static properties:Resources.ckbxShowContent}" Name="ckbxShow" FontSize="12" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"
-                          FontWeight="SemiBold" Style="{StaticResource CkbxRightSide}" VerticalAlignment="Center" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" IsChecked="True"/>
-                <Button Grid.Column="3" Grid.Row="4" x:Name="btnExit" Click="btnExit_Click" UseLayoutRounding="True" AutomationProperties.AutomationId="{x:Static properties:AutomationIDs.StartUpModeExitButton}"
-                        Width="100" Height="30" VerticalAlignment="Center" HorizontalAlignment="Right" Content="{x:Static properties:Resources.StartUpModeControl_btnExit}" Style="{StaticResource BtnBlueRounded}"/>
+            <CheckBox Grid.Column="1" Grid.Row="4" Content="{x:Static properties:Resources.ckbxShowContent}" Name="ckbxShow" FontSize="12" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"
+                        FontWeight="SemiBold" Style="{StaticResource CkbxRightSide}" VerticalAlignment="Center" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" IsChecked="True"/>
+            <Button Grid.Column="3" Grid.Row="4" x:Name="btnExit" Click="btnExit_Click" UseLayoutRounding="True" AutomationProperties.AutomationId="{x:Static properties:AutomationIDs.StartUpModeExitButton}"
+                    Width="100" Height="30" VerticalAlignment="Center" HorizontalAlignment="Right" Content="{x:Static properties:Resources.StartUpModeControl_btnExit}" Style="{StaticResource BtnBlueRounded}"/>
         </Grid>
     </Border>
 </dialogs:ContainedDialog>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -40,10 +40,11 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <TextBlock Name="tbVideo" FontSize="22" Padding="16,10,16,0" FontWeight="Light" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" Style="{StaticResource TbFocusable}" TextWrapping="Wrap">
-              <Run Text="{x:Static properties:Resources.tbVideoText1}"/>
+                        <Run Text="{x:Static properties:Resources.tbVideoText1}"/>
                     </TextBlock>
                     <TextBlock x:Name="videoDescription" Grid.Row="1" FontSize="12" Style="{StaticResource TbFocusable}" Padding="16,10" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" TextWrapping="Wrap" Text="{x:Static properties:Resources.tbVideoText2}"/>
                     <Button Style="{StaticResource BtnStandard}" Cursor="Hand" Grid.Row="2" Width="240" Height="121" BorderThickness="0" Name="btnVideo" Click="btnVideo_Click" AutomationProperties.LabeledBy="{Binding ElementName=videoDescription}" VerticalAlignment="Top">
@@ -65,6 +66,13 @@
                             <fabric:FabricIconControl Foreground="{DynamicResource ResourceKey=WhiteTextBrush}" Name="fabPlay" GlyphName="MSNVideosSolid" GlyphSize="Custom" FontSize="36" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                         </Grid>
                     </Button>
+                    <TextBlock Grid.Column="1" Grid.Row="3" Grid.ColumnSpan="3" TextWrapping="Wrap" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" Padding="0"
+                           FontWeight="Light" VerticalAlignment="Center" TextAlignment="Left" Margin="12,20,12,12">
+                        <Hyperlink x:Name="hlHelp" TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077919"
+                                    AutomationProperties.Name="{x:Static properties:Resources.StartupModeControl_moreGuidanceText}" Style="{StaticResource hLink}">
+                            <Run Text="{x:Static properties:Resources.StartupModeControl_moreGuidanceText}" FontSize="12" FontWeight="Light"/>
+                        </Hyperlink>
+                    </TextBlock>
                 </Grid>
             </Border>
             <Border Grid.Column="3" Grid.Row="2" Background="{DynamicResource ResourceKey=StartupSecondaryBGBrush}" BorderBrush="{DynamicResource ResourceKey=StartupInnerBorderBrush}" BorderThickness="1">

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml.cs
@@ -8,7 +8,6 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Windows;
-using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Navigation;
 

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml.cs
@@ -138,6 +138,6 @@ namespace AccessibilityInsights.SharedUx.Dialogs
 #pragma warning restore CA1031 // Do not catch general exception types
         }
 
-        protected override void SetFocusOnDefaultControl() => btnVideo.Focus();
+        protected override void SetFocusOnDefaultControl() => hlVersion.Focus();
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml.cs
@@ -8,6 +8,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Windows;
+using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Navigation;
 
@@ -22,7 +23,6 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         /// URL to getting started video
         /// </summary>
         const string VideoUrl = "https://go.microsoft.com/fwlink/?linkid=2077681";
-
 
         /// <summary>
         /// App configation
@@ -46,15 +46,15 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             }
         }
 
-
         /// <summary>
-        /// Most recent version string
+        /// Label for AppVersion
         /// </summary>
-        public string VersionString { get; private set; }
+        public static string VersionInfoLabel => VersionTools.AppVersionLabel;
+
+        public static Uri AppVersionUri => VersionTools.AppVersionUri;
 
         public StartUpModeControl()
         {
-            this.VersionString = VersionTools.GetAppVersion();
             InitializeComponent();
             WaitHandle.Reset();
         }

--- a/src/AccessibilityInsights.SharedUx/Misc/VersionTools.cs
+++ b/src/AccessibilityInsights.SharedUx/Misc/VersionTools.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Misc;
+using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 
 namespace AccessibilityInsights.SharedUx.Misc
@@ -16,6 +18,30 @@ namespace AccessibilityInsights.SharedUx.Misc
         {
             string fileVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
             return fileVersion;
+        }
+
+        /// <summary>
+        /// Return the label for use in UI
+        /// </summary>
+        public static string AppVersionLabel => string.Format(CultureInfo.InvariantCulture,
+            Properties.Resources.VersionLinkContentFormat, GetAppVersion());
+
+        /// <summary>
+        /// Provides a Uri to the release notes for this version
+        /// </summary>
+        public static Uri AppVersionUri
+        {
+            get
+            {
+                string compressedVersion = GetAppVersion();
+                Version version = Version.Parse(compressedVersion);
+                return new Uri(string.Format(CultureInfo.InvariantCulture,
+                    Properties.Resources.VersionLinkFormat,
+                    version.Major,
+                    version.Minor,
+                    version.Build,
+                    version.Revision));
+            }
         }
 
         public static string GetAxeVersion() => PackageInfo.InformationalVersion;

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3634,7 +3634,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Default frequently used shortcuts.
+        ///   Looks up a localized string similar to Frequently used shortcuts.
         /// </summary>
         public static string StartupModeControl_shortcutsTitle {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3625,11 +3625,11 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to For more information,.
+        ///   Looks up a localized string similar to More guidance and tutorials.
         /// </summary>
-        public static string StartupModeControl_moreInformationText {
+        public static string StartupModeControl_moreGuidanceText {
             get {
-                return ResourceManager.GetString("StartupModeControl_moreInformationText", resourceCulture);
+                return ResourceManager.GetString("StartupModeControl_moreGuidanceText", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3571,24 +3571,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Go to the full list of keyboard shortcuts for Accessibility Insights for Windows..
-        /// </summary>
-        public static string shortcutsDescription {
-            get {
-                return ResourceManager.GetString("shortcutsDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Frequently used shortcuts.
-        /// </summary>
-        public static string shortcutsTitle {
-            get {
-                return ResourceManager.GetString("shortcutsTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Hue.
         /// </summary>
         public static string sliderColorSliderAutomationPropertiesName {
@@ -3630,6 +3612,33 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string StartupModeControl_moreGuidanceText {
             get {
                 return ResourceManager.GetString("StartupModeControl_moreGuidanceText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to These keystrokes are default, but you can customize your shortcut keystrokes in settings..
+        /// </summary>
+        public static string StartupModeControl_shortcutsDescription {
+            get {
+                return ResourceManager.GetString("StartupModeControl_shortcutsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View the full list of default keyboard shortcuts.
+        /// </summary>
+        public static string StartupModeControl_shortcutsLinkLabel {
+            get {
+                return ResourceManager.GetString("StartupModeControl_shortcutsLinkLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default frequently used shortcuts.
+        /// </summary>
+        public static string StartupModeControl_shortcutsTitle {
+            get {
+                return ResourceManager.GetString("StartupModeControl_shortcutsTitle", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3625,7 +3625,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to View the full list of default keyboard shortcuts.
+        ///   Looks up a localized string similar to More information about shortcuts.
         /// </summary>
         public static string StartupModeControl_shortcutsLinkLabel {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -821,11 +821,11 @@
   <data name="toggleEventText" xml:space="preserve">
     <value>Start or stop event recording for the selected element.</value>
   </data>
-  <data name="shortcutsDescription" xml:space="preserve">
-    <value>Go to the full list of keyboard shortcuts for Accessibility Insights for Windows.</value>
+  <data name="StartupModeControl_shortcutsLinkLabel" xml:space="preserve">
+    <value>View the full list of default keyboard shortcuts</value>
   </data>
-  <data name="shortcutsTitle" xml:space="preserve">
-    <value>Frequently used shortcuts</value>
+  <data name="StartupModeControl_shortcutsTitle" xml:space="preserve">
+    <value>Default frequently used shortcuts</value>
   </data>
   <data name="imageVideoAutomationPropertiesName" xml:space="preserve">
     <value>Getting started video thumbnail</value>
@@ -1532,5 +1532,8 @@ Do you want to change the channel? </value>
   </data>
   <data name="EventRecordControlScopeHeader" xml:space="preserve">
     <value>Event recording scope</value>
+  </data>
+  <data name="StartupModeControl_shortcutsDescription" xml:space="preserve">
+    <value>These keystrokes are default, but you can customize your shortcut keystrokes in settings.</value>
   </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -822,7 +822,7 @@
     <value>Start or stop event recording for the selected element.</value>
   </data>
   <data name="StartupModeControl_shortcutsLinkLabel" xml:space="preserve">
-    <value>View the full list of default keyboard shortcuts</value>
+    <value>More information about shortcuts</value>
   </data>
   <data name="StartupModeControl_shortcutsTitle" xml:space="preserve">
     <value>Frequently used shortcuts</value>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -794,8 +794,8 @@
   <data name="btnFileBugAutomationPropertiesName1" xml:space="preserve">
     <value>File a bug</value>
   </data>
-  <data name="StartupModeControl_moreInformationText" xml:space="preserve">
-    <value>For more information,</value>
+  <data name="StartupModeControl_moreGuidanceText" xml:space="preserve">
+    <value>More guidance and tutorials</value>
   </data>
   <data name="StartupModeControl_latestReleaseNotes" xml:space="preserve">
     <value>go to the latest release notes</value>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -825,7 +825,7 @@
     <value>View the full list of default keyboard shortcuts</value>
   </data>
   <data name="StartupModeControl_shortcutsTitle" xml:space="preserve">
-    <value>Default frequently used shortcuts</value>
+    <value>Frequently used shortcuts</value>
   </data>
   <data name="imageVideoAutomationPropertiesName" xml:space="preserve">
     <value>Getting started video thumbnail</value>

--- a/src/AccessibilityInsights.SharedUx/ViewModels/AboutTabViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/AboutTabViewModel.cs
@@ -4,7 +4,6 @@ using AccessibilityInsights.SharedUx.Misc;
 using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.Win32;
 using System;
-using System.Globalization;
 
 namespace AccessibilityInsights.SharedUx.ViewModels
 {
@@ -31,14 +30,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             {
                 try
                 {
-                    string compressedVersion = VersionTools.GetAppVersion();
-                    Version version = Version.Parse(compressedVersion);
-                    return new Uri(string.Format(CultureInfo.InvariantCulture,
-                        Properties.Resources.VersionLinkFormat,
-                        version.Major,
-                        version.Minor,
-                        version.Build,
-                        version.Revision));
+                    return VersionTools.AppVersionUri;
                 }
 #pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception e)
@@ -53,8 +45,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// <summary>
         /// Provides the version-specific label
         /// </summary>
-        public string VersionInfoLabel => string.Format(CultureInfo.InvariantCulture,
-            Properties.Resources.VersionLinkContentFormat, VersionTools.GetAppVersion());
+        public string VersionInfoLabel => VersionTools.AppVersionLabel;
 
         public string AxeVersion => VersionTools.GetAxeVersion();
 #pragma warning restore CA1822


### PR DESCRIPTION
#### Describe the change
The welcome screen was flagged for update in #299, and also flagged for 200% zoom issues in #787. This PR addresses both via the following changes:
1. It adds a link to the release notes for the version
2. It adds clarifying text about shortcuts, and a link to https://accessibilityinsights.io/docs/en/windows/reference/keyboard, where the user can learn more about shortcuts and how to change them.
3. It massages the formatting to better fit a 200% zoom screen
4. By PM request, it changes the initial focus from the link to play the video to the link to the release notes.

Most of the changes are in StartupModeControl.xaml, although there was also a small refactor to better leverage version code from both the Startup and Settings screens.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #299, #787 
- [ ] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Previous welcome screen at 200% zoom, maximized:
![image](https://user-images.githubusercontent.com/45672944/81982268-66ec4b80-95e6-11ea-8215-b305e3673482.png)

Revised welcome screen at 200% zoom, maximized:
![image](https://user-images.githubusercontent.com/45672944/81982869-4cff3880-95e7-11ea-9180-2a6231680bfa.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



