### PR TITLE
Incorporate PR feedback that I saw after merging

### DIFF
--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -46,8 +46,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         {
             get
             {
-                return this.IsThreeState ? this._ischecked :
-                    this._ischecked.HasValue ? this._ischecked.Value : false;
+                return this.IsThreeState ? this._ischecked : this._ischecked.Value == true;
             }
 
             set

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -46,7 +46,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         {
             get
             {
-                return this.IsThreeState ? this._ischecked : this._ischecked.Value == true;
+                return this.IsThreeState ? this._ischecked : (this._ischecked.HasValue && this._ischecked.Value);
             }
 
             set

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -314,6 +314,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             if (child == null)
                 throw new ArgumentNullException(nameof(child));
 
+            child._parent = null;
             this._children.Remove(child);
             this.SetCheckedInternal(null, respondingToChildChange: true);
             child.IsChecked = false;


### PR DESCRIPTION
#### Describe the change
This includes a PR suggestion from #888 that I didn't see until after the merge was complete. Re-ran the key event listening scenarios to ensure that it's working as expected. 

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



