### PR TITLE
fix issues with FabricIconControls on buttons

### DIFF
--- a/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml
@@ -123,7 +123,7 @@
                             <i:Interaction.Behaviors>
                                 <behaviors:DropDownButtonBehavior/>
                             </i:Interaction.Behaviors>
-                            <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                            <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                             <Button.ContextMenu>
                                 <ContextMenu AutomationProperties.Name="{x:Static Properties:Resources.btnSettingAutomationPropertiesName}">
                                     <MenuItem Header="_Include all properties that have values" x:Name="mniShowCoreProps" IsCheckable="true" 

--- a/src/AccessibilityInsights.SharedUx/Behaviors/DropDownButtonBehavior.cs
+++ b/src/AccessibilityInsights.SharedUx/Behaviors/DropDownButtonBehavior.cs
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.CommonUxComponents.Controls;
+using AccessibilityInsights.SharedUx.Utilities;
 using Microsoft.Xaml.Behaviors;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -15,11 +20,8 @@ namespace AccessibilityInsights.SharedUx.Behaviors
     public class DropDownButtonBehavior : Behavior<Button>
     {
         private bool isContextMenuOpen;
-
-        /// <summary>
-        /// Stores the button's background so that it can be restored later
-        /// </summary>
-        private Brush origBackground;
+        private IReadOnlyList<FabricIconControl> _containedFabricIconControls;
+        private Style _savedFabricIconControlStyle;
 
         /// <summary>
         /// Attach to necessary event handlers
@@ -29,17 +31,6 @@ namespace AccessibilityInsights.SharedUx.Behaviors
             base.OnAttached();
             AssociatedObject.AddHandler(Button.ClickEvent, new RoutedEventHandler(AssociatedObject_Click), true);
             AssociatedObject.AddHandler(Button.ContextMenuOpeningEvent, new ContextMenuEventHandler(AssocisatedObject_ContextMenuOpening), true);
-            AssociatedObject.AddHandler(Button.LoadedEvent, new RoutedEventHandler(AssociatedObject_Loaded), true);
-        }
-
-        /// <summary>
-        /// Save button's original background once loaded
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void AssociatedObject_Loaded(object sender, RoutedEventArgs e)
-        {
-            origBackground = AssociatedObject.Background;
         }
 
         /// <summary>
@@ -52,17 +43,49 @@ namespace AccessibilityInsights.SharedUx.Behaviors
             e.Handled = true;
         }
 
