### PR TITLE
fix: Use a style instead of a fixed color in issue filing radio buttons

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
@@ -39,7 +39,7 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
         private RadioButton CreateRadioButton(IIssueReporting reporter)
         {
             RadioButton issueReportingOption = new RadioButton();
-            issueReportingOption.Foreground = Application.Current.Resources["PrimaryFGBrush"] as SolidColorBrush;
+            issueReportingOption.Style = FindResource("primaryFGRadioButtonStyle") as Style;
             issueReportingOption.Content = reporter.ServiceName;
             issueReportingOption.Tag = reporter.StableIdentifier;
             issueReportingOption.Margin = new Thickness(2, 2, 2, 2);

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1563,4 +1563,8 @@
             </Trigger>
         </Style.Triggers>
     </Style>
+    <Style TargetType="{x:Type RadioButton}" x:Key="primaryFGRadioButtonStyle" BasedOn="{StaticResource {x:Type RadioButton}}">
+        <!-- This style is set programmatically, so renaming it will require a change in the code-behind -->
+        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
#### Describe the change
Radio buttons for issue filing are dynamically created with a color from the theme that is in effect when the controls are created. As such, they're not responsive to theme changes that occur afterward. The solution is to assign a style instead of a color, and then use a theme-responsive color within the style. Since I need to specify the style from code, I chose a name that explicitly names it as a style, which is something that we don't do for styles loaded from XAML.

This GIF only shows changing between dark and light, but I tested changing between HC and non-HC, as well as between HC modes. They all transition as expected.
![828](https://user-images.githubusercontent.com/45672944/95900838-4ff18700-0d47-11eb-99b8-6dfae65f8605.gif)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #828 
- [style only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



