### PR TITLE
feat(tt-aug-2020): Only set focus to hierarchy tree on menu action

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -440,13 +440,13 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// <param name="e"></param>
         private void mniShowAncestry_Click(object sender, RoutedEventArgs e)
         {
+            SetFocusOnHierarchyTree();
             Configuration.ShowAncestry = this.mniShowAncestry.IsChecked;
             if (this.SelectedElement != null)
             {
                 var dic = new Dictionary<string, string>();
                 this.HierarchyActions.RefreshHierarchy(false);
             }
-            SetFocusOnHierarchyTree();
         }
 
         /// <summary>
@@ -458,7 +458,6 @@ namespace AccessibilityInsights.SharedUx.Controls
         private void mniShowAncestry_Loaded(object sender, RoutedEventArgs e)
         {
             ((MenuItem)sender).IsChecked = Configuration.ShowAncestry;
-            SetFocusOnHierarchyTree();
         }
         #endregion
 
@@ -644,13 +643,13 @@ namespace AccessibilityInsights.SharedUx.Controls
         {
             Configuration.TreeViewMode = mode;
             SetTreeViewModeOnSelectAction(mode);
+            SetFocusOnHierarchyTree();
 
             if (this.SelectedElement != null)
             {
                 // refresh tree automatically.
                 this.HierarchyActions.RefreshHierarchy(true);
             }
-            SetFocusOnHierarchyTree();
         }
 
         private static void SetTreeViewModeOnSelectAction(TreeViewMode mode)


### PR DESCRIPTION
#### Describe the change
Focus is shifting unexpectedly to the hierarchy tree when the user cancels the menu action. This change retains the behavior of shifting the focus to the tree when the user takes a menu action, but leaves the focus unchanged if no menu action is taken. This GIF shows the focus changes as the various menu actions are exercised.

![Menu Focus](https://user-images.githubusercontent.com/45672944/92144835-264e5300-edcc-11ea-91fa-e41cb4df1147.gif)

More context: Shifting the focus on menu action was introduced from a [previous accessibility bug](https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/1244534). That change had a side effect of also switching the focus when no action was taken 😦 

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - [1749288](https://mseng.visualstudio.com/1ES/_workitems/edit/1749288)
- [focus only] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



