### PR TITLE
fix: Update high contrast colors of tabs in test view

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -15,7 +15,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="LoadingBrush" Color="#6BADE0"/>            <!-- (UPDATED) Progress ring (dots and text) -->
     <SolidColorBrush po:Freeze="True" x:Key="DisabledOverlayBrush" Color="#FDFDFD"/>    <!-- MainWindow: Overlay for "Tab Stops" ? -->
     <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="#6D767E"/>      <!-- (UPDATED) Background brush of selected tab in Tests view -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabHoverBrush" Color="#444C52"/>           <!-- (UPDATED) Hover color in main window (Detail/HowToFix) -->
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="#444C52"/>   <!-- (UPDATED) Background Hover brush of non-selected tab in Tests view -->
     <SolidColorBrush po:Freeze="True" x:Key="ActiveBlueBrush" Color="#FF0078D6"/>       <!-- "Passed and uncertain tests" foreground, also tree icon -->
     <SolidColorBrush po:Freeze="True" x:Key="TabBorderBrush" Color="#6D767E"/>          <!-- (UPDATED) Vertical Border on tab items in test mode -->
     <SolidColorBrush po:Freeze="True" x:Key="UnselectedTabBrush" Color="#22272B"/>      <!-- (UPDATED) Background brush of non-selected items in list view -->

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -114,4 +114,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>  <!-- Foreground of nav bar icons on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>    <!-- Background of nav bar buttons on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#c7e0f4"/>  <!-- Foreground of hyperlinks on mouse hover -->
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverFGBrush" Color="#FFFFFF"/>   <!-- Foreground hover brush of non-selected tab in Tests view -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -14,7 +14,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="SelectedBrush" Color="#31383D"/>           <!-- (UPDATED) Selected item highlight in Hierarchy and "How to Fix" view -->
     <SolidColorBrush po:Freeze="True" x:Key="LoadingBrush" Color="#6BADE0"/>            <!-- (UPDATED) Progress ring (dots and text) -->
     <SolidColorBrush po:Freeze="True" x:Key="DisabledOverlayBrush" Color="#FDFDFD"/>    <!-- MainWindow: Overlay for "Tab Stops" ? -->
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedTabBrush" Color="#6D767E"/>        <!-- (UPDATED) Background brush of selected tab in Tests view -->
+    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="#6D767E"/>      <!-- (UPDATED) Background brush of selected tab in Tests view -->
     <SolidColorBrush po:Freeze="True" x:Key="TabHoverBrush" Color="#444C52"/>           <!-- (UPDATED) Hover color in main window (Detail/HowToFix) -->
     <SolidColorBrush po:Freeze="True" x:Key="ActiveBlueBrush" Color="#FF0078D6"/>       <!-- "Passed and uncertain tests" foreground, also tree icon -->
     <SolidColorBrush po:Freeze="True" x:Key="TabBorderBrush" Color="#6D767E"/>          <!-- (UPDATED) Vertical Border on tab items in test mode -->
@@ -93,7 +93,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="#000000"/>     <!-- (UPDATED) Foreground of column headers in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="#6D767E"/>     <!-- (UPDATED) Background of column headers in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground of selected row in a data grid (list of properties) -->
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedTabFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground brush of selected tab in Tests view -->
+    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground brush of selected tab in Tests view -->
     <SolidColorBrush po:Freeze="True" x:Key="TabHorizontalBorderBrush" Color="Transparent"/>    <!-- (UPDATED) Horizontal Border between tab items in test mode -->
     <SolidColorBrush po:Freeze="True" x:Key="ACRowHoverBGBrush" Color="#2B3034"/>       <!-- (UPDATED) Hover background color of automated checks rows -->
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="#000000"/>    <!-- (UPDATED) Foreground color of selected tab stop rows -->

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -54,7 +54,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="#6D767E"/> <!-- (UPDATED) Background of selected item in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkFGBrush" Color="#6BADE0"/>       <!-- (UPDATED) Text color for links -->
     <SolidColorBrush po:Freeze="True" x:Key="DataGridBorderBrush" Color="Transparent"/> <!-- (UPDATED) Brush for border of data grid (event view) -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabNonEnabledFGBrush" Color="#B3B3B3"/>    <!-- Foreground color of non-enabled items in tab (test view) -->
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotEnabledFGBrush" Color="#B3B3B3"/>    <!-- Foreground color of non-enabled items in tab (test view) -->
     <SolidColorBrush po:Freeze="True" x:Key="ExpBorderBrush" Color="#6D767E"/>          <!-- (UPDATED) Border color on expandos -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedInspectTabBrush" Color="#22272B"/> <!-- (UPDATED) Background color of selected tab (Details, HowToFix) -->
     <SolidColorBrush po:Freeze="True" x:Key="UnselectedInspectTabBrush" Color="#182025"/>    <!-- (UPDATED) Background color of non-selected tab (Details, HowToFix) -->

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -54,7 +54,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="#6D767E"/> <!-- (UPDATED) Background of selected item in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkFGBrush" Color="#6BADE0"/>       <!-- (UPDATED) Text color for links -->
     <SolidColorBrush po:Freeze="True" x:Key="DataGridBorderBrush" Color="Transparent"/> <!-- (UPDATED) Brush for border of data grid (event view) -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabBGBrush" Color="#B3B3B3"/>              <!-- Foreground color in tab (search bar?) -->
