### PR TITLE
fix: Preserve config files in VersionSwitcher

### DIFF
--- a/src/AccessibilityInsights.VersionSwitcher/FilePreserver.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/FilePreserver.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SetupLibrary;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace AccessibilityInsights.VersionSwitcher
+{
+    /// <summary>
+    /// A class to preserve files in a folder. It preserves files only in the specified
+    /// path, ignoring any subfolders. The folder will be recreated on restore, if needed.
+    /// </summary>
+    internal class FilePreserver : IDisposable
+    {
+        private bool disposedValue;
+
+        private readonly string _pathToPreserve;
+        private bool _pathExisted;
+        private Dictionary<string, string> _filesToPreserve = new Dictionary<string, string>();
+
+        internal FilePreserver(string pathToPreserve)
+        {
+            _pathToPreserve = pathToPreserve;
+        }
+
+        internal void PreserveFiles()
+        {
+            _pathExisted = Directory.Exists(_pathToPreserve);
+            if (_pathExisted)
+            {
+                StringBuilder sb = new StringBuilder();
+
+                foreach (string fileName in Directory.EnumerateFiles(_pathToPreserve))
+                {
+                    _filesToPreserve.Add(fileName, File.ReadAllText(fileName, Encoding.UTF8));
+                }
+
+                LogFiles("Preserved");
+            }
+        }
+
+        private void RestorePreservedFiles()
+        {
+            if (!_pathExisted)
+                return;
+
+            FileHelpers.CreateFolder(_pathToPreserve);
+            foreach (KeyValuePair<string, string> pair in _filesToPreserve)
+            {
+                File.WriteAllText(pair.Key, pair.Value, Encoding.UTF8);  // Will overwrite if necessary
+            }
+
+            LogFiles("Restored");
+
+            _filesToPreserve.Clear();
+            _pathExisted = false;
+        }
+
+        private void LogFiles(string action)
+        {
+            StringBuilder sb = new StringBuilder(action);
+            sb.AppendFormat(" {0} files:\n", _filesToPreserve.Count);
+            foreach(KeyValuePair<string, string> pair in _filesToPreserve)
+            {
+                sb.AppendFormat("  {0} ({1} bytes)\n", pair.Key, pair.Value.Length);
+            }
+            EventLogger.WriteInformationalMessage(sb.ToString());
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    RestorePreservedFiles();
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        ~FilePreserver()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: false);
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
@@ -44,9 +44,13 @@ namespace AccessibilityInsights.VersionSwitcher
             DownloadFromUriToLocalFile(options);
             using (ValidateLocalFile(options.LocalInstallerFile))
             {
-                using (Transaction transaction = new Transaction(_productName, TransactionAttributes.ChainEmbeddedUI))
+                using (FilePreserver configFilePreserver = new FilePreserver(FixedConfigSettingsProvider.CreateDefaultSettingsProvider().ConfigurationFolderPath))
                 {
-                    InstallWithinTransaction(options, transaction);
+                    configFilePreserver.PreserveFiles();
+                    using (Transaction transaction = new Transaction(_productName, TransactionAttributes.ChainEmbeddedUI))
+                    {
+                        InstallWithinTransaction(options, transaction);
+                    }
                 }
             }
             UpdateConfigWithNewChannel(options.NewChannel);


### PR DESCRIPTION
#### Describe the change

As a precursor to fixing #1007, we need to update the VersionSwitcher app to manually preserve config files when it runs. This code saves the config files in memory before uninstalling the existing version, then recreates them before launching the new version. This always occurs, even if an error is encountered during the process, so the user's config files are never lost as a result of running VersionSwitcher.

To facilitate debugging, VersionSwitcher writes to the event log as it goes. Here's a sample of what it writes when saving files:

```
Preserved 4 files:
  C:\Users\Dave\AppData\Local\AccessibilityInsights\V1\Configurations\Configuration.json (2155 bytes)
  C:\Users\Dave\AppData\Local\AccessibilityInsights\V1\Configurations\EventConfig.Json (35698 bytes)
  C:\Users\Dave\AppData\Local\AccessibilityInsights\V1\Configurations\InstallationInfo.json (114 bytes)
  C:\Users\Dave\AppData\Local\AccessibilityInsights\V1\Configurations\Layout.Json (1001 bytes)
```

Here's a sample of what it writes when restoring the files:
```
Restored 4 files:
  C:\Users\Dave\AppData\Local\AccessibilityInsights\V1\Configurations\Configuration.json (2155 bytes)
  C:\Users\Dave\AppData\Local\AccessibilityInsights\V1\Configurations\EventConfig.Json (35698 bytes)
  C:\Users\Dave\AppData\Local\AccessibilityInsights\V1\Configurations\InstallationInfo.json (114 bytes)
  C:\Users\Dave\AppData\Local\AccessibilityInsights\V1\Configurations\Layout.Json (1001 bytes)
```

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



