### PR TITLE
feat(tt-aug_2020): Relocate the source link from the group header to each list item

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -285,10 +285,6 @@
                                                     <local:CustomExpander.Header>
                                                         <StackPanel Focusable="False" Orientation="Horizontal" Height="20">
                                                             <Label Content="{Binding Path=Items[0].Description}" Style="{StaticResource lblRowStyle}" VerticalAlignment="Center" />
-                                                            <Label Margin="4,0,0,0" Padding="0" Style="{StaticResource lblLink}" 
-                                                                   VerticalAlignment="Center" FontWeight="SemiBold"
-                                                                   AutomationProperties.Name="{Binding Path=Items[0].Source, StringFormat='{x:Static Properties:Resources.lvResultsLabelAutomationPropertiesName}'}">
-                                                            </Label>
                                                             <Label Content="(" Style="{StaticResource lblRowStyle}" Margin="4,0,0,0" VerticalAlignment="Center" />
                                                             <fabric:FabricIconControl VerticalAlignment="Bottom" Margin="1,2" GlyphName="{Binding Path=Items[0].GlyphName}" Foreground="{DynamicResource ResourceKey=HLbrushRed}" GlyphSize="Custom" FontSize="14"/>
                                                             <Label Content="{Binding ItemCount}" Style="{StaticResource lblRowStyle}" VerticalAlignment="Center" />

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -124,7 +124,7 @@
                                 </local:CustomGridViewColumnHeader>
                                 <GridViewColumn.CellTemplate>
                                     <DataTemplate>
-                                        <StackPanel Orientation="Horizontal" MinWidth="200">
+                                        <StackPanel Orientation="Horizontal" MinWidth="150">
                                             <fabric:FabricIconControl GlyphName="LadybugSolid" GlyphSize="Custom" FontSize="15" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=BlueButtonBGBrush}" Margin="0,0,4,0" Visibility="{Binding Path=FileBugVisibility}" ShowInControlView="False"/>
                                             <Button Visibility="{Binding FileBugVisibility}" VerticalAlignment="Center" Tag="{Binding}"
                                                 Style="{StaticResource btnLink}" Name="btnFileBug" Click="btnFileBug_Click"
@@ -151,6 +151,22 @@
                                                 </fabric:FabricIconControl.Triggers>
                                             </fabric:FabricIconControl>
                                         </StackPanel>
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                            <GridViewColumn Width="Auto">
+                                <local:CustomGridViewColumnHeader Style="{StaticResource gvchAutomatedChecks}" Focusable="True">
+                                    <Label Visibility="{Binding BugColumnVisibility}" Content="{x:Static Properties:Resources.AutomatedChecksControl_RuleSourceLabel}" VerticalAlignment="Center" Style="{StaticResource lblFaint}"/>
+                                </local:CustomGridViewColumnHeader>
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <Button VerticalAlignment="Center" Tag="{Binding}" MinWidth="200"
+                                                Style="{StaticResource btnLink}" Name="btnSourceLink" Click="btnSourceLink_Click"
+                                                Content="{Binding Path=Source}"
+                                                Focusable="True" IsTabStop="False" 
+                                                AutomationProperties.HelpText="{x:Static Properties:Resources.AutomatedChecksControl_RuleSourceHelpText}"
+                                                AutomationProperties.Name="{Binding Path=Source}">
+                                        </Button>
                                     </DataTemplate>
                                 </GridViewColumn.CellTemplate>
                             </GridViewColumn>
@@ -255,13 +271,12 @@
                                         <Setter.Value>
                                             <MultiBinding StringFormat="{x:Static Properties:Resources.lvResultsListViewAutomationPropertiesName}">
                                                 <Binding Path="Items[0].Description"/>
-                                                <Binding Path="Items[0].Source"/>
                                                 <Binding Path="ItemCount"/>
                                                 <Binding Path="Tag" RelativeSource="{RelativeSource Self}"/>
                                             </MultiBinding>
                                         </Setter.Value>
                                     </Setter>
