### PR TITLE
fix: Support ThreeState checkboxes when selecting events to listen to

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
@@ -65,7 +65,7 @@
                     DataType="{x:Type vm:EventConfigNodeViewModel}"
                      ItemsSource="{Binding Children}">
                             <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                                <CheckBox VerticalAlignment="Center" Visibility="{Binding TextVisibility}" IsChecked="{Binding IsChecked}" Margin="0,0,4,0" IsEnabled="{Binding IsEditEnabled}" IsTabStop="False" AutomationProperties.LabeledBy="{Binding ElementName=tbNode}"/>
+                                <CheckBox VerticalAlignment="Center" Visibility="{Binding TextVisibility}" IsThreeState="{Binding IsThreeState}" IsChecked="{Binding IsChecked}" Margin="0,0,4,0" IsEnabled="{Binding IsEditEnabled}" IsTabStop="False" AutomationProperties.LabeledBy="{Binding ElementName=tbNode}"/>
                                 <TextBlock Name="tbNode" VerticalAlignment="Center" Text="{Binding Header}" Visibility="{Binding TextVisibility}" Margin="0,0,4,0" FontSize="11" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                                 <Button VerticalAlignment="Center" Visibility="{Binding ButtonVisibility}" Name="btnConfig" Click="btnConfig_Click" IsEnabled="{Binding IsEditEnabled}" Background="Transparent" BorderThickness="0"
                                     AutomationProperties.HelpText="{x:Static Properties:Resources.btnConfigAutomationPropertiesHelpText}">

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
@@ -147,7 +147,7 @@ namespace AccessibilityInsights.SharedUx.Controls
          
             if (CustomPropertiesNode.Children.Count > 0)
             {
-                CustomNode.Children.Add(CustomPropertiesNode);
+                CustomNode.AddChild(CustomPropertiesNode);
             }
         }
 

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
@@ -74,7 +74,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             RootNodes = new List<EventConfigNodeViewModel>();
             trviewConfigEvents.ItemsSource = RootNodes;
             var ids = SupportedEvents.GetEventsForControl(el.ControlTypeId, el.Patterns);
-            SuggestedNode = new EventConfigNodeViewModel(string.Format(CultureInfo.InvariantCulture, Properties.Resources.EventConfigTabControl_SetElement_Expected_Events_based_on_the_0_control_type, Axe.Windows.Core.Types.ControlType.GetInstance().GetNameById(el.ControlTypeId))) { IsExpanded = true };
+            SuggestedNode = new EventConfigNodeViewModel(string.Format(CultureInfo.InvariantCulture, Properties.Resources.EventConfigTabControl_SetElement_Expected_Events_based_on_the_0_control_type, Axe.Windows.Core.Types.ControlType.GetInstance().GetNameById(el.ControlTypeId)), isThreeState: true) { IsExpanded = true };
 
             if (ids.Any())
             {
@@ -82,7 +82,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 SuggestedNode.SortChildren();
             }
 
-            var properties = new EventConfigNodeViewModel("Properties") { Depth = 1 };
+            var properties = new EventConfigNodeViewModel("Properties", isThreeState: true) { Depth = 1 };
             properties.AddChildren(el.Properties.Values);
             
             if (properties.Children.Any())
@@ -96,7 +96,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 RootNodes.Add(SuggestedNode);
             }
 
-            CustomNode = new EventConfigNodeViewModel("My Events");
+            CustomNode = new EventConfigNodeViewModel("My Events", isThreeState: true);
 
             CustomPropertiesNode = new EventConfigNodeViewModel("Properties") { Depth = 1 };
             EditBtnNode = new EventConfigNodeViewModel("", Visibility.Visible, Properties.Resources.EventConfigTabControl_SetElement_Edit_My_Events) { Depth = 1, TextVisibility = Visibility.Collapsed };
