### PR TITLE
feat(tt-aug-2020): Expose GitHub sample URL as readable text

### DIFF
--- a/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml
+++ b/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml
@@ -21,9 +21,9 @@
         <TextBlock x:Name="connectionInstr" Grid.Row="0" TextWrapping="Wrap" Margin="0 9px" FontSize="{DynamicResource StandardTextSize}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" Focusable="True" >
             <TextBlock.Inlines>
                 <!-- comments here are to avoid space insertion between runs -->
-                <Run Text="{x:Static Properties:Resources.tbURLPlaceHolder1}" /><!--
-                --><Run FontStyle="Italic" Text="{x:Static Properties:Resources.PlaceHolder}" /><!--
-                --><Run Text="{x:Static Properties:Resources.tbURLPlaceHolder2}" />
+                <Run Text="{x:Static Properties:Resources.RepoLinkDescriptionPrefix}" /><!--
+                --><Run FontStyle="Italic" Text="{x:Static Properties:Resources.RepoLinkDescriptionItalicized}" /><!--
+                --><Run Text="{x:Static Properties:Resources.RepoLinkDescriptionSuffix}" />
             </TextBlock.Inlines>
         </TextBlock>
         <Grid Grid.Row="1" HorizontalAlignment="Left" >

--- a/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml
+++ b/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml
@@ -8,7 +8,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:Properties="clr-namespace:AccessibilityInsights.Extensions.GitHub.Properties"
     xmlns:src="clr-namespace:AccessibilityInsights.Extensions.Interfaces.IssueReporting;assembly=AccessibilityInsights.Extensions"
-    xmlns:controls="clr-namespace:AccessibilityInsights.CommonUxComponents.Controls;assembly=AccessibilityInsights.CommonUxComponents"
     mc:Ignorable="d"
     IsVisibleChanged="IssueConfigurationControl_IsVisibleChanged">
     <UserControl.Resources>
@@ -28,26 +27,13 @@
             </TextBlock.Inlines>
         </TextBlock>
         <Grid Grid.Row="1" HorizontalAlignment="Left" >
-            <controls:PlaceholderTextBox
+            <TextBox
                 Width="380px" Height="32px" VerticalContentAlignment="Center" x:Name="tbURL" Margin="5"
                 AutomationProperties.Name="{x:Static Properties:Resources.RepoLinkAutomationName}" 
                 FontSize="{DynamicResource StandardTextSize}"
                 AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.IssueConfigurationUrlTextBox}"
-                BorderThickness="1"
-                Placeholder="{x:Static Properties:Resources.PlaceHolder}">
-                <controls:PlaceholderTextBox.Style>
-                    <Style TargetType="{x:Type controls:PlaceholderTextBox}" BasedOn="{StaticResource ResourceKey=PlaceholderTextBox}">
-                        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
-                        <Setter Property="CaretBrush" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding Text, ElementName=tbURL}" Value="">
-                                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SecondaryFGBrush}"/>
-                                <Setter Property="FontStyle" Value="Italic"/>
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </controls:PlaceholderTextBox.Style>
-            </controls:PlaceholderTextBox>
+                BorderThickness="1" >
+            </TextBox>
         </Grid>
     </Grid>
 </src:IssueConfigurationControl>

--- a/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml
+++ b/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml
@@ -29,7 +29,7 @@
         </TextBlock>
         <Grid Grid.Row="1" HorizontalAlignment="Left" >
             <controls:PlaceholderTextBox
-                Width="294px" Height="32px" VerticalContentAlignment="Center" x:Name="tbURL" Margin="5"
+                Width="380px" Height="32px" VerticalContentAlignment="Center" x:Name="tbURL" Margin="5"
                 AutomationProperties.Name="{x:Static Properties:Resources.RepoLinkAutomationName}" 
                 FontSize="{DynamicResource StandardTextSize}"
                 AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.IssueConfigurationUrlTextBox}"

--- a/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml
+++ b/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml
@@ -19,11 +19,18 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-        <TextBlock x:Name="connectionInstr" Grid.Row="0" Text="{x:Static Properties:Resources.tbURLPlaceHolder}" TextWrapping="Wrap" Margin="0 9px" FontSize="{DynamicResource StandardTextSize}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
-        <Grid Grid.Row="1" >
+        <TextBlock x:Name="connectionInstr" Grid.Row="0" TextWrapping="Wrap" Margin="0 9px" FontSize="{DynamicResource StandardTextSize}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" Focusable="True" >
+            <TextBlock.Inlines>
+                <!-- comments here are to avoid space insertion between runs -->
+                <Run Text="{x:Static Properties:Resources.tbURLPlaceHolder1}" /><!--
+                --><Run FontStyle="Italic" Text="{x:Static Properties:Resources.PlaceHolder}" /><!--
+                --><Run Text="{x:Static Properties:Resources.tbURLPlaceHolder2}" />
+            </TextBlock.Inlines>
+        </TextBlock>
+        <Grid Grid.Row="1" HorizontalAlignment="Left" >
             <controls:PlaceholderTextBox
                 Width="294px" Height="32px" VerticalContentAlignment="Center" x:Name="tbURL" Margin="5"
-                AutomationProperties.Name="{x:Static Properties:Resources.tbURLPlaceHolder}" 
+                AutomationProperties.Name="{x:Static Properties:Resources.RepoLinkAutomationName}" 
                 FontSize="{DynamicResource StandardTextSize}"
                 AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.IssueConfigurationUrlTextBox}"
                 BorderThickness="1"

