### PR TITLE
feat(tt-aug-2020): Expose ADO sample URL as readable text

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -43,24 +43,8 @@
             </Grid.ColumnDefinitions>
             <Grid Grid.ColumnSpan="2">
                 <ComboBox x:Name ="ServerComboBox" Grid.Row="1" IsEditable="True" Height="30" VerticalContentAlignment="Center" FontSize="{DynamicResource StandardTextSize}"
-                              AutomationProperties.Name="{x:Static Properties:Resources.ServerComboBoxAutomationPropertiesName}" KeyDown="ServerComboBox_KeyDown">
+                        AutomationProperties.Name="{x:Static Properties:Resources.ServerComboBoxAutomationPropertiesName}" KeyDown="ServerComboBox_KeyDown">
                 </ComboBox>
-                <TextBlock x:Name="accountPlaceholder" Text="{x:Static Properties:Resources.accountPlaceholderText}" IsHitTestVisible="False">
-                    <TextBlock.Style>
-                        <Style TargetType="TextBlock">
-                            <Setter Property="Visibility" Value="Collapsed"/>
-                            <Setter Property="VerticalAlignment" Value="Center"/>
-                            <Setter Property="Margin" Value="6 0 0 6"/>
-                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SecondaryFGBrush}"/>
-                            <Setter Property="FontSize" Value="{DynamicResource StandardTextSize}"/>
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding ElementName=ServerComboBox, Path=Text.Length}" Value="0">
-                                    <Setter Property="Visibility" Value="Visible"></Setter>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBlock.Style>
-                </TextBlock>
             </Grid>
             <Button Grid.Column="3" x:Name="btnNext" Padding="8,0" HorizontalAlignment="Left" 
                     Content="{x:Static Properties:Resources.btnNextAutomationPropertiesName}" Click="NextButton_Click"

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -25,9 +25,9 @@
                 FontSize="{DynamicResource StandardTextSize}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}">
             <TextBlock.Inlines>
                 <!-- comments here are to avoid space insertion between runs -->
-                <Run Text="{x:Static Properties:Resources.connectionInstrText1}"/><!--
-                --><Run FontStyle="Italic" Text="{x:Static Properties:Resources.accountPlaceholderText}"/><!--
-                --><Run Text="{x:Static Properties:Resources.connectionInstrText2}"/>
+                <Run Text="{x:Static Properties:Resources.ConnectionDescriptionPrefix}"/><!--
+                --><Run FontStyle="Italic" Text="{x:Static Properties:Resources.ConnectionDescriptionItalicized}"/><!--
+                --><Run Text="{x:Static Properties:Resources.ConnectionDescriptionSuffix}"/>
             </TextBlock.Inlines>
         </TextBlock>
         <Grid Grid.Row="1">

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -21,8 +21,15 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <TextBlock x:Name="connectionInstr" Grid.Row="0" Text="{x:Static Properties:Resources.connectionInstrText}"
-                           TextWrapping="Wrap" Margin="0,20,0,8" FontSize="{DynamicResource StandardTextSize}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+        <TextBlock x:Name="connectionInstr" Grid.Row="0" TextWrapping="Wrap" Margin="0,20,0,8" Focusable="True"
+                FontSize="{DynamicResource StandardTextSize}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}">
+            <TextBlock.Inlines>
+                <!-- comments here are to avoid space insertion between runs -->
+                <Run Text="{x:Static Properties:Resources.connectionInstrText1}"/><!--
+                --><Run FontStyle="Italic" Text="{x:Static Properties:Resources.accountPlaceholderText}"/><!--
+                --><Run Text="{x:Static Properties:Resources.connectionInstrText2}"/>
+            </TextBlock.Inlines>
+        </TextBlock>
         <Grid Grid.Row="1">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
@@ -142,14 +142,25 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enter desired Azure Boards link.
+        ///   Looks up a localized string similar to Enter desired Azure Boards link (example: .
         /// </summary>
