### PR TITLE
fix: Specify explicit border color on timer delay edit

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -219,6 +219,7 @@
         <Setter Property="CaretBrush" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
         <Setter Property="Padding" Value="0"/>
         <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
     </Style>
     <Style TargetType="{x:Type TextBox}" x:Key="TxtReadonlyText">
         <Setter Property="FontSize" Value="{DynamicResource ResourceKey=StandardTextSize}"/>


### PR DESCRIPTION
#### Describe the change
The bottom and right border color on the delay timer edit control is failing to provide a contrast ratio of at least 3.0. This changes the style to explicitly set the border brush to the same value as the foreground and caret brush. This is the only control that currently uses this style, so the change is very scoped.

The screenshot shows unfocused colors with the pre-change visual on the left, the post-change visual on the rights. The contrast indicated is the contrast of the bottom and right edges of the edit (which are the edged that failed the contrast check). I also validated contrast when the control has the focus--21.0 in all HC modes. 7.3 in light mode, and 4.6 in dark mode.

![image](https://user-images.githubusercontent.com/45672944/94627313-0480a880-0272-11eb-8008-f5c87a9c93fa.png)


#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #876 
- [x] Includes UI changes?
  - [n/s] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