@@ -122,8 +122,8 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// </summary>
         private void UpdateCustomNode()
         {
-            CustomNode.Children.Remove(CustomPropertiesNode);
-            CustomNode.Children.Remove(EditBtnNode);
+            CustomNode.RemoveChild(CustomPropertiesNode);
+            CustomNode.RemoveChild(EditBtnNode);
             var custom = (from e in ConfigurationManager.GetDefaultInstance().EventConfig.Events
                           where e.IsRecorded
                           select e.Id).ToList();
@@ -133,7 +133,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             var add = custom.Where(id => !CustomNode.Children.Select(c => c.Id).Contains(id)).ToList();
             CustomNode.AddChildren(add, EventConfigNodeType.Event);
             CustomNode.SortChildren();
-            CustomNode.Children.Insert(0, EditBtnNode);
+            CustomNode.InsertChildAtIndex(0, EditBtnNode);
 
             custom = (from e in ConfigurationManager.GetDefaultInstance().EventConfig.Properties
                           where e.IsRecorded

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
@@ -98,7 +98,7 @@ namespace AccessibilityInsights.SharedUx.Controls
 
             CustomNode = new EventConfigNodeViewModel("My Events", isThreeState: true);
 
-            CustomPropertiesNode = new EventConfigNodeViewModel("Properties") { Depth = 1 };
+            CustomPropertiesNode = new EventConfigNodeViewModel("Properties", isThreeState: true) { Depth = 1 };
             EditBtnNode = new EventConfigNodeViewModel("", Visibility.Visible, Properties.Resources.EventConfigTabControl_SetElement_Edit_My_Events) { Depth = 1, TextVisibility = Visibility.Collapsed };
 
             UpdateCustomNode();

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -22,9 +22,11 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     public class EventConfigNodeViewModel : ViewModelBase, INotifyPropertyChanged
     {
         /// <summary>
-        /// Child ViewModels
+        /// Child ViewModels - external code can read but not modify
         /// </summary>
-        public ObservableCollection<EventConfigNodeViewModel> Children { get; private set; }
+        public IReadOnlyCollection<EventConfigNodeViewModel> Children => this._children;
+
+        private readonly ObservableCollection<EventConfigNodeViewModel> _children;
 
         /// <summary>
         /// Depth for treeviewitem
@@ -82,7 +84,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                             SetChecked(ConfigurationManager.GetDefaultInstance().EventConfig, this.Id, RecordEntityType.Property, value.Value, this.Header);
                             break;
                         case EventConfigNodeType.Group:
-                            this.Children?.ToList().ForEach(c => c.IsChecked = value.Value);
+                            this._children?.ToList().ForEach(c => c.IsChecked = value.Value);
                             break;
                     }
                 }
@@ -97,7 +99,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             int uncheckedChildCount = 0;
             int indeterminateChildCount = 0;
 
-            foreach (var child in this.Children)
+            foreach (var child in this._children)
             {
                 // Skip buttons
                 if (!string.IsNullOrWhiteSpace(child.ButtonText))
@@ -205,7 +207,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             if (child == null)
                 throw new ArgumentNullException(nameof(child));
 
-            this.Children.Insert(index, child);
+            this._children.Insert(index, child);
             child._parent = this;
             this.SetCheckedInternal(null, respondingToChildChange: true);
         }
@@ -219,7 +221,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             if (child == null)
                 throw new ArgumentNullException(nameof(child));
 
-            this.Children.Add(child);
+            this._children.Add(child);
             child.IsChecked = isChecked;
             if (child.Id == EventType.UIA_AutomationFocusChangedEventId)
             {
@@ -277,11 +279,11 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// </summary>
         public void SortChildren()
         {
-            var l = Children.OrderBy(e => e.Header).ToList();
-            this.Children.Clear();
+            var l = _children.OrderBy(e => e.Header).ToList();
+            this._children.Clear();
             foreach(var c in l)
             {
-                this.Children.Add(c);
+                this._children.Add(c);
             }
         }
 
@@ -299,7 +301,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             set
             {
                 _iseditenabled = value;
-                this.Children?.AsParallel().ForAll(c => c.IsEditEnabled = value);
+                this._children?.AsParallel().ForAll(c => c.IsEditEnabled = value);
                 OnPropertyChanged(nameof(IsEditEnabled));
             }
         }
@@ -313,7 +315,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             if (child == null)
                 throw new ArgumentNullException(nameof(child));
 
-            this.Children.Remove(child);
+            this._children.Remove(child);
             this.SetCheckedInternal(null, respondingToChildChange: true);
             child.IsChecked = false;
         }
