### PR TITLE
fix: Checkboxes fail color contrast in HC White

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
@@ -65,7 +65,7 @@
                     DataType="{x:Type vm:EventConfigNodeViewModel}"
                      ItemsSource="{Binding Children}">
                             <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                                <CheckBox VerticalAlignment="Center" Visibility="{Binding TextVisibility}" IsThreeState="{Binding IsThreeState}" IsChecked="{Binding IsChecked}" Margin="0,0,4,0" IsEnabled="{Binding IsEditEnabled}" IsTabStop="False" AutomationProperties.LabeledBy="{Binding ElementName=tbNode}"/>
+                                <CheckBox VerticalAlignment="Center" Visibility="{Binding TextVisibility}" IsThreeState="{Binding IsThreeState}" IsChecked="{Binding IsChecked}" Margin="0,0,4,0" IsEnabled="{Binding IsEditEnabled}" IsTabStop="False" AutomationProperties.LabeledBy="{Binding ElementName=tbNode}" Style="{StaticResource CheckBoxContastingBorder}"/>
                                 <TextBlock Name="tbNode" VerticalAlignment="Center" Text="{Binding Header}" Visibility="{Binding TextVisibility}" Margin="0,0,4,0" FontSize="11" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                                 <Button VerticalAlignment="Center" Visibility="{Binding ButtonVisibility}" Name="btnConfig" Click="btnConfig_Click" IsEnabled="{Binding IsEditEnabled}" Background="Transparent" BorderThickness="0"
                                     AutomationProperties.HelpText="{x:Static Properties:Resources.btnConfigAutomationPropertiesHelpText}">
@@ -83,7 +83,7 @@
                 </TreeView>
                 <CheckBox Grid.Row="1" Content="{x:Static Properties:Resources.EventConfigTabControl_ckbxAllEvents}"
                           Margin="27,2" FontSize="11" Name="ckbxAllEvents" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"
-                          Checked="ckbxAllEvents_Checked" Unchecked="ckbxAllEvents_Unchecked"
+                          Checked="ckbxAllEvents_Checked" Unchecked="ckbxAllEvents_Unchecked" Style="{StaticResource CheckBoxContastingBorder}"
                           FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
             </Grid>
         </ScrollViewer>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -71,7 +71,7 @@
                                             <ColumnDefinition Width="17"/>
                                             <ColumnDefinition Width="*"/>
                                         </Grid.ColumnDefinitions>
-                                        <CheckBox Grid.Column="0" VerticalAlignment="Center" Name="chbxSelectAll" Click="chbxSelectAll_Click" AutomationProperties.Name="{x:Static Properties:Resources.chbxSelectAllAutomationPropertiesName}" IsEnabled="True"/>
+                                        <CheckBox Grid.Column="0" VerticalAlignment="Center" Name="chbxSelectAll" Click="chbxSelectAll_Click" AutomationProperties.Name="{x:Static Properties:Resources.chbxSelectAllAutomationPropertiesName}" IsEnabled="True" Style="{StaticResource CheckBoxContastingBorder}"/>
                                         <Button Grid.Column="1" Name="btnExpandAll" Margin="0,-2,0,0" HorizontalAlignment="Left"
                                                 Style="{StaticResource BtnStandard}" Width="8" Height="8" Padding="0"
                                                 BorderThickness="0" Click="btnExpandAll_Click" IsHitTestVisible="True"
@@ -88,7 +88,7 @@
                                     <DataTemplate>
                                         <CheckBox Name="chbxRow" Focusable="True" IsTabStop="False" AutomationProperties.Name="{x:Static Properties:Resources.chbxRowAutomationPropertiesName}" Margin="0.5,0,-2,0" >
                                             <CheckBox.Style>
-                                                <Style TargetType="CheckBox">
+                                                <Style TargetType="CheckBox" BasedOn="{StaticResource CheckBoxContastingBorder}">
                                                     <Style.Setters>
                                                         <Setter Property="IsEnabled" Value="{Binding Path=ScreenshotAvailable, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}"/>
                                                     </Style.Setters>
@@ -230,7 +230,7 @@
                                     <ControlTemplate TargetType="{x:Type Expander}">
                                         <Border Background="{TemplateBinding Background}">
                                             <DockPanel>
