### PR TITLE
fix: Use a custom action to delete user config files on uninstall

### DIFF
--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -34,7 +34,7 @@ jobs:
       command: restore
       projects: |
         **\*.csproj
-        !**\AccessibilityInsights.CustomActions.csproj
+        !**\CustomActions.csproj
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'

--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -34,7 +34,7 @@ jobs:
       command: restore
       projects: |
         **\*.csproj
-        !**\CustomActions.csproj
+        !**\CustomActions*.csproj
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'

--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -34,6 +34,7 @@ jobs:
       command: restore
       projects: |
         **\*.csproj
+        !**\AccessibilityInsights.CustomActions.csproj
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -31,6 +31,7 @@ jobs:
       command: restore
       projects: |
         **\*.csproj
+        !**\AccessibilityInsights.CustomActions.csproj
 
   - task: PowerShell@2
     displayName: 'License Header Check'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -31,7 +31,7 @@ jobs:
       command: restore
       projects: |
         **\*.csproj
-        !**\CustomActions.csproj
+        !**\CustomActions*.csproj
 
   - task: PowerShell@2
     displayName: 'License Header Check'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -31,7 +31,7 @@ jobs:
       command: restore
       projects: |
         **\*.csproj
-        !**\AccessibilityInsights.CustomActions.csproj
+        !**\CustomActions.csproj
 
   - task: PowerShell@2
     displayName: 'License Header Check'

