### PR TITLE
fix: Use "milliseconds" instead of "ms" for label of mouse hover delay

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
@@ -171,7 +171,7 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="135"/>
                     <ColumnDefinition Width="50"/>
-                    <ColumnDefinition Width="140"/>
+                    <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <controls:FabricIconControl Grid.Column="0" Height="16" Width="16" GlyphName="F12DevTools" GlyphSize="Default" Foreground="{DynamicResource ResourceKey=IconBrush}" AutomationProperties.Name="{x:Static Properties:Resources.ApplicationSettingsControl_MouseIconAutomationName}" ShowInControlView="False"/>
                 <Label Name="lblMouseLabel" Grid.Column="1" Margin="8,0,0,0" Content="{x:Static Properties:Resources.lblMouseLabelContent}"  RenderTransformOrigin="0.877,0.538" Padding="0" Style="{StaticResource LblText}" VerticalAlignment="Center"/>
@@ -180,7 +180,7 @@
                     <Label Name="lblDelay" Margin="0,5,0,0" Content="{x:Static Properties:Resources.lblDelayContent}" Padding="0" Style="{StaticResource LblText}" Target="{Binding ElementName=tbMouseDelay}"/>
                     <TextBox Name="tbMouseDelay" Height="26" Width="38" Margin="5,0,5,0" PreviewTextInput="textboxMouseDelay_PreviewTextInput" MaxLines="1" MaxLength="4" 
                      VerticalContentAlignment="Center" HorizontalContentAlignment="Right" Style="{StaticResource TxtBxText}" AutomationProperties.Name="{x:Static Properties:Resources.tbMouseDelayAutomationName}" TextChanged="tbMouseDelay_TextChanged"/>
-                    <Label Content="ms" Margin="0,5,0,0" Padding="0" Style="{StaticResource LblText}"/>
+                    <Label Content="milliseconds" Margin="0,5,0,0" Padding="0" Style="{StaticResource LblText}"/>
                 </StackPanel>
             </Grid>
         </Grid>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3739,7 +3739,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Set delay in MS.
+        ///   Looks up a localized string similar to Set delay in milliseconds.
         /// </summary>
         public static string tbMouseDelayAutomationName {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -292,7 +292,7 @@
     <value>Set _delay</value>
   </data>
   <data name="tbMouseDelayAutomationName" xml:space="preserve">
-    <value>Set delay in MS</value>
+    <value>Set delay in milliseconds</value>
   </data>
   <data name="LabelContentOtherOptions" xml:space="preserve">
     <value>Other options</value>


### PR DESCRIPTION
#### Details

In a recent accessibility pass, it was pointed out that our accessible name on a label could be improved. Upon further review, we concluded that the display name could also be improved.

Old/New | Visual | NVDA
--- | --- | ---
Old | ![image](https://user-images.githubusercontent.com/45672944/117069681-a45b5480-ace1-11eb-8c89-12b223f389f1.png) | Set delay in MS edit 100
New | ![image](https://user-images.githubusercontent.com/45672944/117069838-d4a2f300-ace1-11eb-9cfd-77be434aa69c.png) | Set delay in milliseconds edit 100



##### Motivation

Address https://mseng.visualstudio.com/1ES/_workitems/edit/1750054

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - https://mseng.visualstudio.com/1ES/_workitems/edit/1750054
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