+        private void ForContainedFabricIconControls(Action<FabricIconControl> action)
+        {
+            if (_containedFabricIconControls != null)
+            {
+                foreach (FabricIconControl fabricIconControl in _containedFabricIconControls)
+                {
+                    action(fabricIconControl);
+                }
+            }
+        }
+
+        private void StyleContainedFabricIcons()
+        {
+            _containedFabricIconControls = ContainedControlFinder<FabricIconControl>.Find(AssociatedObject).ToList();
+
+            if (_containedFabricIconControls.Any())
+            {
+                // This assumes that all associated FabricIconControls use the same style
+                _savedFabricIconControlStyle = _containedFabricIconControls[0].Style;
+                Style pressedStyle = AssociatedObject.FindResource("fabricIconOnPressedButtonParentStyle") as Style;
+                ForContainedFabricIconControls(fabricIconControl => fabricIconControl.Style = pressedStyle);
+            }
+        }
+
+        private void UnstyleContainedFabricIcons()
+        {
+            ForContainedFabricIconControls(fabricIconControl => fabricIconControl.Style = _savedFabricIconControlStyle);
+            _containedFabricIconControls = null;
+            _savedFabricIconControlStyle = null;
+        }
+
         /// <summary>
         /// Open context menu when button is clicked.
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        void AssociatedObject_Click(object sender, System.Windows.RoutedEventArgs e)
+        void AssociatedObject_Click(object sender, RoutedEventArgs e)
         {
             Button source = sender as Button;
             if (source != null && source.ContextMenu != null)
-            {                
+            {
                 source.Background = Application.Current.Resources["ButtonHoverBrush"] as SolidColorBrush;
+                StyleContainedFabricIcons();
 
                 if (!isContextMenuOpen)
                 {
@@ -90,7 +113,9 @@ namespace AccessibilityInsights.SharedUx.Behaviors
         /// <param name="e"></param>
         void ContextMenu_Closed(object sender, RoutedEventArgs e)
         {
-            AssociatedObject.Background = origBackground;
+            AssociatedObject.ClearValue(Control.BackgroundProperty);
+            UnstyleContainedFabricIcons();
+
             isContextMenuOpen = false;
             var contextMenu = sender as ContextMenu;
             if (contextMenu != null)

--- a/src/AccessibilityInsights.SharedUx/Behaviors/DropDownButtonBehavior.cs
+++ b/src/AccessibilityInsights.SharedUx/Behaviors/DropDownButtonBehavior.cs
@@ -54,20 +54,20 @@ namespace AccessibilityInsights.SharedUx.Behaviors
             }
         }
 
-        private void StyleContainedFabricIcons()
+        private void StyleContainedFabricIconControls()
         {
             _containedFabricIconControls = ContainedControlFinder<FabricIconControl>.Find(AssociatedObject).ToList();
 
             if (_containedFabricIconControls.Any())
             {
-                // This assumes that all associated FabricIconControls use the same style
+                // This assumes that all contained FabricIconControls use the same style
                 _savedFabricIconControlStyle = _containedFabricIconControls[0].Style;
                 Style pressedStyle = AssociatedObject.FindResource("fabricIconOnPressedButtonParentStyle") as Style;
                 ForContainedFabricIconControls(fabricIconControl => fabricIconControl.Style = pressedStyle);
             }
         }
 
-        private void UnstyleContainedFabricIcons()
+        private void UnstyleContainedFabricIconControls()
         {
             ForContainedFabricIconControls(fabricIconControl => fabricIconControl.Style = _savedFabricIconControlStyle);
             _containedFabricIconControls = null;
@@ -85,7 +85,7 @@ namespace AccessibilityInsights.SharedUx.Behaviors
             if (source != null && source.ContextMenu != null)
             {
                 source.Background = Application.Current.Resources["ButtonHoverBrush"] as SolidColorBrush;
-                StyleContainedFabricIcons();
+                StyleContainedFabricIconControls();
 
                 if (!isContextMenuOpen)
                 {
@@ -114,7 +114,7 @@ namespace AccessibilityInsights.SharedUx.Behaviors
         void ContextMenu_Closed(object sender, RoutedEventArgs e)
         {
             AssociatedObject.ClearValue(Control.BackgroundProperty);
-            UnstyleContainedFabricIcons();
+            UnstyleContainedFabricIconControls();
 
             isContextMenuOpen = false;
             var contextMenu = sender as ContextMenu;

--- a/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml
@@ -18,7 +18,7 @@
         <StackPanel Orientation="Horizontal" Grid.Row="0">
             <Button x:Name="colorPicker" Style="{StaticResource BtnStandard}" Width="32" Height="32" BorderBrush="Transparent"
                 Click="colorPicker_Click" AutomationProperties.Name="{Binding Path=ColorPickerName, StringFormat='{x:Static Properties:Resources.colorPickerAutomationPropertiesName}'}">
-                <fabric:FabricIconControl GlyphName="Eyedropper" GlyphSize="Default" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                <fabric:FabricIconControl GlyphName="Eyedropper" GlyphSize="Default" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
             </Button>
             <ComboBox Name="cbColorPicker" DropDownOpened="Popup_Opened" Width="120" Style="{StaticResource tgbtnColorPicker}" AutomationProperties.Name="{Binding Path=ColorPickerName, StringFormat='{x:Static Properties:Resources.cbColorPickerAutomationPropertiesName}'}">
                 <ComboBox.Background>

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml
@@ -100,7 +100,7 @@
                                 AutomationProperties.Name="{x:Static Properties:Resources.btnMoveRightAutomationPropertiesName}"
                                 AutomationProperties.HelpText="{x:Static Properties:Resources.btnMoveRightAutomationPropertiesHelpText}"
                                 AutomationProperties.AcceleratorKey="Alt+A">
-                            <fabric:FabricIconControl GlyphName="CaretSolidRight" GlyphSize="Default" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                            <fabric:FabricIconControl GlyphName="CaretSolidRight" GlyphSize="Default" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                         </Button>
                     </DockPanel>
                     <DockPanel VerticalAlignment="Center" Grid.Row="2">
@@ -110,7 +110,7 @@
                                 AutomationProperties.Name="{x:Static Properties:Resources.btnMoveLeftAutomationPropertiesName}"
                                 AutomationProperties.HelpText="{x:Static Properties:Resources.btnMoveLeftAutomationPropertiesHelpText}"
                                 AutomationProperties.AcceleratorKey="Alt+R">
-                            <fabric:FabricIconControl GlyphName="CaretSolidLeft" GlyphSize="Default" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                            <fabric:FabricIconControl GlyphName="CaretSolidLeft" GlyphSize="Default" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                         </Button>
                     </DockPanel>
                 </Grid>
@@ -150,7 +150,7 @@
                     <Button.ToolTip>
                         <ToolTip Content="{x:Static Properties:Resources.btnMoveUpAutomationPropertiesName}"/>
                     </Button.ToolTip>
-                    <fabric:FabricIconControl GlyphName="Up" GlyphSize="Small" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                    <fabric:FabricIconControl GlyphName="Up" GlyphSize="Small" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                 </Button>
                 <Button x:Name="btnMoveDown" Width="20" Height="20" Click="btnMoveDown_Click"
                   Style="{StaticResource BtnStandard}"
@@ -164,7 +164,7 @@
                     <Button.ToolTip>
                         <ToolTip Content="{x:Static Properties:Resources.btnMoveDownAutomationPropertiesName}"/>
                     </Button.ToolTip>
-                    <fabric:FabricIconControl GlyphName="Down" GlyphSize="Small" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                    <fabric:FabricIconControl GlyphName="Down" GlyphSize="Small" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                 </Button>
             </Grid>
         </Grid>

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -114,7 +114,7 @@
                             <Setter Property="Button.ToolTip" Value="{x:Static Properties:Resources.SetterValueEventSetting}" />
                         </Style>
                     </Button.Style>
-                    <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                    <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                     <Button.ContextMenu>
                         <ContextMenu FlowDirection="LeftToRight" Loaded="ContextMenu_Loaded" Unloaded="ContextMenu_Unloaded">
                             <MenuItem Header="{x:Static Properties:Resources.EventRecordControlScopeHeader}">

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -129,7 +129,7 @@
                 <Button.ToolTip>
                     <ToolTip Content="{x:Static Properties:Resources.btnSettingToolTip1}"/>
                 </Button.ToolTip>
-                <controls:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                <controls:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                 <Button.ContextMenu>
                     <ContextMenu FlowDirection="LeftToRight" x:Name="cmHierarchySettings">
                         <MenuItem Header="Tree view">

--- a/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
@@ -89,7 +89,7 @@
                                     <Button.ToolTip>
                                         <ToolTip Content="{x:Static Properties:Resources.btnSettingToolTip2}"/>
                                     </Button.ToolTip>
-                                    <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="9"  VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=SearchAndIconForegroundBrush}"/>
+                                    <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="9" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource ResourceKey=hoverAwareFabricIconOnButtonParent}"/>
                                     <Button.ContextMenu>
                                         <ContextMenu AutomationProperties.Name="{x:Static Properties:Resources.btnSettingAutomationPropertiesName2}">
                                             <MenuItem Header="_Include all properties that have values" x:Name="mniShowCoreProps" IsCheckable="true" 

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -79,7 +79,7 @@
                                                 AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.AutomatedChecksExpandAllButton}">
                                             <Grid>
                                                 <AccessText Text="_c" Opacity="0"/>
-                                                <fabric:FabricIconControl x:Name="fabicnExpandAll" GlyphName="CaretSolidRight" GlyphSize="Custom" FontSize="8" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}" Margin="0,2,0,-2"/>
+                                                <fabric:FabricIconControl x:Name="fabicnExpandAll" GlyphName="CaretSolidRight" GlyphSize="Custom" FontSize="8" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}" Margin="0,2,0,-2"/>
                                             </Grid>
                                         </Button>
                                     </Grid>

--- a/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
@@ -98,7 +98,7 @@
                         <i:Interaction.Behaviors>
                             <behaviors:DropDownButtonBehavior/>
                         </i:Interaction.Behaviors>
-                        <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                        <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                         <Button.ContextMenu>
                             <ContextMenu FlowDirection="LeftToRight">
                                 <MenuItem Header="_Collapse AnnotationTypes" IsChecked="True" IsCheckable="True" Click="MenuItem_Click"/>
@@ -175,7 +175,7 @@
                 <i:Interaction.Behaviors>
                     <behaviors:DropDownButtonBehavior/>
                 </i:Interaction.Behaviors>
-                <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                 <Button.ContextMenu>
                     <ContextMenu FlowDirection="LeftToRight">
                         <MenuItem Header="_Replace whitespace with formatting symbols" IsChecked="True" IsCheckable="True" Name="mniWhitespace" Click="mniWhitespace_Click"/>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/ElementInfoDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/ElementInfoDialog.xaml
@@ -70,7 +70,7 @@
                             <i:Interaction.Behaviors>
                                 <behaviors:DropDownButtonBehavior/>
                             </i:Interaction.Behaviors>
-                            <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="9"  VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=SearchAndIconForegroundBrush}"/>
+                            <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="9" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                             <Button.ContextMenu>
                                 <ContextMenu AutomationProperties.Name="{x:Static Properties:Resources.btnSettingContextMenuAutomationPropertiesName}">
                                     <MenuItem Header="{x:Static Properties:Resources.mniShowCorePropsHeader}" x:Name="mniShowCoreProps" IsCheckable="true" 

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1517,6 +1517,10 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
+    <Style TargetType="fabric:FabricIconControl" x:Key="fabricIconOnPressedButtonParentStyle">
+        <!-- This style is set programmatically, so renaming it will require a change in the code-behind -->
+        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=IconHoverFGBrush}"/>
+    </Style>
     <Style TargetType="fabric:FabricIconControl" x:Key="hoverAwareNavBarFabricIcon">
         <Style.Triggers>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="True">