@@ -364,7 +366,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         {
             this.Type = EventConfigNodeType.Group;
             this.Header = name;
-            this.Children = new ObservableCollection<EventConfigNodeViewModel>();
+            this._children = new ObservableCollection<EventConfigNodeViewModel>();
             this.Depth = 0;
             this.ButtonText = txt;
             this.ButtonVisibility = vis;
@@ -386,9 +388,9 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         {
             this.IsExpanded = true;
 
-            if(expandchildren && this.Children.Count != 0)
+            if(expandchildren && this._children.Count != 0)
             {
-                foreach(var c in this.Children)
+                foreach(var c in this._children)
                 {
                     c.Expand(true);
                 }
@@ -400,14 +402,14 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// </summary>
         internal void Clear()
         {
-            if (this.Children != null)
+            if (this._children != null)
             {
-                foreach (var c in this.Children)
+                foreach (var c in this._children)
                 {
                     c.Clear();
                 }
 
-                this.Children.Clear();
+                this._children.Clear();
             }
         }
 

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -64,7 +64,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                 }
                 else if (!value.HasValue)
                 {
-                    value = false; // Skip user-driven intermediate state (false is the next step in the cycle)
+                    value = false; // Skip user-driven intermediate state (false follows indeterminate in the cycle)
                 }
             }
 
@@ -435,8 +435,8 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// Set the checked state based on id and type
         /// </summary>B
         /// <param name="id"></param>
-        /// <param name="type">Event or Property</param>
-        /// <param name="val">The new value for IsChecked</param>
+        /// <param name="type"></param>
+        /// <param name="val"></param>
         private static void SetChecked(RecorderSetting setting, int id, RecordEntityType type, bool val, string name = null)
         {
             int change = val ? 1 : -1;
@@ -476,6 +476,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
 
         private void NewChildCheckState(bool? childIsChecked)
         {
+            // Respond to children only if their state doesn't match the current state
             if (this.IsThreeState && childIsChecked != IsChecked)
             {
                 SetCheckedInternal(null, respondingToChildChange: true);

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -321,8 +321,8 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// <summary>
         /// Constructor for property leaf node with given name
         /// </summary>
-        /// <param name="id">Event or Property ID/param>
-        /// <param name="type">Event/Property</param>
+        /// <param name="id"></param>
+        /// <param name="type"></param>
         public EventConfigNodeViewModel(int id, string name, EventConfigNodeType type)
         {
             this.Id = id;
@@ -335,8 +335,8 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// <summary>
         /// Constructor for event or property leaf node from id
         /// </summary>
-        /// <param name="id">Event or Property ID/param>
-        /// <param name="type">Event/Property</param>
+        /// <param name="id"></param>
+        /// <param name="type"></param>
         public EventConfigNodeViewModel(int id, EventConfigNodeType type)
         {
             this.Id = id;

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -86,7 +86,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                             break;
                     }
                 }
-                this._parent?.NewChildCheckState(value);
+                this._parent?.ChildCheckStateHasChanged(value);
                 OnPropertyChanged(nameof(this.IsChecked));
             }
         }
@@ -474,7 +474,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
 
         private EventConfigNodeViewModel _parent;
 
-        private void NewChildCheckState(bool? childIsChecked)
+        private void ChildCheckStateHasChanged(bool? childIsChecked)
         {
             // Respond to children only if their state doesn't match the current state
             if (this.IsThreeState && childIsChecked != IsChecked)

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -64,7 +64,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                 }
                 else if (!value.HasValue)
                 {
-                    value = false; // Skip user-driven intermediate state (false follows indeterminate in the cycle)
+                    value = false; // Skip user-driven intermediate state (false follows "mixed" in the cycle)
                 }
             }
 

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -56,9 +56,16 @@ namespace AccessibilityInsights.SharedUx.ViewModels
 
         private void SetCheckedInternal(bool? value, bool respondingToChildChange = false)
         {
-            if (this.IsThreeState && (respondingToChildChange || !value.HasValue))
+            if (this.IsThreeState)
             {
-                value = ComputeCheckedStateFromChildrenAndCurrentCheckedState(respondingToChildChange);
+                if (respondingToChildChange)
+                {
+                    value = ComputeCheckedStateBasedOnChildren();
+                }
+                else if (!value.HasValue)
+                {
+                    value = false; // Skip user-driven intermediate state (false is the next step in the cycle)
+                }
             }
 
             if (value != this._ischecked)
@@ -83,19 +90,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                 OnPropertyChanged(nameof(this.IsChecked));
             }
         }
