### PR TITLE
chore: Improve UIFramework identifiers documentation (telemetry)

### DIFF
--- a/docs/TelemetryDetails.md
+++ b/docs/TelemetryDetails.md
@@ -318,7 +318,7 @@ This table includes only officially published builds. The data in table may also
 These values identify the UI framework used to create the application being evaluated. These values come from 2 sources--some are recognized and reported by Axe.Windows; others are dynamically reported by application frameworks:
 
 ###### Values reported by Axe.Windows
-The following values (sorted alphabetically) are returned from Axe.Windows:
+The following values (sorted alphabetically) are reported by Axe.Windows:
 Value | Framework
 --- | ---
 `InternetExplorer` | Microsoft Internet Explorer

--- a/docs/TelemetryDetails.md
+++ b/docs/TelemetryDetails.md
@@ -315,32 +315,25 @@ Value | OS Version
 This table includes only officially published builds. The data in table may also include builds that were not officially published, such as insider or preview builds.
 
 ##### UIFramework identifiers
-These values identify the UI framework used to create the application being evaluated. These values come from 2 sources--some are recognized and reported by Axe.Windows; others are dynamically reported by application frameworks:
+These identifiers are provided by UI frameworks and allow assistive technologies to provide framework-specific behaviors. This table reports the values (sorted alphabetically) that have appeared in telemetry, and their corresponding UI frameworks:
 
-###### Values reported by Axe.Windows
-The following values (sorted alphabetically) are reported by Axe.Windows:
-Value | Framework
---- | ---
-`DirectUI` | DirectUI framework (C++)
-`InternetExplorer` | Microsoft Internet Explorer
-`MicrosoftEdge` | Microsoft Edge (non-Chromium version)
-`Win32` | Generic Win32 apps (multiple languages)
-`WinForm` | Windows Forms (.NET)
-`WPF` | Windows Presentation Framework (.NET)
-`XAML` | Universal Windows Platform (.NET)
-
-###### Values reported by application frameworks
-The following framework values (sorted alphabetically) have also been observed:
 Value | Framework
 --- | ---
 `Avalonia` | Avalonia framework (.NET)
 `Chrome` | Chromium (C++, includes Google Chrome and newer versions of Microsoft Edge)
+`DirectUI` | DirectUI framework (C++)
 `Gecko` | Gecko browser engine (C++, used in FireFox and Thunderbird)
+`InternetExplorer` | Microsoft Internet Explorer
 `JUCE` | Juce framework (C++)
+`MicrosoftEdge` | Microsoft Edge (non-Chromium version)
 `nexacro` | Nexacro platform (HTML5/JavaScript)
 `Qt` | Qt framework (multiple languages)
 `Silveright` | Silverlight (.NET)
 `SWT` | Standard Widgets Toolkit (Java)
+`Win32` | Generic Win32 apps (multiple languages)
+`WinForm` | Windows Forms (.NET)
+`WPF` | Windows Presentation Framework (.NET)
+`XAML` | Universal Windows Platform (.NET)
 
 ### Sample Queries
 Queries are written using the [Kusto Query Language](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/). Here are some sample queries:

--- a/docs/TelemetryDetails.md
+++ b/docs/TelemetryDetails.md
@@ -315,29 +315,32 @@ Value | OS Version
 This table includes only officially published builds. The data in table may also include builds that were not officially published, such as insider or preview builds.
 
 ##### UIFramework identifiers
-These values identify the UI framework used to create the application being evaluated. These values come from 2 sources--some are from Axe.Windows, and others are dynamically reported by application frameworks:
+These values identify the UI framework used to create the application being evaluated. These values come from 2 sources--some are reported from Axe.Windows, and others are dynamically reported by application frameworks:
 
-###### Values from Axe.Windows
-These values are returned from Axe.Windows:
+###### Values reported by Axe.Windows
+The following values (sorted alphabetically) are returned from Axe.Windows:
 Value | Framework
 --- | ---
+`InternetExplorer` | Microsoft Internet Explorer
 `MicrosoftEdge` | Microsoft Edge (non-Chromium version)
