### PR TITLE
fix: Make Action buttons more obvious in HC modes

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
@@ -45,8 +45,8 @@
                                 VerticalContentAlignment="Center" VerticalAlignment="Center"
                                 Visibility="{Binding Path=ActionVisibility, BindsDirectlyToSource=True}"
                                 Content="{Binding Path=ActionName, BindsDirectlyToSource=True}"
-                                IsEnabled="True" Padding="4,0" FontWeight="Normal"
-                                Height="18" IsTabStop="False"
+                                IsEnabled="True" FontWeight="Normal"
+                                IsTabStop="False"
                                 Margin="5,0,0,0">
                         </Button>
                     </StackPanel>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -78,6 +78,7 @@
     <!-- NEW SETTINGS -->
     <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">1</Thickness>          <!-- (UPDATED) Thickness of border around search panel -->
     <Thickness po:Freeze="True" x:Key="TestModeBorderThickness">0</Thickness>             <!-- (UPDATED) Thickness of border around test mode view -->
+    <Thickness po:Freeze="True" x:Key="ActionsButtonBorderThickness">0</Thickness>        <!-- Thickness of border around Actions buttons (patterns view) -->
 
     <SolidColorBrush x:Key="EventStartBrush" Color="#CD4A45"/>                          <!-- (UPDATED) Color of "start recording" button in events -->
     <SolidColorBrush x:Key="WarningBrush" Color="#D67F3C"/>                             <!-- (UPDATED) Color of "warning" icon in results -->

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -64,6 +64,7 @@
     <!-- NEW SETTINGS -->
     <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">0</Thickness>
     <Thickness po:Freeze="True" x:Key="TestModeBorderThickness">1</Thickness>
+    <Thickness po:Freeze="True" x:Key="ActionsButtonBorderThickness">1</Thickness>
 
     <SolidColorBrush x:Key="EventStartBrush" Color="#A80000 "/>
     <SolidColorBrush x:Key="WarningBrush" Color="#FF8C00 "/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -78,6 +78,7 @@
     <!-- NEW SETTINGS -->
     <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">0</Thickness>
     <Thickness po:Freeze="True" x:Key="TestModeBorderThickness">1</Thickness>
+    <Thickness po:Freeze="True" x:Key="ActionsButtonBorderThickness">0</Thickness>
 
     <SolidColorBrush x:Key="EventStartBrush" Color="#A80000"/>
     <SolidColorBrush x:Key="WarningBrush" Color="#FF8C00"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -113,7 +113,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Border Background="{TemplateBinding Background}">
+                    <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding Foreground}" BorderThickness="{DynamicResource ResourceKey=ActionsButtonBorderThickness}" CornerRadius="3" Padding="4,1">
                         <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                     </Border>
                     <ControlTemplate.Triggers>


### PR DESCRIPTION
#### Describe the change
Issue #872 points out that the patterns actions buttons have no visual indication in HC modes that they're anything more than generic text. This PR adds a border in HC modes. The eagle-eyed observer might note that it also makes the buttons in non-HC modes a tiny bit taller and rounds the corners, both of which look better to my (potentially biased) eye. Happy to discuss alternatives here.

One potential oddity is that I'm using the button foreground color as the button's border color. That's to ensure that the button outline is still visible on mouse hover when the pattern is selected in the UI. You can observe this in the following GIFs (the `InvokePattern` is selected, the `LegacyIAccessiblePattern` is not):

Mode | GIF
--- | ---
Light | ![872-light](https://user-images.githubusercontent.com/45672944/96291956-b40d8880-0f9d-11eb-8bd7-be28269fb20c.gif)
Dark | ![872-dark](https://user-images.githubusercontent.com/45672944/96291976-bc65c380-0f9d-11eb-9762-91852a6d7fc6.gif)
HC 1 | ![872-hc1](https://user-images.githubusercontent.com/45672944/96291997-c4bdfe80-0f9d-11eb-8bf9-ddc5af5d2aec.gif)
HC 2 | ![872-hc2](https://user-images.githubusercontent.com/45672944/96292102-ecad6200-0f9d-11eb-8f87-83ebc14eda19.gif)
HC Black | ![872-black](https://user-images.githubusercontent.com/45672944/96292143-f636ca00-0f9d-11eb-984e-4a9fd2f0fec2.gif)
HC White | ![872-white](https://user-images.githubusercontent.com/45672944/96292241-fdf66e80-0f9d-11eb-860a-916e0566fad5.gif)


#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #872 
- [visual only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



