### PR TITLE
fix: Persist zoom level from ADO issue filing

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
@@ -125,5 +125,11 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
             ConfigurationControl.UpdateSaveButton = UpdateSaveButton;
             return ConfigurationControl;
         }
+
+        public bool TryGetCurrentSerializedSettings(out string settings)
+        {
+            settings = _devOpsIntegration?.Configuration?.GetSerializedConfig();
+            return settings != null;
+        }
     }
 }

--- a/src/AccessibilityInsights.Extensions.GitHub/IssueReporter.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/IssueReporter.cs
@@ -107,5 +107,11 @@ namespace AccessibilityInsights.Extensions.GitHub
             this.ConfigurationControl.UpdateSaveButton = UpdateSaveButton;
             return ConfigurationControl;
         }
+
+        public bool TryGetCurrentSerializedSettings(out string settings)
+        {
+            settings = null;
+            return false;
+        }
     }
 }

--- a/src/AccessibilityInsights.Extensions/Interfaces/IssueReporting/IIssueReporting.cs
+++ b/src/AccessibilityInsights.Extensions/Interfaces/IssueReporting/IIssueReporting.cs
@@ -41,8 +41,14 @@ namespace AccessibilityInsights.Extensions.Interfaces.IssueReporting
         /// <summary>
         /// Method to restore the extension’s configuration, presumably on app startup
         /// </summary>
-        /// <returns>A Task that completes when complete</returns>
+        /// <returns>A Task that completes when the config is ready</returns>
         Task RestoreConfigurationAsync(string serializedConfig);
+
+        /// <summary>
+        /// Method to try to fetch the current serialized settings
+        /// </summary>
+        /// <returns>true (and sets settings) if supported</returns>
+        bool TryGetCurrentSerializedSettings(out string settings);
 
         /// <summary>
         /// Control to let user configure/login to issue reporting service. 

--- a/src/AccessibilityInsights.ExtensionsTests/DummyClasses/DummyIssueReporting.cs
+++ b/src/AccessibilityInsights.ExtensionsTests/DummyClasses/DummyIssueReporting.cs
@@ -40,6 +40,11 @@ namespace AccessibilityInsights.ExtensionsTests.DummyClasses
         {
             throw new NotImplementedException();
         }
+
+        public bool TryGetCurrentSerializedSettings(out string settings)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     [Export(typeof(IIssueReporting))]

--- a/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporter.cs
+++ b/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
+using AccessibilityInsights.SharedUx.Settings;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -79,7 +80,9 @@ namespace AccessibilityInsights.SharedUx.FileIssue
                 // It does seem like we currently block the main thread when we show the win form for azure devops
                 // so keeping it as is till we have a discussion. Check for blocking behavior at that link.
                 // https://github.com/Microsoft/accessibility-insights-windows/blob/master/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs#L858
-                return IssueReporting.FileIssueAsync(issueInformation).Result;
+                IIssueResult result = IssueReporting.FileIssueAsync(issueInformation).Result;
+                IssueReporterManager.GetInstance().UpdateIssueReporterSettings(IssueReporting);
+                return result;
             }
             return null;
         }

--- a/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporterManager.cs
+++ b/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporterManager.cs
@@ -101,6 +101,11 @@ namespace AccessibilityInsights.SharedUx.FileIssue
                 JsonConvert.SerializeObject(configsDictionary);
         }
 