--- a/src/AccessibilityInsights.CustomActions/ConfigFileCleaner.cs
+++ b/src/AccessibilityInsights.CustomActions/ConfigFileCleaner.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SetupLibrary;
+using Microsoft.Deployment.WindowsInstaller;
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace AccessibilityInsights.CustomActions
+{
+    public class ConfigFileCleaner
+    {
+        [CustomAction]
+        public static ActionResult RemoveUserConfigFiles(Session session)
+        {
+            try
+            {
+                if (IsVersionSwitcherRunning())
+                {
+                    session.Log("RemoveUserConfigFiles: Found VersionSwitcher, leaving config files intact.");
+                }
+                else
+                {
+                    DeleteConfigFiles(session);
+                }
+            }
+            catch (Exception e)
+            {
+                session.Log("Caught Exception: " + e);
+            }
+
+            return ActionResult.Success;  // Don't block installer if we can't clean up the files
+        }
+
+        private static bool IsVersionSwitcherRunning()
+        {
+            foreach (var x in Process.GetProcesses())
+            {
+                if (x.ProcessName.Equals("AccessibilityInsights.VersionSwitcher", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void DeleteConfigFiles(Session session)
+        {
+            string configPath = FixedConfigSettingsProvider.CreateDefaultSettingsProvider().ConfigurationFolderPath;
+
+            foreach (string fileName in Directory.EnumerateFiles(configPath))
+            {
+                session.Log("RemoveUserConfigFiles: Deleting file: {0}", fileName);
+                File.Delete(fileName);
+            }
+        }
+    }
+}

--- a/src/AccessibilityInsights.CustomActions/CustomAction.config
+++ b/src/AccessibilityInsights.CustomActions/CustomAction.config
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup useLegacyV2RuntimeActivationPolicy="true">
+
+        <!--
+          Use supportedRuntime tags to explicitly specify the version(s) of the .NET Framework runtime that
+          the custom action should run on. If no versions are specified, the chosen version of the runtime
+          will be the "best" match to what Microsoft.Deployment.WindowsInstaller.dll was built against.
+
+          WARNING: leaving the version unspecified is dangerous as it introduces a risk of compatibility
+          problems with future versions of the .NET Framework runtime. It is highly recommended that you specify
+          only the version(s) of the .NET Framework runtime that you have tested against.
+
+          Note for .NET Framework v3.0 and v3.5, the runtime version is still v2.0.
+
+          In order to enable .NET Framework version 2.0 runtime activation policy, which is to load all assemblies
+          by using the latest supported runtime, @useLegacyV2RuntimeActivationPolicy="true".
+
+          For more information, see http://msdn.microsoft.com/en-us/library/bbx34a2h.aspx
+        -->
+
+        <supportedRuntime version="v4.0" />
+        <supportedRuntime version="v2.0.50727"/>
+
+    </startup>
+
+    <!--
+      Add additional configuration settings here. For more information on application config files,
+      see http://msdn.microsoft.com/en-us/library/kza1yk3a.aspx
+    -->
+
+</configuration>

--- a/src/AccessibilityInsights.CustomActions/CustomActions.csproj
+++ b/src/AccessibilityInsights.CustomActions/CustomActions.csproj
@@ -44,7 +44,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConfigFileCleaner.cs" />
+    <Compile Include="ISystemShim.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SystemShim.cs" />
     <Content Include="CustomAction.config" />
     <Compile Include="$(TEMP)\A11yInsightsVersionInfo.cs" Link="A11yInsightsVersionInfo.cs" />
   </ItemGroup>

--- a/src/AccessibilityInsights.CustomActions/CustomActions.csproj
+++ b/src/AccessibilityInsights.CustomActions/CustomActions.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{01426834-55CE-4942-8445-194E4E1BE22A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AccessibilityInsights.CustomActions</RootNamespace>
+    <AssemblyName>AccessibilityInsights.CustomActions</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.Deployment.WindowsInstaller">
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ConfigFileCleaner.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Content Include="CustomAction.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AccessibilityInsights.SetupLibrary\SetupLibrary.csproj">
+      <Project>{b1ded5b2-fa82-4b17-8e10-7b3b6f6a14fb}</Project>
+      <Name>SetupLibrary</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(WixCATargetsPath)" Condition=" '$(WixCATargetsPath)' != '' " />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.CA.targets" Condition=" '$(WixCATargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.CA.targets') " />
+  <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixCATargetsImported)' != 'true' ">
+    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
+  </Target>
+</Project>

--- a/src/AccessibilityInsights.CustomActions/CustomActions.csproj
+++ b/src/AccessibilityInsights.CustomActions/CustomActions.csproj
@@ -46,6 +46,7 @@
     <Compile Include="ConfigFileCleaner.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="CustomAction.config" />
+    <Compile Include="$(TEMP)\A11yInsightsVersionInfo.cs" Link="A11yInsightsVersionInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AccessibilityInsights.SetupLibrary\SetupLibrary.csproj">

--- a/src/AccessibilityInsights.CustomActions/ISystemShim.cs
+++ b/src/AccessibilityInsights.CustomActions/ISystemShim.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Collections.Generic;
+
+namespace AccessibilityInsights.CustomActions
+{
+    /// <summary>
+    /// Simple interface to allow unit testing of CustomActions.ConfigFileCleaner
+    /// </summary>
+    internal interface ISystemShim
+    {
+        IEnumerable<string> GetRunningProcessNames();
+        IEnumerable<string> GetConfigFiles();
+        void DeleteFile(string fileName);
+        void LogToSession(string message);
+    }
+}

--- a/src/AccessibilityInsights.CustomActions/Properties/AssemblyInfo.cs
+++ b/src/AccessibilityInsights.CustomActions/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AccessibilityInsights.CustomActions")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AccessibilityInsights.CustomActions")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("01426834-55ce-4942-8445-194e4e1be22a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/AccessibilityInsights.CustomActions/Properties/AssemblyInfo.cs
+++ b/src/AccessibilityInsights.CustomActions/Properties/AssemblyInfo.cs
@@ -21,15 +21,3 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("01426834-55ce-4942-8445-194e4e1be22a")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/AccessibilityInsights.CustomActions/Properties/AssemblyInfo.cs
+++ b/src/AccessibilityInsights.CustomActions/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/AccessibilityInsights.CustomActions/Properties/AssemblyInfo.cs
+++ b/src/AccessibilityInsights.CustomActions/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -22,3 +23,13 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("01426834-55ce-4942-8445-194e4e1be22a")]
 
+#if ENABLE_SIGNING
+/* The following PublicKey comes from
+* https://groups.google.com/forum/#!topic/moqdisc/6QqQZ5Oavu0
+*/
+[assembly:InternalsVisibleTo("DynamicProxyGenAssembly2,PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+[assembly: InternalsVisibleTo("AccessibilityInsights.CustomActionsUnitTests,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+#else
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+[assembly: InternalsVisibleTo("AccessibilityInsights.CustomActionsUnitTests")]
+#endif

--- a/src/AccessibilityInsights.CustomActions/SystemShim.cs
+++ b/src/AccessibilityInsights.CustomActions/SystemShim.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SetupLibrary;
+using Microsoft.Deployment.WindowsInstaller;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace AccessibilityInsights.CustomActions
+{
+    /// <summary>
+    /// Production implementation of ISystemShim
+    /// </summary>
+    internal class SystemShim: ISystemShim
+    {
+        private readonly Session _session;
+
+        public SystemShim(Session session)
+        {
+            _session = session;
+        }
+
+        public IEnumerable<string> GetRunningProcessNames()
+        {
+            foreach (Process process in Process.GetProcesses())
+            {
+                yield return process.ProcessName;
+            }
+        }
+
+        public IEnumerable<string> GetConfigFiles()
+        {
+            string configPath = FixedConfigSettingsProvider.CreateDefaultSettingsProvider().ConfigurationFolderPath;
+
+            return Directory.EnumerateFiles(configPath);
+        }
+
+        public void DeleteFile(string fileName)
+        {
+            File.Delete(fileName);
+        }
+
+        public void LogToSession(string message)
+        {
+            _session.Log(message);
+        }
+    }
+}

--- a/src/AccessibilityInsights.CustomActionsUnitTests/ConfigFileCleanerUnitTests.cs
+++ b/src/AccessibilityInsights.CustomActionsUnitTests/ConfigFileCleanerUnitTests.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.CustomActions;
+using Microsoft.Deployment.WindowsInstaller;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AccessibilityInsights.CustomActionsUnitTests
+{
+    [TestClass]
+    public class ConfigFileCleanerUnitTests
+    {
+        private Mock<ISystemShim> _systemShimMock;
+        private ConfigFileCleaner _cleaner;
+
+        [TestInitialize]
+        public void TestInit()
+        {
+            _systemShimMock = new Mock<ISystemShim>(MockBehavior.Strict);
+            _systemShimMock.Setup(x => x.GetRunningProcessNames())
+                .Returns(new List<string> { "abc", "def" });
+            _systemShimMock.Setup(x => x.LogToSession(It.IsAny<string>()));
+
+            _cleaner = new ConfigFileCleaner(_systemShimMock.Object);
+        }
+
+        [TestMethod]
+        public void RunAction_VersionSwitcherIsRunning_ConfigFilesAreIgnored()
+        {
+            _systemShimMock.Setup(x => x.GetRunningProcessNames())
+                .Returns(new List<string> { "abc", "AccessibilityInsights.VersionSwitcher", "def" });
+
+            Assert.AreEqual(ActionResult.Success, _cleaner.RunAction());
+
+            _systemShimMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void RunAction_VersionSwitcherIsNotRunning_NoConfigFilesExist_NothingIsDeleted()
+        {
+            _systemShimMock.Setup(x => x.GetConfigFiles())
+                .Returns(Enumerable.Empty<string>);
+
+            Assert.AreEqual(ActionResult.Success, _cleaner.RunAction());
+
+            _systemShimMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void RunAction_VersionSwitcherIsNotRunning_ConfigFilesExist_FilesAreDeleted()
+        {
+            List<string> configFiles = new List<string>{ "a.json", "b.json", "c.json" };
+            List<string> deletedFiles = new List<string>();
+
+            _systemShimMock.Setup(x => x.GetConfigFiles())
+                .Returns(configFiles);
+            _systemShimMock.Setup(x => x.DeleteFile(It.IsAny<string>()))
+                .Callback<string>(fileName => deletedFiles.Add(fileName));
+
+            Assert.AreEqual(ActionResult.Success, _cleaner.RunAction());
+            Assert.IsTrue(configFiles.SequenceEqual(deletedFiles));
+
+            _systemShimMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void RunAction_ExceptionThrownDuringExecution_EatsAndLogsException()
+        {
+            List<string> logMessages = new List<string>();
+
+            _systemShimMock.Setup(x => x.GetRunningProcessNames())
+                .Throws<AccessViolationException>();
+            _systemShimMock.Setup(x => x.LogToSession(It.IsAny<string>()))
+                .Callback<string>(message => logMessages.Add(message));
+
+            Assert.AreEqual(ActionResult.Success, _cleaner.RunAction());
+            Assert.AreEqual(1, logMessages.Count);
+            Assert.IsTrue(logMessages[0].Contains("AccessViolationException"));
+
+            _systemShimMock.VerifyAll();
+        }
+    }
+}

--- a/src/AccessibilityInsights.CustomActionsUnitTests/CustomActionsUnitTests.csproj
+++ b/src/AccessibilityInsights.CustomActionsUnitTests/CustomActionsUnitTests.csproj
@@ -9,13 +9,13 @@
   <Import Project="..\..\build\NetFrameworkTest.targets" />
 
   <ItemGroup>
-    <Reference Include="Microsoft.Deployment.WindowsInstaller" Version="3.0.0.0" >
+    <Reference Include="Microsoft.Deployment.WindowsInstaller" Version="3.0.0.0">
       <HintPath>..\packages\WiX.3.11.2\tools\Microsoft.Deployment.WindowsInstaller.dll</HintPath>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codecov" Version="1.12.3" />
+    <PackageReference Include="Codecov" Version="1.12.4" />
     <PackageReference Include="coverlet.collector" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.15.2" />
+    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
   </ItemGroup>

--- a/src/AccessibilityInsights.CustomActionsUnitTests/CustomActionsUnitTests.csproj
+++ b/src/AccessibilityInsights.CustomActionsUnitTests/CustomActionsUnitTests.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <AssemblyName>AccessibilityInsights.CustomActionsUnitTests</AssemblyName>
+    <RootNamespace>AccessibilityInsights.CustomActionsUnitTests</RootNamespace>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <Import Project="..\..\build\NetFrameworkTest.targets" />
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Deployment.WindowsInstaller" Version="3.0.0.0" >
+      <HintPath>..\packages\WiX.3.11.2\tools\Microsoft.Deployment.WindowsInstaller.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Codecov" Version="1.12.3" />
+    <PackageReference Include="coverlet.collector" Version="3.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.15.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AccessibilityInsights.CustomActions\CustomActions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/AccessibilityInsights.sln
+++ b/src/AccessibilityInsights.sln
@@ -73,6 +73,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UITests", "UITests\UITests.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CustomActions", "AccessibilityInsights.CustomActions\CustomActions.csproj", "{01426834-55CE-4942-8445-194E4E1BE22A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomActionsUnitTests", "AccessibilityInsights.CustomActionsUnitTests\CustomActionsUnitTests.csproj", "{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -452,6 +454,24 @@ Global
 		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|x64.Build.0 = Debug|x86
 		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|x86.ActiveCfg = Release|x86
 		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|x86.Build.0 = Release|x86
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.Debug|x64.Build.0 = Debug|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.Debug|x86.Build.0 = Debug|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.Release|x64.ActiveCfg = Release|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.Release|x64.Build.0 = Release|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.Release|x86.ActiveCfg = Release|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.Release|x86.Build.0 = Release|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.SignedRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.SignedRelease|Any CPU.Build.0 = Release|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.SignedRelease|x64.ActiveCfg = Release|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.SignedRelease|x64.Build.0 = Release|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.SignedRelease|x86.ActiveCfg = Release|Any CPU
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.SignedRelease|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -478,6 +498,7 @@ Global
 		{EEE9CD52-CA10-41AE-AC6E-98AE4BBDFA2D} = {809F77B0-82E0-4990-A9A4-4806157385E9}
 		{7A7C04EA-8279-4D69-959D-E804DD81BC70} = {809F77B0-82E0-4990-A9A4-4806157385E9}
 		{01426834-55CE-4942-8445-194E4E1BE22A} = {2190F103-4B22-43FE-A047-093356B1007A}
+		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E} = {2190F103-4B22-43FE-A047-093356B1007A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {25101A75-9178-4066-B360-E932959B9758}

--- a/src/AccessibilityInsights.sln
+++ b/src/AccessibilityInsights.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedUxTests", "AccessibilityInsights.SharedUxTests\SharedUxTests.csproj", "{F595A9C3-E625-40C9-82A5-79F05804F535}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedUxTests", "AccessibilityInsights.SharedUxTests\SharedUxTests.csproj", "{F595A9C3-E625-40C9-82A5-79F05804F535}"
 EndProject
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "MSI", "MSI\MSI.wixproj", "{137DB774-6464-48BC-B577-091ABEAF0178}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -19,15 +19,15 @@ Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "MSI", "MSI\MSI.wixproj", "{
 		{58DBF9FE-0029-408F-A8A4-23AE500E938D} = {58DBF9FE-0029-408F-A8A4-23AE500E938D}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensions.Telemetry", "AccessibilityInsights.Extensions.Telemetry\Extensions.Telemetry.csproj", "{D17E1749-28FE-44B9-A9F6-AF8985124FE4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extensions.Telemetry", "AccessibilityInsights.Extensions.Telemetry\Extensions.Telemetry.csproj", "{D17E1749-28FE-44B9-A9F6-AF8985124FE4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedUx", "AccessibilityInsights.SharedUx\SharedUx.csproj", "{723DDC93-8AB7-403C-9D03-C90B01CAE774}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedUx", "AccessibilityInsights.SharedUx\SharedUx.csproj", "{723DDC93-8AB7-403C-9D03-C90B01CAE774}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AccessibilityInsights", "AccessibilityInsights\AccessibilityInsights.csproj", "{5E06484C-A156-46D7-830B-68275ED64F44}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AccessibilityInsights", "AccessibilityInsights\AccessibilityInsights.csproj", "{5E06484C-A156-46D7-830B-68275ED64F44}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensions.AzureDevOps", "AccessibilityInsights.Extensions.AzureDevOps\Extensions.AzureDevOps.csproj", "{58DBF9FE-0029-408F-A8A4-23AE500E938D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extensions.AzureDevOps", "AccessibilityInsights.Extensions.AzureDevOps\Extensions.AzureDevOps.csproj", "{58DBF9FE-0029-408F-A8A4-23AE500E938D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensions.AzureDevOpsTests", "AccessibilityInsights.Extensions.AzureDevOpsTests\Extensions.AzureDevOpsTests.csproj", "{723F3286-D001-4CB1-9F4D-29EF6B894877}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extensions.AzureDevOpsTests", "AccessibilityInsights.Extensions.AzureDevOpsTests\Extensions.AzureDevOpsTests.csproj", "{723F3286-D001-4CB1-9F4D-29EF6B894877}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Packages", "Packages", "{C23FB215-D2F6-454D-BD08-7736562CDFB3}"
 EndProject
@@ -35,41 +35,43 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Runtime", "Runtime", "{7514
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WindowsUx", "WindowsUx", "{809F77B0-82E0-4990-A9A4-4806157385E9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Win32", "AccessibilityInsights.Win32\Win32.csproj", "{608E7EF9-C670-4152-A056-46448E2F1E18}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Win32", "AccessibilityInsights.Win32\Win32.csproj", "{608E7EF9-C670-4152-A056-46448E2F1E18}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Extensions", "Extensions", "{A7D302E8-FBAD-4564-80FF-F5A9BEEAAF76}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensions", "AccessibilityInsights.Extensions\Extensions.csproj", "{EAA85D0D-712D-4D85-A246-D3C699C6C602}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extensions", "AccessibilityInsights.Extensions\Extensions.csproj", "{EAA85D0D-712D-4D85-A246-D3C699C6C602}"
 	ProjectSection(ProjectDependencies) = postProject
 		{608E7EF9-C670-4152-A056-46448E2F1E18} = {608E7EF9-C670-4152-A056-46448E2F1E18}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensions.GitHubAutoUpdate", "AccessibilityInsights.Extensions.GitHubAutoUpdate\Extensions.GitHubAutoUpdate.csproj", "{80165CCC-6D76-4590-A16B-1790A35B08E4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extensions.GitHubAutoUpdate", "AccessibilityInsights.Extensions.GitHubAutoUpdate\Extensions.GitHubAutoUpdate.csproj", "{80165CCC-6D76-4590-A16B-1790A35B08E4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensions.GitHubAutoUpdateUnitTests", "AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests\Extensions.GitHubAutoUpdateUnitTests.csproj", "{7199C6A9-DD07-46A2-8D89-8458968C0897}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extensions.GitHubAutoUpdateUnitTests", "AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests\Extensions.GitHubAutoUpdateUnitTests.csproj", "{7199C6A9-DD07-46A2-8D89-8458968C0897}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensions.TelemetryTests", "AccessibilityInsights.Extensions.TelemetryTests\Extensions.TelemetryTests.csproj", "{53A83593-015F-460A-9797-D910CB997E62}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extensions.TelemetryTests", "AccessibilityInsights.Extensions.TelemetryTests\Extensions.TelemetryTests.csproj", "{53A83593-015F-460A-9797-D910CB997E62}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VersionSwitcher", "AccessibilityInsights.VersionSwitcher\VersionSwitcher.csproj", "{1D4F9843-B1CB-4CCC-A13A-D132336750F2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VersionSwitcher", "AccessibilityInsights.VersionSwitcher\VersionSwitcher.csproj", "{1D4F9843-B1CB-4CCC-A13A-D132336750F2}"
 	ProjectSection(ProjectDependencies) = postProject
 		{608E7EF9-C670-4152-A056-46448E2F1E18} = {608E7EF9-C670-4152-A056-46448E2F1E18}
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Setup Tools", "Setup Tools", "{2190F103-4B22-43FE-A047-093356B1007A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SetupLibrary", "AccessibilityInsights.SetupLibrary\SetupLibrary.csproj", "{B1DED5B2-FA82-4B17-8E10-7B3B6F6A14FB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SetupLibrary", "AccessibilityInsights.SetupLibrary\SetupLibrary.csproj", "{B1DED5B2-FA82-4B17-8E10-7B3B6F6A14FB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SetupLibraryUnitTests", "AccessibilityInsights.SetupLibraryUnitTests\SetupLibraryUnitTests.csproj", "{F9F353A9-CC0B-4FA4-990E-4390D6A6D825}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SetupLibraryUnitTests", "AccessibilityInsights.SetupLibraryUnitTests\SetupLibraryUnitTests.csproj", "{F9F353A9-CC0B-4FA4-990E-4390D6A6D825}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensions.GitHub", "AccessibilityInsights.Extensions.GitHub\Extensions.GitHub.csproj", "{F421AAFD-D85F-49B8-B95E-CA17718C38DD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extensions.GitHub", "AccessibilityInsights.Extensions.GitHub\Extensions.GitHub.csproj", "{F421AAFD-D85F-49B8-B95E-CA17718C38DD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExtensionsTests", "AccessibilityInsights.ExtensionsTests\ExtensionsTests.csproj", "{BE9F7E62-D9D6-4FC7-B449-820899498621}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtensionsTests", "AccessibilityInsights.ExtensionsTests\ExtensionsTests.csproj", "{BE9F7E62-D9D6-4FC7-B449-820899498621}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensions.GitHubUnitTests", "AccessibilityInsights.Extensions.GitHubUnitTests\Extensions.GitHubUnitTests.csproj", "{8CCBEC10-F28B-4330-A351-0B4B900F1169}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extensions.GitHubUnitTests", "AccessibilityInsights.Extensions.GitHubUnitTests\Extensions.GitHubUnitTests.csproj", "{8CCBEC10-F28B-4330-A351-0B4B900F1169}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonUxComponents", "AccessibilityInsights.CommonUxComponents\CommonUxComponents.csproj", "{EEE9CD52-CA10-41AE-AC6E-98AE4BBDFA2D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonUxComponents", "AccessibilityInsights.CommonUxComponents\CommonUxComponents.csproj", "{EEE9CD52-CA10-41AE-AC6E-98AE4BBDFA2D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UITests", "UITests\UITests.csproj", "{7A7C04EA-8279-4D69-959D-E804DD81BC70}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UITests", "UITests\UITests.csproj", "{7A7C04EA-8279-4D69-959D-E804DD81BC70}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CustomActions", "AccessibilityInsights.CustomActions\CustomActions.csproj", "{01426834-55CE-4942-8445-194E4E1BE22A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -106,6 +108,7 @@ Global
 		{137DB774-6464-48BC-B577-091ABEAF0178}.Debug|x64.ActiveCfg = Debug|x86
 		{137DB774-6464-48BC-B577-091ABEAF0178}.Debug|x86.ActiveCfg = Debug|x86
 		{137DB774-6464-48BC-B577-091ABEAF0178}.Release|Any CPU.ActiveCfg = Release|x86
+		{137DB774-6464-48BC-B577-091ABEAF0178}.Release|Any CPU.Build.0 = Release|x86
 		{137DB774-6464-48BC-B577-091ABEAF0178}.Release|x64.ActiveCfg = Release|x86
 		{137DB774-6464-48BC-B577-091ABEAF0178}.Release|x86.ActiveCfg = Release|x86
 		{137DB774-6464-48BC-B577-091ABEAF0178}.Release|x86.Build.0 = Release|x86
@@ -434,6 +437,21 @@ Global
 		{7A7C04EA-8279-4D69-959D-E804DD81BC70}.SignedRelease|Any CPU.ActiveCfg = Release|Any CPU
 		{7A7C04EA-8279-4D69-959D-E804DD81BC70}.SignedRelease|x64.ActiveCfg = Release|Any CPU
 		{7A7C04EA-8279-4D69-959D-E804DD81BC70}.SignedRelease|x86.ActiveCfg = Release|Any CPU
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Debug|x64.ActiveCfg = Debug|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Debug|x86.ActiveCfg = Debug|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Debug|x86.Build.0 = Debug|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Release|Any CPU.ActiveCfg = Release|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Release|Any CPU.Build.0 = Release|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Release|x64.ActiveCfg = Release|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Release|x86.ActiveCfg = Release|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Release|x86.Build.0 = Release|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|Any CPU.ActiveCfg = Debug|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|Any CPU.Build.0 = Debug|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|x64.ActiveCfg = Debug|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|x64.Build.0 = Debug|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|x86.ActiveCfg = Release|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -459,6 +477,7 @@ Global
 		{8CCBEC10-F28B-4330-A351-0B4B900F1169} = {A7D302E8-FBAD-4564-80FF-F5A9BEEAAF76}
 		{EEE9CD52-CA10-41AE-AC6E-98AE4BBDFA2D} = {809F77B0-82E0-4990-A9A4-4806157385E9}
 		{7A7C04EA-8279-4D69-959D-E804DD81BC70} = {809F77B0-82E0-4990-A9A4-4806157385E9}
+		{01426834-55CE-4942-8445-194E4E1BE22A} = {2190F103-4B22-43FE-A047-093356B1007A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {25101A75-9178-4066-B360-E932959B9758}

--- a/src/MSI/MSI.wixproj
+++ b/src/MSI/MSI.wixproj
@@ -58,6 +58,16 @@
       <Name>WixUtilExtension</Name>
     </WixExtension>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AccessibilityInsights.CustomActions\CustomActions.csproj">
+      <Name>CustomActions</Name>
+      <Project>{01426834-55ce-4942-8445-194e4e1be22a}</Project>
+      <Private>True</Private>
+      <DoNotHarvest>True</DoNotHarvest>
+      <RefProjectOutputGroups>Binaries;Content;Satellites</RefProjectOutputGroups>
+      <RefTargetDir>INSTALLFOLDER</RefTargetDir>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
   <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -12,6 +12,8 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                   AllowDowngrades="no"
                   DowngradeErrorMessage="A newer version of [ProductName] is already installed." 
                   AllowSameVersionUpgrades="no"/>
+    <Binary Id="CustomActions"
+            SourceFile="..\AccessibilityInsights.CustomActions\bin\Release\AccessibilityInsights.CustomActions.CA.dll" />
     <UI>
       <UIRef Id="WixUI_InstallDir"/>
       <Publish Dialog="ExitDialog"
@@ -170,9 +172,11 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <Property Id="WixShellExecTarget" Value="[#FileExe]"/>
     <CustomAction Id="LaunchInstalledExe" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
+    <CustomAction Id="RemoveUserConfigFiles" BinaryKey="CustomActions" DllEntry="RemoveUserConfigFiles" Impersonate="yes" />
 
     <InstallExecuteSequence>
-      <Custom Action='LaunchInstalledExe' After='InstallFinalize'>NOT REMOVE and WIX_UPGRADE_DETECTED and NOT SECONDSEQUENCE</Custom>
+      <Custom Action='RemoveUserConfigFiles' After='InstallFinalize'>Installed and (REMOVE="ALL") and NOT UPGRADINGPRODUCTCODE</Custom>
+      <Custom Action='LaunchInstalledExe' After='RemoveUserConfigFiles'>NOT REMOVE and WIX_UPGRADE_DETECTED and NOT SECONDSEQUENCE</Custom>
     </InstallExecuteSequence>
 
     <DirectoryRef Id="ApplicationProgramsFolder">


### PR DESCRIPTION
#### Describe the change

To fix #1007, we've chosen to use a custom action per the following spec:
1. It is invoked only on uninstall
2. When invoked, it checks to see if a process named AccessibilityInsights.VersionSwitcher.exe is currently running
3. If AccessibilityInsights.VersionSwitcher.exe is not running, the custom action deletes all files in the configuration directory (ignoring subdirectories)

Ran full E2E tests using actual MSI files in the following scenarios (config files exist at the beginning of each scenario):
Scenario | Result
--- | ---
Install | Config files are preserved
Upgrade by manually running MSI (no VersionSwitcher) | Config files are preserved
Uninstall MSI while VersionSwitcher is running | Config files are preserved
Uninstall MSI while VersionSwitcher is not running | Config files are deleted

#### Implementation notes
- The csproj file for the new assembly uses the old-style csproj format. This is because VisualStudio's template for a CustomAction assembly uses the old format and I was unable to find a way to generate the post-build step that bundles all of the assemblies into `AccessibilityInsights.VersionSwitcher.CA.dll`, which is ultimately the file that gets bundled into the MSI.
- Since both the CustomActions and CustomActionsUnitTests assemblies have a dependency on WiX ToolSet, and since WiX ToolSet doesn't play nicely with `dotnet restore`, both assemblies are excluded from the `dotnet restore` steps in pipeline builds

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #1007 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



