### PR TITLE
fix: Address code that triggers CA1024 warnings

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1024;CA1027;CA1031;CA1508;CA1708;CA1813;CA2201</NoWarn>
+	<NoWarn>RS0016;CA1002;CA1003;CA1008;CA1012;CA1014;CA1027;CA1031;CA1508;CA1708;CA1813;CA2201</NoWarn>
       <!-- used by Microsoft.CodeAnalysis.NetAnalyzers -->
       <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/src/AccessibilityInsights.Extensions.GitHub/IssueReporter.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/IssueReporter.cs
@@ -33,6 +33,7 @@ namespace AccessibilityInsights.Extensions.GitHub
             this.IsConfigured = isConfigured;
         }
 
+#pragma warning disable CA1024 // This should not be a property
         public IssueReporter GetDefaultInstance()
         {
             if (_instance == null)
@@ -41,6 +42,7 @@ namespace AccessibilityInsights.Extensions.GitHub
             }
             return _instance;
         }
+#pragma warning restore CA1024 // This should not be a property
 
         public string ServiceName => Properties.Resources.extensionName;
 

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -427,10 +427,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// Returns currently selected element in hierarchy tree
         /// </summary>
         /// <returns></returns>
-        public A11yElement GetSelectedElement()
-        {
-            return (this.treeviewHierarchy.SelectedItem as HierarchyNodeViewModel).Element;
-        }
+        public A11yElement SelectedElement => (this.treeviewHierarchy.SelectedItem as HierarchyNodeViewModel).Element;
 
         #region Handle context menu for showing ancestry
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -46,12 +46,12 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// <summary>
         /// Element that was selected originally to set up this tree hierarchy. 
         /// </summary>
-        A11yElement SelectedElement;
+        A11yElement _selectedElement;
 
         /// <summary>
         /// Root Node ViewModel on Hierarchy tree
         /// </summary>
-        HierarchyNodeViewModel RootNode;
+        HierarchyNodeViewModel _rootNode;
 
         /// <summary>
         /// Contains necessary actions for hierarchy control
@@ -143,7 +143,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 else
                 {
                     UpdateTreeView(ec.DataContext.GetRootNodeHierarchyViewModel(Configuration.ShowAncestry,Configuration.ShowUncertain, this.IsLiveMode), expandall);
-                    this.SelectedElement = ec.Element;
+                    this._selectedElement = ec.Element;
                 }
 
                 UpdateButtonVisibility();
@@ -279,7 +279,7 @@ namespace AccessibilityInsights.SharedUx.Controls
 
             UpdateTreeView(rnvm, expandall);
 
-            this.SelectedElement = ec.Element;
+            this._selectedElement = ec.Element;
             var span = DateTime.Now - begin;
 
             this.tbTimeSpan.Visibility = Visibility.Collapsed;
@@ -296,7 +296,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             {
                 CleanUpTreeView();
             }
-            this.RootNode = rnvm;
+            this._rootNode = rnvm;
             this.treeviewHierarchy.ItemsSource = new List<HierarchyNodeViewModel>() { rnvm };
             this.treeviewHierarchy.IsEnabled = true;
             this.HierarchyActions.SelectedElementChanged();
@@ -312,13 +312,13 @@ namespace AccessibilityInsights.SharedUx.Controls
 
         private void textboxSearch_TextChanged(object sender, TextChangedEventArgs e)
         {
-            if (this.RootNode != null)
+            if (this._rootNode != null)
             {
-                this.RootNode.ApplyFilter(this.textboxSearch.Text);
+                this._rootNode.ApplyFilter(this.textboxSearch.Text);
 
                 // we do the following so that when focus moves to the tree, focus will be placed on a tree item
                 // Otherwise, keyboard users won't be able to navigate through the tree.
-                this.RootNode.SelectFirstVisibleLeafNode();
+                this._rootNode.SelectFirstVisibleLeafNode();
 
                 FireAsyncContentLoadedEvent();
             }
@@ -351,8 +351,8 @@ namespace AccessibilityInsights.SharedUx.Controls
                 this.SelectedInHierarchyElement = null;
                 this.ElementContext = null;
                 // clean up all data.
-                this.SelectedElement = null;
-                this.RootNode = null;
+                this._selectedElement = null;
+                this._rootNode = null;
                 this.btnTestElement.Visibility = Visibility.Collapsed;
                 this.btnMenu.Visibility = Visibility.Collapsed;
             }
