### PR TITLE
chore: Fix duplicate signing

### DIFF
--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <DropSignedFile Include="$(TargetPath)" />
     <Drop3PartySignedFile Include="$(TargetDir)\Ben.Demystifier.dll" />
     <Drop3PartySignedFile Include="$(TargetDir)\CommandLine.dll" />
     <Drop3PartySignedFile Include="$(TargetDir)\Microsoft.Deployment.WindowsInstaller.dll" />

--- a/src/MSI/MSI.wixproj
+++ b/src/MSI/MSI.wixproj
@@ -40,11 +40,6 @@
     <Content Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <SignMsi Include="$(TargetPath)">
-      <Authenticode>Microsoft400</Authenticode>
-    </SignMsi>
-  </ItemGroup>
-  <ItemGroup>
     <Folder Include="bin\" />
     <Folder Include="bin\Debug\" />
   </ItemGroup>


### PR DESCRIPTION
#### Describe the change
Our current signed build is producing the following signing-related warnings:

[warning]E:\A\_work\5\a\MicroBuild\Plugins\MicroBuild.Plugins.Signing.1.1.295\build\MicroBuild.Plugins.Signing.targets(43,5): **Warning : File E:\A\_work\5\s\src\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.exe is listed more than once in the file list. Duplicate instances are being ignored**
[warning]E:\A\_work\5\a\MicroBuild\Plugins\MicroBuild.Plugins.Signing.1.1.295\build\MicroBuild.Plugins.Signing.targets(93,5): **Warning : File E:\A\_work\5\s\src\MSI\bin\Release\AccessibilityInsights.msi is listed more than once in the file list. Duplicate instances are being ignored**

The root cause is that we add `$(TargetPath)` to `$(DropSignedFile)` inside `build\NetFrameworkRelease.targets`, then we repeat the process in the projects--in `src\AccessibilityInsights\AccessibilityInsights.csproj` it's explicitly repeated, and in `src\MSI\MSI.wixproj` it's via the `SignMsi` attribute. By removing both of these duplications we remove the warning (validation build: https://dev.azure.com/mseng/1ES/_build/results?buildId=12764353&view=results)

Validation:
- Download the MSI from today's Canary build and the validation build
- Ensure that both MSI's are identical size
- Ensure that the authenticode signature matches in both MSI's
- Ensure that the timestamp signatures differ between the MSI's
- Install from each MSI, ensure that the LUA dialog prompt hasn't changed
- Install that the authenticode signature matches in both EXE's
- Ensure that the timestamp signatures differ between the EXE's

Note: This is very similar to https://github.com/microsoft/axe-windows/pull/419

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