+    <SolidColorBrush po:Freeze="True" x:Key="TabNonEnabledFGBrush" Color="#B3B3B3"/>    <!-- Foreground color of non-enabled items in tab (test view) -->
     <SolidColorBrush po:Freeze="True" x:Key="ExpBorderBrush" Color="#6D767E"/>          <!-- (UPDATED) Border color on expandos -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedInspectTabBrush" Color="#22272B"/> <!-- (UPDATED) Background color of selected tab (Details, HowToFix) -->
     <SolidColorBrush po:Freeze="True" x:Key="UnselectedInspectTabBrush" Color="#182025"/>    <!-- (UPDATED) Background color of non-selected tab (Details, HowToFix) -->

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -18,7 +18,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="#444C52"/>   <!-- (UPDATED) Background Hover brush of non-selected tab in Tests view -->
     <SolidColorBrush po:Freeze="True" x:Key="ActiveBlueBrush" Color="#FF0078D6"/>       <!-- "Passed and uncertain tests" foreground, also tree icon -->
     <SolidColorBrush po:Freeze="True" x:Key="TabBorderBrush" Color="#6D767E"/>          <!-- (UPDATED) Vertical Border on tab items in test mode -->
-    <SolidColorBrush po:Freeze="True" x:Key="UnselectedTabBrush" Color="#22272B"/>      <!-- (UPDATED) Background brush of non-selected items in list view -->
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedBGBrush" Color="#22272B"/>   <!-- (UPDATED) Background brush of non-selected items in Tests view -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedACRowBGBrush" Color="#31383D"/>    <!-- (UPDATED) Background brush for selected row in Automated checks -->
     <SolidColorBrush po:Freeze="True" x:Key="StartupSampleKeyBGBrush" Color="#575757"/> <!-- Background sample keys on Startup dialog -->
     <SolidColorBrush po:Freeze="True" x:Key="LeftNavBorderBrush" Color="Transparent"/>  <!-- Keep Transparent for dark mode -->

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -14,11 +14,8 @@
     <SolidColorBrush po:Freeze="True" x:Key="SelectedBrush" Color="#31383D"/>           <!-- (UPDATED) Selected item highlight in Hierarchy and "How to Fix" view -->
     <SolidColorBrush po:Freeze="True" x:Key="LoadingBrush" Color="#6BADE0"/>            <!-- (UPDATED) Progress ring (dots and text) -->
     <SolidColorBrush po:Freeze="True" x:Key="DisabledOverlayBrush" Color="#FDFDFD"/>    <!-- MainWindow: Overlay for "Tab Stops" ? -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="#6D767E"/>      <!-- (UPDATED) Background brush of selected tab in Tests view -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="#444C52"/>   <!-- (UPDATED) Background Hover brush of non-selected tab in Tests view -->
     <SolidColorBrush po:Freeze="True" x:Key="ActiveBlueBrush" Color="#FF0078D6"/>       <!-- "Passed and uncertain tests" foreground, also tree icon -->
     <SolidColorBrush po:Freeze="True" x:Key="TabBorderBrush" Color="#6D767E"/>          <!-- (UPDATED) Vertical Border on tab items in test mode -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedBGBrush" Color="#22272B"/>   <!-- (UPDATED) Background brush of non-selected items in Tests view -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedACRowBGBrush" Color="#31383D"/>    <!-- (UPDATED) Background brush for selected row in Automated checks -->
     <SolidColorBrush po:Freeze="True" x:Key="StartupSampleKeyBGBrush" Color="#575757"/> <!-- Background sample keys on Startup dialog -->
     <SolidColorBrush po:Freeze="True" x:Key="LeftNavBorderBrush" Color="Transparent"/>  <!-- Keep Transparent for dark mode -->