@@ -387,12 +387,12 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// <param name="e"></param>
         private void btnMoveToParent_Click(object sender, RoutedEventArgs e)
         {
-            if (this.SelectedElement.Parent != null)
+            if (this._selectedElement.Parent != null)
             {
-                if (this.SelectedElement.Parent.IsRootElement() == false)
+                if (this._selectedElement.Parent.IsRootElement() == false)
                 {
                     var sa = SelectAction.GetDefaultInstance();
-                    sa.SetCandidateElement(this.ElementContext.Id, this.SelectedElement.Parent.UniqueId);
+                    sa.SetCandidateElement(this.ElementContext.Id, this._selectedElement.Parent.UniqueId);
                     sa.Select();
                     this.HierarchyActions.RefreshHierarchy(true);
                 }
@@ -416,9 +416,9 @@ namespace AccessibilityInsights.SharedUx.Controls
         {
             if(this.treeviewHierarchy.SelectedItem == null)
             {
-                if(this.RootNode != null)
+                if(this._rootNode != null)
                 {
-                    this.RootNode.IsSelected = true;
+                    this._rootNode.IsSelected = true;
                 }
             }
         }
@@ -442,7 +442,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         {
             SetFocusOnHierarchyTree();
             Configuration.ShowAncestry = this.mniShowAncestry.IsChecked;
-            if (this.SelectedElement != null)
+            if (this._selectedElement != null)
             {
                 var dic = new Dictionary<string, string>();
                 this.HierarchyActions.RefreshHierarchy(false);
@@ -471,7 +471,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         private void mniShowUncertain_Click(object sender, RoutedEventArgs e)
         {
             Configuration.ShowUncertain = this.mniShowUncertain.IsChecked;
-            if (this.SelectedElement != null)
+            if (this._selectedElement != null)
             {
                 var dic = new Dictionary<string, string>();
                 this.HierarchyActions.RefreshHierarchy(false);
@@ -645,7 +645,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             SetTreeViewModeOnSelectAction(mode);
             SetFocusOnHierarchyTree();
 
-            if (this.SelectedElement != null)
+            if (this._selectedElement != null)
             {
                 // refresh tree automatically.
                 this.HierarchyActions.RefreshHierarchy(true);
@@ -863,9 +863,9 @@ namespace AccessibilityInsights.SharedUx.Controls
 
                 if (IssueReporter.IsConnected)
                 {
-                    IssueInformation issueInformation = this.SelectedElement.GetIssueInformation(IssueType.NoFailure);
-                    FileIssueAction.AttachIssueData(issueInformation, this.ElementContext.Id, this.SelectedElement.BoundingRectangle,
-                                this.SelectedElement.UniqueId);
+                    IssueInformation issueInformation = this._selectedElement.GetIssueInformation(IssueType.NoFailure);
+                    FileIssueAction.AttachIssueData(issueInformation, this.ElementContext.Id, this._selectedElement.BoundingRectangle,
+                                this._selectedElement.UniqueId);
                     IIssueResult issueResult = FileIssueAction.FileIssueAsync(issueInformation);
                     if (issueResult != null)
                     {

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
@@ -60,7 +60,7 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
             Guid clickedOptionTag = (Guid)((RadioButton)sender).Tag;
             if (clickedOptionTag != Guid.Empty)
             {
-                IssueReporterManager.GetInstance().GetIssueFilingOptionsDict().TryGetValue(clickedOptionTag, out selectedIssueReporter);
+                IssueReporterManager.GetInstance().IssueFilingOptionsDict.TryGetValue(clickedOptionTag, out selectedIssueReporter);
                 issueConfigurationControl = selectedIssueReporter?.RetrieveConfigurationControl(this.UpdateSaveButton);
                 Grid.SetRow(issueConfigurationControl, 3);
                 issueFilingGrid.Children.Add(issueConfigurationControl);
@@ -136,7 +136,7 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
         /// </summary>
         public void InitializeView()
         {
-            IReadOnlyDictionary<Guid, IIssueReporting> options = IssueReporterManager.GetInstance().GetIssueFilingOptionsDict();
+            IReadOnlyDictionary<Guid, IIssueReporting> options = IssueReporterManager.GetInstance().IssueFilingOptionsDict;
             availableIssueReporters.Children.Clear();
             Guid selectedGUID = IssueReporter.IssueReporting != null ? IssueReporter.IssueReporting.StableIdentifier : default(Guid);
             foreach (var reporter in options)

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
@@ -167,15 +167,9 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             this.tbConfidence.Text = string.Empty;
         }
 
-        public object getConfidence()
-        {
-            return this.tbConfidence.Text;
-        }
+        public object Confidence => this.tbConfidence.Text;
 
-        public object getRatio()
-        {
-            return this.output.Text;
-        }
+        public object Ratio => this.output.Text;
 
         /// <summary>
         /// App configuration

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
@@ -340,7 +340,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
             // record the number of items highlighted.
             Logger.PublishTelemetryEvent(TelemetryAction.TabStop_Select_Records,
-                TelemetryProperty.By, ha.GetElementCount().ToString(CultureInfo.InvariantCulture));
+                TelemetryProperty.By, ha.ElementCount.ToString(CultureInfo.InvariantCulture));
 
             var list = from TabStopItemViewModel l in lvElements.SelectedItems where !e.AddedItems.Contains(l) select l;
             foreach (TabStopItemViewModel mes in list)

--- a/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporter.cs
+++ b/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporter.cs
@@ -31,7 +31,7 @@ namespace AccessibilityInsights.SharedUx.FileIssue
                     return TestControlledIsEnabled.Value;
                 }
 
-                return (IssueReporterManager.GetInstance().GetIssueFilingOptionsDict() != null && IssueReporterManager.GetInstance().GetIssueFilingOptionsDict().Any());
+                return (IssueReporterManager.GetInstance().IssueFilingOptionsDict != null && IssueReporterManager.GetInstance().IssueFilingOptionsDict.Any());
             }
         }
 
@@ -54,7 +54,7 @@ namespace AccessibilityInsights.SharedUx.FileIssue
 
         public static Dictionary<Guid, IIssueReporting> GetIssueReporters()
         {
-            return IssueReporterManager.GetInstance().GetIssueFilingOptionsDict();
+            return IssueReporterManager.GetInstance().IssueFilingOptionsDict;
         }
 
         public static Task RestoreConfigurationAsync(string serializedConfig)

--- a/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporterManager.cs
+++ b/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporterManager.cs
@@ -119,10 +119,7 @@ namespace AccessibilityInsights.SharedUx.FileIssue
             }
         }
 
-        public Dictionary<Guid, IIssueReporting> GetIssueFilingOptionsDict()
-        {
-            return IssueReportingOptionsDict;
-        }
+        public Dictionary<Guid, IIssueReporting> IssueFilingOptionsDict => IssueReportingOptionsDict;
 
         /// <summary>
         /// Sets the issue reporter guid in the issue reporter manager and makes sure that the bug reporter instance is updated.

--- a/src/AccessibilityInsights.SharedUx/Highlighting/ClearOverlayDriver.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/ClearOverlayDriver.cs
@@ -161,10 +161,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// Get the element count
         /// </summary>
         /// <returns></returns>
-        public int GetElementCount()
-        {
-            return Highlighter.Items.Count;
-        }
+        public int ElementCount => Highlighter.Items.Count;
 
         #region static members
         private static ClearOverlayDriver defaultHighlightOverlayAction;

--- a/src/AccessibilityInsights.SharedUx/Highlighting/ClearOverlayDriver.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/ClearOverlayDriver.cs
@@ -169,6 +169,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         #region static members
         private static ClearOverlayDriver defaultHighlightOverlayAction;
 
+#pragma warning disable CA1024 // This should not be a property
         /// <summary>
         /// Get default HighlightAction
         /// </summary>
@@ -181,8 +182,8 @@ namespace AccessibilityInsights.SharedUx.Highlighting
             }
 
             return defaultHighlightOverlayAction;
-            
         }
+#pragma warning disable CA1024 // This should not be a property
 
         /// <summary>
         /// Clear default Highlighter instance

--- a/src/AccessibilityInsights.SharedUx/Highlighting/ImageOverlayDriver.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/ImageOverlayDriver.cs
@@ -135,6 +135,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
 
         static ImageOverlayDriver defaultHighlightImageAction;
 
+#pragma warning disable CA1024 // This should not be a property
         /// <summary>
         /// Get default HighlightAction
         /// </summary>
@@ -148,6 +149,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
 
             return defaultHighlightImageAction;
         }
+#pragma warning restore CA1024 // This should not be a property
 
         /// <summary>
         /// Clear default Highlighter instance

--- a/src/AccessibilityInsights.SharedUx/Misc/VersionTools.cs
+++ b/src/AccessibilityInsights.SharedUx/Misc/VersionTools.cs
@@ -44,6 +44,6 @@ namespace AccessibilityInsights.SharedUx.Misc
             }
         }
 
