### PR TITLE
fix: Improve CCA handling when we can't get a color pair

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
@@ -18,7 +18,6 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
-using System.Windows.Media;
 
 namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 {
@@ -120,9 +119,6 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
             if (pair == null)
             {
-                this.ContrastVM.FirstColor = Colors.Gray;
-                this.ContrastVM.SecondColor = Colors.Gray;
-                tbConfidence.Text = ColorContrastResult.Confidence.None.ToString();
                 throw new InvalidOperationException("Unable to determine colors!");
             }
 
@@ -168,6 +164,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             this.ContrastVM.Reset();
             this.firstChooser.Reset();
             this.secondChooser.Reset();
+            this.tbConfidence.Text = string.Empty;
         }
 
         public object getConfidence()

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
@@ -18,6 +18,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 {
@@ -115,18 +116,19 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         {
             var bmc = new BitmapCollection(bitmap);
             var result = bmc.RunColorContrastCalculation();
-            var pair = result?.GetMostLikelyColorPair();
+            var pair = result.GetMostLikelyColorPair();
 
             if (pair == null)
             {
+                this.ContrastVM.FirstColor = Colors.Gray;
+                this.ContrastVM.SecondColor = Colors.Gray;
                 tbConfidence.Text = ColorContrastResult.Confidence.None.ToString();
+                throw new InvalidOperationException("Unable to determine colors!");
             }
-            else 
-            {
-                this.ContrastVM.FirstColor = pair.DarkerColor.DrawingColor.ToMediaColor();
-                this.ContrastVM.SecondColor = pair.LighterColor.DrawingColor.ToMediaColor();
-                tbConfidence.Text = result.ConfidenceValue().ToString();
-            }
+
+            this.ContrastVM.FirstColor = pair.DarkerColor.DrawingColor.ToMediaColor();
+            this.ContrastVM.SecondColor = pair.LighterColor.DrawingColor.ToMediaColor();
+            tbConfidence.Text = result.ConfidenceValue().ToString();
         }
 
         private void RaiseLiveRegionEvents()

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
@@ -115,10 +115,18 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         {
             var bmc = new BitmapCollection(bitmap);
             var result = bmc.RunColorContrastCalculation();
-            var pair = result.GetMostLikelyColorPair();
-            this.ContrastVM.FirstColor = pair.DarkerColor.DrawingColor.ToMediaColor();
-            this.ContrastVM.SecondColor = pair.LighterColor.DrawingColor.ToMediaColor();
-            tbConfidence.Text = result.ConfidenceValue().ToString();
+            var pair = result?.GetMostLikelyColorPair();
+
+            if (pair == null)
+            {
+                tbConfidence.Text = ColorContrastResult.Confidence.None.ToString();
+            }
+            else 
+            {
+                this.ContrastVM.FirstColor = pair.DarkerColor.DrawingColor.ToMediaColor();
+                this.ContrastVM.SecondColor = pair.LighterColor.DrawingColor.ToMediaColor();
+                tbConfidence.Text = result.ConfidenceValue().ToString();
+            }
         }
 
         private void RaiseLiveRegionEvents()

--- a/src/AccessibilityInsights/Modes/CCAModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/CCAModeControl.xaml.cs
@@ -232,6 +232,7 @@ namespace AccessibilityInsights.Modes
                         // enable element selector
                         MainWin.EnableElementSelector();
 
+                        this.ctrlContrast.ClearUI();
                         this.ctrlContrast.DeactivateProgressRing();
                     });
                 }

--- a/src/AccessibilityInsights/Modes/CCAModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/CCAModeControl.xaml.cs
@@ -188,7 +188,7 @@ namespace AccessibilityInsights.Modes
                     {
                         if (ec == null || ec.Element == null)
                         {
-                            toolTipText = "No Eelement Selected!";
+                            toolTipText = "No Element Selected!";
                         }
                         else
                         {


### PR DESCRIPTION
#### Describe the change
The automatic color contrast code is heuristic-based, and can't always guess at a color pair. When this happens, we dereference a null object, which triggers a NullReferenceException. This has the following effects:
1. If running under the debugger, the NullReferenceException causes a (very annoying) DebugBreak
2. The error handler handles the exception and sets the highlighter to "Unable to detect colors!", but leaves the stale data in the dialog.

This PR does 4 things:
1. Instead of throwing a NullReferenceException, it throws an InvalidOperationException. This avoids the automatic break in the debugger
2. In the exception handler, it calls the ClearUI method to flush the stale color and confidence information
3. The ClearUI method now clears the stale confidence information
4. Fixes a typo in a tooltip message

GIF before, showing the "Unable to detect colors!" message but not resetting the UI
![Old](https://user-images.githubusercontent.com/45672944/96648294-fb6c7f80-12e3-11eb-9497-9d2e8ca2878b.gif)

GIF after, showing the "Unable to detect colors!" message and the UI being reset
![New](https://user-images.githubusercontent.com/45672944/96648311-01626080-12e4-11eb-8e40-c876b1727957.gif)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