@@ -54,7 +51,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="#6D767E"/> <!-- (UPDATED) Background of selected item in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkFGBrush" Color="#6BADE0"/>       <!-- (UPDATED) Text color for links -->
     <SolidColorBrush po:Freeze="True" x:Key="DataGridBorderBrush" Color="Transparent"/> <!-- (UPDATED) Brush for border of data grid (event view) -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotEnabledFGBrush" Color="#B3B3B3"/>    <!-- Foreground color of non-enabled items in tab (test view) -->
     <SolidColorBrush po:Freeze="True" x:Key="ExpBorderBrush" Color="#6D767E"/>          <!-- (UPDATED) Border color on expandos -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedInspectTabBrush" Color="#22272B"/> <!-- (UPDATED) Background color of selected tab (Details, HowToFix) -->
     <SolidColorBrush po:Freeze="True" x:Key="UnselectedInspectTabBrush" Color="#182025"/>    <!-- (UPDATED) Background color of non-selected tab (Details, HowToFix) -->
@@ -70,6 +66,14 @@
     <SolidColorBrush x:Key="HLGreenTextBrush" Color="#00FF00 "/>                        <!-- Text color for highlighter tooltip -->
     <SolidColorBrush x:Key="HLTextBrush" Color="#FFFF00 "/>                             <!-- Background color for highlighter tooltip -->
     <Thickness po:Freeze="True" x:Key="BtnBrdrThickness">0</Thickness>                    <!-- Keep as 0 in dark -->
+
+    <!-- Brushes used exclusively in tabs of test view-->
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotEnabledFGBrush" Color="#B3B3B3"/>    <!-- Foreground color of non-enabled items in tab (test view) -->
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedBGBrush" Color="#22272B"/>   <!-- (UPDATED) Background brush of non-selected items in Tests view -->
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="#444C52"/>   <!-- (UPDATED) Background Hover brush of non-selected tab in Tests view -->
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverFGBrush" Color="#FFFFFF"/>   <!-- Foreground hover brush of non-selected tab in Tests view -->
+    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="#6D767E"/>      <!-- (UPDATED) Background brush of selected tab in Tests view -->
+    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground brush of selected tab in Tests view -->
 
     <!-- NEW SETTINGS -->
     <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">1</Thickness>          <!-- (UPDATED) Thickness of border around search panel -->