-        public static string GetAxeVersion() => PackageInfo.InformationalVersion;
+        public static string AxeVersion => PackageInfo.InformationalVersion;
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Settings/Layout.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/Layout.cs
@@ -46,6 +46,7 @@ namespace AccessibilityInsights.SharedUx.Settings
         /// </summary>
         public WindowState WinState { get; set; }
 
+#pragma warning disable CA1024 // This should not be a property
         /// <summary>
         /// Returns a Layout with default values for a Live Mode window.
         /// </summary>
@@ -65,7 +66,9 @@ namespace AccessibilityInsights.SharedUx.Settings
                 WinState = WindowState.Normal
             };
         }
+#pragma warning restore CA1024 // This should not be a property
 
+#pragma warning disable CA1024 // This should not be a property
         /// <summary>
         /// Returns a Layout with default values for a Snapshot Mode window.
         /// </summary>
@@ -85,5 +88,6 @@ namespace AccessibilityInsights.SharedUx.Settings
                 WinState = WindowState.Normal
             };
         }
+#pragma warning restore CA1024 // This should not be a property
     }
 }

--- a/src/AccessibilityInsights.SharedUx/ViewModels/AboutTabViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/AboutTabViewModel.cs
@@ -47,7 +47,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// </summary>
         public string VersionInfoLabel => VersionTools.AppVersionLabel;
 
