### PR TITLE
fix: Improve keyboard only nav experience in color contrast

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/GlobalEyedropperWindow.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/GlobalEyedropperWindow.xaml.cs
@@ -147,23 +147,23 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         }
 
         /// <summary>
-        /// Move window and mouse cursor with arrow keys
+        /// Control window and mouse cursor with keyboard
         /// </summary>
         private void Window_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
         {
-            switch(e.Key)
+            switch (e.Key)
             {
                 case Key.Up:
-                    MoveCursor(0, -1);
+                    MoveCursor(0, -StepSize(e, Height));
                     break;
                 case Key.Down:
-                    MoveCursor(0, 1);
+                    MoveCursor(0, StepSize(e, Height));
                     break;
                 case Key.Left:
-                    MoveCursor(-1,0);
+                    MoveCursor(-StepSize(e, Width), 0);
                     break;
                 case Key.Right:
-                    MoveCursor(1,0);
+                    MoveCursor(StepSize(e, Width), 0);
                     break;
                 case Key.Enter:
                 case Key.Escape:
@@ -172,6 +172,13 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             }
 
             e.Handled = true;
+        }
+
+        private int StepSize(System.Windows.Input.KeyEventArgs e, double stepWithCtrl)
+        {
+            if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl))
+                return (int)(stepWithCtrl / zoomLevel);
+            return 1;
         }
     }
 }


### PR DESCRIPTION
#### Describe the change
The color contrast eyedropper is intended to use the mouse to get "close" to a point, then you can use the keyboard to nudge to the exact position desired. Unfortunately, there's no keyboard-only way to travel quickly and get "close". This PR adds a way to move quickly by holding the ctrl key while pressing the arrows.

Without a mouse, the default mouse cursor will be the center of the primary screen. AIWin updates this position, but these videos both assume it's in the default location. The objective is to get to the center of the 't' in "switch".

Old navigation
![old-steps](https://user-images.githubusercontent.com/45672944/101813805-0ff21a80-3ad2-11eb-9dac-4e99e8c13225.gif)

New navigation
![new-steps](https://user-images.githubusercontent.com/45672944/101813832-17b1bf00-3ad2-11eb-88b8-9cd72b4985ef.gif)

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [?] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



