### PR TITLE
fix: Update visuals in Hot key grabber dialog

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
@@ -11,6 +11,7 @@
         Title="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}" Height="162" Width="319" 
         KeyUp="WindowAndTextBox_KeyUp" WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False" FocusManager.FocusedElement="{Binding ElementName=tbHotkey}"
+        Background="{DynamicResource ResourceKey=PrimaryBGBrush}"
         AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.SettingsHotkeyGrabDialog}">
     <Window.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/HotkeyGrabDialog.xaml
@@ -12,6 +12,8 @@
         KeyUp="WindowAndTextBox_KeyUp" WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False" FocusManager.FocusedElement="{Binding ElementName=tbHotkey}"
         Background="{DynamicResource ResourceKey=PrimaryBGBrush}"
+        BorderBrush="{DynamicResource ResourceKey=PrimaryFGBrush}"
+        BorderThickness="2"
         AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.SettingsHotkeyGrabDialog}">
     <Window.Resources>
         <ResourceDictionary Source="pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml"/>
@@ -27,8 +29,8 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Label Content="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}" HorizontalAlignment="Left" Margin="8,8,0,0" Grid.Row="0" VerticalAlignment="Top" Style="{StaticResource LblH5}" Padding="0"/>
-        <TextBox Grid.Row="2" Margin="0,10" Name="tbHotkey"  
-                 Height="24" Width="300" HorizontalContentAlignment="Center"
+        <TextBox Grid.Row="2" Margin="0,10" Name="tbHotkey"
+                 Height="30" Width="300" HorizontalContentAlignment="Center"
                  VerticalContentAlignment="Center" Style="{StaticResource StandardTextBox}"
                  AutomationProperties.Name="{x:Static Properties:Resources.HotkeyGrabDialogWindowTitle}"
                  AutomationProperties.HelpText="{x:Static Properties:Resources.RunTextToChangeKeyBoard}"


### PR DESCRIPTION
#### Describe the change
The HotkeyGrabDialog has a few issues:
- It always uses the default background color, which is a problem in dark mode, since it's putting white text on a white background
- It has no border, which is confusing on a busy screen
- The TextBlock that displays the shortcut gets truncated in HC modes

Changes:
- Specify a palette-keyed background color, border color, and a border thickness (even in non-HC modes)
- Make the TextBlock taller (even in non-HC modes)

Mode | Old behavior | New behavior
--- | --- | ---
Light | ![image](https://user-images.githubusercontent.com/45672944/97620014-3191b980-19de-11eb-8010-702c629917e5.png) | ![image](https://user-images.githubusercontent.com/45672944/97620069-42dac600-19de-11eb-9972-701197b6b427.png)
Dark | ![image](https://user-images.githubusercontent.com/45672944/97620193-70c00a80-19de-11eb-9751-36aba12d24e7.png) | ![image](https://user-images.githubusercontent.com/45672944/97620233-81708080-19de-11eb-9cb9-1036610c9fab.png)
HC 1 | ![image](https://user-images.githubusercontent.com/45672944/97619429-71a46c80-19dd-11eb-8bcf-2dfda209c2fa.png) | ![image](https://user-images.githubusercontent.com/45672944/97619487-83860f80-19dd-11eb-90f1-a866e6641848.png)
HC 2 | ![image](https://user-images.githubusercontent.com/45672944/97619624-aca6a000-19dd-11eb-80c7-8db9b434f8ed.png) | ![image](https://user-images.githubusercontent.com/45672944/97619664-baf4bc00-19dd-11eb-86f0-4511b9956abc.png)
HC Black | ![image](https://user-images.githubusercontent.com/45672944/97619129-12def300-19dd-11eb-9ad7-d8cc39972aea.png) | ![image](https://user-images.githubusercontent.com/45672944/97619261-3c981a00-19dd-11eb-9abd-66a6d04e58cf.png)
HC White | ![image](https://user-images.githubusercontent.com/45672944/97619828-f1323b80-19dd-11eb-9167-1c4f269320c0.png) | ![image](https://user-images.githubusercontent.com/45672944/97619861-ff805780-19dd-11eb-82a1-f3ae5884ca79.png)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [styles only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



