### PR TITLE
fix(HC): Prevent breadcrumbs from overlapping tabs in HC modes

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -35,6 +35,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="WindowBorderTextBrush" Color="{x:Static SystemColors.ActiveCaptionTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="LeftNavBorderBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SelectedInspectTabBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="UnselectedInspectTabBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="DisabledOverlayBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="BtnBrderBrush" Color="{x:Static SystemColors.ControlDarkColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ToggleSliderBlueBrush" Color="{x:Static SystemColors.HighlightColor}"/>


### PR DESCRIPTION
#### Describe the change
There is no definition for `UnselectedInspectTabBrush` in HC modes, meaning that a null (transparent) brush gets used. This brush sets the background for the Inspect Tabs control, and when viewing the UIA tree after running a test, the breadcrumbs text can (depending on the splitter position) collide with the text control. This PR simply defines `UnselectedInspectTabBrush` in HC modes, using SystemColor.ControlColor--this is the same color used as the background in all HC modes.

Screenshots--the top of the screenshot shows the updated behavior, the bottom shows the current production behavior, where the breadcrumbs overlap the tabs)
Mode | Screenshot
--- | ---
Light (unchanged) | ![Light](https://user-images.githubusercontent.com/45672944/96638209-a1b08900-12d4-11eb-853d-1ed292898e6c.PNG)
Dark (unchanged) | ![Dark](https://user-images.githubusercontent.com/45672944/96638237-a8d79700-12d4-11eb-9193-ed296fcbbae7.PNG)
HC 1 (fixed) | ![HC1](https://user-images.githubusercontent.com/45672944/96638256-af660e80-12d4-11eb-8ea3-3df28426c216.PNG)
HC 2 (fixed) | ![HC2](https://user-images.githubusercontent.com/45672944/96638276-b4c35900-12d4-11eb-87fa-2f4d89e53002.PNG)
HC Black (fixed) | ![Black](https://user-images.githubusercontent.com/45672944/96638307-c278de80-12d4-11eb-9f41-f27b816247dc.PNG)
HC White (fixed) | ![HCWhite](https://user-images.githubusercontent.com/45672944/96638340-cc9add00-12d4-11eb-8bff-7bcaccc3fc0a.PNG)


#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [color only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