-        public string AxeVersion => VersionTools.GetAxeVersion();
+        public string AxeVersion => VersionTools.AxeVersion;
 #pragma warning restore CA1822
     }
 }

--- a/src/AccessibilityInsights.SharedUxTests/FileIssue/IssueReporterManagerTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/FileIssue/IssueReporterManagerTests.cs
@@ -64,7 +64,7 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
             repManager.RestorePersistedConfigurations();
 
             issueReporterMock.Verify(p => p.RestoreConfigurationAsync(TestReporterConfigs), Times.Once);
-            Assert.IsTrue(repManager.GetIssueFilingOptionsDict().ContainsKey(TestGuid));
+            Assert.IsTrue(repManager.IssueFilingOptionsDict.ContainsKey(TestGuid));
         }
 
         [TestMethod]
@@ -81,7 +81,7 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
             repManager.RestorePersistedConfigurations();
 
             issueReporterMock.Verify(p => p.RestoreConfigurationAsync(TestReporterConfigs), Times.Never);
-            Assert.IsTrue(repManager.GetIssueFilingOptionsDict().ContainsKey(TestGuid));
+            Assert.IsTrue(repManager.IssueFilingOptionsDict.ContainsKey(TestGuid));
         }
 
         [TestMethod]
@@ -96,7 +96,7 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
             repManager.RestorePersistedConfigurations();
 
             issueReporterMock.Verify(p => p.RestoreConfigurationAsync(TestReporterConfigs), Times.Never);
-            Assert.IsTrue(repManager.GetIssueFilingOptionsDict().ContainsKey(TestGuid));
+            Assert.IsTrue(repManager.IssueFilingOptionsDict.ContainsKey(TestGuid));
         }
 
         [TestMethod]