-        public static string connectionInstrText {
+        public static string connectionInstrText1 {
             get {
-                return ResourceManager.GetString("connectionInstrText", resourceCulture);
+                return ResourceManager.GetString("connectionInstrText1", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to ).
+        /// </summary>
+        public static string connectionInstrText2
+        {
+            get
+            {
+                return ResourceManager.GetString("connectionInstrText2", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Enter your desired Azure Boards link.
         /// </summary>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
@@ -63,9 +63,9 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         /// <summary>
         ///   Looks up a localized string similar to https://dev.azure.com/fabrikam.
         /// </summary>
-        public static string accountPlaceholderText {
+        public static string ConnectionDescriptionItalicized {
             get {
-                return ResourceManager.GetString("accountPlaceholderText", resourceCulture);
+                return ResourceManager.GetString("ConnectionDescriptionItalicized", resourceCulture);
             }
         }
         
@@ -144,20 +144,20 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Enter desired Azure Boards link (example: .
         /// </summary>
-        public static string connectionInstrText1 {
+        public static string ConnectionDescriptionPrefix {
             get {
-                return ResourceManager.GetString("connectionInstrText1", resourceCulture);
+                return ResourceManager.GetString("ConnectionDescriptionPrefix", resourceCulture);
             }
         }
 
         /// <summary>
         ///   Looks up a localized string similar to ).
         /// </summary>
-        public static string connectionInstrText2
+        public static string ConnectionDescriptionSuffix
         {
             get
             {
-                return ResourceManager.GetString("connectionInstrText2", resourceCulture);
+                return ResourceManager.GetString("ConnectionDescriptionSuffix", resourceCulture);
             }
         }
 

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -117,11 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="connectionInstrText" xml:space="preserve">
-    <value>Enter desired Azure Boards link</value>
+  <data name="connectionInstrText1" xml:space="preserve">
+    <value>Enter desired Azure Boards link (example: </value>
+  </data>
+  <data name="connectionInstrText2" xml:space="preserve">
+    <value>)</value>
   </data>
   <data name="ServerComboBoxAutomationPropertiesName" xml:space="preserve">
-    <value>Enter your desired Azure Boards link</value>
+    <value>Repo link</value>
   </data>
   <data name="accountPlaceholderText" xml:space="preserve">
     <value>https://dev.azure.com/fabrikam</value>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -117,16 +117,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="connectionInstrText1" xml:space="preserve">
+  <data name="ConnectionDescriptionPrefix" xml:space="preserve">
     <value>Enter desired Azure Boards link (example: </value>
   </data>
-  <data name="connectionInstrText2" xml:space="preserve">
+  <data name="ConnectionDescriptionSuffix" xml:space="preserve">
     <value>)</value>
   </data>
   <data name="ServerComboBoxAutomationPropertiesName" xml:space="preserve">
     <value>Repo link</value>
   </data>
-  <data name="accountPlaceholderText" xml:space="preserve">
+  <data name="ConnectionDescriptionItalicized" xml:space="preserve">
     <value>https://dev.azure.com/fabrikam</value>
   </data>
   <data name="btnNextAutomationPropertiesName" xml:space="preserve">


### PR DESCRIPTION
#### Describe the change
The placeholder text for the ADO issue filing link is not being exposed to screen readers. This change makes the sample text readable as text outside the combobox. It also shortens the accessible name of the combobox, since its functionality is described by the previous control. Finally, feedback from design was to remove the placeholder (they're discouraged by design and no longer necessary)

Screenshot of revised dialog (with no user-provided text):
![image](https://user-images.githubusercontent.com/45672944/92020690-64d10880-ed0d-11ea-989e-c4278a283ffc.png)

Screenshot of revised dialog (with user-provided text):
![image](https://user-images.githubusercontent.com/45672944/92020668-5b47a080-ed0d-11ea-9da9-50bf9b0c4725.png)

#### PR checklist

- [] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue [1766304](https://mseng.visualstudio.com/1ES/_workitems/edit/1766304)
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



