### PR TITLE
fix: Re-add app manifest to VersionSwitcher

### DIFF
--- a/src/AccessibilityInsights.VersionSwitcher/VersionSwitcher.csproj
+++ b/src/AccessibilityInsights.VersionSwitcher/VersionSwitcher.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyName>AccessibilityInsights.VersionSwitcher</AssemblyName>
     <RootNamespace>AccessibilityInsights.VersionSwitcher</RootNamespace>
+	<ApplicationManifest>AppManifests\app.manifest</ApplicationManifest>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
   </PropertyGroup>


### PR DESCRIPTION
#### Describe the change
As called out in #891, VersionSwitcher is no longer elevating, meaning that upgrade and channel changing scenarios are broken. This was a regression introduced when we recently changed the csproj formats (#836). It only impacts Canary builds since we haven't yet shipepd that build. Just as insurance against this in the future, I'll add a test for this in the validation template.

I validated this locally by simply running VersionSwitcher.exe from the explorer. Before the change, it skips the LUA prompt and goes directly to the message about bad parameters. After the change, it gives a LUA prompt. If permissions are granted, the bad parameters message is displayed. If permissions are denied, no message is displayed.

I also double-checked that the external UIAccess manifest for AccessibilityInsights.exe is working properly. Since VersionSwitcher is the only other project that requires a manifest, we won't have any other manifest-related regressions linked to the project format change.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #891 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



