### PR TITLE
chore: Limit CLSCompliant attribute to released files

### DIFF
--- a/build/NetFrameworkAll.targets
+++ b/build/NetFrameworkAll.targets
@@ -9,8 +9,4 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="$(TEMP)\A11yInsightsAttributesInfo.cs" Link="A11yInsightsAttributesInfo.cs" />
-  </ItemGroup>
-
 </Project>

--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(TEMP)\A11yInsightsAttributesInfo.cs" Link="A11yInsightsAttributesInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
#### Details

#1065 added the CLSCompliant attribute to all assemblies, including test assemblies. Test assemblies don't need this since we don't run the analyzers on them. This change simply reduces the scope such that the CLSCompliant attribute gets set only for released assemblies.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



