### PR TITLE
Include only the signed Newtonsoft DLL in MSI

### DIFF
--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -153,7 +153,8 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                 <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net472\AccessibilityInsights.SetupLibrary.dll" Id ="version_switcher_setuplibrary"/>
                 <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net472\AccessibilityInsights.Win32.dll" Id ="version_switcher_win32"/>
                 <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net472\Microsoft.Deployment.WindowsInstaller.dll" Id ="version_switcher_deployment"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net472\Newtonsoft.Json.dll" Id ="version_switcher_newtonsoft"/>
+                <!-- We sign Newtonsoft.Json.dll in the main AccessibilityInsights project. To avoid duplicate signing, we reuse it below. -->
+                <File Source="..\AccessibilityInsights\bin\Release\net472\Newtonsoft.Json.dll" Id ="version_switcher_newtonsoft"/>
               </Component>
             </Directory>
 


### PR DESCRIPTION
#### Describe the change
PR #847 ensured that we sign third party assemblies that we ship. It missed the Newtonsoft.JSON DLL that we include in the VersionSwitcher directory. Rather than signing the same DLL twice, this PR changes Product.wxs to reuse the already signed Newtonsoft DLL in the VersionSwitcher directory. 

#### PR checklist

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



