### PR TITLE
feat(tt-aug-2020): Replace CCA tooltip with help text

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -55,13 +55,12 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <Label Name="lblAutoDetect" Content="{x:Static Properties:Resources.lblAutoDetectContent}" Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource lblDark}"/>
-                    <ToggleButton Style="{StaticResource tgbSlider}" Grid.Column="2" Name="tgbtnAutoDetect" Margin="20,0,0,0" AutomationProperties.LabeledBy="{Binding ElementName=lblAutoDetect}" Click="TgbtnAutoDetect_Click">
-                        <ToggleButton.ToolTip>
-                            <Run Text="{x:Static Properties:Resources.CCToggleToolTip}"/>
-                        </ToggleButton.ToolTip>
-                    </ToggleButton>
+                    <ToggleButton Style="{StaticResource tgbSlider}" Grid.Column="2" Name="tgbtnAutoDetect" Margin="20,0,0,0" AutomationProperties.LabeledBy="{Binding ElementName=lblAutoDetect}" Click="TgbtnAutoDetect_Click">                    </ToggleButton>
                 </Grid>
-                <Grid Grid.Row="3" Grid.Column="0" Margin="0,16,0,0">
+                <TextBlock Grid.Row="3" FontSize="{DynamicResource StandardTextSize}" Margin="0,0,0,0" TextWrapping="Wrap" Grid.ColumnSpan="2" VerticalAlignment="Center" Focusable="True">
+                    <Run FontSize="{DynamicResource StandardTextSize}" Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}" Text="{x:Static Properties:Resources.ColorContrast_AutoDetectGuidance}" />
+                </TextBlock>
+                <Grid Grid.Row="4" Grid.Column="0" Margin="0,16,0,0">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" MinWidth="240"/>
                         <ColumnDefinition Width="1*"/>
@@ -99,7 +98,7 @@
                                />
                     </StackPanel>
                 </Grid>
-                <Border Margin="20,43,20,0" Grid.Row="3" Grid.Column="1" BorderThickness="2" BorderBrush="{DynamicResource ResourceKey=CCABorderBrush}"
+                <Border Margin="20,43,20,0" Grid.Row="4" Grid.Column="1" BorderThickness="2" BorderBrush="{DynamicResource ResourceKey=CCABorderBrush}"
                         VerticalAlignment="Top" Height="110" Width="200">
                     <StackPanel Background="{DynamicResource ResourceKey=CCABackgroundBrush}">
                         <StackPanel Orientation="Vertical" Margin="10,6,0,0" MinWidth="132">
@@ -121,7 +120,7 @@
                         </StackPanel>
                     </StackPanel>
                 </Border>
-                <Grid Grid.Row="4" Margin="0,12,115,0" Grid.ColumnSpan="2">
+                <Grid Grid.Row="5" Margin="0,12,115,0" Grid.ColumnSpan="2">
                     <Grid.Resources>
                         <Style TargetType="{x:Type TextBlock}">
                             <Setter Property="FontSize" Value="12"/>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -729,7 +729,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to When you enable auto-detection of color contrast ratios, you can detect color contrast ratios by hovering over an element or setting the keyboard focus on it..
+        ///   Looks up a localized string similar to Auto-detection allows you to evaulate color contrast ratios by hovering over an element or setting the keyboard focus on it..
         /// </summary>
         public static string ColorContrast_AutoDetectGuidance {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -727,13 +727,13 @@ namespace AccessibilityInsights.SharedUx.Properties {
                 return ResourceManager.GetString("CCALink", resourceCulture);
             }
         }
-        
+
         /// <summary>
-        ///   Looks up a localized string similar to Hover over the element or set keyboard focus to auto detect color contrast ratio..
+        ///   Looks up a localized string similar to When you enable auto-detection of color contrast ratios, you can detect color contrast ratios by hovering over an element or setting the keyboard focus on it..
         /// </summary>
-        public static string CCToggleToolTip {
+        public static string ColorContrast_AutoDetectGuidance {
             get {
-                return ResourceManager.GetString("CCToggleToolTip", resourceCulture);
+                return ResourceManager.GetString("ColorContrast_AutoDetectGuidance", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1379,8 +1379,8 @@ We collect anonymized data to identify the top accessibility issues found by use
   <data name="InspectModeLink" xml:space="preserve">
     <value>Learn more about Inspect.</value>
   </data>
-  <data name="CCToggleToolTip" xml:space="preserve">
-    <value>Hover over the element or set keyboard focus to auto detect color contrast ratio.</value>
+  <data name="ColorContrast_AutoDetectGuidance" xml:space="preserve">
+    <value>When you enable auto-detection of color contrast ratios, you can detect color contrast ratios by hovering over an element or setting the keyboard focus on it.</value>
   </data>
   <data name="ADO_URL_Fromat_Message" xml:space="preserve">
     <value>URL format is not valid. Example URL: https://dev.azure.com/fabrikam</value>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1380,7 +1380,7 @@ We collect anonymized data to identify the top accessibility issues found by use
     <value>Learn more about Inspect.</value>
   </data>
   <data name="ColorContrast_AutoDetectGuidance" xml:space="preserve">
-    <value>When you enable auto-detection of color contrast ratios, you can detect color contrast ratios by hovering over an element or setting the keyboard focus on it.</value>
+    <value>Auto-detection allows you to evaulate color contrast ratios by hovering over an element or setting the keyboard focus on it.</value>
   </data>
   <data name="ADO_URL_Fromat_Message" xml:space="preserve">
     <value>URL format is not valid. Example URL: https://dev.azure.com/fabrikam</value>


### PR DESCRIPTION
#### Describe the change
The guidance for auto-detection of color contrast is in a tooltip, which is not fully accessible via a screen reader. After considering our options, we decided to replace the tooltip with explanatory text that remains on-screen.

![image](https://user-images.githubusercontent.com/45672944/92019434-774a4280-ed0b-11ea-87b0-8675064d71fc.png)

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