@@ -111,7 +111,7 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
             repManager.RestorePersistedConfigurations();
 
             issueReporterMock.Verify(p => p.RestoreConfigurationAsync(TestReporterConfigs), Times.Never);
-            Assert.IsTrue(repManager.GetIssueFilingOptionsDict().ContainsKey(TestGuid));
+            Assert.IsTrue(repManager.IssueFilingOptionsDict.ContainsKey(TestGuid));
         }
 
         [TestMethod]
@@ -127,7 +127,7 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
             repManager.RestorePersistedConfigurations();
 
             issueReporterMock.Verify(p => p.RestoreConfigurationAsync(string.Empty), Times.Never);
-            Assert.IsTrue(repManager.GetIssueFilingOptionsDict().ContainsKey(TestGuid));
+            Assert.IsTrue(repManager.IssueFilingOptionsDict.ContainsKey(TestGuid));
         }
 
         [TestMethod]
@@ -142,7 +142,7 @@ namespace AccessibilityInsights.SharedUxTests.FileIssue
             repManager.RestorePersistedConfigurations();
 
             issueReporterMock.Verify(p => p.RestoreConfigurationAsync(null), Times.Never);
-            Assert.IsTrue(repManager.GetIssueFilingOptionsDict().ContainsKey(TestGuid));
+            Assert.IsTrue(repManager.IssueFilingOptionsDict.ContainsKey(TestGuid));
         }
 
         [TestMethod]

--- a/src/AccessibilityInsights/Modes/CCAModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/CCAModeControl.xaml.cs
@@ -199,7 +199,7 @@ namespace AccessibilityInsights.Modes
                                     this.ctrlContrast.SetElement(ec);
                                 })).Wait();
                                 toolTipText = string.Format(CultureInfo.InvariantCulture, "Ratio: {0}\nConfidence: {1}",
-                                    this.ctrlContrast.getRatio(), this.ctrlContrast.getConfidence());
+                                    this.ctrlContrast.Ratio, this.ctrlContrast.Confidence);
                             }
                             else
                             {

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
@@ -338,7 +338,7 @@ namespace AccessibilityInsights.Modes
         {
             if (this.ElementContext != null)
             {
-                var elementToCopy = this.ctrlHierarchy.GetSelectedElement() ?? this.ElementContext.Element;
+                var elementToCopy = this.ctrlHierarchy.SelectedElement ?? this.ElementContext.Element;
 
                 if (elementToCopy != null)
                 {

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
@@ -390,7 +390,7 @@ namespace AccessibilityInsights.Modes
             }
             else if (this.ElementContext != null)
             {
-                var se = this.ctrlHierarchy.GetSelectedElement() ?? this.ElementContext.Element;
+                var se = this.ctrlHierarchy.SelectedElement ?? this.ElementContext.Element;
 
                 // glimpse
                 sb.AppendFormat(CultureInfo.InvariantCulture, "Glimpse: {0}", se.Glimpse);
@@ -492,7 +492,7 @@ namespace AccessibilityInsights.Modes
                 {
                     try
                     {
-                        SaveAction.SaveSnapshotZip(dlg.FileName, this.ElementContext.Id, this.ctrlHierarchy.GetSelectedElement().UniqueId, A11yFileMode.Inspect);
+                        SaveAction.SaveSnapshotZip(dlg.FileName, this.ElementContext.Id, this.ctrlHierarchy.SelectedElement.UniqueId, A11yFileMode.Inspect);
                     }
 #pragma warning disable CA1031 // Do not catch general exception types
                     catch (Exception ex)


### PR DESCRIPTION
#### Details

In #1054, we suppressed [CA1024](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1024) warnings, which nudge users to use properties where practical. The analyzer isn't perfect, and some cases that shouldn't be properties were manually suppressed. It did, however, identify a few places where properties were appropriate. I needed to do some in-class renaming to have an intuitive property name, but it's pretty simple to follow the process if you do review each commit--look for commits prefixed **phase 1**, **phase 2**, etc.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
