### PR TITLE
chore: Extensions should not depend on SharedUX

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
@@ -35,8 +35,8 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="Unofficial.Microsoft.mshtml" Version="7.0.3300" />
+    <ProjectReference Include="..\AccessibilityInsights.CommonUxComponents\CommonUxComponents.csproj" />
     <ProjectReference Include="..\AccessibilityInsights.Extensions\Extensions.csproj" />
-    <ProjectReference Include="..\AccessibilityInsights.SharedUx\SharedUx.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### Describe the change
To help maintain modularity, extensions are allowed to depend only on a set of low-level assemblies (SharedUX, SetupLibrary, Win32, and CommonUxComponents). Somehow the ADO extension is depending on SharedUx, even though it only needs CommonUxComponents (for the FabricIcon control). This machine-driven change simply replaces the SharedUx dependency with a CommonUxComponents dependency. Sanity tested that ADO still works as expected.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

The search icon (highlighted in red) is visible in this snippet from a screenshot of running the ADO login process with this change:
![image](https://user-images.githubusercontent.com/45672944/92292547-98a95b00-eed2-11ea-966c-b028ee8b7730.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