@@ -93,7 +97,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="#000000"/>     <!-- (UPDATED) Foreground of column headers in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="#6D767E"/>     <!-- (UPDATED) Background of column headers in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground of selected row in a data grid (list of properties) -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground brush of selected tab in Tests view -->
     <SolidColorBrush po:Freeze="True" x:Key="TabHorizontalBorderBrush" Color="Transparent"/>    <!-- (UPDATED) Horizontal Border between tab items in test mode -->
     <SolidColorBrush po:Freeze="True" x:Key="ACRowHoverBGBrush" Color="#2B3034"/>       <!-- (UPDATED) Hover background color of automated checks rows -->
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="#000000"/>    <!-- (UPDATED) Foreground color of selected tab stop rows -->
@@ -114,5 +117,4 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>  <!-- Foreground of nav bar icons on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>    <!-- Background of nav bar buttons on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#c7e0f4"/>  <!-- Foreground of hyperlinks on mouse hover -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverFGBrush" Color="#FFFFFF"/>   <!-- Foreground hover brush of non-selected tab in Tests view -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -68,12 +68,12 @@
     <Thickness po:Freeze="True" x:Key="BtnBrdrThickness">0</Thickness>                    <!-- Keep as 0 in dark -->
 
     <!-- Brushes used exclusively in tabs of test view-->
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotEnabledFGBrush" Color="#B3B3B3"/>    <!-- Foreground color of non-enabled items in tab (test view) -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedBGBrush" Color="#22272B"/>   <!-- (UPDATED) Background brush of non-selected items in Tests view -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="#444C52"/>   <!-- (UPDATED) Background Hover brush of non-selected tab in Tests view -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverFGBrush" Color="#FFFFFF"/>   <!-- Foreground hover brush of non-selected tab in Tests view -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="#6D767E"/>      <!-- (UPDATED) Background brush of selected tab in Tests view -->
-    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground brush of selected tab in Tests view -->
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotEnabledFGBrush" Color="#B3B3B3"/>    <!-- Foreground color of non-enabled items in tab (test view) -->
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedBGBrush" Color="#22272B"/>   <!-- (UPDATED) Background brush of non-selected items in Tests view -->
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedHoverBGBrush" Color="#444C52"/>   <!-- (UPDATED) Background Hover brush of non-selected tab in Tests view -->
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedHoverFGBrush" Color="#FFFFFF"/>   <!-- Foreground hover brush of non-selected tab in Tests view -->
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemSelectedBGBrush" Color="#6D767E"/>      <!-- (UPDATED) Background brush of selected tab in Tests view -->
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemSelectedFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground brush of selected tab in Tests view -->
 
     <!-- NEW SETTINGS -->
     <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">1</Thickness>          <!-- (UPDATED) Thickness of border around search panel -->

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -68,12 +68,12 @@
     <Thickness po:Freeze="True" x:Key="BtnBrdrThickness">0</Thickness>                    <!-- Keep as 0 in dark -->
 
     <!-- Brushes used exclusively in tabs of test view-->
