### PR TITLE
chore: Sort using blocks (done by a tool)

### DIFF
--- a/src/AccessibilityInsights.CommonUxComponents/Controls/DualFabricIconControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/DualFabricIconControl.xaml.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Windows.Controls;
 using System.Windows;
-using System.Windows.Media;
 using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace AccessibilityInsights.CommonUxComponents.Controls
 {

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/IssueInformationHelpers.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/IssueInformationHelpers.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
 using AccessibilityInsights.Extensions.AzureDevOps.Enums;
+using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/AccessibilityInsights.Extensions.AzureDevOpsTests/FileIssue/FileIssueHelpersTests.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOpsTests/FileIssue/FileIssueHelpersTests.cs
@@ -5,8 +5,8 @@ using AccessibilityInsights.Extensions.AzureDevOps.Enums;
 using AccessibilityInsights.Extensions.AzureDevOps.FileIssue;
 using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using Moq;
+using System;
 using System.Collections.Generic;
 
 namespace AccessibilityInsights.Extensions.AzureDevOpsTests.FileIssue

--- a/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using AccessibilityInsights.CommonUxComponents.Dialogs;
 using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
 using Newtonsoft.Json;
+using System;
 
 namespace AccessibilityInsights.Extensions.GitHub
 {

--- a/src/AccessibilityInsights.Extensions.GitHub/Properties/AssemblyInfo.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Resources;
 using System.Reflection;
+using System.Resources;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.CommonUxComponents.Dialogs;
 using AccessibilityInsights.SharedUx.Dialogs;
-using AccessibilityInsights.SharedUx.ViewModels;
 using AccessibilityInsights.SharedUx.Utilities;
+using AccessibilityInsights.SharedUx.ViewModels;
 using System;
 using System.Timers;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Controls;
 using System.Windows.Input;
-using AccessibilityInsights.CommonUxComponents.Dialogs;
 
 namespace AccessibilityInsights.SharedUx.ActionViews
 {

--- a/src/AccessibilityInsights.SharedUx/Controls/ColorPicker/ColorUtilities.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ColorPicker/ColorUtilities.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
-using System.Windows.Media;
 using System.Collections.Generic;
+using System.Windows.Media;
 
 namespace AccessibilityInsights.SharedUx.Controls.ColorPicker
 {

--- a/src/AccessibilityInsights.SharedUx/Controls/ColorPicker/SpectrumSlider.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ColorPicker/SpectrumSlider.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
+using System.Collections.Generic;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Shapes;
-using System.Windows.Controls;
-using System.Collections.Generic;
 
 namespace AccessibilityInsights.SharedUx.Controls.ColorPicker
 {

--- a/src/AccessibilityInsights.SharedUx/Controls/PrivacyLearnMore.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/PrivacyLearnMore.xaml.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Windows.Controls;
-using System.Windows.Navigation;
-using System;
-using System.Diagnostics;
+using AccessibilityInsights.CommonUxComponents.Dialogs;
 using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Telemetry;
+using System;
+using System.Diagnostics;
 using System.Globalization;
-using AccessibilityInsights.CommonUxComponents.Dialogs;
+using System.Windows.Controls;
+using System.Windows.Navigation;
 
 namespace AccessibilityInsights.SharedUx.Controls
 {

--- a/src/AccessibilityInsights.SharedUx/Converters/A11yPropertyConverter.cs
+++ b/src/AccessibilityInsights.SharedUx/Converters/A11yPropertyConverter.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Bases;
 using AccessibilityInsights.SharedUx.ViewModels;
+using Axe.Windows.Core.Bases;
 using System;
 using System.Globalization;
 using System.Windows.Data;

--- a/src/AccessibilityInsights.SharedUx/Converters/ActionViewModelConverter.cs
+++ b/src/AccessibilityInsights.SharedUx/Converters/ActionViewModelConverter.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Properties;
 using AccessibilityInsights.SharedUx.ViewModels;
 using System;
 using System.Globalization;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Markup;
-using AccessibilityInsights.SharedUx.Properties;
 
 namespace AccessibilityInsights.SharedUx.Converters
 {

--- a/src/AccessibilityInsights.SharedUx/Converters/CheckStateConverter.cs
+++ b/src/AccessibilityInsights.SharedUx/Converters/CheckStateConverter.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Properties;
 using System;
 using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Markup;
-using AccessibilityInsights.SharedUx.Properties;
 
 namespace AccessibilityInsights.SharedUx.Converters
 {

--- a/src/AccessibilityInsights.SharedUx/Converters/ColorStringConverter.cs
+++ b/src/AccessibilityInsights.SharedUx/Converters/ColorStringConverter.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Properties;
+using AccessibilityInsights.SharedUx.Telemetry;
 using System;
 using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Markup;
-using AccessibilityInsights.SharedUx.Properties;
-using AccessibilityInsights.SharedUx.Telemetry;
 
 namespace AccessibilityInsights.SharedUx.Converters
 {

--- a/src/AccessibilityInsights.SharedUx/Converters/ElementToSenderTextConverter.cs
+++ b/src/AccessibilityInsights.SharedUx/Converters/ElementToSenderTextConverter.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Properties;
 using Axe.Windows.Core.Bases;
 using System;
 using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Markup;
-using AccessibilityInsights.SharedUx.Properties;
 
 namespace AccessibilityInsights.SharedUx.Converters
 {

--- a/src/AccessibilityInsights.SharedUx/Dialogs/ControlPatternDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/ControlPatternDialog.xaml.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.ViewModels;
+using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Input;
-using AccessibilityInsights.SharedUx.ViewModels;
-using System.Globalization;
-using System;
 
 namespace AccessibilityInsights.SharedUx.Dialogs
 {

--- a/src/AccessibilityInsights.SharedUx/Dialogs/EventConfigDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/EventConfigDialog.xaml.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Desktop.Settings;
 using AccessibilityInsights.SharedUx.Settings;
+using Axe.Windows.Desktop.Settings;
 using System.Linq;
 using System.Windows;
 

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Desktop.UIAutomation.Patterns;
+using AccessibilityInsights.CommonUxComponents.Dialogs;
 using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.SharedUx.ViewModels;
+using Axe.Windows.Desktop.UIAutomation.Patterns;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
-using System.Globalization;
-using AccessibilityInsights.CommonUxComponents.Dialogs;
 
 namespace AccessibilityInsights.SharedUx.Dialogs
 {

--- a/src/AccessibilityInsights.SharedUx/Settings/RecorderSetting.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/RecorderSetting.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Desktop.Types;
 using Axe.Windows.Core.Types;
+using Axe.Windows.Desktop.Types;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/AccessibilityInsights.SharedUx/ViewModels/BaseActionViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/BaseActionViewModel.cs
@@ -1,19 +1,19 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Bases;
+using AccessibilityInsights.CommonUxComponents.Dialogs;
+using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Telemetry;
+using Axe.Windows.Actions;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Enums;
 using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Desktop.UIAutomation.Patterns;
-using AccessibilityInsights.SharedUx.Dialogs;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Input;
-using Axe.Windows.Actions;
-using Axe.Windows.Core.Enums;
-using System.Globalization;
-using AccessibilityInsights.CommonUxComponents.Dialogs;
 
 namespace AccessibilityInsights.SharedUx.ViewModels
 {

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Bases;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using Axe.Windows.Core.Types;
-using Axe.Windows.Desktop.Types;
-using AccessibilityInsights.SharedUx.Settings;
 using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.SharedUx.Properties;
+using AccessibilityInsights.SharedUx.Settings;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Core.Types;
+using Axe.Windows.Desktop.Types;
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
 using System.Windows.Input.StylusPlugIns;
 
 namespace AccessibilityInsights.SharedUx.ViewModels

--- a/src/AccessibilityInsights.SharedUx/ViewModels/GeneralActionViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/GeneralActionViewModel.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Reflection;
-using Axe.Windows.Core.Bases;
 using AccessibilityInsights.SharedUx.ActionViews;
+using Axe.Windows.Core.Bases;
+using System.Reflection;
 
 namespace AccessibilityInsights.SharedUx.ViewModels
 {

--- a/src/AccessibilityInsights.SharedUx/ViewModels/HierarchyNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/HierarchyNodeViewModel.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
+using AccessibilityInsights.SharedUx.Properties;
+using AccessibilityInsights.SharedUx.Utilities;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Results;
 using Axe.Windows.Core.Types;
-using AccessibilityInsights.SharedUx.Properties;
-using AccessibilityInsights.SharedUx.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/AccessibilityInsights.SharedUx/ViewModels/NotSupportedActionViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/NotSupportedActionViewModel.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Core.Bases;
 using AccessibilityInsights.SharedUx.ActionViews;
+using Axe.Windows.Core.Bases;
 using System.Reflection;
 
 namespace AccessibilityInsights.SharedUx.ViewModels

--- a/src/AccessibilityInsights.SharedUx/ViewModels/PatternViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/PatternViewModel.cs
@@ -1,19 +1,19 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Dialogs;
+using AccessibilityInsights.SharedUx.Interfaces;
+using AccessibilityInsights.SharedUx.Properties;
 using Axe.Windows.Core.Attributes;
 using Axe.Windows.Core.Bases;
-using AccessibilityInsights.SharedUx.Dialogs;
+using Axe.Windows.Core.Misc;
+using Axe.Windows.Core.Types;
+using Axe.Windows.Desktop.UIAutomation.Patterns;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Input;
-using Axe.Windows.Core.Types;
-using Axe.Windows.Desktop.UIAutomation.Patterns;
-using Axe.Windows.Core.Misc;
-using AccessibilityInsights.SharedUx.Interfaces;
-using AccessibilityInsights.SharedUx.Properties;
-using System;
 
 namespace AccessibilityInsights.SharedUx.ViewModels
 {

--- a/src/AccessibilityInsights.SharedUx/ViewModels/ReturnA11yElementsViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/ReturnA11yElementsViewModel.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.ActionViews;
+using Axe.Windows.Core.Bases;
+using Axe.Windows.Desktop.UIAutomation;
 using System.Collections.Generic;
 using System.Reflection;
-using Axe.Windows.Core.Bases;
-using AccessibilityInsights.SharedUx.ActionViews;
-using Axe.Windows.Desktop.UIAutomation;
 
 namespace AccessibilityInsights.SharedUx.ViewModels
 {

--- a/src/AccessibilityInsights.SharedUx/ViewModels/RuleResultViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/RuleResultViewModel.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
+using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
+using AccessibilityInsights.SharedUx.Utilities;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Results;
 using Axe.Windows.Desktop.Utility;
-using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
-using AccessibilityInsights.SharedUx.Utilities;
 using System;
 using System.Globalization;
 using System.Linq;

--- a/src/AccessibilityInsights.SharedUx/ViewModels/ScanListViewItemViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/ScanListViewItemViewModel.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
+using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
+using AccessibilityInsights.SharedUx.Properties;
+using AccessibilityInsights.SharedUx.Utilities;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.HelpLinks;
 using Axe.Windows.Core.Misc;
 using Axe.Windows.Core.Results;
 using Axe.Windows.Desktop.Utility;
-using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
-using AccessibilityInsights.SharedUx.Properties;
-using AccessibilityInsights.SharedUx.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/AccessibilityInsights.SharedUx/ViewModels/TextAttributeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/TextAttributeViewModel.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Axe.Windows.Desktop.UIAutomation;
 using AccessibilityInsights.SharedUx.Dialogs;
+using Axe.Windows.Desktop.Types;
+using Axe.Windows.Desktop.UIAutomation;
+using System;
 using System.Windows;
 using System.Windows.Input;
-using Axe.Windows.Desktop.Types;
-using System;
 
 namespace AccessibilityInsights.SharedUx.ViewModels
 {

--- a/src/AccessibilityInsights.SharedUx/ViewModels/TextRangeActionViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/TextRangeActionViewModel.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Reflection;
-using Axe.Windows.Core.Bases;
 using AccessibilityInsights.SharedUx.ActionViews;
+using Axe.Windows.Core.Bases;
+using System.Reflection;
 
 namespace AccessibilityInsights.SharedUx.ViewModels
 {

--- a/src/AccessibilityInsights.SharedUx/ViewModels/TextRangeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/TextRangeViewModel.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Properties;
 using Axe.Windows.Desktop.Styles;
 using Axe.Windows.Desktop.Types;
 using Axe.Windows.Desktop.UIAutomation;
@@ -7,12 +8,11 @@ using Axe.Windows.Desktop.UIAutomation.Patterns;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows;
 using UIAutomationClient;
-using System.Text.RegularExpressions;
-using System.Globalization;
-using AccessibilityInsights.SharedUx.Properties;
 using static System.FormattableString;
 
 namespace AccessibilityInsights.SharedUx.ViewModels

--- a/src/AccessibilityInsights.SharedUxTests/Converters/BoolToVisibilityConverterTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Converters/BoolToVisibilityConverterTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using System.Windows;
 using AccessibilityInsights.SharedUx.Converters;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Windows;
 
 namespace AccessibilityInsights.SharedUxTests.Converters
 {

--- a/src/AccessibilityInsights.SharedUxTests/FileIssue/FileIssueActionTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/FileIssue/FileIssueActionTests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
 using AccessibilityInsights.SharedUx.FileIssue;
+using AccessibilityInsights.SharedUx.Telemetry;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;

--- a/src/AccessibilityInsights.SharedUxTests/Settings/LayoutTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/LayoutTests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Settings;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Windows;
-using AccessibilityInsights.SharedUx.Settings;
 
 namespace AccessibilityInsights.SharedUxTests.Tests
 {

--- a/src/AccessibilityInsights.SharedUxTests/Telemetry/LoggerUnitTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Telemetry/LoggerUnitTests.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.Telemetry;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using System;
 using System.Collections.Generic;
-using Moq;
 
 using TelemetryPropertyBag = System.Collections.Generic.IReadOnlyDictionary<AccessibilityInsights.SharedUx.Telemetry.TelemetryProperty, string>;
 using StringPropertyBag = System.Collections.Generic.IReadOnlyDictionary<string, string>;

--- a/src/AccessibilityInsights.SharedUxTests/ViewModels/ColorContrastViewModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/ViewModels/ColorContrastViewModelTests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using AccessibilityInsights.SharedUx.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Windows.Media;
 
 namespace AccessibilityInsights.SharedUxTest.ViewModels

--- a/src/AccessibilityInsights.SharedUxTests/ViewModels/ViewModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/ViewModels/ViewModelTests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.ViewModels;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Results;
-using AccessibilityInsights.SharedUx.ViewModels;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using System.Collections.Generic;

--- a/src/AccessibilityInsights/MainWindowHelpers/InspectMode.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/InspectMode.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Enums;
 using AccessibilityInsights.Misc;
+using AccessibilityInsights.SharedUx.Highlighting;
 using Axe.Windows.Actions;
 using Axe.Windows.Actions.Enums;
-using AccessibilityInsights.SharedUx.Highlighting;
 
 namespace AccessibilityInsights
 {

--- a/src/AccessibilityInsights/MainWindowHelpers/TelemetryStartup.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/TelemetryStartup.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Windows;
 using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Settings;
+using System.Windows;
 
 namespace AccessibilityInsights
 {

--- a/src/AccessibilityInsights/MainWindowHelpers/TestMode.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/TestMode.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.CommonUxComponents.Dialogs;
 using AccessibilityInsights.Enums;
 using AccessibilityInsights.Misc;
+using AccessibilityInsights.SharedUx.Dialogs;
+using AccessibilityInsights.SharedUx.Highlighting;
+using AccessibilityInsights.SharedUx.Telemetry;
 using Axe.Windows.Actions;
 using Axe.Windows.Desktop.Settings;
-using AccessibilityInsights.SharedUx.Telemetry;
-using AccessibilityInsights.SharedUx.Dialogs;
 using System;
 using System.Globalization;
-using AccessibilityInsights.SharedUx.Highlighting;
-using AccessibilityInsights.CommonUxComponents.Dialogs;
 
 namespace AccessibilityInsights
 {

--- a/src/AccessibilityInsights/MainWindowHelpers/Timers.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Timers.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Enums;
+using AccessibilityInsights.SharedUx.Telemetry;
 using Axe.Windows.Actions;
 using Axe.Windows.Core.Misc;
-using AccessibilityInsights.SharedUx.Telemetry;
 using System.Globalization;
 using System.Timers;
 using System.Windows;


### PR DESCRIPTION
#### Details

Our using blocks have been left in a disarray after multiple renames that have occurred over the last year or two. This PR sorts the using blocks. It was done via a tool. Three files that didn't previously end with a newline now have the newline--I left them that way since those files were outliers and normalizing them would make future tool-driven changes simpler.

##### Motivation

Code hygiene

##### Context

This PR does not remove unneeded using blocks. VS is smart enough to handle this, but the tool that I created isn't.

Also, this makes no attempt to sort `using static` blocks or `using` blocks that are used as aliases.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



