### PR TITLE
Chore: Switch from using Microsoft.CodeAnalysis.FxCopAnalyzers to Microsoft.CodeAnalysis.NetAnalyzers

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	<NoWarn>RS0016</NoWarn>
-    <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
+      <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
       <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 

--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	<NoWarn>RS0016</NoWarn>
+    <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
+      <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,7 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.BinSkim" Version="1.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AccessibilityInsights.Win32/Properties/AssemblyInfo.cs
+++ b/src/AccessibilityInsights.Win32/Properties/AssemblyInfo.cs
@@ -45,9 +45,7 @@ using System.Runtime.InteropServices;
 
 #region FxCop analysis suppressions for entire assembly
 [assembly: SuppressMessage("Microsoft.Naming", "CA1707", Justification = "Underscores are allowed to keep the same name as Win32")]
-[assembly: SuppressMessage("Microsoft.Naming", "CA1714", Justification = "Keep the same name as Win32")]
 [assembly: SuppressMessage("Microsoft.Naming", "CA1717", Justification = "Keep the same name as Win32")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1028", Justification = "Keep the same name as Win32")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1815", Justification = "== or != operators are not needed for parity with Win32")]
-[assembly: SuppressMessage("Microsoft.Design", "CA1051", Justification = "For Win32 structure parity, allow visible instance fields")]
 #endregion

--- a/src/AccessibilityInsights/Properties/AssemblyInfo.cs
+++ b/src/AccessibilityInsights/Properties/AssemblyInfo.cs
@@ -41,7 +41,3 @@ using System.Windows;
                                               // app, or any theme specific resource dictionaries)
 )]
 [assembly: NeutralResourcesLanguage("en-US")]
-
-#region FxCop analysis suppressions for entire assembly
-[assembly: SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.GC.Collect", Justification = "We use GC.Collect to accelerate memory recovery")]
-#endregion


### PR DESCRIPTION
#### Describe the change

Based on recommendation from https://docs.microsoft.com/en-us/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers?view=vs-2019

Also removed some disabled warnings which appear to no longer be necessary after the change.
