### PR TITLE
Fix ui tests

### DIFF
--- a/src/UITests/LiveMode.cs
+++ b/src/UITests/LiveMode.cs
@@ -11,7 +11,7 @@ namespace UITests
     [TestClass]
     public class LiveMode : AIWinSession
     {
-        readonly string TestAppPath = Path.GetFullPath("../../../../tools/WildlifeManager/WildlifeManager.exe");
+        readonly string TestAppPath = Path.GetFullPath("../../../../../tools/WildlifeManager/WildlifeManager.exe");
         Process _wildlifeManager;
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace UITests
 
         private void ValidateResultsInUIATree()
         {
-            int expectedResultsCount = 12; // this number should only change if axe-windows or WildlifeManager are modified.
+            int expectedResultsCount = 13; // this number should only change if axe-windows or WildlifeManager are modified.
 
             driver.TestMode.ResultsInUIATree.ValidateResults(2, expectedResultsCount);
             driver.TestMode.ResultsInUIATree.SwitchToDetailsTab();

--- a/src/UITests/UILibrary/LiveMode.cs
+++ b/src/UITests/UILibrary/LiveMode.cs
@@ -13,10 +13,9 @@ namespace UITests.UILibrary
         // These AutomationIDs came from inspecting the open file dialog with ai-win.
         // The assumption is that they are the same accross machines--if they aren't,
         // we'll need a more robust way to navigate the dialog.
-        const string OpenFileToolBarAutomationID = "1001";
         const string OpenFileFolderTextBoxAutomationID = "41477";
         const string OpenFileFileTextBoxAutomationID = "1148";
-        const string OpenFileSearchBoxAutomationID = "SearchEditBox";
+        const string OpenFileAllLocationsElementName = "All locations";
 
         public string SelectedElementText => Session.FindElementByAccessibilityId(AutomationIDs.InspectTabsElementTextBlock).Text;
 
@@ -28,19 +27,13 @@ namespace UITests.UILibrary
         public void OpenFile(string folder, string fileName)
         {
             Session.FindElementByAccessibilityId(AutomationIDs.MainWinLoadButton).Click();
-
-            // this puts focus on the toolbar, which we need for the next command to work
-            Session.FindElementByAccessibilityId(OpenFileSearchBoxAutomationID).SendKeys(Keys.Shift + Keys.Tab);
-            // this turns the toolbar into a text box
-            Session.FindElementByAccessibilityId(OpenFileToolBarAutomationID).SendKeys(Keys.Enter);
-
+            Session.FindElementByName(OpenFileAllLocationsElementName).Click();
+            
             var folderTextbox = Session.FindElementByAccessibilityId(OpenFileFolderTextBoxAutomationID);
-            folderTextbox.SendKeys(folder);
-            folderTextbox.SendKeys(Keys.Enter);
+            folderTextbox.SendKeys(folder + Keys.Enter);
 
             var fileTextbox = Session.FindElementByAccessibilityId(OpenFileFileTextBoxAutomationID);
-            fileTextbox.SendKeys(fileName);
-            fileTextbox.SendKeys(Keys.Enter);
+            fileTextbox.SendKeys(fileName + Keys.Enter);
         }
 
         public void TogglePause() => Session.FindElementByAccessibilityId(AutomationIDs.MainWindow).SendKeys(Keys.Shift + Keys.F5);


### PR DESCRIPTION
#### Describe the change
Currently, there are two issues with our UI tests:
1. The live mode UI tests fail because axe-windows has been updated and reports a different number of results and because we changed our directory structure.
2. The automation to load test and event files fails on my machine (but not the remote build).

This PR addresses 1 by updating the expected result count and WildlifeManager executable path and 2 by removing some unnecessary automation complexity.

#### PR checklist

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



