### PR TITLE
fix: Custom Action is failing in signed pipeline

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -98,6 +98,7 @@ jobs:
       command: restore
       projects: |
         **\*.csproj
+        !**\CustomActions*.csproj
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -229,6 +229,7 @@ jobs:
       command: restore
       projects: |
         **\*.csproj
+        !**\CustomActions*.csproj
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'

--- a/src/AccessibilityInsights.CustomActions/CustomActions.csproj
+++ b/src/AccessibilityInsights.CustomActions/CustomActions.csproj
@@ -62,9 +62,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="WiX">
-      <Version>3.11.2</Version>
-    </PackageReference>
+    <PackageReference Include="WiX" Version="3.11.2" />
+    <Reference Include="Microsoft.Deployment.WindowsInstaller" Version="3.0.0.0" >
+      <HintPath>..\packages\WiX.3.11.2\tools\Microsoft.Deployment.WindowsInstaller.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(WixCATargetsPath)" Condition=" '$(WixCATargetsPath)' != '' " />

--- a/src/AccessibilityInsights.CustomActions/CustomActions.csproj
+++ b/src/AccessibilityInsights.CustomActions/CustomActions.csproj
@@ -56,6 +56,16 @@
       <Name>SetupLibrary</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core">
+      <Version>0.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="WiX">
+      <Version>3.11.2</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(WixCATargetsPath)" Condition=" '$(WixCATargetsPath)' != '' " />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.CA.targets" Condition=" '$(WixCATargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.CA.targets') " />


### PR DESCRIPTION
#### Describe the change (Please provide an overview of the change in this PR)

#1029 broke the signed build because of omissions that aren't validated in the PR build. This adds the omissions. You can find a signed build run to validate the changes at: https://dev.azure.com/mseng/1ES/_build/results?buildId=14150678&view=results. Problems are being reported with Policheck, but they appear to be unrelated to any of the changes in this PR.

#### PR checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



