### PR TITLE
feat(tt-aug-2020): Use correct string for splitter help text

### DIFF
--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml
@@ -75,7 +75,7 @@
                             ResizeDirection="Columns" Margin="0,-34,0,0"
                             BorderBrush="Gray" BorderThickness="1"
                             AutomationProperties.Name="{x:Static properties:Resources.gsMidAutomationPropertiesName}"
-                            AutomationProperties.HelpText="{x:Static properties:Resources.gsMidAutomationPropertiesHelpText1}" DragDelta="gsMid_DragDelta" KeyDown="gsMid_KeyDown"/>
+                            AutomationProperties.HelpText="{x:Static properties:Resources.gsMidAutomationPropertiesHelpText}" DragDelta="gsMid_DragDelta" KeyDown="gsMid_KeyDown"/>
         </Grid>
         <controls:InspectTabsControl Name="ctrlTabs" Grid.Column="1" CurrentMode="Live" Grid.RowSpan="2"
                                      AutomationProperties.Name="{x:Static properties:Resources.ctrlTabsElementAutomationPropertiesName}"

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml
@@ -39,7 +39,7 @@
                         ResizeDirection="Columns"
                         BorderBrush="Gray" BorderThickness="1"
                         AutomationProperties.Name="{x:Static properties:Resources.gsMidAutomationPropertiesName}"
-                        AutomationProperties.HelpText="{x:Static properties:Resources.HandleFailedSelectionResetConnectionLostMessage}"/>
+                        AutomationProperties.HelpText="{x:Static properties:Resources.gsMidAutomationPropertiesHelpText}"/>
         <controls:InspectTabsControl Name="ctrlTabs" Grid.Column="1" CurrentMode="TestProperties" AutomationProperties.Name="{x:Static properties:Resources.ctrlTabsElementAutomationPropertiesName}" Grid.RowSpan="2"/>
         <fabric:ProgressRingControl Size="30" Grid.RowSpan="2"
                                 x:Name="ctrlProgressRing"

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -583,15 +583,6 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to change horizontal size of Hierarchy pane.
-        /// </summary>
-        public static string gsMidAutomationPropertiesHelpText1 {
-            get {
-                return ResourceManager.GetString("gsMidAutomationPropertiesHelpText1", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to splitter for Hierarchy pane.
         /// </summary>
         public static string gsMidAutomationPropertiesName {

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -518,9 +518,6 @@ Please ensure that you are opening a valid test file using the most recent relea
   <data name="ctrlNamedCommandbarAutomationPropertiesName" xml:space="preserve">
     <value>Command bar</value>
   </data>
-  <data name="gsMidAutomationPropertiesHelpText1" xml:space="preserve">
-    <value>change horizontal size of Hierarchy pane</value>
-  </data>
   <data name="btnConfigAutomationPropertiesNameNoBugFiling" xml:space="preserve">
     <value>Settings</value>
   </data>


### PR DESCRIPTION
#### Describe the change
The vertical splitter specifies the wrong constant as its help text. This specifies the correct constant and consolidates 2 copies of the same string into a single constant.

Here are the before and after views of the help text for the splitter pane:
Before:
![image](https://user-images.githubusercontent.com/45672944/91619334-aba3b480-e941-11ea-86ab-9eb407088085.png)

After:
![image](https://user-images.githubusercontent.com/45672944/91619375-c2e2a200-e941-11ea-9f11-5821b43eb154.png)

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue [1750622](https://mseng.visualstudio.com/1ES/_workitems/edit/1750622)
- [A/T only] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



