### PR TITLE
fix: Change glyph color on button hover

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1492,6 +1492,16 @@
             </Trigger>
         </Style.Triggers>
     </Style>
+    <Style TargetType="fabric:FabricIconControl" x:Key="hoverAwareFabricIconOnButtonParent">
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=IconHoverFGBrush}"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
     <Style TargetType="ColumnDefinition" x:Key="LeftPaneColumn">
         <Setter Property="MaxWidth">
             <Setter.Value>

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -345,12 +345,12 @@
                                                     <DataTrigger Binding="{Binding Path=vmHilighter.State, Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:MainWindow}}" Value="Off">
                                                         <Setter Property="GlyphName" Value="UnSetColor"/>
                                                     </DataTrigger>
-                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="True">
                                                         <Setter Property="Foreground" Value="{DynamicResource ResourceKey=IconHoverFGBrush}"/>
-                                                    </Trigger>
-                                                    <Trigger Property="IsMouseOver" Value="False">
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="False">
                                                         <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
-                                                    </Trigger>
+                                                    </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>
                                         </fabric:FabricIconControl.Style>
@@ -368,7 +368,7 @@
                                     <i:Interaction.Behaviors>
                                         <behaviors:KeyboardToolTipButtonBehavior/>
                                     </i:Interaction.Behaviors>
-                                    <fabric:FabricIconControl GlyphName="Refresh" FontSize="16" Style="{StaticResource hoverAwareFabricIcon}"/>
+                                    <fabric:FabricIconControl GlyphName="Refresh" FontSize="16" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                                 </Button>
                                 <Button x:Name="btnSave"
                                         Style="{StaticResource BtnNoAutoHelpText}"
@@ -382,7 +382,7 @@
                                     <i:Interaction.Behaviors>
                                         <behaviors:KeyboardToolTipButtonBehavior/>
                                     </i:Interaction.Behaviors>
-                                    <fabric:FabricIconControl GlyphName="Save" FontSize="16" Style="{StaticResource hoverAwareFabricIcon}"/>
+                                    <fabric:FabricIconControl GlyphName="Save" FontSize="16" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                                 </Button>
                                 <Button x:Name="btnPause"
                                         VerticalAlignment="Center" HorizontalAlignment="Left" Height="24" Width="24" Margin="4,0,0,0"
@@ -427,12 +427,12 @@
                                                     <DataTrigger Binding="{Binding Path=vmLiveModePauseResume.State, Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:MainWindow}}" Value="Off">
                                                         <Setter Property="GlyphName" Value="Play"/>
                                                     </DataTrigger>
-                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="True">
                                                         <Setter Property="Foreground" Value="{DynamicResource ResourceKey=IconHoverFGBrush}"/>
-                                                    </Trigger>
-                                                    <Trigger Property="IsMouseOver" Value="False">
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="False">
                                                         <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
-                                                    </Trigger>
+                                                    </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>
                                         </fabric:FabricIconControl.Style>
@@ -451,7 +451,7 @@
                                         <behaviors:DropDownButtonBehavior/>
                                         <behaviors:KeyboardToolTipButtonBehavior/>
                                     </i:Interaction.Behaviors>
-                                    <fabric:FabricIconControl GlyphName="Timer" FontSize="16" Style="{StaticResource hoverAwareFabricIcon}"/>
+                                    <fabric:FabricIconControl GlyphName="Timer" FontSize="16" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                                     <Button.ContextMenu>
                                         <ContextMenu>
                                             <MenuItem Name="miTimer" AutomationProperties.Name="{x:Static properties:Resources.miTimerAutomationPropertiesName}" Click="btnTimer_Click">
@@ -479,7 +479,7 @@
                                     <i:Interaction.Behaviors>
                                         <behaviors:KeyboardToolTipButtonBehavior/>
                                     </i:Interaction.Behaviors>
-                                    <fabric:FabricIconControl GlyphName="OpenFolderHorizontal" FontSize="16" Style="{StaticResource hoverAwareFabricIcon}"/>
+                                    <fabric:FabricIconControl GlyphName="OpenFolderHorizontal" FontSize="16" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                                 </Button>
                             </StackPanel>
                             <Label DockPanel.Dock="Right" Padding="8,0" Name="lblVersion" HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Row="0" FontSize="{StaticResource ConstStandardTextSize}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>


### PR DESCRIPTION
#### Describe the change
We have several cases where we have button that wraps a FabricIconControl. Even if the FabricIconControl is hover-aware, there's a range of mouse positions where IsMouseOver for the button is true, but IsMouseOver for the FabricIconControl is false, which causes us to fail color contrast. This change allows a FabricIconControl to be hover-aware for its button parent, so that we always have sufficient contrast.

Note that this fixes only the contrast issue of glyph color to button color--there may also be an issue of highlighted button color to background color that will be tracked separately.

Before change:
![862 (Old)](https://user-images.githubusercontent.com/45672944/95109544-957fd580-06f1-11eb-806f-7345db7b1c8b.gif)

After change:
![862 (New)](https://user-images.githubusercontent.com/45672944/95109559-9add2000-06f1-11eb-9de3-ce11a7402fb8.gif)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #862 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



