### PR TITLE
chore: Remove BinSkim package reference

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -23,7 +23,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.BinSkim" Version="1.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -201,7 +201,7 @@ jobs:
   pool: VSEng-MicroBuildVS2019
   variables:
     runCodesignValidationInjection: 'true'
-    SignAppForRelease: 'true'
+    SignAppForRelease: 'false'
     GDN_CODESIGN_TARGETDIRECTORY: '$(Build.ArtifactStagingDirectory)\SigningValidation'
 
   steps:

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -201,7 +201,7 @@ jobs:
   pool: VSEng-MicroBuildVS2019
   variables:
     runCodesignValidationInjection: 'true'
-    SignAppForRelease: 'false'
+    SignAppForRelease: 'true'
     GDN_CODESIGN_TARGETDIRECTORY: '$(Build.ArtifactStagingDirectory)\SigningValidation'
 
   steps:


### PR DESCRIPTION
#### Describe the change
We have been unnecessarily including a PackageReference to the BinSkim tools. BinSkim 1.7.1 has a breaking change that prevents us from including the PackageReference, so we're removing the reference. I'll kick off a signed build after this merges to ensure that the BinSkim build task is working correctly without the PackageReference.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



