### PR TITLE
fix: Address code that triggers CS8073 warnings

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1711;CA1725;CA1801;CA1813;CA1822;CA2109;CA2201;CS8073</NoWarn>
+	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1711;CA1725;CA1801;CA1813;CA1822;CA2109;CA2201</NoWarn>
       <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
       <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
@@ -141,7 +141,7 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
             Guid selectedGUID = IssueReporter.IssueReporting != null ? IssueReporter.IssueReporting.StableIdentifier : default(Guid);
             foreach (var reporter in options)
             {
-                if (reporter.Key == null || reporter.Value == null)
+                if (reporter.Key == Guid.Empty || reporter.Value == null)
                     continue;
 
                 RadioButton rb = CreateRadioButton(reporter.Value);

--- a/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporter.cs
+++ b/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporter.cs
@@ -59,7 +59,7 @@ namespace AccessibilityInsights.SharedUx.FileIssue
 
         public static Task RestoreConfigurationAsync(string serializedConfig)
         {
-            if (IsEnabled && IssueReporting != null && IssueReporterManager.SelectedIssueReporterGuid != null)
+            if (IsEnabled && IssueReporting != null && IssueReporterManager.SelectedIssueReporterGuid != Guid.Empty)
             {
                 return IssueReporting.RestoreConfigurationAsync(serializedConfig);
             }

--- a/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
@@ -84,7 +84,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// <param name="element"></param>
         void SetElementInternal(A11yElement element)
         {
-            if (element != null && element.BoundingRectangle != null)
+            if (element != null && !element.BoundingRectangle.IsEmpty)
             {
                 if (this.BoundingRectangle == null || element.BoundingRectangle.Equals(this.BoundingRectangle) == false)
                 {

--- a/src/AccessibilityInsights.SharedUx/Highlighting/Win32SnapshotButton.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/Win32SnapshotButton.cs
@@ -204,7 +204,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
 
         private double UpdateBeakerSize()
         {
-            double currentDPI = this.HiLighterRect != null ? this.HiLighterRect.GetDPI() : 1.0;
+            double currentDPI = this.HiLighterRect.IsEmpty ? 1.0 : this.HiLighterRect.GetDPI();
 
             this.Width = Convert.ToInt32((Convert.ToDouble(DefaultWidth) * currentDPI));
             this.Height = Convert.ToInt32((Convert.ToDouble(DefaultHeight) * currentDPI));

--- a/src/AccessibilityInsights.Win32/Win32Structures.cs
+++ b/src/AccessibilityInsights.Win32/Win32Structures.cs
@@ -140,7 +140,7 @@ namespace AccessibilityInsights.Win32
 
         protected virtual void Dispose(bool disposing)
         {
-            if (FileInfoPtr != null)
+            if (FileInfoPtr != IntPtr.Zero)
             {
                 Marshal.FreeCoTaskMem(FileInfoPtr);
                 FileInfoPtr = IntPtr.Zero;


### PR DESCRIPTION
#### Details

In #1054, we suppressed CS8073 warnings. This benign warning indicates that a conditional has a clause that is always either true or false. The "change nothing" change is just to remove the clause. I went a bit beyond that and tried to capture the _intent_ of the check, as opposed to the actual effect. There are 3 basic cases that are addressed here:
1. Guid is a value type, not a reference type. It will never be null, but its default value is Guid.Empty. I changed checks of Guid == null to Guid.IsEmpty
2. Rectangle is a value type, not a reference type. It will never be null, but its default value is (0,0,0,0) . I changed checks of Rectangle == null to Rectangle.IsEmpty
3. IntPtr is a value type, not a reference type. It will never be null, but its default value is IntPtr.Zero. I changed 1 check of IntPtr == null to IntPtr == IntPtr.Zero

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