-                                    <Setter Property="AutomationProperties.HelpText" Value="{Binding Path=Items[0].Source, StringFormat='{x:Static Properties:Resources.lvResultsListViewHelpText}'}"/>
+                                    <Setter Property="AutomationProperties.HelpText" Value="{x:Static Properties:Resources.lvResultsListViewHelpText}"/>
                                     <Setter Property="Template">
                                         <Setter.Value>
                                             <ControlTemplate>
@@ -273,11 +288,6 @@
                                                             <Label Margin="4,0,0,0" Padding="0" Style="{StaticResource lblLink}" 
                                                                    VerticalAlignment="Center" FontWeight="SemiBold"
                                                                    AutomationProperties.Name="{Binding Path=Items[0].Source, StringFormat='{x:Static Properties:Resources.lvResultsLabelAutomationPropertiesName}'}">
-                                                                <Hyperlink KeyboardNavigation.IsTabStop="False" NavigateUri="{Binding Path=Items[0].URL}"
-                                                                           RequestNavigate="Hyperlink_RequestNavigate" TextDecorations="None" Style="{StaticResource hLink}"
-                                                                           FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">
-                                                                    <Run Text="{Binding Mode=OneWay,Path=Items[0].Source}"/>
-                                                                </Hyperlink>
                                                             </Label>
                                                             <Label Content="(" Style="{StaticResource lblRowStyle}" Margin="4,0,0,0" VerticalAlignment="Center" />
                                                             <fabric:FabricIconControl VerticalAlignment="Bottom" Margin="1,2" GlyphName="{Binding Path=Items[0].GlyphName}" Foreground="{DynamicResource ResourceKey=HLbrushRed}" GlyphSize="Custom" FontSize="14"/>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -878,11 +878,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             }
             else if (e.Key == Key.Left)
             {
-                if (Keyboard.FocusedElement is Hyperlink)
-                {
-                    gi.Focus();
-                }
-                else if (exp.IsExpanded)
+                if (exp.IsExpanded)
                 {
                     exp.IsExpanded = false;
                 }

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -280,15 +280,17 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         }
 
         /// <summary>
-        /// Handles hyperlink click
+        /// Handles click on source link button
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        private void btnSourceLink_Click(object sender, RoutedEventArgs e)
         {
-            if (!String.IsNullOrEmpty(e.Uri.OriginalString))
+            var vm = ((Button)sender).Tag as RuleResultViewModel;
+            string urlToLaunch = vm?.URL?.ToString();
+            if (!string.IsNullOrEmpty(urlToLaunch))
             {
-                Process.Start(e.Uri.ToString());
+                Process.Start(urlToLaunch);
             }
         }
 
@@ -864,7 +866,6 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
             var gi = sender as GroupItem;
             var sp = GetFirstChildElement<StackPanel>(gi) as StackPanel;
-            var urlLink = FindChildren<Label>(sp).FirstOrDefault(obj => obj.Content is Hyperlink).Content as Hyperlink;
             var exp = GetParentElem<Expander>(sp) as Expander;
 
             if (e.Key == Key.Right)
@@ -872,10 +873,6 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 if (!exp.IsExpanded)
                 {
                     exp.IsExpanded = true;
-                }
-                else
-                {
-                    urlLink?.Focus();
                 }
                 e.Handled = true;
             }
@@ -892,19 +889,12 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
                 e.Handled = true;
             }
