### PR TITLE
chore: Simplify Flags attribution

### DIFF
--- a/src/AccessibilityInsights.Win32/Win32Enums.cs
+++ b/src/AccessibilityInsights.Win32/Win32Enums.cs
@@ -58,7 +58,7 @@ namespace AccessibilityInsights.Win32
     /// <summary>
     /// Windows Style Extended
     /// </summary>
-    [FlagsAttribute]
+    [Flags]
     public enum WindowStylesEx
     {
         WS_EX_ACCEPTFILES = 0x00000010,
@@ -183,7 +183,7 @@ namespace AccessibilityInsights.Win32
         CLEARTYPE_NATURAL_QUALITY = 6,
     }
 
-    [FlagsAttribute]
+    [Flags]
     public enum FontPitchAndFamily : UInt32
     {
         DEFAULT_PITCH = 0,
@@ -294,7 +294,7 @@ namespace AccessibilityInsights.Win32
         SM_SYSTEMDOCKED = 0x2004,
     }
 
-    [FlagsAttribute]
+    [Flags]
     public enum WindowStyles : uint
     {
         WS_POPUP = 0x80000000,
@@ -348,7 +348,7 @@ namespace AccessibilityInsights.Win32
     }
 #pragma warning restore CA1027 // These are not flags
 
-    [FlagsAttribute]
+    [Flags]
     public enum ClassStyles : uint
     {
         ByteAlignClient = 0x1000,


### PR DESCRIPTION
#### Details

#1063 added `[FlagsAttribute]` to some enums. It's better to just use the simpler form of `[Flags]`.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



