### PR TITLE
fix: Validate MSI signer before installing it

### DIFF
--- a/src/AccessibilityInsights.SetupLibrary/TrustVerifier.cs
+++ b/src/AccessibilityInsights.SetupLibrary/TrustVerifier.cs
@@ -57,9 +57,9 @@ namespace AccessibilityInsights.SetupLibrary
             using (X509Certificate cert = X509Certificate.CreateFromSignedFile(filePath))
             {
                 string issuer = cert.Issuer;
-                foreach (string trustecCertIssuerEnding in TrustedCertIssuerEndings)
+                foreach (string trustedCertIssuerEnding in TrustedCertIssuerEndings)
                 {
-                    if (issuer.EndsWith(trustecCertIssuerEnding, StringComparison.Ordinal))
+                    if (issuer.EndsWith(trustedCertIssuerEnding, StringComparison.Ordinal))
                     {
                         return true;
                     }

--- a/src/AccessibilityInsights.SetupLibrary/TrustVerifier.cs
+++ b/src/AccessibilityInsights.SetupLibrary/TrustVerifier.cs
@@ -22,12 +22,14 @@ namespace AccessibilityInsights.SetupLibrary
         private FileStream _file;
 
         public bool IsVerified { get; }
+        public bool IsSignerTrusted { get; }
 
         public TrustVerifier(string filePath)
         {
             try
             {
                 IsVerified = IsFileTrusted(filePath);
+                IsSignerTrusted = IsFileSignerSubjectTrusted(filePath);
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
@@ -48,8 +50,7 @@ namespace AccessibilityInsights.SetupLibrary
             using (var winTrustData = new WinTrustData(fileInfo))
             {
                 var result = WinVerifyTrust(IntPtr.Zero, WINTRUST_ACTION_GENERIC_VERIFY_V2, winTrustData);
-                return result == WinVerifyTrustResult.Success && 
-                    IsFileSignerSubjectTrusted(filePath);
+                return result == WinVerifyTrustResult.Success;
             }
         }
 

--- a/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
@@ -173,7 +173,7 @@ namespace AccessibilityInsights.VersionSwitcher
 
             if (!verifier.IsSignerTrusted)
             {
-                // TODO : Allow user to approve?
+                // TODO : Allow user to install anyway?
                 throw new ArgumentException(Properties.Resources.UntrustedFile, nameof(localFile));
             }
             EventLogger.WriteInformationalMessage("Successfully validated local file: {0}", localFile);

--- a/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
@@ -171,6 +171,11 @@ namespace AccessibilityInsights.VersionSwitcher
                 throw new ArgumentException(Properties.Resources.UntrustedFile, nameof(localFile));
             }
 
+            if (!verifier.IsSignerTrusted)
+            {
+                // TODO : Allow user to approve?
+                throw new ArgumentException(Properties.Resources.UntrustedFile, nameof(localFile));
+            }
             EventLogger.WriteInformationalMessage("Successfully validated local file: {0}", localFile);
 
             return verifier;

--- a/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
@@ -171,11 +171,6 @@ namespace AccessibilityInsights.VersionSwitcher
                 throw new ArgumentException(Properties.Resources.UntrustedFile, nameof(localFile));
             }
 
-            if (!verifier.IsSignerTrusted)
-            {
-                // TODO : Allow user to install anyway?
-                throw new ArgumentException(Properties.Resources.UntrustedFile, nameof(localFile));
-            }
             EventLogger.WriteInformationalMessage("Successfully validated local file: {0}", localFile);
 
             return verifier;


### PR DESCRIPTION
#### Describe the change
Issue #731 came from a previous security review and was intended to prevent us from launching an MSI that we weren't sure that we trusted. We already verify that the MSI is authenticode signed and that the signing chain is valid. This change adds a check based on the organization that issued the certificate used to sign the MSI. I've confirmed that the same issuer is reported in current Production and Canary builds. 

This adds no unit tests to avoid adding binary files to the repo. We could definitely change that, if desired. 

This approach is future-proofed against _anticipated_ changes to the issuer of the signing certificate. Should that happen, we'd just add another entry in `TrustedCertIssuerEndings` some time before the change, and the transition from old to new will be seamless. We risk problems, however, if there are _unanticipated_ changes in the name of the organization of the issuing cert. That would only occur if there were major changes in the company signing policy, and we'd probably know about those in advance, so it seems like a reasonable risk--it also aligns with the guidance from the team than manages certs, and with how we handle this in the Unified client.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #731 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