-            else if (e.Key == Key.Space && Keyboard.FocusedElement == sender)
+            else if ((e.Key == Key.Space || e.Key == Key.Enter) && Keyboard.FocusedElement == sender)
             {
                 var cb = GetFirstChildElement<CheckBox>(exp) as CheckBox;
                 cb.IsChecked = !cb.IsChecked ?? false;
                 CheckBox_Click(cb, null);
                 e.Handled = true;
-            }
-            else if (e.Key == Key.Enter && Keyboard.FocusedElement == sender)
-            {
-                if (urlLink != null)
-                {
-                    Hyperlink_RequestNavigate(urlLink, new RequestNavigateEventArgs(urlLink.NavigateUri, null));
-                }
             }
             else if (e.Key == Key.Down)
             {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -152,6 +152,24 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Press Enter or Space to view more information in browser.
+        /// </summary>
+        public static string AutomatedChecksControl_RuleSourceHelpText {
+            get {
+                return ResourceManager.GetString("AutomatedChecksControl_RuleSourceHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rule source.
+        /// </summary>
+        public static string AutomatedChecksControl_RuleSourceLabel {
+            get {
+                return ResourceManager.GetString("AutomatedChecksControl_RuleSourceLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} failures were.
         /// </summary>
         public static string AutomatedChecksControl_SetRuleResults_0_failures_were {
@@ -2512,7 +2530,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {2} errors - {0}, rule from {1}, {3} children highlighted.
+        ///   Looks up a localized string similar to {1} errors - {0}, {2} children highlighted.
         /// </summary>
         public static string lvResultsListViewAutomationPropertiesName {
             get {
@@ -2521,7 +2539,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Press right arrow key to expand, enter to view {0} in browser, or space to toggle children highlighting.
+        ///   Looks up a localized string similar to Press right arrow key to expand, enter or space to toggle children highlighting.
         /// </summary>
         public static string lvResultsListViewHelpText {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2521,15 +2521,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open link to {0} rule information.
-        /// </summary>
-        public static string lvResultsLabelAutomationPropertiesName {
-            get {
-                return ResourceManager.GetString("lvResultsLabelAutomationPropertiesName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {1} errors - {0}, {2} children highlighted.
         /// </summary>
         public static string lvResultsListViewAutomationPropertiesName {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -393,9 +393,6 @@
   <data name="lvResultsListViewHelpText" xml:space="preserve">
     <value>Press right arrow key to expand, enter or space to toggle children highlighting</value>
   </data>
-  <data name="lvResultsLabelAutomationPropertiesName" xml:space="preserve">
-    <value>Open link to {0} rule information</value>
-  </data>
   <data name="lblCongratsContent" xml:space="preserve">
     <value>Congratulations</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -388,10 +388,10 @@
     <value>Highlight elements</value>
   </data>
   <data name="lvResultsListViewAutomationPropertiesName" xml:space="preserve">
-    <value>{2} errors - {0}, rule from {1}, {3} children highlighted</value>
+    <value>{1} errors - {0}, {2} children highlighted</value>
   </data>
   <data name="lvResultsListViewHelpText" xml:space="preserve">
-    <value>Press right arrow key to expand, enter to view {0} in browser, or space to toggle children highlighting</value>
+    <value>Press right arrow key to expand, enter or space to toggle children highlighting</value>
   </data>
   <data name="lvResultsLabelAutomationPropertiesName" xml:space="preserve">
     <value>Open link to {0} rule information</value>
@@ -1526,5 +1526,11 @@ Do you want to change the channel? </value>
   </data>
   <data name="StartupModeControl_shortcutsDescription" xml:space="preserve">
     <value>These keystrokes are default, but you can customize your shortcut keystrokes in settings.</value>
+  </data>
+  <data name="AutomatedChecksControl_RuleSourceHelpText" xml:space="preserve">
+    <value>Press Enter or Space to view more information in browser</value>
+  </data>
+  <data name="AutomatedChecksControl_RuleSourceLabel" xml:space="preserve">
+    <value>Rule source</value>
   </data>
 </root>


### PR DESCRIPTION
#### Describe the change
The current UI puts the rule source in the group header in automated results view. This looks great but has accessibility issues because the link never makes it into the UIA tree. Feedback from users is that having the link at the top level is useful, so we're going with the approach of putting the link in each row. It's busy visually, but we'll see what sort of feedback we get and adjust accordingly.

The rule source link is announced a button instead of a hyperlink to better fit into the custom handling within the control.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - [1750586](https://mseng.visualstudio.com/1ES/_workitems/edit/1750586)
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

![image](https://user-images.githubusercontent.com/45672944/93143096-1a9c3f80-f69c-11ea-896e-500eca2274ff.png)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



