### PR TITLE
fix: Set automation name on CustomGridViewColumn headers

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CustomGridViewColumn.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CustomGridViewColumn.xaml
@@ -6,7 +6,7 @@
                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                 mc:Ignorable="d">
-    <GridViewColumnHeader HorizontalContentAlignment="Stretch" Margin="0,0,0,2" VerticalContentAlignment="Stretch">
+    <GridViewColumnHeader Name="gvcHeader" HorizontalContentAlignment="Stretch" Margin="0,0,0,2" VerticalContentAlignment="Stretch">
         <Border Background="{DynamicResource ResourceKey=DataGridBGBrush}" Margin="0,0,4,0" >
             <StackPanel Orientation="Horizontal" Background="{DynamicResource ResourceKey=ColumnHeaderBGBrush}">
                 <TextBlock Name="tbHeader" Style="{DynamicResource columnHeaderRow}" Margin="3,0"/>

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CustomGridViewColumn.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CustomGridViewColumn.xaml.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
@@ -40,6 +41,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
             {
                 SetValue(HeaderTextProperty, value);
                 tbHeader.Text = value;
+                AutomationProperties.SetName(gvcHeader, value);
             }
         }
 


### PR DESCRIPTION
#### Details
Currently, our properties table column headers are visible and directly accessible via assistive technology as `TextBlock` elements. Unfortunately, the header elements exposed by the table patterns are not those `TextBlock` elements and do not have accessible names set. This PR addresses the issue by setting `AutomationProperties.Name` on those header elements to the same value has the text displayed.
 
##### Motivation
Fixes an accessibility issue.

##### Context
I tried a few different ways to do this without success, including setting the Header property on the table directly, setting `LabeledBy` on the header to the visible text element, and changing the TextBlock we use to render the text to be a Label. I bet there are other ways to achieve the desired behavior, but this was simple and successful so I stopped searching.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/master/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



