### PR TITLE
feat(tt-aug-2020): Revise help text for search box

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -93,7 +93,7 @@
                     <controls:PlaceholderTextBox x:Name="textboxSearch" TextChanged="textboxSearch_TextChanged"
                         AutomationProperties.Name="{x:Static Properties:Resources.HierarchyControl_textboxSearchAutomationName}"
                         Height="24" HorizontalAlignment="Stretch" VerticalContentAlignment="Center"
-                        AutomationProperties.HelpText="{Binding ElementName=tbSearch, Path=Text}"
+                        AutomationProperties.HelpText="{Binding SearchBoxHelpText, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:HierarchyControl}}"
                         BorderThickness="{DynamicResource ResourceKey=BtnBrdrThickness}">
                         <controls:PlaceholderTextBox.Style>
                             <Style TargetType="{x:Type controls:PlaceholderTextBox}" BasedOn="{StaticResource ResourceKey=PlaceholderTextBox}">

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -100,7 +100,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         {
             get
             {
-                if (string.IsNullOrWhiteSpace(this.textboxSearch.Text))
+                if (string.IsNullOrEmpty(this.textboxSearch.Text))
                 {
                     return this.IsLiveMode ? Properties.Resources.SetterValueSearchByName : Properties.Resources.SetterValueSearchByString;
                 }

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -94,6 +94,22 @@ namespace AccessibilityInsights.SharedUx.Controls
         }
 
         /// <summary>
+        /// Help text for search box
+        /// </summary>
+        public string SearchBoxHelpText
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(this.textboxSearch.Text))
+                {
+                    return this.IsLiveMode ? Properties.Resources.SetterValueSearchByName : Properties.Resources.SetterValueSearchByString;
+                }
+
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
         /// Constructor
         /// </summary>
         public HierarchyControl()
@@ -306,6 +322,7 @@ namespace AccessibilityInsights.SharedUx.Controls
 
                 FireAsyncContentLoadedEvent();
             }
+            this.textboxSearch.SetValue(AutomationProperties.HelpTextProperty, SearchBoxHelpText);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3472,7 +3472,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search by name and control type..
+        ///   Looks up a localized string similar to Search by name and control type.
         /// </summary>
         public static string SetterValueSearchByName {
             get {
@@ -3481,7 +3481,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search by common string properties and patterns..
+        ///   Looks up a localized string similar to Search by common string properties and patterns.
         /// </summary>
         public static string SetterValueSearchByString {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -663,10 +663,10 @@
     <value>Bug {0}</value>
   </data>
   <data name="SetterValueSearchByString" xml:space="preserve">
-    <value>Search by common string properties and patterns.</value>
+    <value>Search by common string properties and patterns</value>
   </data>
   <data name="SetterValueSearchByName" xml:space="preserve">
-    <value>Search by name and control type.</value>
+    <value>Search by name and control type</value>
   </data>
   <data name="btnSettingsAutomationPropertiesName1" xml:space="preserve">
     <value>Settings</value>


### PR DESCRIPTION
#### Describe the change
The placeholder text used in the Search box is not being announced via an A/T. After consulting with @RobGallo, we opted to read the placeholder text only if the user hasn't typed anything into the control. That prevents overwhelming the user with the prompt, and provides an experience analogous to what a visual user experiences. The matrix looks like this:

Mode | HelpText before user enters data | HelpText after user enters non-trivial data
--- | --- | ---
Live | Search by name and control type | _none_
Test | Search by common string properties and patterns | _none_

This can be viewed in the following screenshots--the upper instance of AIWin shows the user state, and the lower instance of AIWin shows the help text:

Live mode, no text in search box:
![image](https://user-images.githubusercontent.com/45672944/91770946-f66a3a00-eb96-11ea-97ce-98b958ed3bfe.png)

Live mode, text in search box:
![image](https://user-images.githubusercontent.com/45672944/91771084-316c6d80-eb97-11ea-9dfc-0b3be1b9508c.png)

Test mode, no text in search box:
![image](https://user-images.githubusercontent.com/45672944/91771122-4517d400-eb97-11ea-83f0-4e5e60814a01.png)

Test mode, text in search box:
![image](https://user-images.githubusercontent.com/45672944/91771169-5eb91b80-eb97-11ea-9a45-11a228574dd8.png)

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# [1749289](https://mseng.visualstudio.com/1ES/_workitems/edit/1749289)
- [A/T only] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