+        /// <summary>
+        /// Call this when settings for an IIssueReporting object may have changed. The
+        /// settings will be fetched and updated in the store.
+        /// </summary>
+        /// <param name="issueReporting">The object whose settings may have changed</param>
         public void UpdateIssueReporterSettings(IIssueReporting issueReporting)
         {
             if (issueReporting == null)

--- a/src/AccessibilityInsights.SharedUxTests/FileIssue/IssueReporterManagerTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/FileIssue/IssueReporterManagerTests.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace AccessibilityInsights.SharedUxTests.FileIssue
@@ -23,7 +24,33 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
 
         [TestMethod]
         [Timeout(1000)]
-        public void Constructor_Normal_DictionaryPopulated()
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Constructor_AppConfigIsNull_ThrowsArgumentNullException()
+        {
+            new IssueReporterManager(null, Enumerable.Empty<IIssueReporting>());
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void Constructor_EnumerbleIsNull_DoesNotThrow()
+        {
+            ConfigurationModel configs = new ConfigurationModel();
+
+            new IssueReporterManager(configs, null);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void Constructor_NoNullInputs_DoesNotThrow()
+        {
+            ConfigurationModel configs = new ConfigurationModel();
+
+            new IssueReporterManager(configs, Enumerable.Empty<IIssueReporting>());
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void RestorePersistedConfigurations_Normal_DictionaryPopulated()
         {
             ConfigurationModel configs = new ConfigurationModel();
             configs.IssueReporterSerializedConfigs = TestSerializedConfigs;
@@ -33,13 +60,15 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
 
             IssueReporterManager repManager = new IssueReporterManager(configs, issueReportingOptions);
 
+            repManager.RestorePersistedConfigurations();
+
             issueReporterMock.Verify(p => p.RestoreConfigurationAsync(TestReporterConfigs), Times.Once);
             Assert.IsTrue(repManager.GetIssueFilingOptionsDict().ContainsKey(TestGuid));
         }
 
         [TestMethod]
         [Timeout(1000)]
-        public void Constructor_NullConfigs_NoRestore()
+        public void RestorePersistedConfigurations_NullConfigs_NoRestore()
         {
             ConfigurationModel configs = GetConfigurationModel(null);
 
@@ -48,20 +77,22 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
 
             IssueReporterManager repManager = new IssueReporterManager(configs, issueReportingOptions);
 
+            repManager.RestorePersistedConfigurations();
+
             issueReporterMock.Verify(p => p.RestoreConfigurationAsync(TestReporterConfigs), Times.Never);
             Assert.IsTrue(repManager.GetIssueFilingOptionsDict().ContainsKey(TestGuid));
         }
 
         [TestMethod]
         [Timeout(1000)]
-        public void Constructor_EmptyConfigs_NoRestore()
+        public void RestorePersistedConfigurations_EmptyConfigs_NoRestore()
         {
             ConfigurationModel configs = GetConfigurationModel(string.Empty);
-
             var issueReporterMock = GetIssueReporterMock();
             List<IIssueReporting> issueReportingOptions = new List<IIssueReporting>() { issueReporterMock.Object };
-
             IssueReporterManager repManager = new IssueReporterManager(configs, issueReportingOptions);
+
+            repManager.RestorePersistedConfigurations();
 
             issueReporterMock.Verify(p => p.RestoreConfigurationAsync(TestReporterConfigs), Times.Never);
             Assert.IsTrue(repManager.GetIssueFilingOptionsDict().ContainsKey(TestGuid));
@@ -69,14 +100,14 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
 
         [TestMethod]
         [Timeout(1000)]
-        public void Constructor_WhitespaceConfigs_NoRestore()
+        public void RestorePersistedConfigurations_WhitespaceConfigs_NoRestore()
         {
             ConfigurationModel configs = GetConfigurationModel(" ");
-
             var issueReporterMock = GetIssueReporterMock();
             List<IIssueReporting> issueReportingOptions = new List<IIssueReporting>() { issueReporterMock.Object };
-
             IssueReporterManager repManager = new IssueReporterManager(configs, issueReportingOptions);
+
+            repManager.RestorePersistedConfigurations();
 
             issueReporterMock.Verify(p => p.RestoreConfigurationAsync(TestReporterConfigs), Times.Never);
             Assert.IsTrue(repManager.GetIssueFilingOptionsDict().ContainsKey(TestGuid));
@@ -84,15 +115,15 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
 
         [TestMethod]
         [Timeout(1000)]
-        public void Constructor_EmptyReporterConfig_NoRestore()
+        public void RestorePersistedConfigurations_EmptyReporterConfig_NoRestore()
         {
             ConfigurationModel configs = GetConfigurationModel("{\"" + TestGuidString + "\":\"\"}");
-
             var issueReporterMock = GetIssueReporterMock();
             issueReporterMock.Setup(p => p.RestoreConfigurationAsync(string.Empty)).Returns(new Task<IIssueResult>(() => { return null; }));
             List<IIssueReporting> issueReportingOptions = new List<IIssueReporting>() { issueReporterMock.Object };
-
             IssueReporterManager repManager = new IssueReporterManager(configs, issueReportingOptions);
+
+            repManager.RestorePersistedConfigurations();
 
             issueReporterMock.Verify(p => p.RestoreConfigurationAsync(string.Empty), Times.Never);
             Assert.IsTrue(repManager.GetIssueFilingOptionsDict().ContainsKey(TestGuid));
@@ -100,14 +131,14 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
 
         [TestMethod]
         [Timeout(1000)]
-        public void Constructor_NullReporterConfig_NoRestore()
+        public void RestorePersistedConfigurations_NullReporterConfig_NoRestore()
         {
             ConfigurationModel configs = GetConfigurationModel("{\"" + RandomTestGuid + "\":\"\"}");
-
             var issueReporterMock = GetIssueReporterMock();
             List<IIssueReporting> issueReportingOptions = new List<IIssueReporting>() { issueReporterMock.Object };
-
             IssueReporterManager repManager = new IssueReporterManager(configs, issueReportingOptions);
+
+            repManager.RestorePersistedConfigurations();
 
             issueReporterMock.Verify(p => p.RestoreConfigurationAsync(null), Times.Never);
             Assert.IsTrue(repManager.GetIssueFilingOptionsDict().ContainsKey(TestGuid));
@@ -118,10 +149,10 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
         public void SetIssueReporter_Valid_ReporterSet()
         {
             ConfigurationModel configs = GetConfigurationModel(null);
-
             var issueReporterMock = GetIssueReporterMock();
             List<IIssueReporting> issueReportingOptions = new List<IIssueReporting>() { issueReporterMock.Object };
             IssueReporterManager repManager = new IssueReporterManager(configs, issueReportingOptions);
+            repManager.RestorePersistedConfigurations();
 
             repManager.SetIssueReporter(TestGuid);
 
@@ -143,11 +174,88 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
             Assert.IsNull(IssueReporter.IssueReporting);
         }
 
-        private Mock<IIssueReporting> GetIssueReporterMock()
+        [TestMethod]
+        [Timeout(1000)]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void UpdateIssueReporterSettings_InputIsNull_ThrowsArgumentNullException()
         {
-            var issueReporterMock = new Mock<IIssueReporting>();
-            issueReporterMock.Setup(p => p.StableIdentifier).Returns(TestGuid);
-            issueReporterMock.Setup(p => p.RestoreConfigurationAsync(TestReporterConfigs)).Returns(new Task<IIssueResult>(() => { return null; }));
+            ConfigurationModel configs = GetConfigurationModel(null);
+            IssueReporterManager repManager = new IssueReporterManager(configs, Enumerable.Empty<IIssueReporting>());
+
+            repManager.UpdateIssueReporterSettings(null);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void UpdateIssueReporterSettings_ReporterDoesNotSupportGetSettings_DoesNothing()
+        {
+            ConfigurationModel configs = GetConfigurationModel(null);
+            IssueReporterManager repManager = new IssueReporterManager(configs, Enumerable.Empty<IIssueReporting>());
+            Mock<IIssueReporting> issueReportingMock = GetIssueReporterMock(
+                setStableIdentifier: false, expectRestoreConfig: false, supportGetSerializedSettings: false);
+
+            repManager.UpdateIssueReporterSettings(issueReportingMock.Object);
+
+            issueReportingMock.VerifyAll();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void UpdateIssueReporterSettings_SettingNotInOriginalConfig_AddsToConfig()
+        {
+            ConfigurationModel configs = GetConfigurationModel(null);
+            IssueReporterManager repManager = new IssueReporterManager(configs, Enumerable.Empty<IIssueReporting>());
+            Mock<IIssueReporting> issueReportingMock = GetIssueReporterMock(
+                expectRestoreConfig: false, supportGetSerializedSettings: true);
+
+            repManager.UpdateIssueReporterSettings(issueReportingMock.Object);
+
+            issueReportingMock.VerifyAll();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void UpdateIssueReporterSettings_SettingInOriginalConfig_UpdatesConfig()
+        {
+            const string newSettings = "la di dah";
+            ConfigurationModel configs = GetConfigurationModel(null);
+            configs.IssueReporterSerializedConfigs = TestSerializedConfigs;
+            IssueReporterManager repManager = new IssueReporterManager(configs, Enumerable.Empty<IIssueReporting>());
+            Mock<IIssueReporting> issueReportingMock = GetIssueReporterMock(
+                expectRestoreConfig: false, supportGetSerializedSettings: true,
+                newSettings: newSettings);
+            Assert.IsFalse(configs.IssueReporterSerializedConfigs.Contains(newSettings));
+
+            repManager.UpdateIssueReporterSettings(issueReportingMock.Object);
+
+            issueReportingMock.VerifyAll();
+            Assert.IsTrue(configs.IssueReporterSerializedConfigs.Contains(newSettings));
+        }
+
+        private Mock<IIssueReporting> GetIssueReporterMock(bool setStableIdentifier = true,
+            bool expectRestoreConfig = true, bool? supportGetSerializedSettings = null,
+            string newSettings = TestReporterConfigs)
+        {
+            var issueReporterMock = new Mock<IIssueReporting>(MockBehavior.Strict);
+
+            if (setStableIdentifier)
+            {
+                issueReporterMock.Setup(p => p.StableIdentifier).Returns(TestGuid);
+            }
+
+            if (expectRestoreConfig)
+            {
+                issueReporterMock.Setup(p => p.RestoreConfigurationAsync(TestReporterConfigs)).Returns(new Task<IIssueResult>(() => { return null; }));
+            }
+
+            if (supportGetSerializedSettings.HasValue)
+            {
+                string settings = supportGetSerializedSettings.Value 
+                    ? newSettings : null;
+                issueReporterMock.Setup(p => p.TryGetCurrentSerializedSettings(out settings))
+                    .Returns(supportGetSerializedSettings.Value);
+            }
+
             return issueReporterMock;
         }
 

--- a/src/AccessibilityInsights.SharedUxTests/FileIssue/IssueReporterManagerTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/FileIssue/IssueReporterManagerTests.cs
@@ -6,6 +6,7 @@ using AccessibilityInsights.SharedUx.FileIssue;
 using AccessibilityInsights.SharedUx.Settings;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -211,6 +212,7 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
             repManager.UpdateIssueReporterSettings(issueReportingMock.Object);
 
             issueReportingMock.VerifyAll();
+            Assert.AreEqual(TestReporterConfigs, GetIssueReporterConfig(configs, TestGuid));
         }
 
         [TestMethod]
@@ -225,11 +227,22 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
                 expectRestoreConfig: false, supportGetSerializedSettings: true,
                 newSettings: newSettings);
             Assert.IsFalse(configs.IssueReporterSerializedConfigs.Contains(newSettings));
+            Assert.AreEqual(TestReporterConfigs, GetIssueReporterConfig(configs, TestGuid));
 
             repManager.UpdateIssueReporterSettings(issueReportingMock.Object);
 
             issueReportingMock.VerifyAll();
-            Assert.IsTrue(configs.IssueReporterSerializedConfigs.Contains(newSettings));
+            Assert.AreEqual(newSettings, GetIssueReporterConfig(configs, TestGuid));
+        }
+
+        private string GetIssueReporterConfig(ConfigurationModel config, Guid stableIdentifier)
+        {
+            string serializedData = config.IssueReporterSerializedConfigs;
+
+            Dictionary<Guid, string> configsDictionary = 
+                JsonConvert.DeserializeObject<Dictionary<Guid, string>>(serializedData);
+
+            return configsDictionary[stableIdentifier];
         }
 
         private Mock<IIssueReporting> GetIssueReporterMock(bool setStableIdentifier = true,


### PR DESCRIPTION
#### Describe the change
As called out in #809, we're failing to save user customizations in zoom level. The root cause is that when we make each IIssueReporting responsible to serialize its own settings, we assumed (incorrectly) that settings would only ever change from the settings tab. As such, when the user zoom is customized, it never gets written to the config file. 

The fix is to add a new method to IIssueReporting, which optionally exposes the current serialized object, and then update this after calling FileIssueAsync. If the IIssueReporting implementation provides information, save it to the config file.

Test:
1. Open AIWin
2. Scan an app (Wildlife Manager will do nicely)
3. Start bug filing via ADO
4. Change the zoom level from its original value
5. Exit the bug filing (doesn't matter if you file the bug)
6. Exit AIWin
7. Open AIWin again
8. Scan an app
9. Start bug filing via ADO

Validation: The zoom level you set before should be restored.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# ; #809 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



