### PR TITLE
chore: Move property management into AIWin (from Axe.Windows)

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
+using AccessibilityInsights.SharedUx.Settings;
 using AccessibilityInsights.SharedUx.Utilities;
 using AccessibilityInsights.SharedUx.ViewModels;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
-using Axe.Windows.Desktop.UIAutomation;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -63,7 +63,7 @@ namespace AccessibilityInsights.SharedUx.Controls
 
         private static IEnumerable<int> GetBasicPropertyList()
         {
-            return DesktopElementHelper.GetCorePropertiesList();
+            return PropertySettings.DefaultCoreProperties;
         }
 
         private void UpdateControlPatterns()

--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationManager.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationManager.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Desktop.UIAutomation;
 using AccessibilityInsights.SetupLibrary;
 using AccessibilityInsights.SharedUx.Telemetry;
 using System;
@@ -29,6 +28,11 @@ namespace AccessibilityInsights.SharedUx.Settings
         /// Event recorder settings
         /// </summary>
         public RecorderSetting EventConfig { get; private set; }
+
+        /// <summary>
+        /// Property settings
+        /// </summary>
+        public PropertySettings PropertyConfig { get; } = new PropertySettings();
 
         /// <summary>
         /// Provider for fixed configuration settings such as path to user config folder
@@ -117,7 +121,7 @@ namespace AccessibilityInsights.SharedUx.Settings
             }
 #pragma warning restore CA1031 // Do not catch general exception types
 
-            DesktopElementHelper.SetCorePropertiesList(this.AppConfig.CoreProperties);
+            PropertyConfig.SelectedCoreProperties = AppConfig.CoreProperties;
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
@@ -5,7 +5,6 @@ using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.SharedUx.Misc;
 using Axe.Windows.Core.Enums;
 using Axe.Windows.Core.Misc;
-using Axe.Windows.Desktop.UIAutomation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -543,7 +542,7 @@ namespace AccessibilityInsights.SharedUx.Settings
 
             if (!config.CoreProperties.Any())
             {
-                config.CoreProperties = DesktopElementHelper.GetDefaultCoreProperties();
+                config.CoreProperties = PropertySettings.DefaultCoreProperties;
             }
 
             if (config.CoreTPAttributes == null)
@@ -616,7 +615,7 @@ namespace AccessibilityInsights.SharedUx.Settings
                 HotKeyForMoveToNextSibling = ConfigurationModel.DefaultHotKeyMoveToNextSibling,
                 HotKeyForMoveToPreviousSibling = ConfigurationModel.DefaultHotKeyMoveToPreviousSibling,
 
-                CoreProperties = DesktopElementHelper.GetDefaultCoreProperties(),
+                CoreProperties = PropertySettings.DefaultCoreProperties,
                 CoreTPAttributes = new List<int>(),
 
                 MouseSelectionDelayMilliSeconds = ConfigurationModel.DefaultSelectionDelayMilliseconds,

--- a/src/AccessibilityInsights.SharedUx/Settings/PropertySettings.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/PropertySettings.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Axe.Windows.Core.Types;
+using System;
+using System.Collections.Generic;
+
+namespace AccessibilityInsights.SharedUx.Settings
+{
+    public class PropertySettings
+    {
+        /// <summary>
+        /// Default properties to display if no config exists
+        /// </summary>
+        internal static readonly IEnumerable<int> DefaultCoreProperties = new List<int>
+        {
+            PropertyType.UIA_NamePropertyId,
+            PropertyType.UIA_ControlTypePropertyId,
+            PropertyType.UIA_LocalizedControlTypePropertyId,
+            PropertyType.UIA_IsKeyboardFocusablePropertyId,
+            PropertyType.UIA_BoundingRectanglePropertyId,
+            PropertyType.UIA_AccessKeyPropertyId,
+            PropertyType.UIA_AcceleratorKeyPropertyId,
+            PropertyType.UIA_HelpTextPropertyId,
+            PropertyType.UIA_AriaPropertiesPropertyId,
+            PropertyType.UIA_AriaRolePropertyId,
+        };
+
+        /// <summary>
+        /// Currently configured properties to display
+        /// </summary>
+        public IEnumerable<int> SelectedCoreProperties { get; set; }
+
+        public PropertySettings()
+        {
+            SelectedCoreProperties = Array.Empty<int>();
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
@@ -4,7 +4,6 @@ using AccessibilityInsights.SetupLibrary;
 using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.SharedUx.Settings;
 using Axe.Windows.Core.Enums;
-using Axe.Windows.Desktop.UIAutomation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Globalization;
@@ -40,7 +39,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
         {
             string path = Path.Combine(testProvider.ConfigurationFolderPath, "config.test");
 
-            var coreProps = DesktopElementHelper.GetDefaultCoreProperties();
+            var coreProps = PropertySettings.DefaultCoreProperties;
 
             ConfigurationModel config = new ConfigurationModel
             {


### PR DESCRIPTION
#### Details

While addressing some analyzer issues in Axe.Windows, I realized that the following methods (and their backing code) in https://github.com/microsoft/axe-windows/blob/main/src/Desktop/UIAutomation/DesktopElementHelper.cs are not used anywhere in Axe.Windows, and should be migrated into AIWin:

`SetCorePropertiesList`
`GetCorePropertiesList`
`GetDefaultCoreProperties`

After talking with @jalkire, we've chosen the following plan of action:
1. Give AIWin its own implementation of this functionality (this PR)
2. Remove the code from Axe.Windows (https://github.com/microsoft/axe-windows/pull/550). 

I've tested the changes locally and we seem to have parity with the old code, including resetting to the default set of properties if the user happens to remove all properties from the config (it may be a separate conversation whether or not that behavior is correct)

##### Motivation

Improve code cohesion (and will help to address CA1024 warnings in Axe.Windows)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