-    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotEnabledFGBrush" Color="#B3B3B3"/>    <!-- Foreground color of non-enabled items in tab (test view) -->
-    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedBGBrush" Color="#22272B"/>   <!-- (UPDATED) Background brush of non-selected items in Tests view -->
-    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedHoverBGBrush" Color="#444C52"/>   <!-- (UPDATED) Background Hover brush of non-selected tab in Tests view -->
-    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedHoverFGBrush" Color="#FFFFFF"/>   <!-- Foreground hover brush of non-selected tab in Tests view -->
-    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemSelectedBGBrush" Color="#6D767E"/>      <!-- (UPDATED) Background brush of selected tab in Tests view -->
-    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemSelectedFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground brush of selected tab in Tests view -->
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotEnabledFGBrush" Color="#B3B3B3"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedBGBrush" Color="#22272B"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedHoverBGBrush" Color="#444C52"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedHoverFGBrush" Color="#FFFFFF"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemSelectedBGBrush" Color="#6D767E"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemSelectedFGBrush" Color="#FFFFFF"/>
 
     <!-- NEW SETTINGS -->
     <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">1</Thickness>          <!-- (UPDATED) Thickness of border around search panel -->

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -98,4 +98,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="{x:Static SystemColors.HotTrackColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -36,6 +36,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="WindowBorderTextBrush" Color="{x:Static SystemColors.ActiveCaptionTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="LeftNavBorderBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedTabBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNonEnabledFGBrush" Color="{x:Static SystemColors.GrayTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedInspectTabBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="UnselectedTabBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="DisabledOverlayBrush" Color="{x:Static SystemColors.ControlColor}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -38,7 +38,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TabNonEnabledFGBrush" Color="{x:Static SystemColors.GrayTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedInspectTabBrush" Color="{x:Static SystemColors.HighlightColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="UnselectedTabBrush" Color="{x:Static SystemColors.ControlColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="DisabledOverlayBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="BtnBrderBrush" Color="{x:Static SystemColors.ControlDarkColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ToggleSliderBlueBrush" Color="{x:Static SystemColors.HighlightColor}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -12,7 +12,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="ButtonHoverRedBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="StartupInnerBorderBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="StartupFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActiveBlueBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SecondaryBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="PrimaryBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
@@ -35,10 +34,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="WindowBorderBrush" Color="{x:Static SystemColors.ActiveCaptionColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="WindowBorderTextBrush" Color="{x:Static SystemColors.ActiveCaptionTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="LeftNavBorderBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotEnabledFGBrush" Color="{x:Static SystemColors.GrayTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedInspectTabBrush" Color="{x:Static SystemColors.HighlightColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="DisabledOverlayBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="BtnBrderBrush" Color="{x:Static SystemColors.ControlDarkColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ToggleSliderBlueBrush" Color="{x:Static SystemColors.HighlightColor}"/>
@@ -56,6 +52,14 @@
     <SolidColorBrush po:Freeze="True" x:Key="CCABorderBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledFGBrush" Color="{x:Static SystemColors.GrayTextColor}"/>
     <Thickness po:Freeze="True" x:Key="BtnBrdrThickness">1</Thickness>
+
+    <!-- Brushes used exclusively in tabs of test view-->
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotEnabledFGBrush" Color="{x:Static SystemColors.GrayTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
 
     <!-- NEW SETTINGS -->
     <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">0</Thickness>
@@ -79,7 +83,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ACRowHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
@@ -98,5 +101,4 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="{x:Static SystemColors.HotTrackColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -36,7 +36,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="WindowBorderTextBrush" Color="{x:Static SystemColors.ActiveCaptionTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="LeftNavBorderBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNonEnabledFGBrush" Color="{x:Static SystemColors.GrayTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotEnabledFGBrush" Color="{x:Static SystemColors.GrayTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedInspectTabBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="DisabledOverlayBrush" Color="{x:Static SystemColors.ControlColor}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -54,12 +54,12 @@
     <Thickness po:Freeze="True" x:Key="BtnBrdrThickness">1</Thickness>
 
     <!-- Brushes used exclusively in tabs of test view-->
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotEnabledFGBrush" Color="{x:Static SystemColors.GrayTextColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotEnabledFGBrush" Color="{x:Static SystemColors.GrayTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemSelectedFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
 
     <!-- NEW SETTINGS -->
     <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">0</Thickness>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -79,7 +79,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ACRowHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -12,7 +12,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="ButtonHoverRedBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="StartupInnerBorderBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="StartupFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabHoverBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActiveBlueBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SecondaryBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="PrimaryBGBrush" Color="{x:Static SystemColors.ControlColor}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -35,7 +35,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="WindowBorderBrush" Color="{x:Static SystemColors.ActiveCaptionColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="WindowBorderTextBrush" Color="{x:Static SystemColors.ActiveCaptionTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="LeftNavBorderBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedTabBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TabNonEnabledFGBrush" Color="{x:Static SystemColors.GrayTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedInspectTabBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="UnselectedTabBrush" Color="{x:Static SystemColors.ControlColor}"/>
@@ -79,7 +79,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedTabFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ACRowHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -15,7 +15,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="LoadingBrush" Color="#0000FF"/>
     <SolidColorBrush po:Freeze="True" x:Key="DisabledOverlayBrush" Color="#FDFDFD"/>
     <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="#EFF6FC"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabHoverBrush" Color="#F4F4F4"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="#F4F4F4"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActiveBlueBrush" Color="#FF0078D6"/>
     <SolidColorBrush po:Freeze="True" x:Key="TabBorderBrush" Color="#EAEAEA"/>
     <SolidColorBrush po:Freeze="True" x:Key="UnselectedTabBrush" Color="#FFFFFF"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -14,7 +14,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="SelectedBrush" Color="#F4F4F4"/> 
     <SolidColorBrush po:Freeze="True" x:Key="LoadingBrush" Color="#0000FF"/>
     <SolidColorBrush po:Freeze="True" x:Key="DisabledOverlayBrush" Color="#FDFDFD"/>
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedTabBrush" Color="#EFF6FC"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="#EFF6FC"/>
     <SolidColorBrush po:Freeze="True" x:Key="TabHoverBrush" Color="#F4F4F4"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActiveBlueBrush" Color="#FF0078D6"/>
     <SolidColorBrush po:Freeze="True" x:Key="TabBorderBrush" Color="#EAEAEA"/>
@@ -93,7 +93,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="#D9D9D9"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="#000000"/>
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedTabFGBrush" Color="#000000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="TabHorizontalBorderBrush" Color="#EAEAEA"/>
     <SolidColorBrush po:Freeze="True" x:Key="ACRowHoverBGBrush" Color="#F4F4F4"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="#000000"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -114,4 +114,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#FF0000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverFGBrush" Color="#000000"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -54,7 +54,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="#3C000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkFGBrush" Color="#106EBE"/>
     <SolidColorBrush po:Freeze="True" x:Key="DataGridBorderBrush" Color="#FFFFFF"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNonEnabledFGBrush" Color="#B3B3B3"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotEnabledFGBrush" Color="#B3B3B3"/>
     <SolidColorBrush po:Freeze="True" x:Key="ExpBorderBrush" Color="#E0E0E0"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedInspectTabBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="UnselectedInspectTabBrush" Color="#D9D9D9"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -14,11 +14,8 @@
     <SolidColorBrush po:Freeze="True" x:Key="SelectedBrush" Color="#F4F4F4"/> 
     <SolidColorBrush po:Freeze="True" x:Key="LoadingBrush" Color="#0000FF"/>
     <SolidColorBrush po:Freeze="True" x:Key="DisabledOverlayBrush" Color="#FDFDFD"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="#EFF6FC"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="#F4F4F4"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActiveBlueBrush" Color="#FF0078D6"/>
     <SolidColorBrush po:Freeze="True" x:Key="TabBorderBrush" Color="#EAEAEA"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedBGBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedACRowBGBrush" Color="#EFF6FC"/>
     <SolidColorBrush po:Freeze="True" x:Key="StartupSampleKeyBGBrush" Color="#575757"/>
     <SolidColorBrush po:Freeze="True" x:Key="LeftNavBorderBrush" Color="Transparent"/>
@@ -54,7 +51,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="#3C000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkFGBrush" Color="#106EBE"/>
     <SolidColorBrush po:Freeze="True" x:Key="DataGridBorderBrush" Color="#FFFFFF"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotEnabledFGBrush" Color="#B3B3B3"/>
     <SolidColorBrush po:Freeze="True" x:Key="ExpBorderBrush" Color="#E0E0E0"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedInspectTabBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="UnselectedInspectTabBrush" Color="#D9D9D9"/>
@@ -70,6 +66,14 @@
     <SolidColorBrush x:Key="HLGreenTextBrush" Color="#00FF00 "/>
     <SolidColorBrush x:Key="HLTextBrush" Color="#FFFF00 "/>
     <Thickness po:Freeze="True" x:Key="BtnBrdrThickness">0</Thickness>
+
+    <!-- Brushes used exclusively in tabs of test view-->
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotEnabledFGBrush" Color="#B3B3B3"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedBGBrush" Color="#FFFFFF"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="#F4F4F4"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverFGBrush" Color="#000000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="#EFF6FC"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="#000000"/>
 
     <!-- NEW SETTINGS -->
     <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">0</Thickness>
@@ -93,7 +97,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="#D9D9D9"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="#000000"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="TabHorizontalBorderBrush" Color="#EAEAEA"/>
     <SolidColorBrush po:Freeze="True" x:Key="ACRowHoverBGBrush" Color="#F4F4F4"/>
     <SolidColorBrush po:Freeze="True" x:Key="TSRowSelectedFGBrush" Color="#000000"/>
@@ -114,5 +117,4 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#FF0000"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverFGBrush" Color="#000000"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -54,7 +54,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="#3C000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkFGBrush" Color="#106EBE"/>
     <SolidColorBrush po:Freeze="True" x:Key="DataGridBorderBrush" Color="#FFFFFF"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabBGBrush" Color="#B3B3B3"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNonEnabledFGBrush" Color="#B3B3B3"/>
     <SolidColorBrush po:Freeze="True" x:Key="ExpBorderBrush" Color="#E0E0E0"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedInspectTabBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="UnselectedInspectTabBrush" Color="#D9D9D9"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -18,7 +18,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="#F4F4F4"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActiveBlueBrush" Color="#FF0078D6"/>
     <SolidColorBrush po:Freeze="True" x:Key="TabBorderBrush" Color="#EAEAEA"/>
-    <SolidColorBrush po:Freeze="True" x:Key="UnselectedTabBrush" Color="#FFFFFF"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedBGBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedACRowBGBrush" Color="#EFF6FC"/>
     <SolidColorBrush po:Freeze="True" x:Key="StartupSampleKeyBGBrush" Color="#575757"/>
     <SolidColorBrush po:Freeze="True" x:Key="LeftNavBorderBrush" Color="Transparent"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -68,12 +68,12 @@
     <Thickness po:Freeze="True" x:Key="BtnBrdrThickness">0</Thickness>
 
     <!-- Brushes used exclusively in tabs of test view-->
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotEnabledFGBrush" Color="#B3B3B3"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedBGBrush" Color="#FFFFFF"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverBGBrush" Color="#F4F4F4"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabNotSelectedHoverFGBrush" Color="#000000"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedBGBrush" Color="#EFF6FC"/>
-    <SolidColorBrush po:Freeze="True" x:Key="TabSelectedFGBrush" Color="#000000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotEnabledFGBrush" Color="#B3B3B3"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedBGBrush" Color="#FFFFFF"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedHoverBGBrush" Color="#F4F4F4"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemNotSelectedHoverFGBrush" Color="#000000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemSelectedBGBrush" Color="#EFF6FC"/>
+    <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemSelectedFGBrush" Color="#000000"/>
 
     <!-- NEW SETTINGS -->
     <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">0</Thickness>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -404,6 +404,7 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TabNotSelectedHoverBGBrush}"/>
                             <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
+                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TabNotSelectedHoverFGBrush}"/>
                         </MultiTrigger>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TabSelectedBGBrush}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -394,7 +394,7 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsSelected" Value="False">
-                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=UnselectedTabBrush}"/>
+                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TabNotSelectedBGBrush}"/>
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                         </Trigger>
                         <MultiTrigger>
@@ -417,8 +417,8 @@
                         </Trigger>
                         <DataTrigger Binding="{Binding IsEnabled, RelativeSource={RelativeSource AncestorType={x:Type TabControl}, Mode=FindAncestor}}" Value="False">
                             <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TabBGBrush}" />
-                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=UnselectedTabBrush}"/>
-                            <Setter TargetName="rctActiveBar" Property="Fill" Value="{DynamicResource ResourceKey=UnselectedTabBrush}"/>
+                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TabNotSelectedBGBrush}"/>
+                            <Setter TargetName="rctActiveBar" Property="Fill" Value="{DynamicResource ResourceKey=TabNotSelectedBGBrush}"/>
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TabNonEnabledFGBrush}" />
                         </DataTrigger>
                     </ControlTemplate.Triggers>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -416,7 +416,7 @@
                             <Setter Property="Margin" Value="0,-3,0,0"/>
                         </Trigger>
                         <DataTrigger Binding="{Binding IsEnabled, RelativeSource={RelativeSource AncestorType={x:Type TabControl}, Mode=FindAncestor}}" Value="False">
-                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TabBGBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TabNotEnabledFGBrush}" />
                             <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TabNotSelectedBGBrush}"/>
                             <Setter TargetName="rctActiveBar" Property="Fill" Value="{DynamicResource ResourceKey=TabNotSelectedBGBrush}"/>
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TabNotEnabledFGBrush}" />

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -418,6 +418,7 @@
                             <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TabBGBrush}" />
                             <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=UnselectedTabBrush}"/>
                             <Setter TargetName="rctActiveBar" Property="Fill" Value="{DynamicResource ResourceKey=UnselectedTabBrush}"/>
