### PR TITLE
fix: Use correct HC foreground color for Actions buttons

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -93,7 +93,8 @@
     <SolidColorBrush po:Freeze="True" x:Key="StartupPrimaryBGBrush" Color="#22272B"/>   <!-- (UPDATED) Startup Primary background brush -->
     <SolidColorBrush po:Freeze="True" x:Key="StartupSecondaryBGBrush" Color="#2B3034"/> <!-- (UPDATED) Startup Secondary background brush -->
     <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedFGBrush" Color="#FFFFFF"/> <!-- (UPDATED) Selected text color in TreeView -->
-    <SolidColorBrush po:Freeze="True" x:Key="ActionsButtonHoverBGBrush" Color="#6D767E"/>   <!-- (UPDATED NEEDS UI REVIEW) Background Hover for "Actions" button in Patterns pane -->
+    <SolidColorBrush po:Freeze="True" x:Key="ActionsButtonHoverBGBrush" Color="#6D767E"/>   <!-- Background Hover brush for "Actions" button in Patterns pane -->
+    <SolidColorBrush po:Freeze="True" x:Key="ActionsButtonHoverFGBrush" Color="#FFFFFF"/>   <!-- Foreground Hover brush for "Actions" button in Patterns pane -->
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="#000000"/>     <!-- (UPDATED) Foreground of column headers in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="#6D767E"/>     <!-- (UPDATED) Background of column headers in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="#FFFFFF"/>      <!-- (UPDATED) Foreground of selected row in a data grid (list of properties) -->

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -80,6 +80,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="StartupSecondaryBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActionsButtonHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ActionsButtonHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -94,6 +94,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="StartupSecondaryBGBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="TreeViewSelectedFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActionsButtonHoverBGBrush" Color="#BEE6FD"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ActionsButtonHoverFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderBGBrush" Color="#D9D9D9"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedRowFGBrush" Color="#000000"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -119,6 +119,7 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter Property="Background" Value="{DynamicResource ResourceKey=ActionsButtonHoverBGBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ActionsButtonHoverFGBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>


### PR DESCRIPTION
#### Describe the change
In HC modes, hovering on the actions button sets the background to HighContrastColor without setting the foreground to HighContrastTextColor, which causes problems in HC White and HC Black modes. This PR adds an explicit foreground brush and sets it on hover. The brush color for Light and Dark mode are aligned with PrimaryFGBrush.

GIF | Mode
--- | ---
![873-Light](https://user-images.githubusercontent.com/45672944/95889110-dc477e00-0d36-11eb-9fba-d4700c175581.gif) | Light
![873-Dark](https://user-images.githubusercontent.com/45672944/95889140-e5d0e600-0d36-11eb-9df9-f8fb2a36d507.gif) | Dark
![873-HC1](https://user-images.githubusercontent.com/45672944/95889167-ee292100-0d36-11eb-85e0-3c5f440bb8ea.gif) | HC 1
![873-HC2](https://user-images.githubusercontent.com/45672944/95889219-fd0fd380-0d36-11eb-9ab8-14a4dd74a7fa.gif) | HC 2
![873-black](https://user-images.githubusercontent.com/45672944/95889250-06993b80-0d37-11eb-9182-03e8a76ee0d3.gif) | HC Black
![873-white](https://user-images.githubusercontent.com/45672944/95889291-13b62a80-0d37-11eb-8211-6ca73da4d29b.gif). HC White


#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #873
- [style only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



