### PR TITLE
fix: Don't clip descriptive text unnecessarily

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -33,7 +33,7 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <TextBlock Name="tbGlimpse" TextTrimming="CharacterEllipsis" Grid.Row="1" Grid.Column="0" VerticalAlignment="Top" Style="{StaticResource tbHeaderDark}"/>
-                <Label Name="lblTitle" Grid.Row="2" Grid.Column="0" Content="{x:Static Properties:Resources.lblTitleContent}" VerticalAlignment="Top" Style="{StaticResource lblHeader3}"/>
+                <Label Name="lblTitle" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Content="{x:Static Properties:Resources.lblTitleContent}" VerticalAlignment="Top" Style="{StaticResource lblHeader3}"/>
                 <Button Grid.Column="1"  Grid.Row="1" Margin="8,0" Style="{StaticResource BtnNoHoverColor}" 
                         Foreground="{DynamicResource ResourceKey=ActiveBlueBrush}" HorizontalAlignment="Right"
                         VerticalAlignment="Top" Name="btnTree" Click="btnTree_Click"
@@ -44,7 +44,7 @@
                         <TextBlock Name="tbViewResults" Text="{x:Static Properties:Resources.tbViewResultsText}" Style="{StaticResource tbLink}" Focusable="False"/>
                     </StackPanel>
                 </Button>
-                <Grid Visibility="Collapsed" Name="gdFailures" Grid.Row="3" Grid.Column="0">
+                <Grid Visibility="Collapsed" Name="gdFailures" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" >
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="16"/>
                         <ColumnDefinition/>


### PR DESCRIPTION
#### Describe the change
If you resize the app when in automated checks view, the descriptive text at the top of the view gets clipped as the window gets narrower. This is because we're using a Grid without allowing the contents to span multiple columns. 

Before: 
![Columns-old](https://user-images.githubusercontent.com/45672944/96786434-210d8d80-13a5-11eb-8f72-493042848982.gif)

After:
![Columns-new](https://user-images.githubusercontent.com/45672944/96786457-2cf94f80-13a5-11eb-839b-54180ed811a8.gif)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [style only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