-                                                <CheckBox Margin="0,5,2,0" Tag="tag" Focusable="True" IsTabStop="False" Click="CheckBox_Click" AutomationProperties.Name="{x:Static Properties:Resources.lvResultsCheckBoxAutomationPropertiesName}"/>
+                                                <CheckBox Margin="0,5,2,0" Tag="tag" Focusable="True" IsTabStop="False" Click="CheckBox_Click" AutomationProperties.Name="{x:Static Properties:Resources.lvResultsCheckBoxAutomationPropertiesName}" Style="{StaticResource CheckBoxContastingBorder}"/>
                                                 <ToggleButton x:Name="HeaderSite" IsTabStop="False" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" 
                                                               Content="{TemplateBinding Header}" DockPanel.Dock="Top" Foreground="{TemplateBinding Foreground}" 
                                                               FontWeight="{TemplateBinding FontWeight}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" 

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml
@@ -15,6 +15,9 @@
         Icon="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Icons/BrandIcon.ico"
         Title="{x:Static Properties:Resources.TextRangeFindDialogWindowTitle}" SizeToContent="Height" Width="450" Loaded="Window_Loaded" Unloaded="Window_Unloaded"
         ShowInTaskbar="False" Topmost="True">
+    <Window.Resources>
+        <ResourceDictionary Source="..\Resources\Styles.xaml"/>
+    </Window.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -78,6 +81,7 @@
                       AutomationProperties.Name="{x:Static Properties:Resources.chbIgnoreCaseAutomationPropertiesName}"
                       Margin="10,0,0,0"
                       VerticalAlignment="Center"
+                      Style="{StaticResource CheckBoxContastingBorder}"
                       Content="{x:Static Properties:Resources.chbIgnoreCaseAutomationPropertiesName}"/>
             <StackPanel Orientation="Horizontal"
                         Grid.Column="1"

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1165,7 +1165,10 @@
         <Setter Property="BorderBrush" Value="{DynamicResource ResourceKey=LeftNavBorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
     </Style>
-    <Style TargetType="{x:Type CheckBox}" x:Key="CkbxLeftSide">
+    <Style TargetType="{x:Type CheckBox}" x:Key="CheckBoxContastingBorder">
+        <Setter Property="BorderBrush" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+    </Style>
+    <Style TargetType="{x:Type CheckBox}" x:Key="CkbxLeftSide" BasedOn="{StaticResource CheckBoxContastingBorder}">
         <Style.Resources>
             <Style TargetType="{x:Type Path}">
                 <Setter Property="FlowDirection" Value="LeftToRight" />
@@ -1176,7 +1179,7 @@
         </Style.Resources>
         <Setter Property="FlowDirection" Value="RightToLeft" />
     </Style>
-    <Style TargetType="{x:Type CheckBox}" x:Key="CkbxRightSide">
+    <Style TargetType="{x:Type CheckBox}" x:Key="CkbxRightSide" BasedOn="{StaticResource CheckBoxContastingBorder}">
         <Setter Property="FontSize" Value="14"/>
     </Style>
     <Style TargetType="{x:Type MenuItem}" x:Key="miFabIcon">

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1168,17 +1168,6 @@
     <Style TargetType="{x:Type CheckBox}" x:Key="CheckBoxContastingBorder">
         <Setter Property="BorderBrush" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
     </Style>
-    <Style TargetType="{x:Type CheckBox}" x:Key="CkbxLeftSide" BasedOn="{StaticResource CheckBoxContastingBorder}">
-        <Style.Resources>
-            <Style TargetType="{x:Type Path}">
-                <Setter Property="FlowDirection" Value="LeftToRight" />
-            </Style>
-            <Style TargetType="{x:Type TextBlock}">
-                <Setter Property="FlowDirection" Value="LeftToRight" />
-            </Style>
-        </Style.Resources>
-        <Setter Property="FlowDirection" Value="RightToLeft" />
-    </Style>
     <Style TargetType="{x:Type CheckBox}" x:Key="CkbxRightSide" BasedOn="{StaticResource CheckBoxContastingBorder}">
         <Setter Property="FontSize" Value="14"/>
     </Style>


### PR DESCRIPTION
#### Describe the change
Default checkboxes are failing WCAG 2.1 color contrast requirements in High Contrast White mode. They're OK in other modes, but this change applies in all modes. These are the default colors from .NET, so I'll probably file an issue there, as well (they probably haven't yet picked up the latest WCAG requirements).

The workaround is to create a new style called `CheckBoxContrastingBorder` and use this as the base style for all checkboxes in the product. This includes:
- The first-boot telemetry permissions dialog
- The Welcome screen
- The configuration page for event listening
- The Automated checks results page
- The Text Range find dialog

I've sanity checked all of these and found no issues other than the checkbox is a little darker than it use to be in the light theme. Here's a screenshot of the first-boot telemetry dialog in all 6 modes--I've confirmed that all contrasts are greater than 3.0:

![image](https://user-images.githubusercontent.com/45672944/94751197-c308ff80-033c-11eb-9e34-705b09d0d4f1.png)


#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #854 
- [styles only] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



