### PR TITLE
fix: Address issues triggering CA1711 warnings

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1711;CA1725;CA1813;CA1822;CA2201</NoWarn>
+	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1725;CA1813;CA1822;CA2201</NoWarn>
       <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
       <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/FabricIconControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/FabricIconControl.xaml.cs
@@ -2657,7 +2657,9 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
         StackedBarChart,
         StackedLineChart,
         BuildQueue,
+#pragma warning disable CA1711 // These are defined externally so we keep the existing name
         BuildQueueNew,
+#pragma warning restore CA1711 // These are defined externally so we keep the existing name
         UserFollowed,
         ContactLink,
         Stack,

--- a/src/AccessibilityInsights.Win32/Win32Enums.cs
+++ b/src/AccessibilityInsights.Win32/Win32Enums.cs
@@ -54,6 +54,7 @@ namespace AccessibilityInsights.Win32
         MaxTokenInfoClass,
     }
 
+#pragma warning disable CA1711 // These are Win32 definitions
     /// <summary>
     /// Windows Style Extended
     /// </summary>
@@ -84,6 +85,7 @@ namespace AccessibilityInsights.Win32
         WS_EX_TRANSPARENT = 0x00000020,
         WS_EX_WINDOWEDGE = 0x00000100
     }
+#pragma warning restore CA1711 // These are Win32 definitions
 
     public enum TernaryRasterOperations
     {


### PR DESCRIPTION
#### Details

In #1054, we suppressed CA171 warnings. We only just two of these, and since the names both reflect external values, it makes sense to suppress the warning, but to suppress close to the code instead of globally.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
