### PR TITLE
fix(tt-aug-2020): Enable connect button, add error message

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -49,7 +49,6 @@
             <Button Grid.Column="3" x:Name="btnNext" Padding="8,0" HorizontalAlignment="Left" 
                     Content="{x:Static Properties:Resources.btnNextAutomationPropertiesName}" Click="NextButton_Click"
                     AutomationProperties.Name="{x:Static Properties:Resources.btnNextAutomationPropertiesName}" IsTabStop="True"
-                    IsEnabled="{Binding ElementName=ServerComboBox, Path=Text.Length, Mode=OneWay}"
                     Style="{DynamicResource BtnBlueSquared}" Visibility="{Binding BtnConnectVisibility}" />
             <Button Name="btnDisconnect" Content="{x:Static Properties:Resources.ButtonAutomationPropertiesName}"
                     Click="disconnectButton_Click" Cursor="Hand" Grid.Column="3" HorizontalAlignment="Right" Padding="8,0"

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.Services.Common;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
@@ -153,6 +154,8 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                     else
                     {
                         ToggleLoading(false);
+                        Dispatcher.Invoke(() => MessageDialog.Show(string.Format(CultureInfo.InvariantCulture,
+                            Properties.Resources.UnableToConnectFormattedMessage, serverUri.ToString())));
                         Dispatcher.Invoke(ServerComboBox.Focus);
                     }
                 }

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
@@ -214,5 +214,14 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
                         "not_been_uploaded", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to connect to &apos;{0}&apos;. Please confirm that you have entered the correct Azure Boards link..
+        /// </summary>
+        public static string UnableToConnectFormattedMessage {
+            get {
+                return ResourceManager.GetString("UnableToConnectFormattedMessage", resourceCulture);
+            }
+        }
     }
 }

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -168,4 +168,8 @@
   <data name="CantPopulateProjects" xml:space="preserve">
     <value>Error populating Projects</value>
   </data>
+  <data name="UnableToConnectFormattedMessage" xml:space="preserve">
+    <value>Unable to connect to '{0}'. Please confirm that you have entered the correct Azure Boards link.</value>
+    <comment>{0} is the server Uri</comment>
+  </data>
 </root>


### PR DESCRIPTION
#### Describe the change
This fixes 2 issues with the ADO connection experience:
1. We no longer disable the connection button, because its disabled state wasn't distinguishable in high contrast modes.
2. We now display an error message if we're unable to connect to the server. The same code covers both the "unknown server" case (manifests as a timeout) and the "unknown project" case (manifests as an immediate error).

For brevity, the GIF excludes the timeout case.
![Connect Error](https://user-images.githubusercontent.com/45672944/92154388-9663d580-edda-11ea-9131-1e45f1b10628.gif)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue [1750608](https://mseng.visualstudio.com/1ES/_workitems/edit/1750608) and [1750005](https://mseng.visualstudio.com/1ES/_workitems/edit/1750005)

- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



