### PR TITLE
fix(HC): Add a contrasting border around tab icons when they're focused

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -119,5 +119,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>  <!-- Foreground of nav bar icons on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>    <!-- Background of nav bar buttons on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#c7e0f4"/>  <!-- Foreground of hyperlinks on mouse hover -->
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedFocusedTabBorderBrush" Color="#22272B"/> <!-- Border around focused selected tab (Details, HowToFix). Matches SelectedInspectTabBrush -->
+    <SolidColorBrush po:Freeze="True" x:Key="InspectTabsFocusOverlayBorderBrush" Color="#22272B"/> <!-- Border around focused selected tab (Details, HowToFix). Matches SelectedInspectTabBrush -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -119,4 +119,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>  <!-- Foreground of nav bar icons on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>    <!-- Background of nav bar buttons on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#c7e0f4"/>  <!-- Foreground of hyperlinks on mouse hover -->
+    <SolidColorBrush po:Freeze="True" x:Key="SelectedFocusedTabBorderBrush" Color="#22272B"/> <!-- Border around focused selected tab (Details, HowToFix). Matches SelectedInspectTabBrush -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -104,5 +104,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="{x:Static SystemColors.HotTrackColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedFocusedTabBorderBrush" Color="{x:Static SystemColors.WindowColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="InspectTabsFocusOverlayBorderBrush" Color="{x:Static SystemColors.WindowColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -104,4 +104,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="{x:Static SystemColors.HotTrackColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="SelectedFocusedTabBorderBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -104,5 +104,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="{x:Static SystemColors.HotTrackColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedFocusedTabBorderBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="SelectedFocusedTabBorderBrush" Color="{x:Static SystemColors.WindowColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -119,4 +119,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#FF0000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="SelectedFocusedTabBorderBrush" Color="#FFFFFF"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -119,5 +119,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarIconHoverFGBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#FF0000"/>
-    <SolidColorBrush po:Freeze="True" x:Key="SelectedFocusedTabBorderBrush" Color="#FFFFFF"/>
+    <SolidColorBrush po:Freeze="True" x:Key="InspectTabsFocusOverlayBorderBrush" Color="#FFFFFF"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -861,7 +861,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabItem}">
-                    <Border BorderThickness="0,0,1,0" BorderBrush="White" Margin="0,-2,0,0">
+                    <Border x:Name="Overlay" BorderThickness="0,0,1,0" BorderBrush="White" Margin="0,-2,0,0">
                         <Grid x:Name="gdTab">
                             <ContentPresenter x:Name="ContentSite"
                                         VerticalAlignment="Center"
@@ -886,6 +886,11 @@
                             <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=PrimaryBGBrush}"/>
                             <Setter TargetName="gdTab" Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
                         </MultiTrigger>
+                        <Trigger Property="IsFocused" Value="True">
+                            <Setter TargetName="Overlay" Property="BorderThickness" Value="3"/>
+                            <Setter TargetName="Overlay" Property="Margin" Value="-1"/>
+                            <Setter TargetName="Overlay" Property="BorderBrush" Value="{DynamicResource ResourceKey=SelectedFocusedTabBorderBrush}"/>
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -889,7 +889,7 @@
                         <Trigger Property="IsFocused" Value="True">
                             <Setter TargetName="Overlay" Property="BorderThickness" Value="3"/>
                             <Setter TargetName="Overlay" Property="Margin" Value="-1"/>
-                            <Setter TargetName="Overlay" Property="BorderBrush" Value="{DynamicResource ResourceKey=SelectedFocusedTabBorderBrush}"/>
+                            <Setter TargetName="Overlay" Property="BorderBrush" Value="{DynamicResource ResourceKey=InspectTabsFocusOverlayBorderBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>


### PR DESCRIPTION
#### Describe the change
As reported in #866, the focus rectangle on the tabs in the inspect view is really hard to see in HC modes, especially HC White. This PR changes the styling of the tabs so that they draw a border inside the focus rectangle. The color is chosen to match the tab background color in Light and Dark modes, but to contrast against it in HC modes. This makes the focus rectangle stand out a lot more clearly in HC modes.

There's on minor side effect--when the focus moves to the tab, the border causes a very small shift to the text in the tab, so there's a small visual "jump" that isn't there in the current code. I mention this only to call out that it's there, but I'm not proposing that we try to fix it--at least not unless we get complaints about it.

Here are the GIF's showing before and after in all 6 modes:
Mode | Before | After
--- | --- | ---
Light | ![Current-light](https://user-images.githubusercontent.com/45672944/96748885-06282280-137f-11eb-980d-9c43264f73c1.gif) | ![New-light](https://user-images.githubusercontent.com/45672944/96748967-18a25c00-137f-11eb-9a38-6190d12a6249.gif)
Dark | ![Current-dark](https://user-images.githubusercontent.com/45672944/96749012-23f58780-137f-11eb-83de-bc081ab94656.gif) | ![New-dark](https://user-images.githubusercontent.com/45672944/96749041-2c4dc280-137f-11eb-8390-06e1e3d1e19e.gif)
HC 1 | ![Current-hc-1](https://user-images.githubusercontent.com/45672944/96749070-34a5fd80-137f-11eb-82e7-dfb0b38e312e.gif) | ![New-hc-1](https://user-images.githubusercontent.com/45672944/96775123-ec490880-139b-11eb-8c3b-955066b9639c.gif)
HC 2 | ![Current-hc-2](https://user-images.githubusercontent.com/45672944/96749142-45ef0a00-137f-11eb-914d-97192fe5ebb9.gif) | ![New-hc-2](https://user-images.githubusercontent.com/45672944/96775170-fa972480-139b-11eb-9271-b2c7ba2fbc9e.gif)
HC Black | ![Current-hc-black](https://user-images.githubusercontent.com/45672944/96749185-5606e980-137f-11eb-9179-41db1839bff3.gif) | ![New-hc-black](https://user-images.githubusercontent.com/45672944/96749204-5d2df780-137f-11eb-804e-b522fd10145f.gif)
HC White | ![Current-hc-white](https://user-images.githubusercontent.com/45672944/96749221-64550580-137f-11eb-8ce5-373b77f13597.gif) | ![New-hc-white](https://user-images.githubusercontent.com/45672944/96749228-6a4ae680-137f-11eb-9d53-c7513c8a3b08.gif)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #866 
- [style only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