+                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TabNonEnabledFGBrush}" />
                         </DataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -406,9 +406,9 @@
                             <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
                         </MultiTrigger>
                         <Trigger Property="IsSelected" Value="True">
-                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=SelectedTabBrush}"/>
+                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TabSelectedBGBrush}"/>
                             <Setter TargetName="rctActiveBar" Property="Fill" Value="{DynamicResource ResourceKey=ActiveBlueBrush}"/>
-                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=SelectedTabFGBrush}"/>
+                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TabSelectedFGBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Height" Value="42"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -419,7 +419,7 @@
                             <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TabBGBrush}" />
                             <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TabNotSelectedBGBrush}"/>
                             <Setter TargetName="rctActiveBar" Property="Fill" Value="{DynamicResource ResourceKey=TabNotSelectedBGBrush}"/>
-                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TabNonEnabledFGBrush}" />
+                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TabNotEnabledFGBrush}" />
                         </DataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -394,7 +394,7 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsSelected" Value="False">
-                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TabNotSelectedBGBrush}"/>
+                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TestViewTabItemNotSelectedBGBrush}"/>
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                         </Trigger>
                         <MultiTrigger>
@@ -402,24 +402,24 @@
                                 <Condition Property="IsMouseOver" Value="True"/>
                                 <Condition Property="IsSelected" Value="False"/>
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TabNotSelectedHoverBGBrush}"/>
+                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TestViewTabItemNotSelectedHoverBGBrush}"/>
                             <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
