### PR TITLE
fix: Correct the colors used for bubbles

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -336,7 +336,7 @@
                                 <Run Text="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_11}" />
                             </Hyperlink><Run Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}" Text="{x:Static Properties:Resources.ColorContrast_RequiresNonTextObjectsPost}" />
                             <Border Margin="6,0,0,-7" VerticalAlignment="Center" Background="{DynamicResource ResourceKey=BubbleBGBrush}" CornerRadius="10">
-                                <TextBlock Text="{x:Static Properties:Resources.TextNewForWCAG_2_1}" Margin="6,4,6,4" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                                <TextBlock Text="{x:Static Properties:Resources.TextNewForWCAG_2_1}" Margin="6,4,6,4" Foreground="{DynamicResource ResourceKey=BubbleFGBrush}"/>
                             </Border>
                         </TextBlock>
                     </StackPanel>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -28,7 +28,8 @@
     </LinearGradientBrush>
     <SolidColorBrush po:Freeze="True" x:Key="PrimaryFGBrush" Color="#FFFFFF"/>          <!-- (UPDATED) Primary Foreground color (used most eveywhere) -->
     <SolidColorBrush po:Freeze="True" x:Key="SecondaryFGBrush" Color="#B2B3B5"/>        <!-- (UPDATED) Secondary Foreground color (de-emphasized text) -->
-    <SolidColorBrush po:Freeze="True" x:Key="BubbleBGBrush" Color="#696C6F"/>           <!-- (UPDATED) Used ONLY for "New for WCAG 2.1" bubble -->
+    <SolidColorBrush po:Freeze="True" x:Key="BubbleBGBrush" Color="#696C6F"/>           <!-- (UPDATED) Used ONLY for "New for WCAG 2.1" bubble BG -->
+    <SolidColorBrush po:Freeze="True" x:Key="BubbleFGBrush" Color="#FFFFFF"/>           <!-- (UPDATED) Used ONLY for "New for WCAG 2.1" bubble FG -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedTextBrush" Color="#FFFFFF"/>       <!-- (UPDATED) Generic selected text color (used everywhere) -->
     <SolidColorBrush po:Freeze="True" x:Key="IconBrush" Color="#FFFFFF"/>               <!-- (UPDATED) Used for fabric icons, some (incorrect?) borders -->
     <SolidColorBrush po:Freeze="True" x:Key="WhiteTextBrush" Color="#FFFFFF"/>          <!-- Text color (normal) for video player -->

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -21,6 +21,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="IconBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="LightIconBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="BubbleBGBrush" Color="{x:Static SystemColors.WindowTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="BubbleFGBrush" Color="{x:Static SystemColors.WindowColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="BlueButtonBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="BlueButtonHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="BlueButtonFGBrush" Color="{x:Static SystemColors.WindowTextColor}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -28,7 +28,8 @@
     </LinearGradientBrush>
     <SolidColorBrush po:Freeze="True" x:Key="PrimaryFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="SecondaryFGBrush" Color="#6E6E6E"/>
-    <SolidColorBrush po:Freeze="True" x:Key="BubbleBGBrush" Color="#000000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="BubbleBGBrush" Color="#F4F4F4"/>
+    <SolidColorBrush po:Freeze="True" x:Key="BubbleFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedTextBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="IconBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="WhiteTextBrush" Color="#FFFFFF"/>


### PR DESCRIPTION
#### Describe the change
The "New for WCAG 2.1" bubble background colors were broken in #719. This change restores the Light colors to their original values from #502, and revisits the HC modes to reasonably display a bubble (#502 originally omitted the bubble in HC modes). We do this by explicitly assigning a bubble foreground color, in addition to the button background color (which was incorrect in Light mode). The Light background color disappeared when inserting the screenshot directly (limited palette, I'm guessing), so I've attached the zipped PNG file to the bug, instead.

[Bubbles.png.zip](https://github.com/microsoft/accessibility-insights-windows/files/5190243/Bubbles.png.zip)

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #914 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



