### PR TITLE
fix: Change where eventconfig.json is stored

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationManager.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationManager.cs
@@ -125,7 +125,7 @@ namespace AccessibilityInsights.SharedUx.Settings
         /// </summary>
         public void PopulateEventConfiguration()
         {
-            var configpath = Path.Combine(SettingsProvider.UserDataFolderPath, EventConfigFileName);
+            var configpath = Path.Combine(SettingsProvider.ConfigurationFolderPath, EventConfigFileName);
             try
             {
                 var rcfg = RecorderSetting.LoadConfiguration(configpath);
@@ -147,7 +147,7 @@ namespace AccessibilityInsights.SharedUx.Settings
         /// </summary>
         public void SaveEventsConfiguration()
         {
-            var configpath = Path.Combine(SettingsProvider.UserDataFolderPath, EventConfigFileName);
+            var configpath = Path.Combine(SettingsProvider.ConfigurationFolderPath, EventConfigFileName);
 
             this.EventConfig.SerializeInJSON(configpath);
         }

--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationManager.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationManager.cs
@@ -121,16 +121,42 @@ namespace AccessibilityInsights.SharedUx.Settings
         }
 
         /// <summary>
+        /// Temporary method to migrate EventConfig.json from the legacy folder (under documents)
+        /// to the config folder (under %localappdata%). This is a one-way migration that will
+        /// be removed after a couple of production releases.
+        /// </summary>
+        private void MigrateEventConfigurationFile()
+        {
+            try
+            {
+                string legacyConfigPath = Path.Combine(SettingsProvider.UserDataFolderPath, EventConfigFileName);
+                string newConfigPath = Path.Combine(SettingsProvider.ConfigurationFolderPath, EventConfigFileName);
+
+                if (File.Exists(legacyConfigPath) && !File.Exists(newConfigPath))
+                {
+                    FileHelpers.CreateFolder(SettingsProvider.ConfigurationFolderPath);
+                    File.Move(legacyConfigPath, newConfigPath);
+                }
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception e)
+            {
+                e.ReportException();
+            }
+#pragma warning restore CA1031 // Do not catch general exception types
+        }
+
+        /// <summary>
         /// Populate event configuration
         /// </summary>
         public void PopulateEventConfiguration()
         {
+            MigrateEventConfigurationFile();
             var configpath = Path.Combine(SettingsProvider.ConfigurationFolderPath, EventConfigFileName);
             try
             {
                 var rcfg = RecorderSetting.LoadConfiguration(configpath);
                 this.EventConfig = rcfg;
-
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception e)


### PR DESCRIPTION
#### Describe the change
As called out in #1009, the EventConfig.json file should be stored with the other config files, instead of being stored with the user's documents. This is a 2 line fix, but it will have the side effect of "losing" user event configs on upgrade. Since this impacts a very small set of users, this PR makes no effort to migrate existing data. That doesn't mean that we can't migrate the data, only that it's not in this PR.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 1009
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



