### PR TITLE
fix: Address code that triggers CA1801 warning

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1711;CA1725;CA1801;CA1813;CA1822;CA2201</NoWarn>
+	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1711;CA1725;CA1813;CA1822;CA2201</NoWarn>
       <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
       <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/GlobalEyedropperWindow.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/GlobalEyedropperWindow.xaml.cs
@@ -154,16 +154,16 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             switch (e.Key)
             {
                 case Key.Up:
-                    MoveCursor(0, -StepSize(e, Height));
+                    MoveCursor(0, -StepSize(Height));
                     break;
                 case Key.Down:
-                    MoveCursor(0, StepSize(e, Height));
+                    MoveCursor(0, StepSize(Height));
                     break;
                 case Key.Left:
-                    MoveCursor(-StepSize(e, Width), 0);
+                    MoveCursor(-StepSize(Width), 0);
                     break;
                 case Key.Right:
-                    MoveCursor(StepSize(e, Width), 0);
+                    MoveCursor(StepSize(Width), 0);
                     break;
                 case Key.Enter:
                 case Key.Escape:
@@ -174,7 +174,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             e.Handled = true;
         }
 
-        private int StepSize(System.Windows.Input.KeyEventArgs e, double stepWithCtrl)
+        private int StepSize(double stepWithCtrl)
         {
             if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl))
                 return (int)(stepWithCtrl / zoomLevel);


### PR DESCRIPTION
#### Details

In #1054, we suppressed CA1822 warnings. We only have one of these, and it's a trivial fix--remove an unused parameter.

I confirmed that the keyboard movement of the color contrast eyedropper still works as expected.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
