### PR TITLE
feat(tt-aug-2020): add status announcement when app is waiting for ADO connection

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -156,7 +156,7 @@
                                    HorizontalAlignment="Center" 
                                    VerticalAlignment="Center" Grid.RowSpan="5"
                                    AutomationProperties.LiveSetting="Assertive"
-                                   AutomationProperties.Name="Waiting to connect to Azure Boards">
+                                   AutomationProperties.Name="{x:Static Properties:Resources.WaitingToConnect}">
         </fabric:ProgressRingControl>
     </Grid>
 </issuereporting:IssueConfigurationControl>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -154,7 +154,8 @@
                                    Size="25"  
                                    Visibility="Collapsed"
                                    HorizontalAlignment="Center" 
-                                   VerticalAlignment="Center" Grid.RowSpan="5">
+                                   VerticalAlignment="Center" Grid.RowSpan="5"
+                                   AutomationProperties.LiveSetting="Assertive">
         </fabric:ProgressRingControl>
     </Grid>
 </issuereporting:IssueConfigurationControl>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -155,7 +155,8 @@
                                    Visibility="Collapsed"
                                    HorizontalAlignment="Center" 
                                    VerticalAlignment="Center" Grid.RowSpan="5"
-                                   AutomationProperties.LiveSetting="Assertive">
+                                   AutomationProperties.LiveSetting="Assertive"
+                                   AutomationProperties.Name="Waiting to connect to Azure Boards">
         </fabric:ProgressRingControl>
     </Grid>
 </issuereporting:IssueConfigurationControl>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
@@ -254,6 +254,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                     Dispatcher.Invoke(() => newProjectList.ForEach(p => projects.Add(p)));
                     ToggleLoading(false);
                     Dispatcher.Invoke(() => serverTreeview.ItemsSource = projects);
+                    Dispatcher.Invoke(() => serverTreeview.Focus());
                 }
 #pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception e)
@@ -365,6 +366,14 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
             Dispatcher.Invoke(() =>
             {
                 this.ctrlProgressRing.IsActive = starting;
+                if (starting)
+                {
+                    var peer = FrameworkElementAutomationPeer.FromElement(ctrlProgressRing);
+                    if (peer != null)
+                    {
+                        peer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+                    }
+                }
                 this.IsEnabled = InteractionAllowed;
             });
         }

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
@@ -169,7 +169,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Team project.
+        ///   Looks up a localized string similar to Select team project.
         /// </summary>
         public static string serverTreeviewAutomationPropertiesName {
             get {
@@ -221,6 +221,15 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         public static string UnableToConnectFormattedMessage {
             get {
                 return ResourceManager.GetString("UnableToConnectFormattedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Waiting to connect to Azure Boards.
+        /// </summary>
+        public static string WaitingToConnect {
+            get {
+                return ResourceManager.GetString("WaitingToConnect", resourceCulture);
             }
         }
     }

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -151,7 +151,7 @@
     <value>Select your Azure Boards team</value>
   </data>
   <data name="serverTreeviewAutomationPropertiesName" xml:space="preserve">
-    <value>Team project</value>
+    <value>Select team project</value>
   </data>
   <data name="ConnectionControl_selectTeam" xml:space="preserve">
     <value>Select your Azure Boards team</value>
@@ -171,5 +171,8 @@
   <data name="UnableToConnectFormattedMessage" xml:space="preserve">
     <value>Unable to connect to '{0}'. Please confirm that you have entered the correct Azure Boards link.</value>
     <comment>{0} is the server Uri</comment>
+  </data>
+  <data name="WaitingToConnect" xml:space="preserve">
+    <value>Waiting to connect to Azure Boards</value>
   </data>
 </root>


### PR DESCRIPTION
#### Describe the change

This PR:
- raises a LiveRegionChanged event when the ADO connection screen goes into its indeterminate loading state
- places focus on the team project treeview once its data is populated
- updates the team project treeview automation name to 'select team project'

Using Narrator / NVDA, the user is now notified that the app is waiting to connect to Azure Boards when the "Loading..." control shows up.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



