### PR TITLE
fix: Remove pr:none from prbuild.yml

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -1,6 +1,5 @@
 name: $(date:yyyy-MM-dd)$(rev:.rr)
 trigger: none
-pr: none
 variables:
   BuildPlatform: 'x86'
   MAICreateNuget: 'true'

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -1,5 +1,7 @@
 name: $(date:yyyy-MM-dd)$(rev:.rr)
 trigger: none
+pr:
+- master
 variables:
   BuildPlatform: 'x86'
   MAICreateNuget: 'true'

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -1,6 +1,5 @@
 name: $(date:yyyy-MM-dd)$(rev:.rr)
 trigger: none
-pr: master
 variables:
   BuildPlatform: 'x86'
   MAICreateNuget: 'true'

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -1,7 +1,6 @@
 name: $(date:yyyy-MM-dd)$(rev:.rr)
 trigger: none
-pr:
-- master
+pr: master
 variables:
   BuildPlatform: 'x86'
   MAICreateNuget: 'true'


### PR DESCRIPTION
#### Describe the change
Pipeline support suggested that removing the pr:none flag will unblock the build pipeline. Let's find out...

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



