### PR TITLE
chore: Replace FxCop with Roslyn Analyzers

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -126,14 +126,16 @@ jobs:
       verboseOutput: true
       debugMode: false
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-fxcop.FxCop@2
-    displayName: 'Run FxCop'
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
+    displayName: 'Run Roslyn analyzers'
     inputs:
-      inputType: Basic
-      # Double-quote syntax with trailing backslash on each line concatenates lines without spaces
-      targets: "src\\AccessibilityInsights\\bin\\Debug\\net472\\*.exe;\
-                src\\AccessibilityInsights\\bin\\Debug\\net472\\AccessibilityInsights.*.dll;"
-      ignoreGeneratedCode: true
+        userProvideBuildInfo: msBuildInfo
+        msbuildVersion: 16.0
+        msBuildArchitecture: '$(BuildPlatform)'
+        msBuildCommandline: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AccessibilityInsights.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"'
+        rulesetName: recommended
+        internalAnalyzersVersion: Latest
+        microsoftAnalyzersVersion: Latest
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
     displayName: 'Run PoliCheck'
@@ -142,25 +144,24 @@ jobs:
     continueOnError: true
     
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
-    displayName: 'Create Security Analysis Report (CredScan, FxCop, and PoliCheck)'
+    displayName: 'Create Security Analysis Report (CredScan, RoslynAnalyzers, and PoliCheck)'
     inputs:
       CredScan: true
-      FxCop: true
+      RoslynAnalyzers: true
       PoliCheck: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
-    displayName: 'Publish Security Analysis Logs (CredScan, FxCop, and PoliCheck)'
+    displayName: 'Publish Security Analysis Logs (CredScan, RoslynAnalyzers, and PoliCheck)'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-    displayName: 'Post Analysis (CredScan, FxCop, and PoliCheck)'
+    displayName: 'Post Analysis (CredScan, RoslynAnalyzers, and PoliCheck)'
     inputs:
       CredScan: true
-      FxCop: true
-      FxCopBreakOn: CriticalError
+      RoslynAnalyzers: true
       PoliCheck: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
-    displayName: 'TSA upload (CredScan, FxCop, and PoliCheck)'
+    displayName: 'TSA upload (CredScan, RoslynAnalyzers, and PoliCheck)'
     inputs:
       tsaVersion: TsaV2
       codebase: NewOrUpdate
@@ -174,9 +175,9 @@ jobs:
       uploadAPIScan: false
       uploadBinSkim: false
       uploadFortifySCA: false
+      uploadFxCop: false
       uploadModernCop: false
       uploadPREfast: false
-      uploadRoslyn: false
       uploadTSLint: false
       
   - task: VSTest@2


### PR DESCRIPTION
#### Describe the change
For a long time now, we've had the following warning when our `ComplianceDebug` step of signed pipeline builds tried to run FxCop:

**[warning]Empty target provided.**

It was mostly lost in the noise of other warnings, but it's now the only warning left. Comparing the TSA uploads from AIWin to the TSA uploads from Axe.Windows, AIWin has no security Analyzers in its report.

To fix the warning and to ensure that our TSA reports include Roslyn Analyzers, this PR replaces the (obsolete) FxCop task with the Roslyn Analyzers task and updates the rest of the pipeline accordingly. The changes here are are based on the ComplianceDebug tasks of [Axe.Windows](https://github.com/microsoft/axe-windows/blob/master/build/signedbuild.yml)

Validation build showing no warnings and also showing that we're running Roslyn analyzers appears at https://dev.azure.com/mseng/1ES/_build/results?buildId=12765229&view=results

There's a possibility of new TSA issues appearing because of this change. Analyzers should be running locally, so hopefully the issue count will be low. We won't know for sure until after we merge and check the results in TSA.

#### PR checklist

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



