### PR TITLE
fix: Address code that triggers CA1027 warnings

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1813;CA2201</NoWarn>
+	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1031;CA1508;CA1708;CA1813;CA2201</NoWarn>
       <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
       <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/src/AccessibilityInsights.Win32/Win32Enums.cs
+++ b/src/AccessibilityInsights.Win32/Win32Enums.cs
@@ -58,6 +58,7 @@ namespace AccessibilityInsights.Win32
     /// <summary>
     /// Windows Style Extended
     /// </summary>
+    [FlagsAttribute]
     public enum WindowStylesEx
     {
         WS_EX_ACCEPTFILES = 0x00000010,
@@ -182,6 +183,7 @@ namespace AccessibilityInsights.Win32
         CLEARTYPE_NATURAL_QUALITY = 6,
     }
 
+    [FlagsAttribute]
     public enum FontPitchAndFamily : UInt32
     {
         DEFAULT_PITCH = 0,
@@ -292,6 +294,7 @@ namespace AccessibilityInsights.Win32
         SM_SYSTEMDOCKED = 0x2004,
     }
 
+    [FlagsAttribute]
     public enum WindowStyles : uint
     {
         WS_POPUP = 0x80000000,
@@ -319,6 +322,7 @@ namespace AccessibilityInsights.Win32
         ForceMinimize = 11
     }
 
+#pragma warning disable CA1027 // These are not flags
     public enum StockObjects
     {
         WHITE_BRUSH = 0,
@@ -342,7 +346,9 @@ namespace AccessibilityInsights.Win32
         DC_BRUSH = 18,
         DC_PEN = 19,
     }
+#pragma warning restore CA1027 // These are not flags
 
+    [FlagsAttribute]
     public enum ClassStyles : uint
     {
         ByteAlignClient = 0x1000,
@@ -359,6 +365,7 @@ namespace AccessibilityInsights.Win32
         VerticalRedraw = 0x1
     }
 
+#pragma warning disable CA1027 // These are not flags
     public enum CombineRgnStyles : int
     {
         RGN_AND = 1,
@@ -369,6 +376,7 @@ namespace AccessibilityInsights.Win32
         RGN_MIN = RGN_AND,
         RGN_MAX = RGN_COPY
     }
+#pragma warning restore CA1027 // These are not flags
 
     internal enum WinTrustDataUIChoice : uint
     {


### PR DESCRIPTION
#### Details

In #1054, we suppressed [CA1027](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1027) warnings, which are purely stylistic and don't alter the generated code in any way. I had to suppress the warning in a couple of cases where the rule is overzealous and incorrectly wants non-flag enums to be attributed as flags.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
