### PR TITLE
Sign 3rd party assemblies

### DIFF
--- a/build/settings.targets
+++ b/build/settings.targets
@@ -14,6 +14,11 @@
           <StrongName>StrongName</StrongName>
         </FilesToSign>
       </ItemGroup>
+      <ItemGroup>
+        <FilesToSign Include="@(Drop3PartySignedFile)">
+          <Authenticode>3PartySHA2</Authenticode>
+        </FilesToSign>
+      </ItemGroup>
     </When>
   </Choose>
   

--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -10,6 +10,13 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
+  <ItemGroup>
+    <DropSignedFile Include="$(TargetPath)" />
+    <Drop3PartySignedFile Include="$(TargetDir)\CommandLine.dll" />
+    <Drop3PartySignedFile Include="$(TargetDir)\Ben.Demystifier.dll" />
+    <Drop3PartySignedFile Include="$(TargetDir)\Newtonsoft.Json.dll" />
+  </ItemGroup>
+
   <Import Project="..\..\build\NetFrameworkRelease.targets" />
 
   <ItemGroup>


### PR DESCRIPTION
#### Describe the change
Currently, AI-Win contains several third party assemblies which are not signed with a Microsoft cert. This PR signs those assemblies with the appropriate cert. You can find the signed artifacts [here](https://dev.azure.com/mseng/1ES/_build/results?buildId=12657721&view=artifacts&type=publishedArtifacts) (different branch, same relevant configuration).

#### PR checklist

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



