### PR TITLE
fix: Update nav bar hover colors

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -112,5 +112,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="TextPatternExplorerFGBrush" Color="#333333"/>  <!-- (UPDATED) Foreground in TextPatternExplorer -->
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconFGBrush" Color="#EAEAEA"/>       <!-- Foreground of nav bar icons -->
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>  <!-- Foreground of nav bar icons on mouse hover -->
-    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverBGBrush" Color="#4296D6"/>  <!-- Background of nav bar icons on mouse hover -->
+    <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>    <!-- Background of nav bar buttons on mouse hover -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -35,7 +35,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="WhiteTextBrush" Color="#FFFFFF"/>          <!-- Text color (normal) for video player -->
     <SolidColorBrush po:Freeze="True" x:Key="WhiteTextHoverBrush" Color="#FFFFFF"/>     <!-- Text color (hover) for snapshot button and video player -->
     <SolidColorBrush po:Freeze="True" x:Key="BorderBrush" Color="#C7C7C7"/>             <!-- Generic light border (used everywhere) -->
-    <SolidColorBrush po:Freeze="True" x:Key="LightIconBrush" Color="#EAEAEA"/>          <!-- Used to draw the icons on the nav bar -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonBackgroundBrush" Color="Transparent"/>   <!-- Keep Transparent in Dark -->
     <SolidColorBrush po:Freeze="True" x:Key="ToggleSliderBlueBrush" Color="#FF0078D6"/> <!-- Used for toggles in the "on" position -->
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderEmptyBGBrush" Color="#22272B"/><!-- (UPDATED) Background of "empty" column headers in data grid (list of properties) -->
@@ -111,4 +110,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGHoverBrush" Color="#B2B3B5"/>  <!-- (UPDATED) Background of "BtnGreySquared" buttons on hover -->
     <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedHoverBrush" Color="#FFFFFF"/>   <!-- (UPDATED) Hover of "BtnOnSelectedLine" buttons -->
     <SolidColorBrush po:Freeze="True" x:Key="TextPatternExplorerFGBrush" Color="#333333"/>  <!-- (UPDATED) Foreground in TextPatternExplorer -->
+    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconFGBrush" Color="#EAEAEA"/>       <!-- Foreground of nav bar icons -->
+    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>  <!-- Foreground of nav bar icons on mouse hover -->
+    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverBGBrush" Color="#4296D6"/>  <!-- Background of nav bar icons on mouse hover -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -19,7 +19,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="SelectedACRowBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActiveModeBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="IconBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="LightIconBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="BubbleBGBrush" Color="{x:Static SystemColors.WindowTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="BubbleFGBrush" Color="{x:Static SystemColors.WindowColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="BlueButtonBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
@@ -94,4 +93,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedHoverBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TextPatternExplorerFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -95,5 +95,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="TextPatternExplorerFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -35,7 +35,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="WhiteTextBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="WhiteTextHoverBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="BorderBrush" Color="#C7C7C7"/>
-    <SolidColorBrush po:Freeze="True" x:Key="LightIconBrush" Color="#EAEAEA"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonBackgroundBrush" Color="Transparent"/>
     <SolidColorBrush po:Freeze="True" x:Key="ToggleSliderBlueBrush" Color="#FF0078D6"/>
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderEmptyBGBrush" Color="#EBEBEB"/>
@@ -111,4 +110,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="GreyButtonBGHoverBrush" Color="#CCCCCC"/>
     <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedHoverBrush" Color="#BEE6Fd"/>
     <SolidColorBrush po:Freeze="True" x:Key="TextPatternExplorerFGBrush" Color="#333333"/>
+    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconFGBrush" Color="#EAEAEA"/>
+    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#000000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverBGBrush" Color="#0067B5"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -111,6 +111,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedHoverBrush" Color="#BEE6Fd"/>
     <SolidColorBrush po:Freeze="True" x:Key="TextPatternExplorerFGBrush" Color="#333333"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconFGBrush" Color="#EAEAEA"/>
-    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#000000"/>
-    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverBGBrush" Color="#0067B5"/>
+    <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>
+    <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -722,7 +722,7 @@
         </Setter>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="Background" Value="{DynamicResource ResourceKey=BlueButtonHoverBGBrush}"/>
+                <Setter Property="Background" Value="{DynamicResource ResourceKey=NavBarIconHoverBGBrush}"/>
             </Trigger>
             <Trigger Property="IsFocused" Value="true">
                 <Setter Property="BorderBrush" Value="White"/>
@@ -1499,6 +1499,16 @@
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="False">
                 <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="fabric:FabricIconControl" x:Key="hoverAwareNavBarFabricIcon">
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=NavBarIconHoverFGBrush}"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=NavBarIconFGBrush}"/>
             </DataTrigger>
         </Style.Triggers>
     </Style>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -722,7 +722,7 @@
         </Setter>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="Background" Value="{DynamicResource ResourceKey=NavBarIconHoverBGBrush}"/>
+                <Setter Property="Background" Value="{DynamicResource ResourceKey=NavBarButtonHoverBGBrush}"/>
             </Trigger>
             <Trigger Property="IsFocused" Value="true">
                 <Setter Property="BorderBrush" Value="White"/>

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -95,7 +95,7 @@
                             </i:Interaction.Behaviors>
                             <Grid Width="40" Height="40">
                                 <Canvas x:Name="cvsInspect" HorizontalAlignment="Left" Width="7" Height="Auto" Background="{DynamicResource ResourceKey=ActiveModeBrush}" Visibility="Collapsed"/>
-                                <fabric:FabricIconControl GlyphName="SearchAndApps" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=LightIconBrush}"/>
+                                <fabric:FabricIconControl GlyphName="SearchAndApps" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareNavBarFabricIcon}"/>
                             </Grid>
                         </Button>
                         <Button x:Name="btnTest" 
