### PR TITLE
fix: Change Ctrl+C from KeyUp to KeyDown (typical for Windows apps)

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
@@ -33,7 +33,7 @@
                     <Setter Property="Background" Value="Transparent"/>
                     <Setter Property="AutomationProperties.HelpText" Value="{x:Static Properties:Resources.SetterValueYouCanInspect}"/>
                     <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
-                    <EventSetter Event="KeyUp" Handler="TreeViewItem_KeyUp"></EventSetter>
+                    <EventSetter Event="KeyDown" Handler="TreeViewItem_KeyDown"></EventSetter>
                     <EventSetter Event="Expanded" Handler="TreeViewItem_Expanded"/>
                     <EventSetter Event="Collapsed" Handler="TreeViewItem_Collapsed"/>
                 </Style>

--- a/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml.cs
@@ -180,7 +180,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void TreeViewItem_KeyUp(object sender, KeyEventArgs e)
+        private void TreeViewItem_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.C && (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control)
             {

--- a/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
@@ -53,7 +53,7 @@
                     AutomationProperties.Name="{x:Static Properties:Resources.lvPropertiesAutomationPropertiesName}" 
                     IsTabStop="False" BorderThickness="0" ItemContainerStyle="{StaticResource LviDataGridStyle}"
                     Background="{DynamicResource ResourceKey=PrimaryBGBrush}"
-                    KeyUp="lvProperties_KeyUp">
+                    KeyDown="lvProperties_KeyDown">
                     <i:Interaction.Behaviors>
                         <behaviors:ColumnResizeHotkeyBehavior/>
                     </i:Interaction.Behaviors>

--- a/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml.cs
@@ -231,7 +231,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void lvProperties_KeyUp(object sender, KeyEventArgs e)
+        private void lvProperties_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.C && (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control)
             {

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -24,7 +24,7 @@
         WindowStyle="SingleBorderWindow"
         BorderBrush="{DynamicResource ResourceKey=WindowBorderBrush}"
         Background="{DynamicResource ResourceKey=PrimaryBGBrush}"
-        Topmost="True" KeyUp="Window_KeyUp" StateChanged="onStateChanged" Closing="Window_Closing" Height="601.918"
+        Topmost="True" KeyDown="Window_KeyDown" StateChanged="onStateChanged" Closing="Window_Closing" Height="601.918"
         AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWindow}">
     <Window.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -532,7 +532,7 @@ namespace AccessibilityInsights
             Process.Start(new ProcessStartInfo(HelpDocLink));
         }
 
-        private void Window_KeyUp(object sender, KeyEventArgs e)
+        private void Window_KeyDown(object sender, KeyEventArgs e)
         {
 
             if (e.Key == Key.C && (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control && !(Keyboard.FocusedElement is ListViewItem lvi && !(lvi.DataContext is ScanListViewItemViewModel)))


### PR DESCRIPTION
#### Describe the change
The "standard" for Windows apps (based on notepad, Office, and many others) is to trigger copy on KeyDown of Ctrl+C. AIWin is triggering on KeyUp of Ctrl+C. It probably shouldn't make much difference unless a user's muscle memory (like mine) is to do them quickly enough that the C is released slightly _after_ the Ctrl key. Copying will appear to be broken for users who do this, which is what led to #887. With this change in place, AIWin behaves like other Windows apps and copying feeling robust.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #887 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



