### PR TITLE
feat(tt-aug-2020): Announce version # in version link

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -18,7 +18,7 @@
         <Label Padding="0" FontSize="20" FontWeight="Bold" Content="{x:Static Properties:Resources.LabelContentAccessibilityInsightsForWindows}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
         <Label Padding="0" FontSize="14" Margin="0,5,0,0" Content="{x:Static Properties:Resources.LabelContentByMicrosoftCorporation}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
         <TextBlock Padding="0" FontSize="14" Margin="0,5,0,0" HorizontalAlignment="Left">
-            <Hyperlink x:Name="hlVersion" AutomationProperties.Name="{x:Static Properties:Resources.hlVersion}" 
+            <Hyperlink x:Name="hlVersion" AutomationProperties.Name="{Binding Path=VersionInfoLabel, Mode=OneWay}" 
                     Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 
                     NavigateUri="{Binding Path=VersionInfoUri}" TextDecorations="None" Style="{StaticResource hLink}">
                 <Run Text="{Binding Path=VersionInfoLabel, Mode=OneWay}" />

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1927,15 +1927,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Version.
-        /// </summary>
-        public static string hlVersion {
-            get {
-                return ResourceManager.GetString("hlVersion", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Type a keyboard shortcut.
         /// </summary>
         public static string HotkeyGrabDialogWindowTitle {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1456,9 +1456,6 @@ Do you want to change the channel? </value>
   <data name="LabelUIAccessNotAvailable" xml:space="preserve">
     <value>UIAccess is not available</value>
   </data>
-  <data name="hlVersion" xml:space="preserve">
-    <value>Version</value>
-  </data>
   <data name="VersionLinkContentFormat" xml:space="preserve">
     <value>Version {0}</value>
     <comment>{0} is the placeholder for the app version string</comment>


### PR DESCRIPTION
#### Describe the change
Narrator isn't currently announcing the version number from the version number link. Add the version number to the text that Narrator announces.

It's worth noting that Narrator announces only the automation name, while NVDA announces both the automation name and the text in the run. Making this change means that NVDA is double-speaking, but it's double speaking in the same way that it does with other links in this dialog (although that could be seen as exacerbating an existing problem).

Here's a table of what gets announced, just for reference (a comma represents a brief pause in the speaking)

visual text | old version + Narrator | new version + Narrator | old version + NVDA | new version + NVDA
--- | --- | --- | --- | ---
Version 1.1.1234.1 | Hyperlink, Version | Hyperlink, Version 1.1.1234.1 | Version 1.1.1234.1, Version link | Version 1.1.1234.1, Version 1.1.1234.1 link
Help | Hyperlink, Help | Hyperlink, Help | Help, Help link | Help, Help link
License terms | Hyperlink, License terms | Hyperlink, License terms | License terms, License terms link | License terms, License terms link
Third party notices | Hyperlink, Third party notices | Hyperlink, Third party notices | Third party notices, Third party notices link | Third party notices, Third party notices link

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue [1749999](https://mseng.visualstudio.com/1ES/_workitems/edit/1749999)
- [A/T only] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



