### PR TITLE
Set minimum width in mode control left columns

### DIFF
--- a/src/AccessibilityInsights/Modes/EventModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/EventModeControl.xaml
@@ -20,7 +20,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="columnSnap" Width="410"/>
+            <ColumnDefinition x:Name="columnSnap" Width="410" MinWidth="2"/>
             <ColumnDefinition x:Name="columnInfo" Width="*"/>
         </Grid.ColumnDefinitions>
         <Grid Grid.Column="0" Grid.Row="1">

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml
@@ -22,7 +22,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="columnSnap" Width="410"/>
+            <ColumnDefinition x:Name="columnSnap" Width="410" MinWidth="2"/>
             <ColumnDefinition x:Name="columnInfo" Width="*"/>
         </Grid.ColumnDefinitions>
         <Grid Name="HierarchyGrid" Background="{DynamicResource ResourceKey=PrimaryBGBrush}"

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml
@@ -18,7 +18,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="columnSnap" Width="360"/>
+            <ColumnDefinition x:Name="columnSnap" Width="360" MinWidth="2"/>
             <ColumnDefinition x:Name="columnInfo" Width="*"/>
         </Grid.ColumnDefinitions>
         <Grid Grid.Column="0" Grid.Row="1">


### PR DESCRIPTION
#### Describe the change
Currently, if a user reduces a left column width (such as the hierarchy tree in live mode) to 0, they can no longer use the mouse to resize that column. This PR addresses that concern by setting the min column width of applicable columns to 2. This ensures the user can always resize the column with their mouse.

New behavior:
![column](https://user-images.githubusercontent.com/4615491/88331971-ad46e080-cce2-11ea-974e-6b30a6cdfbb0.gif)

This PR addresses [BUG] Unable to view the UIA tree once the pane width has been reduced to zero #814

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue #814
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



