### PR TITLE
fix: Remove spurious failure message in unit tests

### DIFF
--- a/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
@@ -21,23 +21,15 @@ namespace AccessibilityInsights.SharedUxTests.Settings
     {
         private static FixedConfigSettingsProvider testProvider;
 
-        private static string TestBaseDirectory;
-
         [ClassInitialize()]
         public static void ClassInit(TestContext context)
         {
-            TestBaseDirectory = Path.Combine(context.TestRunDirectory, "ConfigurationModelTests");
+            string testBaseDirectory = Path.Combine(context.TestRunDirectory, "ConfigurationModelTests");
 
-            var configDir = Path.Combine(TestBaseDirectory, "config");
-            var userDir = Path.Combine(TestBaseDirectory, "user");
+            var configDir = Path.Combine(testBaseDirectory, "config");
+            var userDir = Path.Combine(testBaseDirectory, "user");
             testProvider = new FixedConfigSettingsProvider(configDir, userDir);
             Directory.CreateDirectory(testProvider.ConfigurationFolderPath);
-        }
-
-        [ClassCleanup()]
-        public static void ClassCleanup()
-        {
-            Directory.Delete(TestBaseDirectory);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
@@ -24,7 +24,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
         [ClassInitialize()]
         public static void ClassInit(TestContext context)
         {
-            string testBaseDirectory = Path.Combine(context.TestRunDirectory, "ConfigurationModelTests");
+            string testBaseDirectory = Path.Combine(context.TestRunDirectory, context.TestName);
 
             var configDir = Path.Combine(testBaseDirectory, "config");
             var userDir = Path.Combine(testBaseDirectory, "user");

--- a/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
@@ -24,7 +24,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
         [ClassInitialize()]
         public static void ClassInit(TestContext context)
         {
-            string testBaseDirectory = Path.Combine(context.TestRunDirectory, context.TestName);
+            string testBaseDirectory = Path.Combine(context.TestRunDirectory, context.FullyQualifiedTestClassName);
 
             var configDir = Path.Combine(testBaseDirectory, "config");
             var userDir = Path.Combine(testBaseDirectory, "user");

--- a/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
@@ -21,11 +21,15 @@ namespace AccessibilityInsights.SharedUxTests.Settings
     {
         private static FixedConfigSettingsProvider testProvider;
 
+        private static string TestBaseDirectory;
+
         [ClassInitialize()]
         public static void ClassInit(TestContext context)
         {
-            var configDir = Path.Combine(context.TestRunDirectory, "config");
-            var userDir = Path.Combine(context.TestRunDirectory, "user");
+            TestBaseDirectory = Path.Combine(context.TestRunDirectory, "ConfigurationModelTests");
+
+            var configDir = Path.Combine(TestBaseDirectory, "config");
+            var userDir = Path.Combine(TestBaseDirectory, "user");
             testProvider = new FixedConfigSettingsProvider(configDir, userDir);
             Directory.CreateDirectory(testProvider.ConfigurationFolderPath);
         }
@@ -33,8 +37,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
         [ClassCleanup()]
         public static void ClassCleanup()
         {
-            Directory.Delete(testProvider.ConfigurationFolderPath);
-            Directory.Delete(testProvider.UserDataFolderPath);
+            Directory.Delete(TestBaseDirectory);
         }
 
         /// <summary>


### PR DESCRIPTION
#### Describe the change
Our PR tests currently produce the following exception on every execution:

```
Class Cleanup method ConfigurationModelTests.ClassCleanup failed. Error Message: System.IO.DirectoryNotFoundException: Could not find a part of the path 'D:\a\_temp\TestResults\Deploy_VssAdministrator 2021-01-11 13_22_45\user'.. Stack Trace:     at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
   at System.IO.Directory.Delete(String path)
   at AccessibilityInsights.SharedUxTests.Settings.ConfigurationModelTests.ClassCleanup() in D:\a\1\s\src\AccessibilityInsights.SharedUxTests\Settings\ConfigurationModelTests.cs:line 37
```
This isn't a fatal error, but it's a distraction when trying to find and fix real issues. The exception occurs because we try to delete the folder set as `ConfigurationFolderPath`, but we never created it. The minimum solution would be to just remove the line that deletes that folder, but it looks odd and could be prone to breakage if we later change the code or the test.

Stepping back, I wondered why we delete the directory at all, and the only reason I could find was to prevent potential interference with other unit tests. This PR solves that same problem in a different way: create a new folder on each iteration of the test. The `context.TestRunDirectory` is already unique per test run, and `context.TestName` provides the class name. The net result is that file artifacts created by this class will have no impact on other tests, whether in the same or in different test runs.

#### PR checklist

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



