### PR TITLE
chore: Use newer version of signing plugin

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -207,7 +207,7 @@ jobs:
   - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
     displayName: 'Install Localization Plugin'
 
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@2
     displayName: 'Install Signing Plugin'
     inputs:
       signType: real


### PR DESCRIPTION
#### Describe the change
Our signing plugin version is no longer supported, so we need to upgrade. This is the same change as in https://github.com/microsoft/axe-windows/pull/418

Validation build showing it works: https://dev.azure.com/mseng/1ES/_build/results?buildId=12757594&view=results

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