-                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TabNotSelectedHoverFGBrush}"/>
+                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TestViewTabItemNotSelectedHoverFGBrush}"/>
                         </MultiTrigger>
                         <Trigger Property="IsSelected" Value="True">
-                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TabSelectedBGBrush}"/>
+                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TestViewTabItemSelectedBGBrush}"/>
                             <Setter TargetName="rctActiveBar" Property="Fill" Value="{DynamicResource ResourceKey=ActiveBlueBrush}"/>
-                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TabSelectedFGBrush}"/>
+                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TestViewTabItemSelectedFGBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Height" Value="42"/>
                             <Setter Property="Margin" Value="0,-3,0,0"/>
                         </Trigger>
                         <DataTrigger Binding="{Binding IsEnabled, RelativeSource={RelativeSource AncestorType={x:Type TabControl}, Mode=FindAncestor}}" Value="False">
-                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TabNotEnabledFGBrush}" />
-                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TabNotSelectedBGBrush}"/>
-                            <Setter TargetName="rctActiveBar" Property="Fill" Value="{DynamicResource ResourceKey=TabNotSelectedBGBrush}"/>
-                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TabNotEnabledFGBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TestViewTabItemNotEnabledFGBrush}" />
+                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TestViewTabItemNotSelectedBGBrush}"/>
+                            <Setter TargetName="rctActiveBar" Property="Fill" Value="{DynamicResource ResourceKey=TestViewTabItemNotSelectedBGBrush}"/>
+                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TestViewTabItemNotEnabledFGBrush}" />
                         </DataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -402,7 +402,7 @@
                                 <Condition Property="IsMouseOver" Value="True"/>
                                 <Condition Property="IsSelected" Value="False"/>
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TabHoverBrush}"/>
+                            <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TabNotSelectedHoverBGBrush}"/>
                             <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
                         </MultiTrigger>
                         <Trigger Property="IsSelected" Value="True">


