### PR TITLE
Add a new color to handle the text color in the TextRangeControl

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
@@ -78,7 +78,7 @@
                         <ColumnDefinition Width="28"/>
                     </Grid.ColumnDefinitions>
                     <DockPanel>
-                        <fabric:FabricIconControl DockPanel.Dock="Left" GlyphName="Search" GlyphSize="Custom" FontSize="18" Margin="5,0,5,0" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=TextRangeControlFGBrush}"/>
+                        <fabric:FabricIconControl DockPanel.Dock="Left" GlyphName="Search" GlyphSize="Custom" FontSize="18" Margin="5,0,5,0" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=TextPatternExplorerFGBrush}"/>
                         <TextBox x:Name="textboxSearch" TextChanged="textboxSearch_TextChanged"
                                  AutomationProperties.Name="{x:Static Properties:Resources.textboxSearchAutomationPropertiesName1}"
                                  AutomationProperties.HelpText="{x:Static Properties:Resources.textboxSearchAutomationPropertiesHelpText1}"
@@ -148,7 +148,7 @@
                 </ListView.View>
                 <ListView.ItemContainerStyle>
                     <Style TargetType="{x:Type ListViewItem}">
-                        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TextRangeControlFGBrush}"/>
+                        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TextPatternExplorerFGBrush}"/>
                     </Style>
                 </ListView.ItemContainerStyle>
             </ListView>

--- a/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
@@ -78,7 +78,7 @@
                         <ColumnDefinition Width="28"/>
                     </Grid.ColumnDefinitions>
                     <DockPanel>
-                        <fabric:FabricIconControl DockPanel.Dock="Left" GlyphName="Search" GlyphSize="Custom" FontSize="18" Margin="5,0,5,0" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                        <fabric:FabricIconControl DockPanel.Dock="Left" GlyphName="Search" GlyphSize="Custom" FontSize="18" Margin="5,0,5,0" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=TextRangeControlFGBrush}"/>
                         <TextBox x:Name="textboxSearch" TextChanged="textboxSearch_TextChanged"
                                  AutomationProperties.Name="{x:Static Properties:Resources.textboxSearchAutomationPropertiesName1}"
                                  AutomationProperties.HelpText="{x:Static Properties:Resources.textboxSearchAutomationPropertiesHelpText1}"
@@ -148,7 +148,7 @@
                 </ListView.View>
                 <ListView.ItemContainerStyle>
                     <Style TargetType="{x:Type ListViewItem}">
-                        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SearchAndIconForegroundBrush}"/>
+                        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TextRangeControlFGBrush}"/>
                     </Style>
                 </ListView.ItemContainerStyle>
             </ListView>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml
@@ -71,7 +71,7 @@
                             <Menu x:Name="mnTRControl" Grid.Column="1" Visibility="{Binding Path=MenuVisibility, Mode=OneWay}" Margin="10,0,0,0" >
                                 <MenuItem IsCheckable="False" Padding="0" AutomationProperties.Name="{x:Static Properties:Resources.MenuItemAutomationPropertiesNameControlSelectedTextRange}">
                                     <MenuItem.Icon>
-                                        <fabric:FabricIconControl GlyphName="More" Foreground="{DynamicResource ResourceKey=IconBrush}" GlyphSize="Default"/>
+                                        <fabric:FabricIconControl GlyphName="More" Foreground="{DynamicResource ResourceKey=TextPatternExplorerFGBrush}" GlyphSize="Default"/>
                                     </MenuItem.Icon>
                                     <MenuItem Header="{x:Static Properties:Resources.mniCloneHeader}" x:Name="mniClone" Click="mniClone_Click"/>
                                     <MenuItem Header="{x:Static Properties:Resources.MenuItemHeaderCompare}">

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -109,5 +109,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonFGBrush" Color="#000000"/>       <!-- (UPDATED) Foreground of "BtnGreySquared" buttons -->
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGHoverBrush" Color="#B2B3B5"/>  <!-- (UPDATED) Background of "BtnGreySquared" buttons on hover -->
     <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedHoverBrush" Color="#FFFFFF"/>   <!-- (UPDATED) Hover of "BtnOnSelectedLine" buttons -->
-    <SolidColorBrush po:Freeze="True" x:Key="TextRangeControlFGBrush" Color="#333333"/>  <!-- (UPDATED) Text of Attibutes in TextPatternExplorer -->
+    <SolidColorBrush po:Freeze="True" x:Key="TextPatternExplorerFGBrush" Color="#333333"/>  <!-- (UPDATED) Foreground in TextPatternExplorer -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -109,4 +109,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonFGBrush" Color="#000000"/>       <!-- (UPDATED) Foreground of "BtnGreySquared" buttons -->
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGHoverBrush" Color="#B2B3B5"/>  <!-- (UPDATED) Background of "BtnGreySquared" buttons on hover -->
     <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedHoverBrush" Color="#FFFFFF"/>   <!-- (UPDATED) Hover of "BtnOnSelectedLine" buttons -->
+    <SolidColorBrush po:Freeze="True" x:Key="TextRangeControlFGBrush" Color="#333333"/>  <!-- (UPDATED) Text of Attibutes in TextPatternExplorer -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -91,5 +91,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedHoverBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TextRangeControlFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TextPatternExplorerFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -91,4 +91,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedHoverBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TextRangeControlFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -109,5 +109,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGHoverBrush" Color="#CCCCCC"/>
     <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedHoverBrush" Color="#BEE6Fd"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TextRangeControlFGBrush" Color="#333333"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TextPatternExplorerFGBrush" Color="#333333"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -109,4 +109,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGHoverBrush" Color="#CCCCCC"/>
     <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedHoverBrush" Color="#BEE6Fd"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TextRangeControlFGBrush" Color="#333333"/>
 </ResourceDictionary>


### PR DESCRIPTION
#### Describe the change
Fix foreground color in `TextRangeControl` (was incorrectly styled for dark mode)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #799 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

Light mode:
![image](https://user-images.githubusercontent.com/45672944/82505293-2ee77b80-9ab2-11ea-9ce1-afdadad5549c.png)

Dark mode (looks just like light mode since this dialog isn't styled at this time):
![image](https://user-images.githubusercontent.com/45672944/82506438-a28a8800-9ab4-11ea-9023-427e77bc7cff.png)

High Contrast 1:
![image](https://user-images.githubusercontent.com/45672944/82505428-8ede2200-9ab2-11ea-9d71-b7fa023c64d2.png)

High Contrast 2:
![image](https://user-images.githubusercontent.com/45672944/82505472-af0de100-9ab2-11ea-8ea2-a82c42b713bb.png)

High Contrast Black:
![image](https://user-images.githubusercontent.com/45672944/82505552-dcf32580-9ab2-11ea-82d6-55737b827f9c.png)

High Contrast White:
![image](https://user-images.githubusercontent.com/45672944/82505585-f4321300-9ab2-11ea-9c8d-927b19f48d78.png)


> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



