### PR TITLE
fix: Reduce memory usage for eyedropper control

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/GlobalEyedropperWindow.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/GlobalEyedropperWindow.xaml.cs
@@ -56,7 +56,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
 
         private void CaptureScreenshot()
         {
-            screenshot = new Bitmap(SystemInformation.VirtualScreen.Width, SystemInformation.VirtualScreen.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            screenshot = new Bitmap(SystemInformation.VirtualScreen.Width, SystemInformation.VirtualScreen.Height, System.Drawing.Imaging.PixelFormat.Format24bppRgb);
 
             using (Graphics g = Graphics.FromImage(screenshot))
             {


### PR DESCRIPTION
#### Describe the change
Issue #951 calls out that the color picker control's memory footprint is directly linked to the logical size of the screen, so there's a potential to use a lot of memory if the logical size is large. This PR doesn't fundamentally change the approach, but it specifies a 24 bit bitmap format instead of a 32 bit bitmap format. Intuitively, that should reduce our memory footprint by about 25%. I tested the current bits on my machine and found that the working set increased by about 120KB each time I clicked on the color picker. With the change, the working set increased by about 90KB, which is consistent with the expected 25% reduction.

The color contrast [algorithm](https://github.com/microsoft/accessibility-insights-windows/blob/master/src/AccessibilityInsights.SharedUx/ViewModels/ColorContrastViewModel.cs#L171) ignores the Alpha channel, so there should be no impact of removing the alpha from the input. To verify, I created a small WPF app that contains overlapping color objects, and ran both old and new bits side by side--the results were identical and showed that the RGB values we received were already removing any transparency and setting the Alpha to 255. Just for reference, here's the XAML from my test app--everything is boilerplate from the template except the three objects inside the grid:

```
<Window x:Class="AlphaBlendingTest.MainWindow"
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
        xmlns:local="clr-namespace:AlphaBlendingTest"
        mc:Ignorable="d"
        Title="MainWindow" Height="450" Width="800">
    <Grid>
        <Ellipse Height="200" Width="200" Fill="LightGreen" />
        <Rectangle Height="100" Width="200" Fill="Red" Opacity="0.2"/>
        <Rectangle Height="200" Width="100" Fill="Blue" Opacity="0.2"/>
    </Grid>
</Window>

```

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #951
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



