### PR TITLE
feat(tt-aug-2020): Remove WCAG links from Automated Checks view

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -255,13 +255,12 @@
                                         <Setter.Value>
                                             <MultiBinding StringFormat="{x:Static Properties:Resources.lvResultsListViewAutomationPropertiesName}">
                                                 <Binding Path="Items[0].Description"/>
-                                                <Binding Path="Items[0].Source"/>
                                                 <Binding Path="ItemCount"/>
                                                 <Binding Path="Tag" RelativeSource="{RelativeSource Self}"/>
                                             </MultiBinding>
                                         </Setter.Value>
                                     </Setter>
-                                    <Setter Property="AutomationProperties.HelpText" Value="{Binding Path=Items[0].Source, StringFormat='{x:Static Properties:Resources.lvResultsListViewHelpText}'}"/>
+                                    <Setter Property="AutomationProperties.HelpText" Value="{x:Static Properties:Resources.lvResultsListViewHelpText}" />
                                     <Setter Property="Template">
                                         <Setter.Value>
                                             <ControlTemplate>
@@ -270,15 +269,6 @@
                                                     <local:CustomExpander.Header>
                                                         <StackPanel Focusable="False" Orientation="Horizontal" Height="20">
                                                             <Label Content="{Binding Path=Items[0].Description}" Style="{StaticResource lblRowStyle}" VerticalAlignment="Center" />
-                                                            <Label Margin="4,0,0,0" Padding="0" Style="{StaticResource lblLink}" 
-                                                                   VerticalAlignment="Center" FontWeight="SemiBold"
-                                                                   AutomationProperties.Name="{Binding Path=Items[0].Source, StringFormat='{x:Static Properties:Resources.lvResultsLabelAutomationPropertiesName}'}">
-                                                                <Hyperlink KeyboardNavigation.IsTabStop="False" NavigateUri="{Binding Path=Items[0].URL}"
-                                                                           RequestNavigate="Hyperlink_RequestNavigate" TextDecorations="None" Style="{StaticResource hLink}"
-                                                                           FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">
-                                                                    <Run Text="{Binding Mode=OneWay,Path=Items[0].Source}"/>
-                                                                </Hyperlink>
-                                                            </Label>
                                                             <Label Content="(" Style="{StaticResource lblRowStyle}" Margin="4,0,0,0" VerticalAlignment="Center" />
                                                             <fabric:FabricIconControl VerticalAlignment="Bottom" Margin="1,2" GlyphName="{Binding Path=Items[0].GlyphName}" Foreground="{DynamicResource ResourceKey=HLbrushRed}" GlyphSize="Custom" FontSize="14"/>
                                                             <Label Content="{Binding ItemCount}" Style="{StaticResource lblRowStyle}" VerticalAlignment="Center" />

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -600,11 +600,6 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 }
                 e.Handled = true;
             }
-            else if (e.Key == Key.Return && Keyboard.FocusedElement is ListViewItem)
-            {
-                var btn = GetFirstChildElement<Button>(sender as DependencyObject) as Button;
-                ButtonElem_Click(btn, e);
-            }
         }
 
         /// <summary>
@@ -864,7 +859,6 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
             var gi = sender as GroupItem;
             var sp = GetFirstChildElement<StackPanel>(gi) as StackPanel;
-            var urlLink = FindChildren<Label>(sp).FirstOrDefault(obj => obj.Content is Hyperlink).Content as Hyperlink;
             var exp = GetParentElem<Expander>(sp) as Expander;
 
             if (e.Key == Key.Right)
@@ -872,10 +866,6 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 if (!exp.IsExpanded)
                 {
                     exp.IsExpanded = true;
-                }
-                else
-                {
-                    urlLink?.Focus();
                 }
                 e.Handled = true;
             }
@@ -892,19 +882,12 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
                 e.Handled = true;
             }
