### PR TITLE
fix: ensure two calls are made from the dispatcher

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
@@ -251,7 +251,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                     ToggleLoading(true);
                     Dispatcher.Invoke(projects.Clear);
                     var newProjectList = await UpdateTeamProjects().ConfigureAwait(true); // need to come back to original UI thread. 
-                    newProjectList.ForEach(p => projects.Add(p));
+                    Dispatcher.Invoke(() => newProjectList.ForEach(p => projects.Add(p)));
                     ToggleLoading(false);
                     Dispatcher.Invoke(() => serverTreeview.ItemsSource = projects);
                 }
@@ -265,7 +265,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                 }
 #pragma warning restore CA1031 // Do not catch general exception types
 
-                FireAsyncContentLoadedEvent(AsyncContentLoadedState.Completed);
+                Dispatcher.Invoke(() => FireAsyncContentLoadedEvent(AsyncContentLoadedState.Completed));
             }
             else if (state == ControlState.HasServer)
             {


### PR DESCRIPTION
#### Describe the change

These two lines need to be surrounded by Dispatcher.Invoke ([info here](https://docs.microsoft.com/en-us/dotnet/api/system.windows.threading.dispatcher.invoke?view=netcore-3.1#remarks)). Other operations in this area have them. Without these, the two following scenarios occur:
- when the project list is updated, an exception is sometimes caught mentioning the projects treeView can't be updated from a thread other than the one that owns it
- when using Narrator, an exception is thrown when raising the LoadedCompleted event

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



