### PR TITLE
fix(HC): Fix non-text contrast issues in Color Contrast analyzer

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml
@@ -25,7 +25,7 @@
                     <SolidColorBrush Color="{Binding StoredColor}"/>
                 </ComboBox.Background>
             </ComboBox>
-            <TextBox x:Name="colorTb" Width="100px" Height="32" BorderBrush="{DynamicResource ResourceKey=BorderBrush}" FontSize="17"
+            <TextBox x:Name="colorTb" Width="100px" Height="32" BorderBrush="{DynamicResource ResourceKey=ColorPickerBorderBrush}" FontSize="17"
                     Text="{Binding StoredColor, Converter={converters:ColorStringConverter}, FallbackValue=#FFFFFF}"
                     Background="{DynamicResource ResourceKey=PrimaryBGBrush}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" CaretBrush="{DynamicResource ResourceKey=PrimaryFGBrush}"
                     VerticalContentAlignment="Center" TextAlignment="Center"

--- a/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml
@@ -25,7 +25,7 @@
                     <SolidColorBrush Color="{Binding StoredColor}"/>
                 </ComboBox.Background>
             </ComboBox>
-            <TextBox x:Name="colorTb" Width="100px" Height="32" BorderBrush="{DynamicResource ResourceKey=ColorPickerBorderBrush}" FontSize="17"
+            <TextBox x:Name="colorTb" Width="100px" Height="32" BorderBrush="{DynamicResource ResourceKey=ColorChooserBorderBrush}" FontSize="17"
                     Text="{Binding StoredColor, Converter={converters:ColorStringConverter}, FallbackValue=#FFFFFF}"
                     Background="{DynamicResource ResourceKey=PrimaryBGBrush}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" CaretBrush="{DynamicResource ResourceKey=PrimaryFGBrush}"
                     VerticalContentAlignment="Center" TextAlignment="Center"

--- a/src/AccessibilityInsights.SharedUx/Controls/ColorPicker/ColorPickerControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ColorPicker/ColorPickerControl.xaml
@@ -14,7 +14,7 @@
     <UserControl.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
     </UserControl.Resources>
-    <Border Background="{DynamicResource ResourceKey=GreyBackgroundBrush}" BorderBrush="{DynamicResource ResourceKey=WindowBorderBrush}" BorderThickness="1">
+    <Border Background="{DynamicResource ResourceKey=PrimaryBGBrush}" BorderBrush="{DynamicResource ResourceKey=WindowBorderBrush}" BorderThickness="2">
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -154,7 +154,7 @@
                         <RowDefinition MinHeight="56px"/>
                         <RowDefinition MinHeight="56px"/>
                     </Grid.RowDefinitions>
-                    <Border Grid.Row="0" Grid.ColumnSpan="4" BorderBrush="{DynamicResource ResourceKey=GreyBackgroundBrush}" 
+                    <Border Grid.Row="0" Grid.ColumnSpan="4" BorderBrush="{DynamicResource ResourceKey=HorizontalRuleBGBrush}" 
                         BorderThickness="0,0,0,1" Background="{x:Null}" />
                     <TextBlock FontWeight="Bold" Text="{x:Static Properties:Resources.TextBlockTextResult}" Grid.Row="0" Grid.Column="1" Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}"/>
                     <TextBlock FontWeight="Bold" Text="{x:Static Properties:Resources.TextBlockTextElement}" Grid.Row="0" Grid.Column="2" Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}"/>
@@ -215,7 +215,7 @@
                        Foreground="{Binding Path=ContrastVM.SecondColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" 
                        Background="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}" 
                        AutomationProperties.HelpText="{x:Static Properties:Resources.ColorContrast_SmallSampleHelpText}" HorizontalAlignment="Left" FontSize="{DynamicResource ConstStandardTextSize}"/>
-                    <Border Grid.Row="2" Grid.ColumnSpan="4" BorderBrush="{DynamicResource ResourceKey=GreyBackgroundBrush}"
+                    <Border Grid.Row="2" Grid.ColumnSpan="4" BorderBrush="{DynamicResource ResourceKey=HorizontalRuleBGBrush}"
                         BorderThickness="0,0,0,1" Background="{x:Null}" />
                     <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" Margin="4,4">
                         <fabric:FabricIconControl x:Name="largeTextGlyph" VerticalAlignment="Center" Margin="0 0 2 0">
