### PR TITLE
fix: Suppress warnings that VS 16.9.0 is suddenly flagging

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	<NoWarn>RS0016</NoWarn>
+	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1711;CA1725;CA1801;CA1813;CA1822;CA2109;CA2201;CS8073</NoWarn>
       <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
       <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>


### PR DESCRIPTION
#### Details

VisualStudio 16.9.0 recently released, and builds with the new version are suddenly broken due to 18 new warnings that were not occurring before. We've reached out to the Visual Studio team to understand why VS suddenly decided to raise these warnings, but the quickest mitigation to get everyone unstuck is to suppress these warnings globally. 

##### Motivation

Allow the team to develop with VS 16.9.0

##### Context

This is a temporary mitigation to get unstuck. It comes with the understanding that we'll actually evaluate and maybe fix these issues going forward.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



