### PR TITLE
fix: Event configuration is broken in HC Black & HC White

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
@@ -65,8 +65,8 @@
                     DataType="{x:Type vm:EventConfigNodeViewModel}"
                      ItemsSource="{Binding Children}">
                             <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                                <CheckBox VerticalAlignment="Center" Visibility="{Binding TextVisibility}" IsThreeState="{Binding IsThreeState}" IsChecked="{Binding IsChecked}" Margin="0,0,4,0" IsEnabled="{Binding IsEditEnabled}" IsTabStop="False" AutomationProperties.LabeledBy="{Binding ElementName=tbNode}" Style="{StaticResource CheckBoxContastingBorder}"/>
-                                <TextBlock Name="tbNode" VerticalAlignment="Center" Text="{Binding Header}" Visibility="{Binding TextVisibility}" Margin="0,0,4,0" FontSize="11" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                                <CheckBox VerticalAlignment="Center" Visibility="{Binding TextVisibility}" IsThreeState="{Binding IsThreeState}" IsChecked="{Binding IsChecked}" Margin="0,0,4,0" IsEnabled="{Binding IsEditEnabled}" IsTabStop="False" AutomationProperties.LabeledBy="{Binding ElementName=tbNode}" Style="{StaticResource CheckBoxContastingBorder}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                                <TextBlock Name="tbNode" VerticalAlignment="Center" Text="{Binding Header}" Visibility="{Binding TextVisibility}" Margin="0,0,4,0" FontSize="11"/>
                                 <Button VerticalAlignment="Center" Visibility="{Binding ButtonVisibility}" Name="btnConfig" Click="btnConfig_Click" IsEnabled="{Binding IsEditEnabled}" Background="Transparent" BorderThickness="0"
                                     AutomationProperties.HelpText="{x:Static Properties:Resources.btnConfigAutomationPropertiesHelpText}">
                                     <TextBlock TextDecorations="Underline" Foreground="{DynamicResource ResourceKey=ButtonLinkFGBrush}" Text="{Binding ButtonText}" FontSize="11"/>

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -178,7 +178,6 @@
                         <Setter Property="Visibility" Value="{Binding Path=Visibility, Mode=OneWay}"/>
                         <Setter Property="IsSelected" Value="{Binding Path=IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                         <Setter Property="AutomationProperties.Name" Value="{Binding Path=AutomationName, Mode=OneWay}"/>
-                        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                         <EventSetter Event="RequestBringIntoView" Handler="TreeViewItem_RequestBringIntoView"/>
                         <EventSetter Event="Selected" Handler="OnSelected"/>
                         <Style.Triggers>

--- a/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
@@ -32,7 +32,6 @@
                     <Setter Property="IsExpanded" Value="{Binding Path=IsExpanded}"/>
                     <Setter Property="Background" Value="Transparent"/>
                     <Setter Property="AutomationProperties.HelpText" Value="{x:Static Properties:Resources.SetterValueYouCanInspect}"/>
-                    <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                     <EventSetter Event="KeyDown" Handler="TreeViewItem_KeyDown"></EventSetter>
                     <EventSetter Event="Expanded" Handler="TreeViewItem_Expanded"/>
                     <EventSetter Event="Collapsed" Handler="TreeViewItem_Collapsed"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1308,7 +1308,7 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
         <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
-        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
         <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
         <Setter Property="Template">
             <Setter.Value>


### PR DESCRIPTION
#### Describe the change
As noted in #867, the event configuration page has issues in HC White and HC Black modes when an event or property is selected. The checkbox state always appears unchecked (because it's using the same foreground and background color), and the name of the event/property is drawn with a foreground color that isn't appropriate for the background color when selected.

The fix is as follows:
- Modify the `tviStandard` style to default to using PrimaryFGBrush as its foreground color. `tviStandard` already sets the correct colors when an item is selected.
- In the event configuration page, stop overriding the foreground color for the TextBlock, so it uses the values from `tviStandard`
- In the event configuration page, override the foreground color for the checkbox, so it always uses PrimaryFGBrush
- The Hierarchy list and Patterns list both use `tviStandard`, and both override the default foreground color. This is no longer needed since it's the same color as `tviStandard`

Screenshots (selection color is washed out in Light due to compression):

Mode | Event Config | Hierarchy | Patterns
--- | --- | --- | ---
Light | ![image](https://user-images.githubusercontent.com/45672944/96192735-81ab4f00-0efb-11eb-8925-e44acbc885bb.png) | ![image](https://user-images.githubusercontent.com/45672944/96190562-4e66c100-0ef7-11eb-991a-cf02fd9fefd8.png) | ![image](https://user-images.githubusercontent.com/45672944/96192524-0d70ab80-0efb-11eb-92a7-e889c934239c.png)
Dark | ![image](https://user-images.githubusercontent.com/45672944/96192671-5c1e4580-0efb-11eb-837f-12acd0ec8d34.png) | ![image](https://user-images.githubusercontent.com/45672944/96190673-7524f780-0ef7-11eb-9cb8-800c811c8063.png) | ![image](https://user-images.githubusercontent.com/45672944/96192594-2da06a80-0efb-11eb-9977-358427b3cd96.png)
HC 1 | ![image](https://user-images.githubusercontent.com/45672944/96193035-2037b000-0efc-11eb-9507-3b39b6436948.png) | ![image](https://user-images.githubusercontent.com/45672944/96191768-9f77b480-0ef9-11eb-946d-b10dd746609d.png) | ![image](https://user-images.githubusercontent.com/45672944/96192301-99ce9e80-0efa-11eb-8084-2a12247fea37.png)
HC 2 | ![image](https://user-images.githubusercontent.com/45672944/96192991-05fdd200-0efc-11eb-8cfa-208c11d65f0c.png) | ![image](https://user-images.githubusercontent.com/45672944/96191712-8111b900-0ef9-11eb-9049-ace9ad564764.png) | ![image](https://user-images.githubusercontent.com/45672944/96192248-7e639380-0efa-11eb-86c2-103ea04c6267.png)
HC Black | ![image](https://user-images.githubusercontent.com/45672944/96192839-bd461900-0efb-11eb-8299-2ec16710814a.png) | ![image](https://user-images.githubusercontent.com/45672944/96191845-c59d5480-0ef9-11eb-9984-1b9ed92c7010.png) | ![image](https://user-images.githubusercontent.com/45672944/96192394-cc789700-0efa-11eb-9761-a96575ad0297.png)
HC White | ![image](https://user-images.githubusercontent.com/45672944/96192896-d949ba80-0efb-11eb-9ff6-a7764a32c8bb.png) | ![image](https://user-images.githubusercontent.com/45672944/96191899-e5cd1380-0ef9-11eb-8bb6-1db97f4e757f.png) | ![image](https://user-images.githubusercontent.com/45672944/96192110-2e84cc80-0efa-11eb-89f1-dc91f0028683.png)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #867 
- [colors only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



