### PR TITLE
fix: Improve contrast of test tab header focus indicator with inner border

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -12,7 +12,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="ButtonHoverRedBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="StartupInnerBorderBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="StartupFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="ActiveBlueBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ActiveBlueBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SecondaryBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="PrimaryBGBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedACRowBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -378,7 +378,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabItem}">
-                    <Border BorderThickness="0,0,0,1" Background="{DynamicResource ResourceKey=TabHorizontalBorderBrush}">
+                    <Border x:Name="bdTab" BorderThickness="0,0,0,1" Background="{DynamicResource ResourceKey=TabHorizontalBorderBrush}">
                         <Grid x:Name="gdTab">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="4"/>
@@ -411,6 +411,10 @@
                             <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=TestViewTabItemSelectedBGBrush}"/>
                             <Setter TargetName="rctActiveBar" Property="Fill" Value="{DynamicResource ResourceKey=ActiveBlueBrush}"/>
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource ResourceKey=TestViewTabItemSelectedFGBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsFocused" Value="True">
+                            <Setter TargetName="bdTab" Property="BorderThickness" Value="1"/>
+                            <Setter TargetName="bdTab" Property="BorderBrush" Value="{DynamicResource ResourceKey=ButtonBackgroundBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Height" Value="42"/>


### PR DESCRIPTION
#### Describe the change
Addresses Focus indicator on 'selected' test in Fast Pass has insufficient contrast against its background #868. Currently, the focus indicator on a test tab header is the normal black or white outline, but the color of the selected tab can be close to black or white. We had a similar problem with our left nav bar buttons, so I used the same solution here. Now, when a test tab has focus, it gets an inner border with the opposite (black or white) color of the current focus indicator. This means that there will always be a black and white border to indicate focus, which will pass contrast requirements. Also, this active rectangle on the left side of the selected tab now has a better color for high contrast modes.

Screenshots in Light, Dark, HC Black, HC White, HC 1, and HC 2:
![image](https://user-images.githubusercontent.com/4615491/96023536-6f4fe900-0e07-11eb-8ffe-151113aca5fc.png)
![image](https://user-images.githubusercontent.com/4615491/96023590-84c51300-0e07-11eb-877a-433a6c31ad34.png)
![image](https://user-images.githubusercontent.com/4615491/96023700-acb47680-0e07-11eb-848d-a906c72252d2.png)
![image](https://user-images.githubusercontent.com/4615491/96023790-cd7ccc00-0e07-11eb-9f63-b0bf6f7f8508.png)
![image](https://user-images.githubusercontent.com/4615491/96023875-e84f4080-0e07-11eb-8120-4b5db1ca1467.png)
![image](https://user-images.githubusercontent.com/4615491/96023903-f1d8a880-0e07-11eb-871f-136f6fbbeca3.png)


#### PR checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #868
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