@@ -286,7 +286,7 @@
                            Background="{Binding Path=ContrastVM.FirstColor, Converter={converters:ColorStringConverter}, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=local:ColorContrast}}"
                            AutomationProperties.HelpText="{x:Static Properties:Resources.ColorContrast_LargeSampleHelpText}" HorizontalAlignment="Left"/>
                     </StackPanel>
-                    <Border Grid.Row="4" Grid.ColumnSpan="4" BorderBrush="{DynamicResource ResourceKey=GreyBackgroundBrush}"
+                    <Border Grid.Row="4" Grid.ColumnSpan="4" BorderBrush="{DynamicResource ResourceKey=HorizontalRuleBGBrush}"
                         BorderThickness="0,0,0,1" Background="{x:Null}" />
                     <StackPanel Orientation="Horizontal" Grid.Row="5" Grid.Column="1" Margin="4,4">
                         <fabric:FabricIconControl x:Name="graphicalObjectGlyph" VerticalAlignment="Center" Margin="0 0 2 0">

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -120,4 +120,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>    <!-- Background of nav bar buttons on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#c7e0f4"/>  <!-- Foreground of hyperlinks on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="InspectTabsFocusOverlayBorderBrush" Color="#22272B"/> <!-- Border around focused selected tab (Details, HowToFix). Matches SelectedInspectTabBrush -->
+    <SolidColorBrush po:Freeze="True" x:Key="ColorPickerBorderBrush" Color="#6D767E"/>  <!-- Border around color picker -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -120,5 +120,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>    <!-- Background of nav bar buttons on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#c7e0f4"/>  <!-- Foreground of hyperlinks on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="InspectTabsFocusOverlayBorderBrush" Color="#22272B"/> <!-- Border around focused selected tab (Details, HowToFix). Matches SelectedInspectTabBrush -->
-    <SolidColorBrush po:Freeze="True" x:Key="ColorPickerBorderBrush" Color="#6D767E"/>  <!-- Border around color picker -->
+    <SolidColorBrush po:Freeze="True" x:Key="ColorChooserBorderBrush" Color="#6D767E"/> <!-- Border around color chooser (combobox + edit) -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -43,7 +43,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="SettingsTabBgBrush" Color="Transparent"/>  <!-- Keep Transparent in dark -->
     <SolidColorBrush po:Freeze="True" x:Key="ActionsButtonBGBrush" Color="#444C52"/>    <!-- (UPDATED) Background for "Actions" button in Patterns pane -->
     <SolidColorBrush po:Freeze="True" x:Key="SecondaryBGBrush" Color="#2B3034"/>        <!-- (UPDATED) Secondary background brush (not u-->
-    <SolidColorBrush po:Freeze="True" x:Key="GreyBackgroundBrush" Color="#EAEAEA"/>     <!-- Horizontal rules in color contrast -->
+    <SolidColorBrush po:Freeze="True" x:Key="HorizontalRuleBGBrush" Color="#EAEAEA"/>   <!-- Horizontal rules in color contrast -->
     <SolidColorBrush po:Freeze="True" x:Key="ActiveModeBrush" Color="#FFFFFF"/>         <!-- Color of "active" marker in nav bar -->
     <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledFGBrush" Color="#656E75"/>   <!-- (UPDATED) Foreground of disabled button (example: Refresh button in ADO connect when no connection exists) -->
     <SolidColorBrush po:Freeze="True" x:Key="PrimaryBGBrush" Color="#22272B"/>          <!-- (UPDATED) Primary background brush (not in startup mode) -->

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -28,7 +28,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="SelectedBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SettingsTabBgBrush" Color="{x:Static SystemColors.HighlightColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="GreyBackgroundBrush" Color="{x:Static SystemColors.ControlColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="HorizontalRuleBGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonBackgroundBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkFGBrush" Color="{x:Static SystemColors.HotTrackColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="WindowBorderBrush" Color="{x:Static SystemColors.ActiveCaptionColor}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -50,7 +50,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="HLGreenTextBrush" Color="#00FF00 "/>
     <SolidColorBrush po:Freeze="True" x:Key="HLTextBrush" Color="#FFFF00 "/>
     <SolidColorBrush po:Freeze="True" x:Key="BorderBrush" Color="{x:Static SystemColors.InactiveBorderColor}" />
-    <SolidColorBrush po:Freeze="True" x:Key="CCABorderBrush" Color="{x:Static SystemColors.ActiveBorderColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="CCABorderBrush" Color="{x:Static SystemColors.WindowTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledFGBrush" Color="{x:Static SystemColors.GrayTextColor}"/>
     <Thickness po:Freeze="True" x:Key="BtnBrdrThickness">1</Thickness>
 

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -105,4 +105,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="{x:Static SystemColors.HotTrackColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="InspectTabsFocusOverlayBorderBrush" Color="{x:Static SystemColors.WindowColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ColorPickerBorderBrush" Color="{x:Static SystemColors.WindowTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -105,5 +105,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="{x:Static SystemColors.HotTrackColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="InspectTabsFocusOverlayBorderBrush" Color="{x:Static SystemColors.WindowColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="ColorPickerBorderBrush" Color="{x:Static SystemColors.WindowTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ColorChooserBorderBrush" Color="{x:Static SystemColors.WindowTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -28,7 +28,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="SelectedBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="DataGridSelectedBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="SettingsTabBgBrush" Color="{x:Static SystemColors.HighlightColor}"/>
-    <SolidColorBrush po:Freeze="True" x:Key="HorizontalRuleBGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="HorizontalRuleBGBrush" Color="{x:Static SystemColors.ControlDarkColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonBackgroundBrush" Color="{x:Static SystemColors.ControlColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkFGBrush" Color="{x:Static SystemColors.HotTrackColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="WindowBorderBrush" Color="{x:Static SystemColors.ActiveCaptionColor}"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -43,7 +43,7 @@
     <SolidColorBrush po:Freeze="True" x:Key="SettingsTabBgBrush" Color="Transparent"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActionsButtonBGBrush" Color="#CCCCCC"/>
     <SolidColorBrush po:Freeze="True" x:Key="SecondaryBGBrush" Color="#FFFFFF"/>
-    <SolidColorBrush po:Freeze="True" x:Key="GreyBackgroundBrush" Color="#EAEAEA"/>
+    <SolidColorBrush po:Freeze="True" x:Key="HorizontalRuleBGBrush" Color="#EAEAEA"/>
     <SolidColorBrush po:Freeze="True" x:Key="ActiveModeBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonDisabledFGBrush" Color="#A6A6A6"/>
     <SolidColorBrush po:Freeze="True" x:Key="PrimaryBGBrush" Color="#FFFFFF"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -120,4 +120,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#FF0000"/>
     <SolidColorBrush po:Freeze="True" x:Key="InspectTabsFocusOverlayBorderBrush" Color="#FFFFFF"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ColorPickerBorderBrush" Color="#949494"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -120,5 +120,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="NavBarButtonHoverBGBrush" Color="#4296D6"/>
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#FF0000"/>
     <SolidColorBrush po:Freeze="True" x:Key="InspectTabsFocusOverlayBorderBrush" Color="#FFFFFF"/>
-    <SolidColorBrush po:Freeze="True" x:Key="ColorPickerBorderBrush" Color="#949494"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ColorChooserBorderBrush" Color="#949494"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1465,14 +1465,14 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ComboBox}">
-                    <Border BorderThickness="1" BorderBrush="{DynamicResource ResourceKey=ColorPickerBorderBrush}">
+                    <Border BorderThickness="1" BorderBrush="{DynamicResource ResourceKey=ColorChooserBorderBrush}">
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
                             <Border Margin="2" Background="{TemplateBinding Background}" Grid.Column="0"/>
-                            <ToggleButton x:Name="brdrBtn" Grid.Column="1" Padding="4" BorderThickness="1" BorderBrush="{DynamicResource ResourceKey=ColorPickerBorderBrush}" Margin="-1" IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Focusable="False" IsTabStop="False" Background="Transparent">
+                            <ToggleButton x:Name="brdrBtn" Grid.Column="1" Padding="4" BorderThickness="1" BorderBrush="{DynamicResource ResourceKey=ColorChooserBorderBrush}" Margin="-1" IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Focusable="False" IsTabStop="False" Background="Transparent">
                                 <fabric:FabricIconControl GlyphSize="Default" GlyphName="ChevronDown" Foreground="{DynamicResource ResourceKey=IconBrush}" VerticalAlignment="Center"/>
                             </ToggleButton>
                             <Popup PopupAnimation="Slide" x:Name="PART_Popup" IsOpen="{TemplateBinding IsDropDownOpen}" Width="281" Height="338">

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1465,14 +1465,14 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ComboBox}">
-                    <Border BorderThickness="1" BorderBrush="{DynamicResource ResourceKey=BorderBrush}">
+                    <Border BorderThickness="1" BorderBrush="{DynamicResource ResourceKey=ColorPickerBorderBrush}">
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
                             <Border Margin="2" Background="{TemplateBinding Background}" Grid.Column="0"/>
-                            <ToggleButton x:Name="brdrBtn" Grid.Column="1" Padding="4" BorderThickness="1" BorderBrush="{DynamicResource ResourceKey=BorderBrush}" Margin="-1" IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Focusable="False" IsTabStop="False" Background="Transparent">
+                            <ToggleButton x:Name="brdrBtn" Grid.Column="1" Padding="4" BorderThickness="1" BorderBrush="{DynamicResource ResourceKey=ColorPickerBorderBrush}" Margin="-1" IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Focusable="False" IsTabStop="False" Background="Transparent">
                                 <fabric:FabricIconControl GlyphSize="Default" GlyphName="ChevronDown" Foreground="{DynamicResource ResourceKey=IconBrush}" VerticalAlignment="Center"/>
                             </ToggleButton>
                             <Popup PopupAnimation="Slide" x:Name="PART_Popup" IsOpen="{TemplateBinding IsDropDownOpen}" Width="281" Height="338">


### PR DESCRIPTION
#### Describe the change
Issue #874 calls out some non-text color contrast issues in the color contrast analyzer. This fixes _most_ of them--we'll create a new issue to track the focus color of the edit control, as this is part of the edit control and occurs in multiple places. This PR does the following:

1. Use PrimaryBGBrush in the color picker (not called out in the bug, but needed to free up GreyBackgroundBrush)
2. Rename GreyBackgroundBrush to HorizontalRuleBGBrush (used to draw horizontal rules in color contrast dialog), specify a value (SystemColors.ControlDarkColor) that has adequate contrast (>= 3.0) in all HC modes.
3. Add ColorChooserBorderBrush (will be used for the borders of the color chooser (combobox + edit)
4. Use Replace BorderBrush with ColorChooserBorderBrush for the color chooser combobox & edit
5. Use WindowsTextColor as the border color of the color contrast sample in HC modes (old color failed contrast in some modes)

Screenshots--the colors in each screenshot show the contrast for the non-focused edit control. In each screenshot, the 2nd edit control is focused, so the focused edit control is visible. It's OK for all HC modes, not for light mode (as mentioned above). I also retained the color samples showing both the horizontal rules and the result for non-text contrast. Also, there _are_ horizontal rules in light mode, but GitHub's file compression loses them.

Mode | Screenshot
--- | ---
Light | ![874-light](https://user-images.githubusercontent.com/45672944/96800621-96378d80-13ba-11eb-84c4-27aab7afd94f.png)
Dark | ![874-dark](https://user-images.githubusercontent.com/45672944/96800640-9f285f00-13ba-11eb-95d9-a5c4fd47a050.png)
HC 1 | ![874-hc-1](https://user-images.githubusercontent.com/45672944/96800752-eca4cc00-13ba-11eb-85da-a062a023438d.png)
HC 2 | ![874-hc-2](https://user-images.githubusercontent.com/45672944/96800772-f75f6100-13ba-11eb-8ff7-d36e60cec124.png)
HC Black | ![874-hc-black](https://user-images.githubusercontent.com/45672944/96800783-01815f80-13bb-11eb-9f5a-bf6d0f5acc6c.png)
HC White | ![874-hc-white](https://user-images.githubusercontent.com/45672944/96800801-09d99a80-13bb-11eb-9ffe-ee56bdc30849.png)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #874 
- [colors only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



