### PR TITLE
Copy files to signing validation directory & scan it

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -201,6 +201,7 @@ jobs:
   variables:
     runCodesignValidationInjection: 'true'
     SignAppForRelease: 'true'
+    GDN_CODESIGN_TARGETDIRECTORY: '$(Build.ArtifactStagingDirectory)\SigningValidation'
 
   steps:
   - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
@@ -309,6 +310,16 @@ jobs:
       uploadPREfast: false
       uploadRoslyn: false
       uploadTSLint: false
+
+  - task: CopyFiles@2
+    displayName: 'Copy Files for Signing Validation'
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)\src'
+      Contents: |
+       AccessibilityInsights\bin\Release\net472\**\?(*.exe|*.dll)
+       AccessibilityInsights.VersionSwitcher\bin\Release\net472\**\?(*.exe|AccessibilityInsights.*.dll)
+       MSI\bin\Release\msi\**\AccessibilityInsights.msi
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\SigningValidation'
 
   - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
     displayName: 'Perform Cleanup Tasks'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -317,7 +317,8 @@ jobs:
       SourceFolder: '$(Build.SourcesDirectory)\src'
       Contents: |
        AccessibilityInsights\bin\Release\net472\**\?(*.exe|*.dll)
-       AccessibilityInsights.VersionSwitcher\bin\Release\net472\**\?(*.exe|AccessibilityInsights.*.dll)
+       AccessibilityInsights.VersionSwitcher\bin\Release\net472\**\?(*.exe|*.dll)
+       !AccessibilityInsights.VersionSwitcher\bin\Release\net472\**\?(Microsoft.Deployment.WindowsInstaller.dll|Newtonsoft.Json.dll)
        MSI\bin\Release\msi\**\AccessibilityInsights.msi
       TargetFolder: '$(Build.ArtifactStagingDirectory)\SigningValidation'
 


### PR DESCRIPTION
#### Describe the change
Currently, the auto injected signing validation task scans our entire build directory, which results in hundreds of false positives. This PR updates our signed build to copy the assemblies and executables that we ship to a particular directory and directs the signing validation task to scan only that directory. You can find an example of the files copied to the SigningValidation directory [here](https://dev.azure.com/accessibility-insights/Accessibility%20Insights/_build/results?buildId=11813&view=artifacts&type=publishedArtifacts).

#### PR checklist

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



