### PR TITLE
fix: Correct dark mode checkbox in find text dialog

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml
@@ -81,7 +81,6 @@
                       AutomationProperties.Name="{x:Static Properties:Resources.chbIgnoreCaseAutomationPropertiesName}"
                       Margin="10,0,0,0"
                       VerticalAlignment="Center"
-                      Style="{StaticResource CheckBoxContastingBorder}"
                       Style="{StaticResource CheckBoxNoDarkThemeContastingBorder}"
                       Content="{x:Static Properties:Resources.chbIgnoreCaseAutomationPropertiesName}"/>
             <StackPanel Orientation="Horizontal"

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml
@@ -82,6 +82,7 @@
                       Margin="10,0,0,0"
                       VerticalAlignment="Center"
                       Style="{StaticResource CheckBoxContastingBorder}"
+                      Style="{StaticResource CheckBoxNoDarkThemeContastingBorder}"
                       Content="{x:Static Properties:Resources.chbIgnoreCaseAutomationPropertiesName}"/>
             <StackPanel Orientation="Horizontal"
                         Grid.Column="1"

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml
@@ -81,7 +81,7 @@
                       AutomationProperties.Name="{x:Static Properties:Resources.chbIgnoreCaseAutomationPropertiesName}"
                       Margin="10,0,0,0"
                       VerticalAlignment="Center"
-                      Style="{StaticResource CheckBoxNoDarkThemeContastingBorder}"
+                      Style="{StaticResource CheckBoxNoDarkThemeContrastingBorder}"
                       Content="{x:Static Properties:Resources.chbIgnoreCaseAutomationPropertiesName}"/>
             <StackPanel Orientation="Horizontal"
                         Grid.Column="1"

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -123,4 +123,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="ColorChooserBorderBrush" Color="#6D767E"/> <!-- Border around color chooser (combobox + edit) -->
     <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverBGBrush" Color="#BEE6FD"/>  <!-- Background of combobox toggle on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverFGBrush" Color="#000000"/>  <!-- Foreground or combobox toggle on mouse hover -->
+    <SolidColorBrush po:Freeze="True" x:Key="NoDarkThemeContrastingFGBrush" Color="#000000"/>  <!-- Contrasting foreground for screens with no Dark Mode theme -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -108,4 +108,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="ColorChooserBorderBrush" Color="{x:Static SystemColors.WindowTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="NoDarkThemeContrastingFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -123,4 +123,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="ColorChooserBorderBrush" Color="#949494"/>
     <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverBGBrush" Color="#BEE6FD"/>
     <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverFGBrush" Color="#000000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="NoDarkThemeContrastingFGBrush" Color="#000000"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1203,6 +1203,9 @@
     <Style TargetType="{x:Type CheckBox}" x:Key="CheckBoxContastingBorder">
         <Setter Property="BorderBrush" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
     </Style>
+    <Style TargetType="{x:Type CheckBox}" x:Key="CheckBoxNoDarkThemeContastingBorder">
+        <Setter Property="BorderBrush" Value="{DynamicResource ResourceKey=NoDarkThemeContrastingFGBrush}"/>
+    </Style>
     <Style TargetType="{x:Type CheckBox}" x:Key="CkbxRightSide" BasedOn="{StaticResource CheckBoxContastingBorder}">
         <Setter Property="FontSize" Value="14"/>
     </Style>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1203,7 +1203,7 @@
     <Style TargetType="{x:Type CheckBox}" x:Key="CheckBoxContastingBorder">
         <Setter Property="BorderBrush" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
     </Style>
-    <Style TargetType="{x:Type CheckBox}" x:Key="CheckBoxNoDarkThemeContastingBorder">
+    <Style TargetType="{x:Type CheckBox}" x:Key="CheckBoxNoDarkThemeContrastingBorder">
         <Setter Property="BorderBrush" Value="{DynamicResource ResourceKey=NoDarkThemeContrastingFGBrush}"/>
     </Style>
     <Style TargetType="{x:Type CheckBox}" x:Key="CkbxRightSide" BasedOn="{StaticResource CheckBoxContastingBorder}">


### PR DESCRIPTION
#### Details

In #1085, the "Ignore case" checkbox in the Find Text dialog has a disappearing border due to overtheming because this dialog has no dark mode theme. This PR creates and uses a brush that is fully themed in HC modes, but retains the light mode border color in dark mode.

Tested Light mode and HC modes to confirm that they're not modified. Here are the screenshots in Dark mode:

State | Image
--- | ---
Unchecked without hover | ![image](https://user-images.githubusercontent.com/45672944/111709734-6bd0eb80-8805-11eb-93d6-d93e0d447237.png)
Unchecked with hover | ![image](https://user-images.githubusercontent.com/45672944/111709828-a5095b80-8805-11eb-9b6e-3527901da81d.png)
Checked with hover | ![image](https://user-images.githubusercontent.com/45672944/111709763-80ad7f00-8805-11eb-92bd-37b32532d86b.png)
Checked without hover | ![image](https://user-images.githubusercontent.com/45672944/111709807-9ae75d00-8805-11eb-938e-9729dd83f50b.png)


##### Motivation

Correct visuals are important

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #1085
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