-        private bool? ComputeCheckedStateFromChildrenAndCurrentCheckedState(bool respondingToChildChange)
-        {
-            bool? checkedStateFromChildren = ComputeNewCheckedStateFromChildrenCheckedState();
-
-            if (respondingToChildChange)
-            {
-                return checkedStateFromChildren;
-            }
-
-            return !IsChecked;
-        }
-
-        private bool? ComputeNewCheckedStateFromChildrenCheckedState()
+        private bool? ComputeCheckedStateBasedOnChildren()
         {
             int checkboxChildCount = 0;
             int checkedChildCount = 0;

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -37,7 +37,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         public bool IsThreeState { get; } = false;
 
         /// <summary>
-        /// Is node checked (indeterminate if null)
+        /// Is node checked (null if in "mixed" ThreeState value)
         /// </summary>
         private bool? _ischecked = false;
         public bool? IsChecked

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -433,7 +433,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
 
         /// <summary>
         /// Set the checked state based on id and type
-        /// </summary>B
+        /// </summary>
         /// <param name="id"></param>
         /// <param name="type"></param>
         /// <param name="val"></param>


### PR DESCRIPTION
#### Describe the change
As described in #815, the checkboxes in the event selection dialog don't follow the 3-state hierarchical selection pattern and are potentially confusing. This PR adds the plumbing needed to support the expected 3-state selection pattern. It includes the following changes:

- Expose an `IsThreeState` property to the `EventConfigNodeViewModel` class, and provide a way to set it when the node is constructed.
- Bind the `IsThreeState` property to the 3 key checkboxes in the configuration page
- Provide a notification to a ThreeState parent when any of its children change state or if the set of children is modified
- Teach the ThreeState parent to recalculate its `IsChecked` state in response to a modified child
- The natural order of a ThreeState checkbox is On, Mixed, Off, and that order will be respected in response to user actions. We only want to support On or Off in response to user actions on a ThreeState checkbox, so intentionally remap the Mixed state to Off in response to user actions on the ThreeState checkbox
- To ensure that future changes continue to preserve the parent/child linkage, change the type of the public `EventConfigNodeViewModel.Children` to be an `IReadOnlyCollection`, and make the editable version `private readonly`. I had originally resisted this but found a fairly painless way to incorporate it into this change.

Behavior before these changes:
![Checkboxes Before](https://user-images.githubusercontent.com/45672944/89569246-47c21c00-d7d9-11ea-98e5-ef0b8de572d7.gif)

Behavior after these changes:
![Checkboxes After](https://user-images.githubusercontent.com/45672944/89569266-4f81c080-d7d9-11ea-9fd5-5a005e6c492e.gif)

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #815 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



