### PR TITLE
Fix null dereference in text patterns

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Enums/HighlighterColor.cs
+++ b/src/AccessibilityInsights.SharedUx/Enums/HighlighterColor.cs
@@ -8,8 +8,8 @@ namespace AccessibilityInsights.SharedUx.Enums
     /// </summary>
     public enum HighlighterColor
     {
-        DefaultBrush, // This is the default highlighter color
-        PrimaryFGBrush,
-        GreenTextBrush
+        DefaultBrush,   // color resources key = HLDefaultBrush
+        TextBrush,      // color resources key = HLTextBrush
+        GreenTextBrush, // color resources key = HLGreenTextBrush
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Highlighting/Highlighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/Highlighter.cs
@@ -207,7 +207,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// <returns></returns>
         private static SolidColorBrush GetBrush(HighlighterColor color)
         {
-            return Application.Current.Resources[$"HL{color.ToString()}"] as SolidColorBrush;
+            return Application.Current.Resources[$"HL{color}"] as SolidColorBrush;
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Highlighting/TextRangeHilighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/TextRangeHilighter.cs
@@ -26,7 +26,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// constructor
         /// </summary>
         /// <param name="color"></param>
-        public TextRangeHilighter(HighlighterColor color = HighlighterColor.PrimaryFGBrush)
+        public TextRangeHilighter(HighlighterColor color = HighlighterColor.TextBrush)
         {
             this.Color = color;
             this.Hilighters = new List<Highlighter>();


### PR DESCRIPTION
#### Describe the change
As called out in #840, there's a null dereference when using the text patterns dialog. The root cause was overlooking the fact that highlighter colors are prefixed with "HL", and attempting to use a color without this prefix. We couldn't find a color, returned null, and caused a null dereference exception. This is a regression of the palette work for dark mode, so this change essentially reverts the change to the highlighter color and adds comments to help avoid similar breaks in the future.

One thing that is _not_ addressed in this change is that since we choose our highlighter color with no awareness of the colors being used by the target app, there's no guarantee of the visual impact that the highlighter will have in the context of the target app. Our highlighter is always yellow, which seems like an OK starting point and we can tune it in future changes. Just for reference, here are samples of the highlighter in the Chromium-based edge in various color modes--note that Edge isn't yet responding to dark mode, so Light mode and Dark mode are identical. The extra highlighter in HC-Black mode is just because I happened to have the mouse hovering when I grabbed the screenshot:

![image](https://user-images.githubusercontent.com/45672944/88833333-f4bbe980-d186-11ea-971e-38d9bc5a799f.png)

I'd love to add unit tests for highlighters, but I'm not really sure how much value there is there since it relies upon the resources that are external to the class. Feels like something that might work in UITests, but we'd have to work out the details. For now, the main focus is to correct the Exception.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #840 
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



