### PR TITLE
fix (HC): Change focus styling for buttons that superimpose a selected line

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -89,6 +89,22 @@
         </Setter>
     </Style>
     <Style TargetType="{x:Type Button}" x:Key="BtnOnSelectedLine" BasedOn="{StaticResource BtnStandard}">
+        <Setter Property="FocusVisualStyle">
+            <Setter.Value>
+                <Style>
+                    <Setter Property="Control.Template">
+                        <Setter.Value>
+                            <ControlTemplate>
+                                <Rectangle SnapsToDevicePixels="true"
+                                        Margin="-2"
+                                        Stroke="{DynamicResource ResourceKey=SelectedTextBrush}"
+                                        StrokeThickness="4"/>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </Setter.Value>
+        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">


### PR DESCRIPTION
#### Describe the change
As called out in both #817 and #871, keyboard focus around the "Test element" and "More options" buttons of the hierarchy view is too hard to see in some High Contrast modes. These buttons float over a selected line, so their focus needs to stand out against the selected line color. This PR modifies the FocusVisualStyle so that:
1. It's drawn using the same brush as the text on the selected line
2. It's drawn inside the selected line
3. It's drawn with a thicker pen

After some discussion, we decided to follow the same pattern for non-HC modes, as well, since it helps the focus to stand out a lot better than the old way.

Here's the current behavior in Light and HC White modes, just as a reference:
Mode | GIF
--- | ---
Light | ![871-current-light](https://user-images.githubusercontent.com/45672944/96502513-bfafb800-1206-11eb-9abb-e8a982b3113b.gif)
HC White | ![871-current-white](https://user-images.githubusercontent.com/45672944/96502532-c8a08980-1206-11eb-9d9b-e9470f2367e3.gif)

Here's the new behavior in all 6 modes:
Mode | GIF
--- | ---
Light | ![871-light](https://user-images.githubusercontent.com/45672944/96502700-08677100-1207-11eb-89a8-c90a8c919ab9.gif)
Dark | ![871-dark](https://user-images.githubusercontent.com/45672944/96502733-14ebc980-1207-11eb-984d-c4f4b066543e.gif)
HC 1 | ![871-hc1](https://user-images.githubusercontent.com/45672944/96502779-246b1280-1207-11eb-9385-20882723c365.gif)
HC 2 | ![871-hc2](https://user-images.githubusercontent.com/45672944/96502804-2df47a80-1207-11eb-888c-60f864f85304.gif)
HC Black | ![871-black](https://user-images.githubusercontent.com/45672944/96502841-38af0f80-1207-11eb-9162-540b9de31fc4.gif)
HC White | ![871-white](https://user-images.githubusercontent.com/45672944/96502858-41074a80-1207-11eb-81a3-9f34e2d7acd8.gif)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #817, #871
- [style only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



