### PR TITLE
fix: Correct wrong name when logging to event viewer

### DIFF
--- a/src/AccessibilityInsights.VersionSwitcher/EventLogger.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/EventLogger.cs
@@ -13,7 +13,7 @@ namespace AccessibilityInsights.VersionSwitcher
     /// </summary>
     internal class EventLogger : IDisposable
     {
-        private const string EventSource = "ApplicationInsights.VersionSwitcher";
+        private const string EventSource = "AccessibilityInsights.VersionSwitcher";
         private const string ApplicationLog = "Application";
 
         // This gives us an easy static option without making the whole class static


### PR DESCRIPTION
#### Describe the change
The VersionSwitcher writes is progress to the Windows Event Log, but it records that progress from the wrong source. The intended source is AccessibilityInsights.VersionSwitcher, but when the code was first written, the string used was ApplicationInsights.VersionSwitcher. 

Here's the old (incorrect) output in CSV format:
```
Level	Date and Time	Source	Event ID	Task Category
Information	1/5/2021 7:55:23 AM	ApplicationInsights.VersionSwitcher	0	None	Completed Installation
```

Here's the new (corrected) output in CSV format:
```
Level	Date and Time	Source	Event ID	Task Category
Information	1/5/2021 10:56:32 AM	AccessibilityInsights.VersionSwitcher	0	None	Completed Installation
```

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



