### PR TITLE
fix: Address code that triggers CA1725 warnings

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1711;CA1725;CA1801;CA1813;CA1822;CA2201</NoWarn>
+	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1711;CA1801;CA1813;CA1822;CA2201</NoWarn>
       <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
       <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/src/AccessibilityInsights.Extensions.Telemetry/AITelemetry.cs
+++ b/src/AccessibilityInsights.Extensions.Telemetry/AITelemetry.cs
@@ -52,11 +52,11 @@ namespace AccessibilityInsights.Extensions.Telemetry
         /// Publishes telemetry to AI with the given action and propertybag
         /// Sent telemetry will also include all context values unless they are overwritten
         /// </summary>
-        /// <param name="action">Will be used as event name</param>
-        /// <param name="propertyBag">if null, doesn't send any additional property values beyond context</param>
-        public void PublishEvent(string action, IReadOnlyDictionary<string, string> propertyBag = null)
+        /// <param name="eventName">Will be used as event name</param>
+        /// <param name="properties">if null, doesn't send any additional property values beyond context</param>
+        public void PublishEvent(string eventName, IReadOnlyDictionary<string, string> properties = null)
         {
-            var aiEvent = MakeEventTelemetry(action, propertyBag);
+            var aiEvent = MakeEventTelemetry(eventName, properties);
 
             ProcessEvent(aiEvent);
         }
@@ -93,13 +93,13 @@ namespace AccessibilityInsights.Extensions.Telemetry
         /// <summary>
         /// Sets property/value pair of context; all values in context are sent in telemetry events
         /// </summary>
-        /// <param name="property"></param>
-        /// <param name="value"></param>
-        public void AddOrUpdateContextProperty(string property, string value)
+        /// <param name="propertyName"></param>
+        /// <param name="propertyValue"></param>
+        public void AddOrUpdateContextProperty(string propertyName, string propertyValue)
         {
-            if (!string.IsNullOrWhiteSpace(property))
+            if (!string.IsNullOrWhiteSpace(propertyName))
             {
-                ContextProperties[property] = value;
+                ContextProperties[propertyName] = propertyValue;
             }
         }
 

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -121,14 +121,14 @@ namespace AccessibilityInsights
         /// <summary>
         /// allow/disallow Element selection or mode switch
         /// </summary>
-        /// <param name="allow"></param>
-        public void SetAllowFurtherAction(bool allow)
+        /// <param name="enabled"></param>
+        public void SetAllowFurtherAction(bool enabled)
         {
             lock (_lockObject)
             {
-                if (AllowFurtherAction != allow && IsCurrentModeAllowingSelection())
+                if (AllowFurtherAction != enabled && IsCurrentModeAllowingSelection())
                 {
-                    AllowFurtherAction = allow;
+                    AllowFurtherAction = enabled;
                 }
             }
         }


### PR DESCRIPTION
#### Details

In #1054, we suppressed CA1725 warnings. We have just a few of these, and it's a trivial fix--rename a parameter in the implementation to match the parameter in the interface. Changes were done by the IDE.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
