### PR TITLE
chore: mention that ruleset bugs go to axe.windows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,9 +6,9 @@ labels: bug, needs triage
 assignees: ''
 
 ---
-If the bug is about the ruleset, consider filing this issue at [axe-windows](https://github.com/microsoft/axe-windows/issues/new/choose) instead.
-
 Please check whether the bug has [already been filed](https://github.com/Microsoft/accessibility-insights-windows/issues).
+
+This repo contains code for Accessibility Insights for Windows. We maintain code for its automated checks rule engine at [axe-windows](https://github.com/microsoft/axe-windows/issues/). Most false positive questions or rule clarifications belong in [axe-windows](https://github.com/microsoft/axe-windows/issues/new/choose), whereas questions about the Accessibility Insights tool UI should go here. If you aren't sure, it's definitely OK to use this repo. Thanks for contributing!
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,8 @@ labels: bug, needs triage
 assignees: ''
 
 ---
+If the bug is about the ruleset, consider filing this issue at [axe-windows](https://github.com/microsoft/axe-windows/issues/new/choose) instead.
+
 Please check whether the bug has [already been filed](https://github.com/Microsoft/accessibility-insights-windows/issues).
 
 **Describe the bug**


### PR DESCRIPTION
#### Details

Often we need to transfer issue reports from AI-Windows to Axe.Windows because the questions are rule-related. This updates the issue template to encourage ruleset questions should go to Axe.Windows.
