### PR TITLE
chore: Fix/suppress msi warnings

### DIFF
--- a/src/MSI/MSI.wixproj
+++ b/src/MSI/MSI.wixproj
@@ -32,6 +32,7 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants>BuildVer=$(BuildNumber);</DefineConstants>
+    <SuppressSpecificWarnings>1076;69</SuppressSpecificWarnings>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Product.wxs" />

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -31,6 +31,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
       <ComponentRef Id="ProductComponent" />
       <ComponentRef Id="IssueTemplateComp" />
       <ComponentRef Id="VersionSwitcherComp" />
+      <ComponentRef Id="ApplicationShortcut" />
     </Feature>
 
     <!--Until WIX_IS_NETFRAMEWORK_47_OR_LATER_INSTALLED property is supported,
@@ -121,14 +122,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
               <File Source="..\AccessibilityInsights\bin\Release\net472\UIAccess_Disabled.manifest"/>
               <File Source="..\AccessibilityInsights\bin\Release\net472\UIAccess_Enabled.manifest"/>
 
-              <Shortcut Id="ApplicationStartMenuShortcut"
-                        Directory="ApplicationProgramsFolder"
-                        Name="Accessibility Insights for Windows"
-                        Description="Accessibility Insights for Windows v1.1 (Desktop Accessibility tool)"
-                        WorkingDirectory="INSTALLFOLDER"
-                        Target="[#FileExe]"
-                        Icon="AccessibilityInsights.exe" IconIndex="0"/>
-
               <ProgId Id='A11y.Test' Description='Accessibility Insights For Windows Test file'>
                 <Extension Id='a11ytest' ContentType='AccessibilityInsights Test File'>
                   <Verb Id='open' Command='Open' TargetFile='FileExe' Argument='"%1"' />
@@ -139,11 +132,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                   <Verb Id='open' Command='Open' TargetFile='FileExe' Argument='"%1"' />
                 </Extension>
               </ProgId>
-
-              <RemoveFolder Id="DeleteShortcutFolder"
-                            Directory="ApplicationProgramsFolder"
-                            On="uninstall" />
-
             </Component>
 
             <Directory Id="IssueTemplates" Name="IssueTemplates">
@@ -187,5 +175,17 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <InstallExecuteSequence>
       <Custom Action='LaunchInstalledExe' After='InstallFinalize'>NOT REMOVE and WIX_UPGRADE_DETECTED and NOT SECONDSEQUENCE</Custom>
     </InstallExecuteSequence>
+
+    <DirectoryRef Id="ApplicationProgramsFolder">
+      <Component Id="ApplicationShortcut" Guid="63DCD2B5-CF57-494B-A81F-748DFDA7E9CF">
+        <Shortcut Id="ApplicationStartMenuShortcut"
+           Name="Accessibility Insights for Windows"
+           Description="Accessibility Insights for Windows v1.1 (Desktop Accessibility tool)"
+           Target="[#FileExe]"
+           WorkingDirectory="INSTALLFOLDER"/>
+        <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+        <RegistryValue Root="HKCU" Key="Software\AccessibilityInsights" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+      </Component>
+    </DirectoryRef>
   </Product>
 </Wix>

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -47,7 +47,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
         <Directory Id="AccessibilityInsightsFolder" Name="AccessibilityInsights" >
           <Directory Id="INSTALLFOLDER" Name="1.1">
             <Component Id="ProductComponent" Guid="21CE5D3B-FE98-4B24-B1CE-FE2FE646B2A2">
-              <File Id="FileExe" Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.exe" >
+              <File Id="FileExe" Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.exe" KeyPath="yes" >
                 <Shortcut Id="aiforwin" Directory="DesktopFolder" Name="Accessibility Insights For Windows"
                           Description="Accessibility Insights For Windows v1.1" WorkingDirectory='INSTALLFOLDER' Icon="AccessibilityInsights.exe" IconIndex="0" Advertise="yes" />
               </File>

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -31,7 +31,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
       <ComponentRef Id="ProductComponent" />
       <ComponentRef Id="IssueTemplateComp" />
       <ComponentRef Id="VersionSwitcherComp" />
-      <ComponentRef Id="ApplicationShortcut" />
     </Feature>
 
     <!--Until WIX_IS_NETFRAMEWORK_47_OR_LATER_INSTALLED property is supported,
@@ -50,6 +49,13 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
               <File Id="FileExe" Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.exe" KeyPath="yes" >
                 <Shortcut Id="aiforwin" Directory="DesktopFolder" Name="Accessibility Insights For Windows"
                           Description="Accessibility Insights For Windows v1.1" WorkingDirectory='INSTALLFOLDER' Icon="AccessibilityInsights.exe" IconIndex="0" Advertise="yes" />
+                <Shortcut Id="ApplicationStartMenuShortcut"
+                          Directory="ApplicationProgramsFolder"
+                          Name="Accessibility Insights for Windows"
+                          Description="Accessibility Insights for Windows v1.1 (Desktop Accessibility tool)"
+                          WorkingDirectory="INSTALLFOLDER"
+                          Advertise="yes"
+                          Icon="AccessibilityInsights.exe" IconIndex="0"/>
               </File>
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.exe.config" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.exe.manifest" />
@@ -132,6 +138,11 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                   <Verb Id='open' Command='Open' TargetFile='FileExe' Argument='"%1"' />
                 </Extension>
               </ProgId>