--- a/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.Designer.cs
@@ -113,7 +113,16 @@ namespace AccessibilityInsights.Extensions.GitHub.Properties {
                 return ResourceManager.GetString("LinkPatttern", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Repo link.
+        /// </summary>
+        public static string RepoLinkAutomationName {
+            get {
+                return ResourceManager.GetString("RepoLinkAutomationName", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The following accessibility issue needs investigation.
         ///
@@ -196,14 +205,25 @@ namespace AccessibilityInsights.Extensions.GitHub.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enter desired GitHub repo link.
+        ///   Looks up a localized string similar to Enter desired GitHub repo link (example: .
         /// </summary>
-        public static string tbURLPlaceHolder {
+        public static string tbURLPlaceHolder1 {
             get {
-                return ResourceManager.GetString("tbURLPlaceHolder", resourceCulture);
+                return ResourceManager.GetString("tbURLPlaceHolder1", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to ).
+        /// </summary>
+        public static string tbURLPlaceHolder2
+        {
+            get
+            {
+                return ResourceManager.GetString("tbURLPlaceHolder2", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to {0}+([-]{0}+)*.
         /// </summary>

--- a/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.Designer.cs
@@ -152,9 +152,9 @@ namespace AccessibilityInsights.Extensions.GitHub.Properties {
         /// <summary>
         ///   Looks up a localized string similar to https://github.com/owner/repo.
         /// </summary>
-        public static string PlaceHolder {
+        public static string RepoLinkDescriptionItalicized {
             get {
-                return ResourceManager.GetString("PlaceHolder", resourceCulture);
+                return ResourceManager.GetString("RepoLinkDescriptionItalicized", resourceCulture);
             }
         }
         
@@ -207,20 +207,20 @@ namespace AccessibilityInsights.Extensions.GitHub.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Enter desired GitHub repo link (example: .
         /// </summary>
-        public static string tbURLPlaceHolder1 {
+        public static string RepoLinkDescriptionPrefix {
             get {
-                return ResourceManager.GetString("tbURLPlaceHolder1", resourceCulture);
+                return ResourceManager.GetString("RepoLinkDescriptionPrefix", resourceCulture);
             }
         }
 
         /// <summary>
         ///   Looks up a localized string similar to ).
         /// </summary>
-        public static string tbURLPlaceHolder2
+        public static string RepoLinkDescriptionSuffix
         {
             get
             {
-                return ResourceManager.GetString("tbURLPlaceHolder2", resourceCulture);
+                return ResourceManager.GetString("RepoLinkDescriptionSuffix", resourceCulture);
             }
         }
 

--- a/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.resx
@@ -137,7 +137,7 @@
   <data name="NoFailureIssueTitle" xml:space="preserve">
     <value>({0}/{1}) has an accessibility issue that needs investigation</value>
   </data>
-  <data name="PlaceHolder" xml:space="preserve">
+  <data name="RepoLinkDescriptionItalicized" xml:space="preserve">
     <value>https://github.com/owner/repo</value>
   </data>
   <data name="SingleFailureIssueBody" xml:space="preserve">
@@ -156,10 +156,10 @@ This accessibility issue was found using Accessibility Insights for Windows, a t
   <data name="SingleFailureIssueTitle" xml:space="preserve">
     <value>{0}: ({1}/{2}) {3}</value>
   </data>
-  <data name="tbURLPlaceHolder1" xml:space="preserve">
+  <data name="RepoLinkDescriptionPrefix" xml:space="preserve">
     <value>Enter desired GitHub repo link (example: </value>
   </data>
-  <data name="tbURLPlaceHolder2" xml:space="preserve">
+  <data name="RepoLinkDescriptionSuffix" xml:space="preserve">
     <value>)</value>
   </data>
   <data name="AlphaNumricPattern" xml:space="preserve">

--- a/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.resx
@@ -156,8 +156,11 @@ This accessibility issue was found using Accessibility Insights for Windows, a t
   <data name="SingleFailureIssueTitle" xml:space="preserve">
     <value>{0}: ({1}/{2}) {3}</value>
   </data>
-  <data name="tbURLPlaceHolder" xml:space="preserve">
-    <value>Enter desired GitHub repo link</value>
+  <data name="tbURLPlaceHolder1" xml:space="preserve">
+    <value>Enter desired GitHub repo link (example: </value>
+  </data>
+  <data name="tbURLPlaceHolder2" xml:space="preserve">
+    <value>)</value>
   </data>
   <data name="AlphaNumricPattern" xml:space="preserve">
     <value>[a-zA-Z0-9]</value>
@@ -179,5 +182,8 @@ This accessibility issue was found using Accessibility Insights for Windows, a t
   </data>
   <data name="InvalidLink" xml:space="preserve">
     <value>Invalid GitHub Link Format!</value>
+  </data>
+  <data name="RepoLinkAutomationName" xml:space="preserve">
+    <value>Repo link</value>
   </data>
 </root>


### PR DESCRIPTION
#### Describe the change
The placeholder text for the GitHub repo is not being exposed to screen readers. This change makes the sample text readable as text outside the edit control. It also shortens the accessible name of the edit control, since its functionality is described by the previous control, and makes the edit control wider. Design also suggested that we remove the placeholder, as it's redundant and placeholders are tricky in general.

Screenshot of revised dialog (with no user-provided text):
![image](https://user-images.githubusercontent.com/45672944/92021362-8088de80-ed0e-11ea-8f9b-dd3345041ec3.png)

Screenshot of revised dialog (with user-provided text):
![image](https://user-images.githubusercontent.com/45672944/92021485-b3cb6d80-ed0e-11ea-9a3f-4198bc936ed9.png)

#### PR checklist

- [] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue [1766303](https://mseng.visualstudio.com/1ES/_workitems/edit/1766303)
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



