### PR TITLE
feat(tt-aug-2020): Consolidate "File Bug" strings into "File Issue"

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
@@ -128,7 +128,7 @@
                                                     Content="{Binding IssueDisplayText, TargetNullValue='{x:Static Properties:Resources.btnFileIssueContent}'}"
                                                     Margin="-1" Focusable="True" IsTabStop="True" Tag="{Binding }" HorizontalAlignment="Center"
                                                     AutomationProperties.HelpText="{Binding Path=Element.Glimpse, StringFormat='{x:Static Properties:Resources.btnFileBugAutomationPropertiesHelpText1}'}"
-                                                    AutomationProperties.Name="{Binding Path=BugIdString, StringFormat='Open link to bug #{0}', TargetNullValue='{x:Static Properties:Resources.btnFileBugAutomationPropertiesName1}'}"
+                                                    AutomationProperties.Name="{Binding Path=BugIdString, StringFormat='Open link to bug #{0}', TargetNullValue='{x:Static Properties:Resources.btnFileIssueContent}'}"
                                                     Visibility="{Binding Path=FileBugVisibility}"/>
                                                 </StackPanel>
                                             </DataTemplate>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -131,7 +131,7 @@
                                                 Content="{Binding IssueDisplayText, TargetNullValue='{x:Static Properties:Resources.btnFileIssueContent}'}"
                                                 Focusable="True" IsTabStop="False" IsVisibleChanged="btnFileBug_IsVisibleChanged"
                                                 AutomationProperties.HelpText="{Binding Path=Element.Glimpse, StringFormat='{x:Static Properties:Resources.btnFileBugAutomationPropertiesHelpText}'}"
-                                                AutomationProperties.Name="{Binding Path=IssueDisplayText, StringFormat='{x:Static Properties:Resources.btnFileBugAutomationPropertiesName}', TargetNullValue='{x:Static Properties:Resources.btnFileBugAutomationPropertiesNameTargetValue}'}">
+                                                AutomationProperties.Name="{Binding Path=IssueDisplayText, StringFormat='{x:Static Properties:Resources.btnFileBugAutomationPropertiesName}', TargetNullValue='{x:Static Properties:Resources.btnFileIssueContent}'}">
                                             </Button>
                                             <fabric:FabricIconControl x:Name="progressIcon"  GlyphName="ProgressRingDots" 
                                                                       Foreground="LightGray" RenderTransformOrigin="0.5, 0.5"

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -381,9 +381,6 @@
   <data name="btnFileBugAutomationPropertiesName" xml:space="preserve">
     <value>Open link to bug #{0}</value>
   </data>
-  <data name="btnFileBugAutomationPropertiesNameTargetValue" xml:space="preserve">
-    <value>File a bug</value>
-  </data>
   <data name="lvResultsHelpText" xml:space="preserve">
     <value>Press Enter to inspect detail or right arrow key for column options</value>
   </data>
@@ -790,9 +787,6 @@
   </data>
   <data name="btnFileBugAutomationPropertiesHelpText1" xml:space="preserve">
     <value>Bug for {0}</value>
-  </data>
-  <data name="btnFileBugAutomationPropertiesName1" xml:space="preserve">
-    <value>File a bug</value>
   </data>
   <data name="StartupModeControl_moreGuidanceText" xml:space="preserve">
     <value>More guidance and tutorials</value>


### PR DESCRIPTION
#### Describe the change
We have 2 places where the visible text is "File Issue" but the AT-visible text is "File Bug". This change consolidates the 3 strings into 1 so that they're back in sync and will stay in sync until someone explicitly takes them out of sync.

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue [1750005](https://mseng.visualstudio.com/1ES/_workitems/edit/1750005)
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

Validated that NVDA is reading the same string that is displayed on screen

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