-`InternetExplorer` | Internet Explorer
-`WPF` | WPF Apps
-`WinForm` | Windows Forms Apps
-`Win32` | Win32 apps
-`XAML` | UWP apps
+`Win32` | Generic Win32 apps (multiple languages)
+`WinForm` | Windows Forms (.NET)
+`WPF` | Windows Presentation Framework (.NET)
+`XAML` | Universal Windows Platform (.NET)
 
-###### Values from application frameworks
-The following framework values have also been observed:
+###### Values reported by application frameworks
+The following framework values (sorted alphabetically) have also been observed:
 Value | Framework
 --- | ---
-`Chrome` | Chromium (includes Google Chrome and newer versions of Microsoft Edge)
-`DirectUI` | DirectUI apps
-`Gecko` | Undetermined
-`Qt` | Undetermined
-`SWT` | Undetermined
-`Avalonia` | Undetermined
+`Avalonia` | Avalonia framework (.NET)
+`Chrome` | Chromium (C++, includes Google Chrome and newer versions of Microsoft Edge)
+`DirectUI` | DirectUI framework (C++)
+`Gecko` | Gecko browser engine (C++, used in FireFox and Thunderbird)
+`JUCE` | Juce framework (C++)
+`nexacro` | Nexacro platform (HTML5/JavaScript)
+`Qt` | Qt framework (multiple languages)
+`Silveright` | Silverlight (.NET)
+`SWT` | Standard Widgets Toolkit (Java)
 
 ### Sample Queries
 Queries are written using the [Kusto Query Language](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/). Here are some sample queries:
@@ -404,4 +407,14 @@ exceptions
 | summarize count(problemId) by problemId
 | sort by count_problemId desc
 | take 10
+```
+#### What UI frameworks have been scanned in the last 30 days, in descending order of count?
+```
+customEvents 
+| where timestamp >= ago(30d)
+| where name == 'Scan_Statistics'
+| extend framework = tostring(customDimensions.UIFramework)
+| where framework != ''
+| summarize count() by framework
+| sort by count_ desc
 ```

--- a/docs/TelemetryDetails.md
+++ b/docs/TelemetryDetails.md
@@ -321,6 +321,7 @@ These values identify the UI framework used to create the application being eval
 The following values (sorted alphabetically) are reported by Axe.Windows:
 Value | Framework
 --- | ---
+`DirectUI` | DirectUI framework (C++)
 `InternetExplorer` | Microsoft Internet Explorer
 `MicrosoftEdge` | Microsoft Edge (non-Chromium version)
 `Win32` | Generic Win32 apps (multiple languages)
@@ -334,7 +335,6 @@ Value | Framework
 --- | ---
 `Avalonia` | Avalonia framework (.NET)
 `Chrome` | Chromium (C++, includes Google Chrome and newer versions of Microsoft Edge)
-`DirectUI` | DirectUI framework (C++)
 `Gecko` | Gecko browser engine (C++, used in FireFox and Thunderbird)
 `JUCE` | Juce framework (C++)
 `nexacro` | Nexacro platform (HTML5/JavaScript)

--- a/docs/TelemetryDetails.md
+++ b/docs/TelemetryDetails.md
@@ -315,7 +315,7 @@ Value | OS Version
 This table includes only officially published builds. The data in table may also include builds that were not officially published, such as insider or preview builds.
 
 ##### UIFramework identifiers
-These values identify the UI framework used to create the application being evaluated. These values come from 2 sources--some are reported from Axe.Windows, and others are dynamically reported by application frameworks:
+These values identify the UI framework used to create the application being evaluated. These values come from 2 sources--some are recognized and reported by Axe.Windows; others are dynamically reported by application frameworks:
 
 ###### Values reported by Axe.Windows
 The following values (sorted alphabetically) are returned from Axe.Windows:


### PR DESCRIPTION
#### Details

Add some more details to the docs about UIFramework identifiers, based on what's actually in the pipeline. This replaces several places where the previous version just said "Undetermined"

##### Motivation

Desire to have complete docs

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



