### PR TITLE
chore: Remove direct references to System.Drawing.Common

### DIFF
--- a/src/AccessibilityInsights.Extensions.GitHub/Extensions.GitHub.csproj
+++ b/src/AccessibilityInsights.Extensions.GitHub/Extensions.GitHub.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <PackageReference Include="System.IO.Packaging" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/AccessibilityInsights.Extensions.Telemetry/Extensions.Telemetry.csproj
+++ b/src/AccessibilityInsights.Extensions.Telemetry/Extensions.Telemetry.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.16.0" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <PackageReference Include="System.IO.Packaging" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
#### Details

This PR removes some "residual" references to System.Drawing.Common. These are not needed and even led to a hard-to-debug issue in UITests when dependabot tried to update these references for us (reference PR #1042). The best answer seems to be to simply remove them.

##### Motivation

Avoid noise, good hygiene

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



