### PR TITLE
Fix: Unit tests should be in their own namespace

### DIFF
--- a/src/AccessibilityInsights.Extensions.GitHubUnitTests/IssueFormatterTest.cs
+++ b/src/AccessibilityInsights.Extensions.GitHubUnitTests/IssueFormatterTest.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.Extensions.GitHub;
 using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Globalization;
 
-namespace AccessibilityInsights.Extensions.GitHub
+namespace AccessibilityInsights.Extensions.GitHubUnitTests
 {
     [TestClass]
     public class IssueFormatterTest
@@ -50,7 +51,7 @@ namespace AccessibilityInsights.Extensions.GitHub
 
         private string GetLink(string link, IIssueFormatter formatter)
         {
-            string FormattedURL = string.Format(CultureInfo.InvariantCulture, Properties.Resources.FormattedLink,
+            string FormattedURL = string.Format(CultureInfo.InvariantCulture, GitHub.Properties.Resources.FormattedLink,
                link,
                formatter.GetFormattedTitle(),
                formatter.GetFormattedBody());

--- a/src/AccessibilityInsights.Extensions.GitHubUnitTests/LinkValidatorTest.cs
+++ b/src/AccessibilityInsights.Extensions.GitHubUnitTests/LinkValidatorTest.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using AccessibilityInsights.Extensions.GitHub;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace AccessibilityInsights.Extensions.GitHub
+namespace AccessibilityInsights.Extensions.GitHubUnitTests
 {
     [TestClass]
     public class LinkValidatorTest


### PR DESCRIPTION
#### Describe the change
Correct the namespace in a unit tests assembly

#### PR checklist

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



