### PR TITLE
fix: Some dark mode text has insufficient contrast

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
@@ -177,7 +177,7 @@
                                 </Style>
                             </TextBox.Style>
                         </TextBox>
-                        <TextBox Text="{x:Static Properties:Resources.ScannerResultControl_noFailures}" AutomationProperties.LabeledBy="{Binding ElementName=labelFixFollowing}">
+                        <TextBox Text="{x:Static Properties:Resources.ScannerResultControl_noFailures}" AutomationProperties.LabeledBy="{Binding ElementName=labelFixFollowing}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}">
                             <TextBox.Style>
                                 <Style TargetType="TextBox" BasedOn="{StaticResource TxtReadonlyText}">
                                     <Setter Property="Visibility" Value="Collapsed" />

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft. All rights reserved.
      Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
-<!-- Contains theme for the default AccessibilityInsights dark theme -->
+<!-- Contains the color theme for AccessibilityInsights in dark mode -->
 <ResourceDictionary     
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -93,7 +93,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="#000000"/>     <!-- (UPDATED) Foreground of column headers in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="#6D767E"/>     <!-- (UPDATED) Background of column headers in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground of selected row in a data grid (list of properties) -->
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedTabFGBrush" Color="#000000"/>      <!-- (UPDATED) Foreground brush of selected tab in Tests view -->
+    <SolidColorBrush po:Freeze="True" x:Key="SelectedTabFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground brush of selected tab in Tests view -->
     <SolidColorBrush po:Freeze="True" x:Key="TabHorizontalBorderBrush" Color="Transparent"/>    <!-- (UPDATED) Horizontal Border between tab items in test mode -->
     <SolidColorBrush po:Freeze="True" x:Key="ACRowHoverBGBrush" Color="#2B3034"/>       <!-- (UPDATED) Hover background color of automated checks rows -->
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="#000000"/>    <!-- (UPDATED) Foreground color of selected tab stop rows -->

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -78,7 +78,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedTabFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="SelectedTabFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ACRowHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>


### PR DESCRIPTION
#### Describe the change
Issue #843 calls out 2 places where colors are incorrect in dark mode. This fixes both.

The first problem is due to `SelectedFGTabBrush` being set to the wrong value, so we drew the text for the "Automated Checks tab" in the wrong color. This is the only place this value is used, so we can just change the color value without creating another brush. I discovered that HC Black and HC White modes are also broken, so I had to change brushes for both dark and HC modes. I've included screenshots of all 6 modes, just for completeness. In all cases, the old version is on the left, and the new version is on the right:

Mode | Screenshot
--- | ---
Light (no change) | ![image](https://user-images.githubusercontent.com/45672944/95272120-7027c000-07f4-11eb-8217-5e9638906f98.png)
Dark (fixed) | ![image](https://user-images.githubusercontent.com/45672944/95271109-ebd43d80-07f1-11eb-8d36-8aed52294390.png)
HC1 (no change) | ![image](https://user-images.githubusercontent.com/45672944/95272221-b2510180-07f4-11eb-9a9a-c2944926fe49.png)
HC2 (no change) | ![image](https://user-images.githubusercontent.com/45672944/95272190-9cdbd780-07f4-11eb-9def-0055f6f132c7.png)
HC Black (fixed) | ![image](https://user-images.githubusercontent.com/45672944/95272263-cac11c00-07f4-11eb-91b8-4d71349c5bda.png)
HC White (fixed) | ![image](https://user-images.githubusercontent.com/45672944/95272293-df9daf80-07f4-11eb-94ec-bdbb18fc3ce4.png)

The second problem is because we didn't style the control that reports "There were no failures", so it always displays in the default text color. This got weird in some HC modes, since the default mapped colors were inconsistent--in HC1 it mapped to the Text color but in HC2 it mapped to the Disabled Text color. After this change, it's always displayed in the same color as the "Fix the following" header. Again, I've included screenshots of all 6 modes. In all cases, the old version is on the left, and the new version is on the right:

Mode | Screenshot
--- | ---
Light (no change) | ![image](https://user-images.githubusercontent.com/45672944/95273470-090c0a80-07f8-11eb-8e12-7b59fd8d1a73.png)
Dark (fixed) | ![image](https://user-images.githubusercontent.com/45672944/95273530-2e007d80-07f8-11eb-8c53-260e71882925.png)
HC1 (different) | ![image](https://user-images.githubusercontent.com/45672944/95273334-a7e43700-07f7-11eb-947b-a3ed34330021.png)
HC2 (different) | ![image](https://user-images.githubusercontent.com/45672944/95273354-bb8f9d80-07f7-11eb-86f3-2285922eabab.png)
HC Black (no change) | ![image](https://user-images.githubusercontent.com/45672944/95273383-cd714080-07f7-11eb-9bde-6c9d4aafb40a.png)
HC White (no change) | ![image](https://user-images.githubusercontent.com/45672944/95273413-dfeb7a00-07f7-11eb-969b-861af8e1e501.png)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #843 
- [colors only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



