### PR TITLE
Stop left column from extending outside of window

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Converters/ColumnMaxWidthSpacingConverter.cs
+++ b/src/AccessibilityInsights.SharedUx/Converters/ColumnMaxWidthSpacingConverter.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace AccessibilityInsights.SharedUx.Converters
+{
+    /// <summary>
+    /// Converter used to ensure a column isn't wider than the available space
+    /// </summary>
+    [ValueConversion(typeof(double), typeof(double))]
+    public class ColumnMaxWidthSpacingConverter : MarkupExtension, IValueConverter
+    {
+        private static ColumnMaxWidthSpacingConverter _instance;
+        
+        internal const int SpacingConstant = 4;
+
+        public ColumnMaxWidthSpacingConverter() { }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => (double) value - SpacingConstant;
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => (double) value + SpacingConstant;
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return _instance ?? (_instance = new ColumnMaxWidthSpacingConverter());
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1499,4 +1499,17 @@
             </Trigger>
         </Style.Triggers>
     </Style>
+    <Style TargetType="ColumnDefinition" x:Key="LeftPaneColumn">
+        <Setter Property="MaxWidth">
+            <Setter.Value>
+                <Binding Path="ActualWidth" Converter="{converters:ColumnMaxWidthSpacingConverter}">
+                    <Binding.RelativeSource>
+                        <RelativeSource  Mode="FindAncestor" AncestorType="UserControl"/>
+                    </Binding.RelativeSource>
+                </Binding>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="MinWidth" Value="2"/>
+        <Setter Property="Width" Value="410"/>
+    </Style>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUxTests/Converters/ColumnMaxWidthSpacingConverterTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Converters/ColumnMaxWidthSpacingConverterTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Converters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AccessibilityInsights.SharedUxTests.Converters
+{
+    [TestClass]
+    public class ColumnMaxWidthSpacingConverterTests
+    {
+        [TestMethod]
+        public void BoolToVisibilityConverter_Convert()
+        {
+            double testWidth = 10;
+            double expectedWidth = 6;
+            ColumnMaxWidthSpacingConverter converter = new ColumnMaxWidthSpacingConverter();
+
+            Assert.AreEqual(converter.Convert(testWidth, typeof(double), null, null), expectedWidth);
+        }
+
+        [TestMethod]
+        public void BoolToVisibilityConverter_ConvertBack()
+        {
+            double testWidth = 4;
+            double expectedWidth = 8;
+            ColumnMaxWidthSpacingConverter converter = new ColumnMaxWidthSpacingConverter();
+
+            Assert.AreEqual(converter.ConvertBack(testWidth, typeof(double), null, null), expectedWidth);
+        }
+    }
+}

--- a/src/AccessibilityInsights/Modes/EventModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/EventModeControl.xaml
@@ -14,13 +14,16 @@
              AutomationProperties.Name="{x:Static properties:Resources.EventModeControlAutomationPropertiesName}" Height="600" Width="600"
              AutomationProperties.AutomationId="{x:Static sharedUxProperties:AutomationIDs.EventModeControl}"
              IsVisibleChanged="UserControl_IsVisibleChanged">
+    <UserControl.Resources>
+        <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
+    </UserControl.Resources>
     <Grid Panel.ZIndex="1">
         <Grid.RowDefinitions>
             <RowDefinition Height="34"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="columnSnap" Width="410" MinWidth="2"/>
+            <ColumnDefinition x:Name="columnSnap" Style="{StaticResource LeftPaneColumn}"/>
             <ColumnDefinition x:Name="columnInfo" Width="*"/>
         </Grid.ColumnDefinitions>
         <Grid Grid.Column="0" Grid.Row="1">

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml
@@ -72,7 +72,6 @@
                             Grid.Column="0" Grid.RowSpan="2"
                             VerticalAlignment="Stretch"
                             HorizontalAlignment="Right"
-                          Padding="4"
                             ResizeDirection="Columns" Margin="0,-34,0,0"
                             BorderBrush="Gray" BorderThickness="1"
                             AutomationProperties.Name="{x:Static properties:Resources.gsMidAutomationPropertiesName}"

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml
@@ -22,7 +22,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="columnSnap" Width="410" MinWidth="2"/>
+            <ColumnDefinition x:Name="columnSnap" Style="{StaticResource LeftPaneColumn}"/>
             <ColumnDefinition x:Name="columnInfo" Width="*"/>
         </Grid.ColumnDefinitions>
         <Grid Name="HierarchyGrid" Background="{DynamicResource ResourceKey=PrimaryBGBrush}"
@@ -72,6 +72,7 @@
                             Grid.Column="0" Grid.RowSpan="2"
                             VerticalAlignment="Stretch"
                             HorizontalAlignment="Right"
+                          Padding="4"
                             ResizeDirection="Columns" Margin="0,-34,0,0"
                             BorderBrush="Gray" BorderThickness="1"
                             AutomationProperties.Name="{x:Static properties:Resources.gsMidAutomationPropertiesName}"

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml
@@ -12,13 +12,16 @@
              xmlns:Util="clr-namespace:AccessibilityInsights.SharedUx.Utilities;assembly=AccessibilityInsights.SharedUx"
              mc:Ignorable="d" AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.SnapshotModeControl}"
              AutomationProperties.Name="{x:Static properties:Resources.SnapshotModeControlAutomationPropertiesName}" Height="600" Width="600">
+    <UserControl.Resources>
+        <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
+    </UserControl.Resources>
     <Grid Panel.ZIndex="1">
         <Grid.RowDefinitions>
             <RowDefinition Height="34"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="columnSnap" Width="360" MinWidth="2"/>
+            <ColumnDefinition x:Name="columnSnap" Style="{StaticResource LeftPaneColumn}"/>
             <ColumnDefinition x:Name="columnInfo" Width="*"/>
         </Grid.ColumnDefinitions>
         <Grid Grid.Column="0" Grid.Row="1">


### PR DESCRIPTION
#### Describe the change
As promised in #852, this PR introduces a max column width to our main UI's left column (which usually holds the UIA tree). This is analogous to the min column width requested in #814. To accomplish this, ColumnMaxWidthSpacingConverter is introduced and used to limit the column's max width to slightly smaller than its parent control. The LeftPaneColumn style is introduced and used to apply this converter to the left columns in the Live, Event, and Test (Snapshot) mode controls.

Behavior:
![column](https://user-images.githubusercontent.com/4615491/90833777-95707580-e2fd-11ea-9b65-3512b52739ce.gif)

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



