### PR TITLE
fix: Replace tab stops help icon with text

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml
@@ -45,10 +45,9 @@
             <TextBlock Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,0,0,10" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}">
                 <Run FontWeight="SemiBold" FontSize="{DynamicResource ConstXLTextSize}" Text="{x:Static Properties:Resources.RunTextTabStops}" />
                 <Hyperlink TextDecorations="{x:Null}" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"
-                           ToolTip="{x:Static Properties:Resources.RunTextGuidance}"
-                           AutomationProperties.Name="{x:Static Properties:Resources.RunTextGuidance}" AutomationProperties.HelpText=" "
-                           NavigateUri="https://go.microsoft.com/fwlink/?linkid=2080645" RequestNavigate="Hyperlink_RequestNavigate">
-                    <fabric:FabricIconControl GlyphName="Info" GlyphSize="Custom" FontSize="17" Margin="8,0,0,-3" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                           NavigateUri="https://go.microsoft.com/fwlink/?linkid=2080645" RequestNavigate="Hyperlink_RequestNavigate"
+                           Style="{StaticResource hLink}">
+                    <Run Text="{x:Static Properties:Resources.TabStopsControl_TabStopsLink}"/>
                 </Hyperlink>
             </TextBlock>
             <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" Height="24" VerticalAlignment="Top" Margin="0,0,0,24">

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3189,15 +3189,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Guidance.
-        /// </summary>
-        public static string RunTextGuidance {
-            get {
-                return ResourceManager.GetString("RunTextGuidance", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to By opting into telemetry, you.
         /// </summary>
         public static string RunTextHelpCommunity1 {
@@ -3699,6 +3690,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string TabStopControlAutomationPropertiesName {
             get {
                 return ResourceManager.GetString("TabStopControlAutomationPropertiesName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Learn more about tab stops..
+        /// </summary>
+        public static string TabStopsControl_TabStopsLink {
+            get {
+                return ResourceManager.GetString("TabStopsControl_TabStopsLink", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -417,8 +417,8 @@
   <data name="ColorContrastAutomationPropertiesName" xml:space="preserve">
     <value>Color contrast analyzer</value>
   </data>
-  <data name="RunTextGuidance" xml:space="preserve">
-    <value>Guidance</value>
+  <data name="TabStopsControl_TabStopsLink" xml:space="preserve">
+    <value>Learn more about tab stops.</value>
   </data>
   <data name="firstChooserAutomationPropertiesName" xml:space="preserve">
     <value>first color</value>


### PR DESCRIPTION
#### Details
Currently, tab stops has a help (i) icon that is a hyperlink. It does not show a tooltip on keyboard focus. This PR replaces that icon with text to avoid the need for a tooltip.

##### Motivation
Addresses an accessibility issue

##### Context
I tried to adapt `KeyboardToolTipButtonBehavior` to function on hyperlinks. Unfortunately, `Hyperlink` is not a `FrameworkElement` and thus cannot be set as a `ToolTip`'s `PlacementTarget` and does not prove screen location information. This makes it very difficult to position a keyboard focus triggered `ToolTip` on the screen for a `Hyperlink`. As such, this PR's approach was selected instead.

Screenshots, before on top, after below:
Dark Mode:
![image](https://user-images.githubusercontent.com/4615491/109691503-5c328100-7b3c-11eb-87d1-a26d12006a5e.png)
HC White:
![image](https://user-images.githubusercontent.com/4615491/109691553-694f7000-7b3c-11eb-8b13-50e2ff97a670.png)
HC Black:
![image](https://user-images.githubusercontent.com/4615491/109692043-e8dd3f00-7b3c-11eb-8d95-23e6777839a5.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



