### PR TITLE
feat(tt-aug-2020): Make "set delay" edit more HC-friendly

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
@@ -171,16 +171,16 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="135"/>
                     <ColumnDefinition Width="50"/>
-                    <ColumnDefinition Width="130"/>
+                    <ColumnDefinition Width="140"/>
                 </Grid.ColumnDefinitions>
                 <controls:FabricIconControl Grid.Column="0" Height="16" Width="16" GlyphName="F12DevTools" GlyphSize="Default" Foreground="{DynamicResource ResourceKey=IconBrush}" AutomationProperties.Name="{x:Static Properties:Resources.ApplicationSettingsControl_MouseIconAutomationName}" ShowInControlView="False"/>
                 <Label Name="lblMouseLabel" Grid.Column="1" Margin="8,0,0,0" Content="{x:Static Properties:Resources.lblMouseLabelContent}"  RenderTransformOrigin="0.877,0.538" Padding="0" Style="{StaticResource LblText}" VerticalAlignment="Center"/>
                 <ToggleButton Grid.Column="2" Style="{StaticResource tgbSlider}" Name="tgbtnMouse" AutomationProperties.LabeledBy="{Binding ElementName=lblMouseLabel}" IsChecked="{Binding SelectionByMouse}"/>
                 <StackPanel Grid.Column="3" Margin="30,0,0,0" Orientation="Horizontal">
-                    <Label Name="lblDelay" Content="{x:Static Properties:Resources.lblDelayContent}" Padding="0" Style="{StaticResource LblText}" Target="{Binding ElementName=tbMouseDelay}"/>
-                    <TextBox Name="tbMouseDelay" Height="16" Width="28" Margin="5,0,5,0" PreviewTextInput="textboxMouseDelay_PreviewTextInput" MaxLines="1" MaxLength="4" 
-                     VerticalContentAlignment="Center" Style="{StaticResource TxtBxText}" AutomationProperties.Name="{x:Static Properties:Resources.tbMouseDelayAutomationName}" TextChanged="tbMouseDelay_TextChanged"/>
-                    <Label Content="ms" Padding="0" Style="{StaticResource LblText}"/>
+                    <Label Name="lblDelay" Margin="0,5,0,0" Content="{x:Static Properties:Resources.lblDelayContent}" Padding="0" Style="{StaticResource LblText}" Target="{Binding ElementName=tbMouseDelay}"/>
+                    <TextBox Name="tbMouseDelay" Height="26" Width="38" Margin="5,0,5,0" PreviewTextInput="textboxMouseDelay_PreviewTextInput" MaxLines="1" MaxLength="4" 
+                     VerticalContentAlignment="Center" HorizontalContentAlignment="Right" Style="{StaticResource TxtBxText}" AutomationProperties.Name="{x:Static Properties:Resources.tbMouseDelayAutomationName}" TextChanged="tbMouseDelay_TextChanged"/>
+                    <Label Content="ms" Margin="0,5,0,0" Padding="0" Style="{StaticResource LblText}"/>
                 </StackPanel>
             </Grid>
         </Grid>


### PR DESCRIPTION
#### Describe the change
The focus rect in High Contrast modes is thicker. The edit for the "set delay" text is just barely large enough in non-HC modes, and as a result the text can't really be seen in HC modes. This change makes the edit control larger in all modes and adjusts the surrounding elements to accommodate the change. With the wider control, the edit text looks funny left-justified, so I made it right-justified, instead. The text is limited to 4 characters, so it shouldn't fill the edit with only 3 characters

I opted for simplicity and went for fixed sizing, rather than making it sensitive to whether or not HC mode is enabled. I think it looks OK, but let me know if you think the edit needs to be smaller in non-HC modes.

Screenshots of old behavior in light mode, as well as new behavior in all modes (the caret happened be blinked "off" when I grabbed the screenshot for HC#2 and HC black):
![image](https://user-images.githubusercontent.com/45672944/91509012-f4019a80-e88d-11ea-8a9f-647bfff93c4c.png)


#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# [1749998](https://dev.azure.com/mseng/1ES/_workitems/edit/1749998)
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



