### PR TITLE
fix: Use correct HC colors for disabled text

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -93,15 +93,6 @@
             <TextBlock x:Name="selectedTeamText" Grid.Row="1" FontStyle="Italic" HorizontalAlignment="Left" FontSize="{DynamicResource StandardTextSize}"></TextBlock>
         </Grid>
         <Grid x:Name="selectTeamGrid" Visibility="{Binding SelectTeamGridVisibility}" IsEnabled="{Binding IsSelectTeamGridEnabled}" Grid.Row="4" Margin="0px 0px 24px 12px">
-            <Grid.Style>
-                <Style TargetType="Grid">
-                    <Style.Triggers>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value=".3"/>
-                        </Trigger>
-                    </Style.Triggers>
-                </Style>
-            </Grid.Style>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -113,23 +104,23 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <TextBlock Grid.Column="0" Text="{x:Static Properties:Resources.ConnectionControl_selectTeam}" Margin="0 4px"
-                           TextWrapping="Wrap" FontSize="{DynamicResource StandardTextSize}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                           TextWrapping="Wrap" FontSize="{DynamicResource StandardTextSize}" Style="{DynamicResource ResourceKey=tbPrimaryFGBrushWithDisabledFGBrush}" />
                 <Button Click="refreshButton_Click" Grid.Column="1" HorizontalAlignment="Right" AutomationProperties.Name="{x:Static Properties:Resources.ButtonAutomationPropertiesNameRefresh}" IsTabStop="True" Margin="0 4px" Style="{DynamicResource BtnStandard}">
                     <Button.Template>
                         <ControlTemplate>
-                            <TextBlock Text="{x:Static Properties:Resources.ButtonAutomationPropertiesNameRefresh}" TextWrapping="Wrap" Foreground="{DynamicResource ResourceKey=ButtonLinkFGBrush}"/>
+                            <TextBlock Text="{x:Static Properties:Resources.ButtonAutomationPropertiesNameRefresh}" TextWrapping="Wrap" Style="{DynamicResource ResourceKey=tbButtonLinkFGBrushWithDisabledFGBrush}" />
                         </ControlTemplate>
                     </Button.Template>
                 </Button>
             </Grid>
-            <Grid Grid.Row="1">
+            <Grid Grid.Row="1" Style="{DynamicResource ResourceKey=gridPartialOpacityWhenDisabled}">
                 <TextBox Height="30" VerticalContentAlignment="Center" x:Name="tbTeamProjectSearch" TextChanged="TextBox_TextChanged"
                          AutomationProperties.Name="{x:Static Properties:Resources.tbTeamProjectSearchAutomationPropertiesName}"
                          FontSize="{DynamicResource StandardTextSize}"/>
                 <fabric:FabricIconControl HorizontalAlignment="Right" Margin="5,0,5,0" 
                                                   GlyphName="Search" GlyphSize="Custom" FontSize="11" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
             </Grid>
