### PR TITLE
Sign WindowsInstaller assembly & use in MSI

### DIFF
--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -12,8 +12,9 @@
 
   <ItemGroup>
     <DropSignedFile Include="$(TargetPath)" />
-    <Drop3PartySignedFile Include="$(TargetDir)\CommandLine.dll" />
     <Drop3PartySignedFile Include="$(TargetDir)\Ben.Demystifier.dll" />
+    <Drop3PartySignedFile Include="$(TargetDir)\CommandLine.dll" />
+    <Drop3PartySignedFile Include="$(TargetDir)\Microsoft.Deployment.WindowsInstaller.dll" />
     <Drop3PartySignedFile Include="$(TargetDir)\Newtonsoft.Json.dll" />
   </ItemGroup>
 

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -152,8 +152,8 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                 <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net472\AccessibilityInsights.VersionSwitcher.exe.config" Id="version_switcher_config"/>
                 <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net472\AccessibilityInsights.SetupLibrary.dll" Id ="version_switcher_setuplibrary"/>
                 <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net472\AccessibilityInsights.Win32.dll" Id ="version_switcher_win32"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net472\Microsoft.Deployment.WindowsInstaller.dll" Id ="version_switcher_deployment"/>
-                <!-- We sign Newtonsoft.Json.dll in the main AccessibilityInsights project. To avoid duplicate signing, we reuse it below. -->
+                <!-- We sign the following assemblies in the main AccessibilityInsights project. To avoid duplicate signing, we reuse them below. -->
+                <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Deployment.WindowsInstaller.dll" Id ="version_switcher_deployment"/>
                 <File Source="..\AccessibilityInsights\bin\Release\net472\Newtonsoft.Json.dll" Id ="version_switcher_newtonsoft"/>
               </Component>
             </Directory>


### PR DESCRIPTION
#### Describe the change
This PR signs Microsoft.Deployment.WindowsInstaller.dll with the appropriate cert & ensures we ship only signed the DLL. I also verified that no other DLLs included in our MSI lack a signature from a Microsoft cert.

#### PR checklist

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