-            else if (e.Key == Key.Space && Keyboard.FocusedElement == sender)
+            else if ((e.Key == Key.Space || e.Key == Key.Enter) && Keyboard.FocusedElement == sender)
             {
                 var cb = GetFirstChildElement<CheckBox>(exp) as CheckBox;
                 cb.IsChecked = !cb.IsChecked ?? false;
                 CheckBox_Click(cb, null);
                 e.Handled = true;
-            }
-            else if (e.Key == Key.Enter && Keyboard.FocusedElement == sender)
-            {
-                if (urlLink != null)
-                {
-                    Hyperlink_RequestNavigate(urlLink, new RequestNavigateEventArgs(urlLink.NavigateUri, null));
-                }
             }
             else if (e.Key == Key.Down)
             {

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -280,19 +280,6 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         }
 
         /// <summary>
-        /// Handles hyperlink click
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
-        {
-            if (!String.IsNullOrEmpty(e.Uri.OriginalString))
-            {
-                Process.Start(e.Uri.ToString());
-            }
-        }
-
-        /// <summary>
         /// Sets element context and updates UI
         /// </summary>
         /// <param name="ec"></param>
@@ -871,11 +858,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             }
             else if (e.Key == Key.Left)
             {
-                if (Keyboard.FocusedElement is Hyperlink)
-                {
-                    gi.Focus();
-                }
-                else if (exp.IsExpanded)
+                if (exp.IsExpanded)
                 {
                     exp.IsExpanded = false;
                 }

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2503,16 +2503,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open link to {0} rule information.
-        /// </summary>
-        public static string lvResultsLabelAutomationPropertiesName {
-            get {
-                return ResourceManager.GetString("lvResultsLabelAutomationPropertiesName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {2} errors - {0}, rule from {1}, {3} children highlighted.
+        ///   Looks up a localized string similar to {1} errors - {0}, {2} children highlighted.
         /// </summary>
         public static string lvResultsListViewAutomationPropertiesName {
             get {
@@ -2521,7 +2512,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Press right arrow key to expand, enter to view {0} in browser, or space to toggle children highlighting.
+        ///   Looks up a localized string similar to Press right arrow key to expand, enter or space to toggle children highlighting.
         /// </summary>
         public static string lvResultsListViewHelpText {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -388,13 +388,10 @@
     <value>Highlight elements</value>
   </data>
   <data name="lvResultsListViewAutomationPropertiesName" xml:space="preserve">
-    <value>{2} errors - {0}, rule from {1}, {3} children highlighted</value>
+    <value>{1} errors - {0}, {2} children highlighted</value>
   </data>
   <data name="lvResultsListViewHelpText" xml:space="preserve">
-    <value>Press right arrow key to expand, enter to view {0} in browser, or space to toggle children highlighting</value>
-  </data>
-  <data name="lvResultsLabelAutomationPropertiesName" xml:space="preserve">
-    <value>Open link to {0} rule information</value>
+    <value>Press right arrow key to expand, enter or space to toggle children highlighting</value>
   </data>
   <data name="lblCongratsContent" xml:space="preserve">
     <value>Congratulations</value>


### PR DESCRIPTION
#### Describe the change
_Note: This is a proposal, written as though it's a done deal. This comment will be removed if/when we decide to follow this approach._

The WCAG link that is currently included in the automated checks header has no UIA representation, making it invisible to assistive technologies. After iterating with various experts and finding no viable way to fully support the WCAG link, we've opted to remove the WCAG link from the automated checks view. The link  information is still available if you view the result in the UIA tree, and since we already have many other fields that are available only in that way, this shouldn't be too much of an issue for existing users.

Another piece of feedback was that it's generally preferable to have Enter and Space perform the same action on a control. We used to use Enter to trigger the link, but now that the link has been removed, Enter now does the same thing as Space (i.e., select or deselect the items in the group). The help text for the group header has been updated accordingly.

Validated with NVDA to confirm that the link is no longer spoken, and that the help text matches the new behavior.

Screenshot in automated checks view:
![image](https://user-images.githubusercontent.com/45672944/92291770-fb98f300-eece-11ea-8d73-af23ec33b80f.png)

Here's an A11yTest file showing the full UIA tree (GitHub made me zip it up since it's an unrecognized file format):
[AutomatedChecksWithLinksRemoved.a11ytest.zip](https://github.com/microsoft/accessibility-insights-windows/files/5177331/AutomatedChecksWithLinksRemoved.a11ytest.zip)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# [1750586](https://mseng.visualstudio.com/1ES/_workitems/edit/1750586)
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