--- a/src/AccessibilityInsights.SharedUx/Utilities/ContainedControlFinder.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/ContainedControlFinder.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Windows;
+
+namespace AccessibilityInsights.SharedUx.Utilities
+{
+    internal static class ContainedControlFinder<T> where T: DependencyObject
+    {
+        internal static IEnumerable<T> Find(DependencyObject currentControl)
+        {
+            IEnumerable children = LogicalTreeHelper.GetChildren(currentControl);
+            foreach (var child in children)
+            {
+                if (child is DependencyObject childControl)
+                {
+                    if (childControl is T typedChildControl)
+                    {
+                        yield return typedChildControl;
+                    }
+                    foreach (var descendentControl in Find(childControl))
+                    {
+                        yield return descendentControl;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
@@ -28,7 +28,7 @@
                     <Button x:Name="btnClose" Margin="12,24,20,14" Width="15" Height="15" Click="Button_Click" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" VerticalAlignment="Top" HorizontalAlignment="Left" IsCancel="True" IsTabStop="True" AutomationProperties.Name="{x:Static properties:Resources.gdConfigBtnCloseAutomationPropertiesName}" KeyboardNavigation.TabIndex="-2" Style="{StaticResource BtnNoAutoHelpText}">
                         <Grid>
                             <AccessText Text="_x" Opacity="0"/>
-                            <fabric:FabricIconControl GlyphName="ChromeBack" GlyphSize="Custom" FontSize="11" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                            <fabric:FabricIconControl GlyphName="ChromeBack" GlyphSize="Custom" FontSize="11" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                         </Grid>
                         <Button.ToolTip>
                             <ToolTip Content="{x:Static properties:Resources.gdConfigBtnCloseAutomationPropertiesName}"/>


### PR DESCRIPTION
#### Describe the change
This change fixes 3 types of issues (one reported, two not) associated with hover buttons with fabric icons, some of which also have pop-up context menus. The behavior of fixing them separately is bad (controls become invisible), so they're all in a single PR. I scanned the code for all instances and included them here.

Problem 1 (Reported): Buttons with pop-up context menus fail contrast requirements in HC White and HC Black modes once the user clicks on the button (the foreground color of the FabricIconControl doesn't get updated). This was reported in the events dialog, but it happens in several places. Root cause is that the foreground color of the FabricIconControl is never getting updated from its default color. Here's one example of the before and after using HC White:

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/45672944/96060382-3171b580-0e45-11eb-9919-e53ac5807615.png) | ![image](https://user-images.githubusercontent.com/45672944/96060491-7e558c00-0e45-11eb-9882-f44d8e89eb08.png)

Problem 2 (Unreported): Once you've activated a context menu from a button containing a FabricIconControl, the control no longer responds to mouse hover. Root cause is that the button's dynamic styling is getting overwritten by a fixed color after the button is released. Here's the before and after using HC White--I included the welcome screen just to show the beginning of the loop

Before | After
--- | ---
![icons-nohover](https://user-images.githubusercontent.com/45672944/96061051-07b98e00-0e47-11eb-8d7f-a7eb5af8826b.gif) | ![icons-hover](https://user-images.githubusercontent.com/45672944/96061063-10aa5f80-0e47-11eb-9c15-a895361ede77.gif)

Problem 3 (Unreported): Several button icons fail contrast requirements on hover because they contain FabricIconControls that don't change color on mouse hover. The fix is simple--just use a style that knows about mouse hover of the parent button. Here's a sample from the color contrast analyzer, again in HC White:

Before | After
--- | ---
![hover-fail](https://user-images.githubusercontent.com/45672944/96061524-4f8ce500-0e48-11eb-8394-d1d893e5e468.gif) | ![hover-succeed](https://user-images.githubusercontent.com/45672944/96061530-56b3f300-0e48-11eb-9d22-4c4d1e932b0a.gif)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #879 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



