### PR TITLE
Fix: Address code that triggers CA2109 warning

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1711;CA1725;CA1801;CA1813;CA1822;CA2109;CA2201;CS8073</NoWarn>
+	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1711;CA1725;CA1801;CA1813;CA1822;CA2201;CS8073</NoWarn>
       <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
       <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml.cs
@@ -52,7 +52,7 @@ namespace AccessibilityInsights.Extensions.GitHub
             UpdateSaveButton();
         }
 
-        public void TextChangeUpdateSaveButton(object sender, EventArgs e)
+        private void TextChangeUpdateSaveButton(object sender, EventArgs e)
         {
             TextChangeUpdateSaveButtonHelper();
         }


### PR DESCRIPTION
#### Details

In #1054, we suppress CA2019 warnings. We only have one of these, and it's a trivial fix--make a method private instead of public, when it's only called from within the class. To be honest, I'm somewhat impressed that we don't have more of these in the codebase! 😉 

I confirmed that the Save button in the connection config page still updates as expected.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



