### PR TITLE
fix: Address code that triggers CA1508 warnings

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1813;CA2201</NoWarn>
-      <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
-      <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1708;CA1813;CA2201</NoWarn>
+    <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConnectionInfo.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConnectionInfo.cs
@@ -45,16 +45,8 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         public ConnectionInfo(Uri serverUrl, TeamProject project, AdoTeam team)
         {
             ServerUri = serverUrl;
-            if (project != null)
-            {
-                TeamProject typedProject = project as TeamProject;
-                Project = typedProject ?? new TeamProject(project);
-            }
-            if (team != null)
-            {
-                AdoTeam typedTeam = team as AdoTeam;
-                Team = typedTeam ?? new AdoTeam(team);
-            }
+            Project = project;
+            Team = team;
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Models/AdoTeam.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Models/AdoTeam.cs
@@ -18,11 +18,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Models
 
         public AdoTeam(string name, Guid id, TeamProject parent = null) : base(name, id)
         {
-            if (parent != null)
-            {
-                TeamProject typedParent = parent as TeamProject;
-                ParentProject = typedParent ?? new TeamProject(parent);
-            }
+            ParentProject = parent;
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.Extensions/Container.cs
+++ b/src/AccessibilityInsights.Extensions/Container.cs
@@ -95,10 +95,12 @@ namespace AccessibilityInsights.Extensions
             {
                 lock(_lockObject)
                 {
+#pragma warning disable CA1508 // Analyzer doesn't understand threading
                     if (_defaultInstance == null)
                     {
                         _defaultInstance = new Container();
                     }
+#pragma warning restore CA1508 // Analyzer doesn't understand threading
                 }
             }
 

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml.cs
@@ -235,6 +235,7 @@ namespace AccessibilityInsights.SharedUx.Controls
 
         private void UpdateListViews()
         {
+#pragma warning disable CA1508 // Dead code warning doesn't apply here
             using (new ListViewSelectionLock(this.lvLeft))
             using (new ListViewSelectionLock(this.lvRight))
             {
@@ -251,6 +252,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 textboxSearch.Text = "";
                 FireAsyncContentLoadedEvent();
             } // using
+#pragma warning restore CA1508 // Dead code warning doesn't apply here
         }
 
         private void FireAsyncContentLoadedEvent()

--- a/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporterManager.cs
+++ b/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporterManager.cs
@@ -28,12 +28,14 @@ namespace AccessibilityInsights.SharedUx.FileIssue
             {
                 lock (_lockObject)
                 {
+#pragma warning disable CA1508 // Analyzer doesn't understand threading
                     if (_defaultInstance == null)
                     {
                         IssueReporterManager newInstance = new IssueReporterManager();
                         newInstance.RestorePersistedConfigurations();
                         _defaultInstance = newInstance;
                     }
+#pragma warning restore CA1508 // Analyzer doesn't understand threading
                 }
             }
             return _defaultInstance;

--- a/src/AccessibilityInsights.SharedUx/Highlighting/TextTip.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/TextTip.cs
@@ -117,7 +117,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
             set
             {
                 this.text = value;
-                if (value == null || string.IsNullOrEmpty(value))
+                if (string.IsNullOrEmpty(value))
                 {
                     this.IsVisible = false;
                 }

--- a/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
@@ -153,6 +153,7 @@ namespace AccessibilityInsights
             /// make sure that all Mode UIs are clean since new selection will be done. 
             CleanUpAllModeUIs();
 
+#pragma warning disable CA1508 // Dead code warning doesn't apply here
             if (this.CurrentPage == AppPage.Start
                 || (this.CurrentPage == AppPage.CCA)
                 || (this.CurrentPage == AppPage.Test)
@@ -166,6 +167,7 @@ namespace AccessibilityInsights
                 this.CurrentPage = AppPage.Inspect;
                 this.CurrentView = InspectView.Live;
             }
+#pragma warning restore CA1508 // Dead code warning doesn't apply here
 
             // garbage collection for any UI elements
             GC.Collect();


### PR DESCRIPTION
#### Details

In #1054, we suppressed CA1508 warnings, which deal with redundant code. Looking through these, some are legit but many of them are false positives. Details are called out in the comments.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
