### PR TITLE
fix(hc): Fix contrast issues in color picker toggle button

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -121,4 +121,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#c7e0f4"/>  <!-- Foreground of hyperlinks on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="InspectTabsFocusOverlayBorderBrush" Color="#22272B"/> <!-- Border around focused selected tab (Details, HowToFix). Matches SelectedInspectTabBrush -->
     <SolidColorBrush po:Freeze="True" x:Key="ColorChooserBorderBrush" Color="#6D767E"/> <!-- Border around color chooser (combobox + edit) -->
+    <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverBGBrush" Color="#BEE6FD"/>  <!-- Background of combobox toggle on mouse hover -->
+    <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverFGBrush" Color="#000000"/>  <!-- Foreground or combobox toggle on mouse hover -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -106,4 +106,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="{x:Static SystemColors.HotTrackColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="InspectTabsFocusOverlayBorderBrush" Color="{x:Static SystemColors.WindowColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ColorChooserBorderBrush" Color="{x:Static SystemColors.WindowTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -121,4 +121,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="ButtonLinkHoverFGBrush" Color="#FF0000"/>
     <SolidColorBrush po:Freeze="True" x:Key="InspectTabsFocusOverlayBorderBrush" Color="#FFFFFF"/>
     <SolidColorBrush po:Freeze="True" x:Key="ColorChooserBorderBrush" Color="#949494"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverBGBrush" Color="#BEE6FD"/>
+    <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverFGBrush" Color="#000000"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1473,7 +1473,7 @@
                             </Grid.ColumnDefinitions>
                             <Border Margin="2" Background="{TemplateBinding Background}" Grid.Column="0"/>
                             <ToggleButton x:Name="brdrBtn" Grid.Column="1" Padding="4" BorderThickness="1" BorderBrush="{DynamicResource ResourceKey=ColorChooserBorderBrush}" Margin="-1" IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Focusable="False" IsTabStop="False" Background="Transparent">
-                                <fabric:FabricIconControl GlyphSize="Default" GlyphName="ChevronDown" Foreground="{DynamicResource ResourceKey=IconBrush}" VerticalAlignment="Center"/>
+                                <fabric:FabricIconControl x:Name="iconChevron" GlyphName="ChevronDown" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                             </ToggleButton>
                             <Popup PopupAnimation="Slide" x:Name="PART_Popup" IsOpen="{TemplateBinding IsDropDownOpen}" Width="281" Height="338">
                                 <colorpickers:ColorPickerControl x:Name="cpPick"/>
@@ -1482,10 +1482,12 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="brdrBtn" Property="Background" Value="{DynamicResource ResourceKey=ButtonHoverBrush}"/>
+                            <Setter TargetName="brdrBtn" Property="Background" Value="{DynamicResource ResourceKey=ComboToggleHoverBGBrush}"/>
+                            <Setter TargetName="iconChevron" Property="Foreground" Value="{DynamicResource ResourceKey=ComboToggleHoverFGBrush}"/>
                         </Trigger>
                         <Trigger Property="IsDropDownOpen" Value="True">
-                            <Setter TargetName="brdrBtn" Property="Background" Value="{DynamicResource ResourceKey=ButtonHoverBrush}"/>
+                            <Setter TargetName="brdrBtn" Property="Background" Value="{DynamicResource ResourceKey=ComboToggleHoverBGBrush}"/>
+                            <Setter TargetName="iconChevron" Property="Foreground" Value="{DynamicResource ResourceKey=ComboToggleHoverFGBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1473,7 +1473,7 @@
                             </Grid.ColumnDefinitions>
                             <Border Margin="2" Background="{TemplateBinding Background}" Grid.Column="0"/>
                             <ToggleButton x:Name="brdrBtn" Grid.Column="1" Padding="4" BorderThickness="1" BorderBrush="{DynamicResource ResourceKey=ColorChooserBorderBrush}" Margin="-1" IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Focusable="False" IsTabStop="False" Background="Transparent">
-                                <fabric:FabricIconControl x:Name="iconChevron" GlyphName="ChevronDown" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                                <fabric:FabricIconControl x:Name="iconChevron" GlyphSize="Default" GlyphName="ChevronDown" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" VerticalAlignment="Center"/>
                             </ToggleButton>
                             <Popup PopupAnimation="Slide" x:Name="PART_Popup" IsOpen="{TemplateBinding IsDropDownOpen}" Width="281" Height="338">
                                 <colorpickers:ColorPickerControl x:Name="cpPick"/>


### PR DESCRIPTION
#### Describe the change
The color picker creates a custom combobox, but the colors used in the toggle button fail color contrast requirements in multiple modes (tracked in #875). This change adds 2 new brushes (one background, one foreground) that get used for the toggle button.

Some comments:
 1. There's a small flash as the mouse cursor moves across the boundary inside the combobox. This is existing behavior, and I wasn't able to find a nice way to address it in the scope of this change.
 2. I tried to use a new style for the fabricIcon (along the lines of `hoverAwareFabricIconOnButtonParent`, but ran into problems trying to get this to work in the context of the combobox because I wasn't able to align the `IsMouseOver` property of the button and the icon. I ended up just setting the properties within the `tgbtnColorPicker` style.
 3. In dark mode, the hover toggle button background is lighter than it used to be. I prefer the old color, but had trouble aligning the colors when the hover was on the combobox vs on the toggle, so I used the color that the system was using during mouse hover of the combobox (the dark mode GIFs show the differences)

Before & After GIFs:
Mode | Before | After
--- | --- | ---
Light (unchanged) | ![old-light](https://user-images.githubusercontent.com/45672944/101533545-d216ba00-394a-11eb-9cd1-8385c1c2d1c2.gif) | ![new-light](https://user-images.githubusercontent.com/45672944/101533567-da6ef500-394a-11eb-9ba7-fceb518c5b43.gif)
Dark (fixed) | ![old-dark](https://user-images.githubusercontent.com/45672944/101533600-e3f85d00-394a-11eb-8003-367772554139.gif) | ![new-dark](https://user-images.githubusercontent.com/45672944/101533626-ee1a5b80-394a-11eb-94f2-7feaca67fdb9.gif)
HC 1 (unchanged) | ![old-hc-1](https://user-images.githubusercontent.com/45672944/101533674-f7a3c380-394a-11eb-94d4-a7f47431ccdd.gif) | ![new-hc-1](https://user-images.githubusercontent.com/45672944/101533712-01c5c200-394b-11eb-98ce-382dc5573a81.gif)
HC 2 (unchanged) | ![old-hc-2](https://user-images.githubusercontent.com/45672944/101533731-0a1dfd00-394b-11eb-9d0a-87bbbc000989.gif) | ![new-hc-2](https://user-images.githubusercontent.com/45672944/101533750-12763800-394b-11eb-9934-9a89e5dbbd3a.gif)
HC Black (fixed) | ![old-hc-black](https://user-images.githubusercontent.com/45672944/101533772-1ace7300-394b-11eb-92e5-2d08e33712b9.gif) | ![new-hc-black](https://user-images.githubusercontent.com/45672944/101533793-228e1780-394b-11eb-8430-00133d9b4648.gif)
HC White (fixed) | ![old-hc-white](https://user-images.githubusercontent.com/45672944/101533813-2b7ee900-394b-11eb-9649-99009e27684b.gif) | ![new-hc-white](https://user-images.githubusercontent.com/45672944/101533844-33d72400-394b-11eb-9b85-2c1757c4ee18.gif)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #875
- [colors only] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