+
+              <RemoveFolder Id="DeleteShortcutFolder"
+                            Directory="ApplicationProgramsFolder"
+                            On="uninstall" />
+
             </Component>
 
             <Directory Id="IssueTemplates" Name="IssueTemplates">
@@ -175,17 +186,5 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <InstallExecuteSequence>
       <Custom Action='LaunchInstalledExe' After='InstallFinalize'>NOT REMOVE and WIX_UPGRADE_DETECTED and NOT SECONDSEQUENCE</Custom>
     </InstallExecuteSequence>
-
-    <DirectoryRef Id="ApplicationProgramsFolder">
-      <Component Id="ApplicationShortcut" Guid="63DCD2B5-CF57-494B-A81F-748DFDA7E9CF">
-        <Shortcut Id="ApplicationStartMenuShortcut"
-           Name="Accessibility Insights for Windows"
-           Description="Accessibility Insights for Windows v1.1 (Desktop Accessibility tool)"
-           Target="[#FileExe]"
-           WorkingDirectory="INSTALLFOLDER"/>
-        <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
-        <RegistryValue Root="HKCU" Key="Software\AccessibilityInsights" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
-      </Component>
-    </DirectoryRef>
   </Product>
 </Wix>

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -49,13 +49,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
               <File Id="FileExe" Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.exe" KeyPath="yes" >
                 <Shortcut Id="aiforwin" Directory="DesktopFolder" Name="Accessibility Insights For Windows"
                           Description="Accessibility Insights For Windows v1.1" WorkingDirectory='INSTALLFOLDER' Icon="AccessibilityInsights.exe" IconIndex="0" Advertise="yes" />
-                <Shortcut Id="ApplicationStartMenuShortcut"
-                          Directory="ApplicationProgramsFolder"
-                          Name="Accessibility Insights for Windows"
-                          Description="Accessibility Insights for Windows v1.1 (Desktop Accessibility tool)"
-                          WorkingDirectory="INSTALLFOLDER"
-                          Advertise="yes"
-                          Icon="AccessibilityInsights.exe" IconIndex="0"/>
               </File>
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.exe.config" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.exe.manifest" />
@@ -127,6 +120,14 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
               <File Source="..\AccessibilityInsights\bin\Release\net472\UIAccess.cmd"/>
               <File Source="..\AccessibilityInsights\bin\Release\net472\UIAccess_Disabled.manifest"/>
               <File Source="..\AccessibilityInsights\bin\Release\net472\UIAccess_Enabled.manifest"/>
+
+              <Shortcut Id="ApplicationStartMenuShortcut"
+                        Directory="ApplicationProgramsFolder"
+                        Name="Accessibility Insights for Windows"
+                        Description="Accessibility Insights for Windows v1.1 (Desktop Accessibility tool)"
+                        WorkingDirectory="INSTALLFOLDER"
+                        Target="[#FileExe]"
+                        Icon="AccessibilityInsights.exe" IconIndex="0"/>
 
               <ProgId Id='A11y.Test' Description='Accessibility Insights For Windows Test file'>
                 <Extension Id='a11ytest' ContentType='AccessibilityInsights Test File'>


### PR DESCRIPTION
#### Describe the change
Our MSI project is generating some warnings that we'd like to remove to get our build to no warnings in the build pipe. Here's a sample from a recent build:

- [warning]src\MSI\Product.wxs(51,0): Warning CNDL1113: Because it is an advertised shortcut, the target of shortcut 'aiforwin' will be the keypath of component 'FileExe' rather than parent file 'ProductComponent'. To eliminate this warning, you can (1) make the Shortcut element a child of the File element that is the keypath of component 'FileExe', (2) make file 'ProductComponent' the keypath of component 'FileExe', or (3) remove the @Advertise attribute so the shortcut is a non-advertised shortcut.
- [warning]src\MSI\Product.wxs(181,0): Warning LGHT1076: ICE69: Mismatched component reference. Entry 'ApplicationStartMenuShortcut' of the Shortcut table belongs to component 'ApplicationShortcut'. However, the formatted string in column 'Target' references file 'FileExe' which belongs to component 'ProductComponent'. Components are in the same feature.

This PR includes 2 changes:
- Explicitly set the KeyPath attribute on the app's exe. The warning goes away because the Shortcut uses its immediate parent's KeyPath as its target, instead of having to infer it from a non-parent ancestor (the component)
- Suppress the LGHT1076 and ICE69 warnings. This is a quirk of non-advertised shortcuts in WiX. I tried making the program menu shortcut advertised (which also removed the warning), but it had the side effect of having 2 shortcuts (one advertised, one not) for "Accessibility Insights for Windows" when you typed the app name into the search box. Online searches suggested that the warnings are benign, and that the only real choices are suppression or advertised shortcuts, so I went with suppression.

Validated by installing/uninstalling various combinations & making sure that the shortcuts worked as expected.

#### PR checklist

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



