### PR TITLE
fix: Update Link color on hover (dark mode)

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -113,4 +113,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconFGBrush" Color="#EAEAEA"/>       <!-- Foreground of nav bar icons -->
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>  <!-- Foreground of nav bar icons on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>    <!-- Background of nav bar buttons on mouse hover -->
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#FF0000"/>  <!-- Foreground of hyperlinks on mouse hover -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -113,5 +113,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconFGBrush" Color="#EAEAEA"/>       <!-- Foreground of nav bar icons -->
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>  <!-- Foreground of nav bar icons on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>    <!-- Background of nav bar buttons on mouse hover -->
-    <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#FF0000"/>  <!-- Foreground of hyperlinks on mouse hover -->
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#c7e0f4"/>  <!-- Foreground of hyperlinks on mouse hover -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -96,4 +96,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="{x:Static SystemColors.HotTrackColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -113,4 +113,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconFGBrush" Color="#EAEAEA"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#FF0000"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -351,7 +351,14 @@
         </Style.Triggers>
     </Style>
     <Style TargetType="{x:Type Hyperlink}" x:Key="hLink" BasedOn="{StaticResource {x:Type Hyperlink}}">
-        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonLinkFGBrush}"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonLinkHoverFGBrush}"/>
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonLinkFGBrush}"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
     <Style TargetType="{x:Type Label}" x:Key="lblLink">
         <Setter Property="Background" Value="{x:Null}"/>


### PR DESCRIPTION
#### Describe the change
As called out in #842, the default link hover color fails color contrast requirements in dark mode. This PR adds the ability to override the link text and changes the color in dark mode. The link color in other modes is unchanged. Here's a GIF of the new link color in action:

![links-2](https://user-images.githubusercontent.com/45672944/95482474-01a54800-0943-11eb-900d-0fca0ced7c95.gif)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #842
- [style only] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



