### PR TITLE
chore: Remove references to old Windows versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Downloads](https://img.shields.io/github/downloads/microsoft/accessibility-insights-windows/total.svg)](https://github.com/Microsoft/accessibility-insights-windows/releases/latest)
 [![Release](https://img.shields.io/github/release/microsoft/accessibility-insights-windows.svg)](https://github.com/Microsoft/accessibility-insights-windows/releases/latest)
 
-Accessibility Insights for Windows is the project for Accessibility tools on Windows platform (Win7/Win8x/Win10).
+Accessibility Insights for Windows is the project for Accessibility tools on the Windows platform.
 
 ### Installing Accessibility Insights for Windows
 You can download and install the application from https://accessibilityinsights.io.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,6 +1,6 @@
 ## FAQ
 #### Q. What is Accessibility Insights for Windows?
-Accessibility Insights for Windows is the project for Accessibility tools on Windows platform (Win7/Win8x/Win10). This is one of the tools from a suite of tools that help diagnose accessibility issues. 
+Accessibility Insights for Windows is the project for Accessibility tools on the Windows platform. This is one of the tools from a suite of tools that help diagnose accessibility issues. 
 
 #### Q. Why should I contribute to Accessibility Insights for Windows?
 By contributing you will help ensure that people with disabilities have full access to applications. Make the world a better place!


### PR DESCRIPTION
#### Describe the change
I noticed that we're still referencing Win7 & Win8 in a couple of our markdown files, including at the very top of our readme file. Since our current policy is to support Microsoft-supported versions, I just referred to Windows and let the docs be the only place that describe supported versions. There's less to maintain that way. There are still Win7-specific code paths in the tool, and this PR makes no attempt to change or remove them. While we aren't explicitly supporting Win7, we also aren't intentionally breaking it.

#### PR checklist

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



