### PR TITLE
fix: Address code that triggers CA1031 warning

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1813;CA2201</NoWarn>
+	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1508;CA1708;CA1813;CA2201</NoWarn>
       <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
       <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/src/AccessibilityInsights.CustomActions/ConfigFileCleaner.cs
+++ b/src/AccessibilityInsights.CustomActions/ConfigFileCleaner.cs
@@ -34,10 +34,12 @@ namespace AccessibilityInsights.CustomActions
                     DeleteConfigFiles();
                 }
             }
+#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception e)
             {
                 _systemShim.LogToSession("Caught Exception: " + e);
             }
+#pragma warning restore CA1031 // Do not catch general exception types
 
             return ActionResult.Success;  // Don't block installer if an error occurs
         }


### PR DESCRIPTION
#### Details

In #1054, we suppressed CA1031 warnings. We only have one of these, and we just wrap it in an suppression like we do in other places in the code.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