@@ -115,7 +115,7 @@
                             </i:Interaction.Behaviors>
                             <Grid Width="40" Height="40">
                                 <Canvas x:Name="cvsTest" HorizontalAlignment="Left" Width="7" Height="Auto" Background="{DynamicResource ResourceKey=ActiveModeBrush}"/>
-                                <fabric:FabricIconControl GlyphName="TestBeakerSolid" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=LightIconBrush}"/>
+                                <fabric:FabricIconControl GlyphName="TestBeakerSolid" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareNavBarFabricIcon}"/>
                             </Grid>
                         </Button>
                         <Button x:Name="btnCCA" 
@@ -135,7 +135,7 @@
                             </i:Interaction.Behaviors>
                             <Grid Width="40" Height="40">
                                 <Canvas x:Name="cvsCCA" HorizontalAlignment="Left" Width="7" Height="Auto" Background="{DynamicResource ResourceKey=ActiveModeBrush}"/>
-                                <fabric:FabricIconControl GlyphName="Color" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=LightIconBrush}"/>
+                                <fabric:FabricIconControl GlyphName="Color" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareNavBarFabricIcon}"/>
                             </Grid>
                         </Button>
                     </Grid>
@@ -166,7 +166,7 @@
                             <Grid Width="40" Height="40" x:Name="addAccountGrid">
                                 <Grid x:Name="newAccountGrid" Visibility="Visible">
                                     <AccessText Text="_i" Opacity="0"/>
-                                    <fabric:FabricIconControl GlyphName="{Binding Path=vmReporterLogo.FabricIconLogoName, TargetNullValue=PlugDisconnected}" FontSize="24" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=LightIconBrush}"  HorizontalAlignment="Center"/>
+                                    <fabric:FabricIconControl GlyphName="{Binding Path=vmReporterLogo.FabricIconLogoName, TargetNullValue=PlugDisconnected}" FontSize="24" VerticalAlignment="Center" Style="{StaticResource hoverAwareNavBarFabricIcon}" HorizontalAlignment="Center"/>
                                 </Grid>
                             </Grid>
                         </Button>
@@ -186,7 +186,7 @@
                             </i:Interaction.Behaviors>
                             <Grid>
                                 <AccessText Text="_c" Opacity="0"/>
-                                <fabric:FabricIconControl GlyphName="Settings" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=LightIconBrush}"/>
+                                <fabric:FabricIconControl GlyphName="Settings" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareNavBarFabricIcon}"/>
                             </Grid>
                         </Button>
                     </Grid>


### PR DESCRIPTION
#### Describe the change
This PR does the following:
- In the list of brushes, rename `LightIconBrush` to a hopefully more descriptive `NavBarIconFGBrush`. This brush is the foreground brush of non-hovered icons in the nav bar
- Add a brush named `NavBarIconHoverFGBrush`. This is the foreground brush of hovered icons in the nav bar
- Add a brush named `NavBarButtonHoverBGBrush`. This is the background brush of nav bar buttons (fabric icons are transparent, so they appear with the button color as their background). This is mostly identical to `BlueButtonHoverBGBrush`, but I dropped the dark mode value into light mode value to provide adequate color contrast between hover and non-hover.

Here are gifs of the nav bars in all modes. The only expected change is in HC White. Some of the "Contrast" Tooltips appear outside of the capture window, but the are displayed to the user. I apologize in advance for any headache this causes...
Mode | Old | New
--- | --- | ---
HC White (different FG) | ![859-old-hcwhite](https://user-images.githubusercontent.com/45672944/95147256-0dbbba80-0735-11eb-89bd-0ed1cf172339.gif) | ![859-new-hcwhite](https://user-images.githubusercontent.com/45672944/95147271-1a401300-0735-11eb-902b-0489cc673f7e.gif)
HC Black (different FG) | ![859-old-hcblack](https://user-images.githubusercontent.com/45672944/95147421-8884d580-0735-11eb-8222-8c0969d288f7.gif) | ![859-new-hcblack](https://user-images.githubusercontent.com/45672944/95147450-989cb500-0735-11eb-9665-67a4cde94793.gif)
HC 2 (unchanged) | ![859-old-hc2](https://user-images.githubusercontent.com/45672944/95147307-3774e180-0735-11eb-883b-275fc89260a2.gif) | ![859-new-hc2](https://user-images.githubusercontent.com/45672944/95147320-4065b300-0735-11eb-98bc-387930d2760b.gif)
HC1 (unchanged) | ![859-old-hc1](https://user-images.githubusercontent.com/45672944/95147344-5b382780-0735-11eb-9d3d-68d0bc711e71.gif) | ![859-new-hc1](https://user-images.githubusercontent.com/45672944/95147361-6428f900-0735-11eb-8ed4-f0aa679bce4d.gif)
Dark (unchanged) | ![859-old-dark](https://user-images.githubusercontent.com/45672944/95147132-b61d4f00-0734-11eb-9b10-35bad04d2b46.gif) | ![859-new-dark](https://user-images.githubusercontent.com/45672944/95147145-be758a00-0734-11eb-8d58-fff9e2e1b064.gif)
Light (different BG) | ![859-old-light](https://user-images.githubusercontent.com/45672944/95147013-5de64d00-0734-11eb-8779-458ff61d0ba5.gif) | ![859-new-light](https://user-images.githubusercontent.com/45672944/95148180-89b70200-0737-11eb-91cd-740e98dae9e8.gif)

Please note: this PR does not fix the HC White contrast issue between the highlight color and the color of the "active mode" thumb.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #859 
- [style only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



