### PR TITLE
feat(tt-aug-2020): include "Built with Axe Windows" in scan mode when it has focus

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -25,7 +25,7 @@
             </Hyperlink>
         </TextBlock>
         <TextBlock Text="{Binding Path=AxeVersion, StringFormat={x:Static Properties:Resources.AboutTabControl_AxeVersionFormat}}"
-               Style="{StaticResource tbLine}" Margin="0,5,0,0"/>
+               Style="{StaticResource tbHeaderDark}" Margin="0,5,0,0"/>
         <Label Style="{StaticResource lblDark}" Margin="0,5,0,0" Content="{Binding Path=UIAccessStatus, Mode=OneWay}" />
         <TextBlock Padding="0" FontSize="14" Margin="0,32,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlHelp" AutomationProperties.Name="{x:Static Properties:Resources.hlHelpName}" 

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -24,8 +24,8 @@
                 <Run Text="{Binding Path=VersionInfoLabel, Mode=OneWay}" />
             </Hyperlink>
         </TextBlock>
-        <Label Content="{Binding Path=AxeVersion}" ContentStringFormat="{x:Static Properties:Resources.AboutTabControl_AxeVersionFormat}"
-               Style="{StaticResource lblDark}" Margin="0,5,0,0"/>
+        <TextBlock Text="{Binding Path=AxeVersion, StringFormat={x:Static Properties:Resources.AboutTabControl_AxeVersionFormat}}"
+               Style="{StaticResource tbLine}" Margin="0,5,0,0"/>
         <Label Style="{StaticResource lblDark}" Margin="0,5,0,0" Content="{Binding Path=UIAccessStatus, Mode=OneWay}" />
         <TextBlock Padding="0" FontSize="14" Margin="0,32,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlHelp" AutomationProperties.Name="{x:Static Properties:Resources.hlHelpName}" 


### PR DESCRIPTION
#### Describe the change

In the about page, the text 'built with axe windows' is omitted from initial scan mode navigation because the UIA tree currently has 'built with axe windows' as a child of a text node with the axe-windows version. 

before:
![UIA tree shows '0.9.6 prerelease' for the text 'Built with Axe windows 0.9.6 prerelease'](https://user-images.githubusercontent.com/7775527/91604093-eb0ed880-e922-11ea-83a5-ed0a456de417.png)

Using a label / content pair seems to create a parent node with the content, and the computed content string format ends up underneath the text node. Switching to a simple textblock seemed to produce a better representation, with a single node (no parent/child pair) with the computed content string.

after:
![UIA tree shows 'Built with Axe windows 0.9.6 prerelease' for the text](https://user-images.githubusercontent.com/7775527/91604173-08dc3d80-e923-11ea-9282-496e2b2e88fd.PNG)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



