### PR TITLE
chore: release 1.1.1562.02 to insider (validating release promotion pipeline, no behavior changes)

### DIFF
--- a/Channels/Insider/release_info.json
+++ b/Channels/Insider/release_info.json
@@ -1,8 +1,8 @@
 {
   "default": {
-    "current_version": "1.1.1562.01",
-    "minimum_version": "1.1.1562.01",
-    "installer_url": "https://www.github.com/Microsoft/accessibility-insights-windows/releases/download/v1.1.1562.01/AccessibilityInsights.msi",
-    "release_notes_url": "https://www.github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.1562.01"
+    "current_version": "1.1.1562.02",
+    "minimum_version": "1.1.1562.02",
+    "installer_url": "https://www.github.com/Microsoft/accessibility-insights-windows/releases/download/v1.1.1562.02/AccessibilityInsights.msi",
+    "release_notes_url": "https://www.github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.1562.02"
   }
 }

--- a/Channels/Insider/release_notes.md
+++ b/Channels/Insider/release_notes.md
@@ -1,27 +1,3 @@
-## April 12, 2021 Insider Release ([v1.1.1562.01](https://github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.1562.01))
+## May 17, 2021 Insider Release ([v1.1.1562.02](https://github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.1562.02))
 
-Welcome to the April 12, 2021 Insider release of Accessibility Insights for Windows.
-
-Installation Link: https://github.com/microsoft/accessibility-insights-windows/releases/download/v1.1.1562.01/AccessibilityInsights.msi
-
-Documentation Link: https://accessibilityinsights.io/docs/en/windows/overview
-
-### Highlights
-
-- [Rule Updates](#rule-updates)
-- [Bug Fixes](#bug-fixes)
-
-#### Rule Updates
-
-- Add the `FrameworkDoesNotSupportUIAutomation` rule to report failures on frameworks that are known to not support UI AUtomation [#554](https://github.com/microsoft/axe-windows/issues/554)
-- Remove the `ControlShouldNotSupportTablePattern` rule as it wasn't generally useful [#566](https://github.com/microsoft/axe-windows/issues/566)
-- Remove false positives in the `BoundingRectangleCompletelyObscuresContainer` rule [#540](https://github.com/microsoft/axe-windows/issues/540)
-- Remove false positives in the `NameIsNotNull` rule [#556](https://github.com/microsoft/axe-windows/issues/556)
-
-#### Bug Fixes
-
-- Remove user configuration files when uninstalling the application [#1007](https://github.com/microsoft/accessibility-insights-windows/issues/1007)
-- Reduce memory overhead when using the eyedropper control in the Color Contrast Analyzer [#1033](https://github.com/microsoft/accessibility-insights-windows/pull/1033)
-- Improve discoverability of the help link in the TabStops instructions [#1052](https://github.com/microsoft/accessibility-insights-windows/pull/1052)
-- Set the automation names on headers in the properties grid [#1072](https://github.com/microsoft/accessibility-insights-windows/pull/1072)
-- Correct a color contrast issue in the Text Range find text dialog [#1086](https://github.com/microsoft/accessibility-insights-windows/pull/1086)
+This is a re-release of https://www.github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.1562.01 to validate some pipeline changes. No behavior was added.

--- a/ReadME.md
+++ b/ReadME.md
@@ -1,5 +1,5 @@
 # Control Branch
 
-**DO NOT MERGE THIS BRANCH TO OR FROM MASTER!**
+**DO NOT MERGE THIS BRANCH TO OR FROM MAIN!**
 
 This branch contains only the information used to control client behavior, and ***intentionally*** contains no code.


### PR DESCRIPTION
#### Details

Release 1.1.1562.02 to insider, which has identical behavior to https://github.com/Microsoft/accessibility-insights-windows/releases/tag/v1.1.1562.01

##### Motivation

We made some changes to the release promotion pipeline and would like to validate it. Pushing to insider since it's mainly for just our team. We don't intend to promote to production afterwards.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



