### PR TITLE
fix: Increase color contrast of toggle in dark mode

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -33,7 +33,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="WhiteTextHoverBrush" Color="#FFFFFF"/>     <!-- Text color (hover) for snapshot button and video player -->
     <SolidColorBrush po:Freeze="True" x:Key="BorderBrush" Color="#C7C7C7"/>             <!-- Generic light border (used everywhere) -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonBackgroundBrush" Color="Transparent"/>   <!-- Keep Transparent in Dark -->
-    <SolidColorBrush po:Freeze="True" x:Key="ToggleSliderBlueBrush" Color="#FF0078D6"/> <!-- Used for toggles in the "on" position -->
+    <SolidColorBrush po:Freeze="True" x:Key="ToggleSliderBlueBrush" Color="#4296D6"/>   <!-- Used for toggles in the "on" position -->
     <SolidColorBrush po:Freeze="True" x:Key="ColumnHeaderEmptyBGBrush" Color="#22272B"/><!-- (UPDATED) Background of "empty" column headers in data grid (list of properties) -->
     <SolidColorBrush po:Freeze="True" x:Key="BlueButtonBGBrush" Color="#6BADE0"/>       <!-- (UPDATED) Background (normal) of blue buttons -->
     <SolidColorBrush po:Freeze="True" x:Key="BlueButtonHoverBGBrush" Color="#4296D6"/>  <!-- (UPDATED) Background (hover) of blue buttons -->


### PR DESCRIPTION
#### Describe the change
The blue used for toggle buttons in the "on" position fails color contrast in dark mode. This PR switches to the next lighter shade of blue in our palette. Contrast against the background is now 4.168. This GIF shows all of the states of the control--off, off with hover, on with hover, and on:

![841](https://user-images.githubusercontent.com/45672944/95893184-74943180-0d3c-11eb-9341-ba8ad97f4d42.gif)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #841
- [color only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