### PR DESCRIPTION
#### Describe the change
Tabs in test view have some issues in high contrast black and high contrast white (see #870). This does the following:
- Use the HC disabled text color if the tabs are not enabled
- Use the HighlightColor for the tab background if selected or hovered in HC
- Use the HighlightTextColor for tab foreground if selected or hovered in HC
- Use more descriptive names for the brushes that are unique to this view
- In the brushes.xaml files, put the brushes in a group to emphasize their relationships

Here's a screenshot of all 6 modes with the tabs disabled with this change:
![870-new-disabled](https://user-images.githubusercontent.com/45672944/95799959-2551f080-0cab-11eb-9022-3642e4c55dda.png)

Here's a collections of gifs showing the selected and hover behavior. 
GIF | Mode/comment
--- | ---
![new-870-light](https://user-images.githubusercontent.com/45672944/95800023-4a466380-0cab-11eb-811a-8fbc8219eef5.gif) | Light (Same as current production, but PR is compressing out the hover color)
![new-870-dark](https://user-images.githubusercontent.com/45672944/95800040-53cfcb80-0cab-11eb-9a6c-85d93def3ef3.gif) | Dark (Same as current production)
![new-870-hc1](https://user-images.githubusercontent.com/45672944/95800216-c476e800-0cab-11eb-9a4e-f9ff6764a67f.gif) | HC1
![new-870-hc2](https://user-images.githubusercontent.com/45672944/95800244-d0fb4080-0cab-11eb-9bf3-7259e7ab5548.gif) | HC2
![new-870-black](https://user-images.githubusercontent.com/45672944/95800259-d9537b80-0cab-11eb-9962-02ec6e248651.gif) | HC Black
![new-870-white](https://user-images.githubusercontent.com/45672944/95800332-e2444d00-0cab-11eb-866f-ac927a68ac76.gif) | HC White

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #870 
- [colors only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