-            <Grid Grid.Row="2" Height="200px" ScrollViewer.VerticalScrollBarVisibility="Auto" Margin="0 12">
+            <Grid Grid.Row="2" Style="{DynamicResource ResourceKey=gridPartialOpacityWhenDisabled}" Height="200px" ScrollViewer.VerticalScrollBarVisibility="Auto" Margin="0 12">
                 <TreeView x:Name="serverTreeview" ItemsSource="{Binding Path=projects}" 
                                   SelectedItemChanged="serverTreeview_SelectedItemChanged" AutomationProperties.Name="{x:Static Properties:Resources.serverTreeviewAutomationPropertiesName}"
                                   VirtualizingStackPanel.IsVirtualizing="False">

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -49,7 +49,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="SecondaryBGBrush" Color="#2B3034"/>        <!-- (UPDATED) Secondary background brush (not u-->
     <SolidColorBrush po:Freeze="True" x:Key="GreyBackgroundBrush" Color="#EAEAEA"/>     <!-- Horizontal rules in color contrast -->
     <SolidColorBrush po:Freeze="True" x:Key="ActiveModeBrush" Color="#FFFFFF"/>         <!-- Color of "active" marker in nav bar -->
-    <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledFGBrush" Color="#656E75"/>   <!-- (UPDATED) Foreground of disabled button (example: Later button in update dialog on mandatory update) -->
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledFGBrush" Color="#656E75"/>   <!-- (UPDATED) Foreground of disabled button (example: Refresh button in ADO connect when no connection exists) -->
     <SolidColorBrush po:Freeze="True" x:Key="PrimaryBGBrush" Color="#22272B"/>          <!-- (UPDATED) Primary background brush (not in startup mode) -->
     <SolidColorBrush po:Freeze="True" x:Key="DataGridBGBrush" Color="#444C52"/>         <!-- (UPDATED) Background of data grid items (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="#6D767E"/> <!-- (UPDATED) Background of selected item in data grid (list of properties) -->

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -49,7 +49,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="SecondaryBGBrush" Color="#2B3034"/>        <!-- (UPDATED) Secondary background brush (not u-->
     <SolidColorBrush po:Freeze="True" x:Key="GreyBackgroundBrush" Color="#EAEAEA"/>     <!-- Horizontal rules in color contrast -->
     <SolidColorBrush po:Freeze="True" x:Key="ActiveModeBrush" Color="#FFFFFF"/>         <!-- Color of "active" marker in nav bar -->
-    <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledBrush" Color="#656E75"/>     <!-- (UPDATED) Background of disabled button (example: Later button in update dialog on mandatory update) -->
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledFGBrush" Color="#656E75"/>   <!-- (UPDATED) Foreground of disabled button (example: Later button in update dialog on mandatory update) -->
     <SolidColorBrush po:Freeze="True" x:Key="PrimaryBGBrush" Color="#22272B"/>          <!-- (UPDATED) Primary background brush (not in startup mode) -->
     <SolidColorBrush po:Freeze="True" x:Key="DataGridBGBrush" Color="#444C52"/>         <!-- (UPDATED) Background of data grid items (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="#6D767E"/> <!-- (UPDATED) Background of selected item in data grid (list of properties) -->

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -54,6 +54,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="HLTextBrush" Color="#FFFF00 "/>
     <SolidColorBrush po:Freeze="True" x:Key="BorderBrush" Color="{x:Static SystemColors.InactiveBorderColor}" />
     <SolidColorBrush po:Freeze="True" x:Key="CCABorderBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledFGBrush" Color="{x:Static SystemColors.GrayTextColor}"/>
     <Thickness po:Freeze="True" x:Key="BtnBrdrThickness">1</Thickness>
 
     <!-- NEW SETTINGS -->

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -49,7 +49,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="SecondaryBGBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="GreyBackgroundBrush" Color="#EAEAEA"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActiveModeBrush" Color="#FFFFFF"/>
-    <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledBrush" Color="#A6A6A6"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledFGBrush" Color="#A6A6A6"/>
     <SolidColorBrush po:Freeze="True" x:Key="PrimaryBGBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="DataGridBGBrush" Color="#14000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="#3C000000"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -81,7 +81,7 @@
                             <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonDisabledBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonDisabledFGBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -137,7 +137,7 @@
                             <Setter Property="Background" Value="{DynamicResource ResourceKey=ButtonHoverBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonDisabledBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonDisabledFGBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -166,7 +166,7 @@
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Background" Value="{DynamicResource ResourceKey=PrimaryBGBrush}"/>
-                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonDisabledBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonDisabledFGBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1081,7 +1081,7 @@
             </Trigger>
             <Trigger Property="IsEnabled" Value="False">
                 <Setter Property="Background" Value="{DynamicResource ResourceKey=PrimaryBGBrush}"/>
-                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonDisabledBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonDisabledFGBrush}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -1511,5 +1511,33 @@
         </Setter>
         <Setter Property="MinWidth" Value="2"/>
         <Setter Property="Width" Value="410"/>
+    </Style>
+    <Style TargetType="{x:Type Grid}" x:Key="gridPartialOpacityWhenDisabled">
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value=".3"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type TextBlock}" x:Key="tbUseDisabledFGBrush">
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonDisabledFGBrush}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type TextBlock}" x:Key="tbPrimaryFGBrushWithDisabledFGBrush" BasedOn="{StaticResource tbUseDisabledFGBrush}">
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type TextBlock}" x:Key="tbButtonLinkFGBrushWithDisabledFGBrush" BasedOn="{StaticResource tbUseDisabledFGBrush}">
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonLinkFGBrush}"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 </ResourceDictionary>


### PR DESCRIPTION
#### Describe the change
Commit #921 addressed some HC issues in the ADO connection dialog, but missed the text colors for the disabled controls. This PR includes:
- Rename `ButtonDisabledBrush` to `ButtonDisabledFGBrush` to correctly reflect its usage, update its comment
- Move the behavior to set a grid opacity at 30% when disabled into the `gridPartialOpacityWhenDisabled` style
- Don't set `gridPartialOpacityWhenDisabled` on the TextBlock and Button controls, since HC modes define a color that is incompatible with the opacity
- Create 2 new styles (`tbPrimaryFGBrushWithDisabledFGBrush` and `tbButtonLinkFGBrushWithDisabledFGBrush`) to control the colors for the "Select your Azure Boards team" and "Refresh" text blocks, respectively.

![image](https://user-images.githubusercontent.com/45672944/93828418-1afa8480-fc20-11ea-86f8-81d9405ee749.png)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - [1750608](https://mseng.visualstudio.com/1ES/_workitems/edit/1750608)
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



