### PR TITLE
Fix: Use correct brush for TreeView Expand/Collapse icons when selected

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1342,6 +1342,7 @@
                             <Setter Property="Background" TargetName="Bd" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
                             <Setter Property="FontWeight" Value="Bold"/>
                             <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TreeViewSelectedFGBrush}"/>
+                            <Setter TargetName="Expander" Property="Foreground" Value="{DynamicResource ResourceKey=TreeViewSelectedFGBrush}"/>
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>


### PR DESCRIPTION
#### Describe the change
In HC Light and HC Dark, the Expand/Collapse icon in our TreeViews fails contrast when the item is selected. This PR addresses #860 (which calls out the UIA TreeView) as well as our other TreeViews, such as the Patterns tree. It sets the color of the expander to match the color of the other text and icons on selected items.

Screenshots in Light, Dark, HC Dark, HC White, HC 1, and HC 2:
![image](https://user-images.githubusercontent.com/4615491/95923931-66a9d500-0d6b-11eb-96be-528853ac1ee0.png)
![image](https://user-images.githubusercontent.com/4615491/95923952-76291e00-0d6b-11eb-990e-10f7854066f0.png)
![image](https://user-images.githubusercontent.com/4615491/95924000-93f68300-0d6b-11eb-89bd-9d881aea2f68.png)
![image](https://user-images.githubusercontent.com/4615491/95924633-cce32780-0d6c-11eb-8b72-b84a69ef77e5.png)
![image](https://user-images.githubusercontent.com/4615491/95924537-9c02f280-0d6c-11eb-89fd-86282318f11a.png)
![image](https://user-images.githubusercontent.com/4615491/95924567-aa510e80-0d6c-11eb-99a5-97e63ca81f52.png)

#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #860 
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



