### PR TITLE
fix: ensure Tooltip stays up to date with highlighted element

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
@@ -102,7 +102,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
                 }
             }
 
-            this.Highlighter.IsVisible = visible;
+            this.Highlighter.IsVisible = this.IsEnabled && visible;
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
@@ -75,7 +75,9 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// <param name="el"></param>
         public void SetElement(A11yElement el)
         {
+#pragma warning disable CA1062 // Validate arguments of public methods
             SetElementInternal(el);
+#pragma warning restore CA1062 // Validate arguments of public methods
         }
 
         /// <summary>
@@ -84,7 +86,8 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// <param name="element"></param>
         void SetElementInternal(A11yElement element)
         {
-            if (element != null && !element.BoundingRectangle.IsEmpty)
+            bool visible = element != null && !element.BoundingRectangle.IsEmpty;
+            if (visible)
             {
                 if (this.BoundingRectangle == null || element.BoundingRectangle.Equals(this.BoundingRectangle) == false)
                 {
@@ -94,15 +97,12 @@ namespace AccessibilityInsights.SharedUx.Highlighting
 
                 if (this.IsEnabled)
                 {
-                    this.Highlighter.IsVisible = true;
                     var text = GetHighlightText(element);
                     this.Highlighter.SetText(text);
                 }
             }
-            else
-            {
-                this.Highlighter.IsVisible = false;
-            }
+
+            this.Highlighter.IsVisible = visible;
         }
 
         /// <summary>


### PR DESCRIPTION
#### Details

This PR fixes stale tooltip updates described in 1123.

It also suppresses an instance of CA1062 after the refactor - I think the warning is a false positive because `element != null && !element.BoundingRectangle.IsEmpty;` should short-circuit if `element` is null. Let me know if I'm mistaken or there's a better way to match with the rule.

##### Motivation

addresses #1123 

##### Context

This fix works because we move the `IsVisible` setter after `Highlighter.SetText`.

The issue in 1123 occurs because:
- The TextTip text is drawn when [`WndProc`](https://github.com/microsoft/accessibility-insights-windows/blob/main/src/AccessibilityInsights.SharedUx/Highlighting/TextTip.cs#L364) is triggered with `WM_ERASEBKGND`
- `WndProc` is triggered if we explicitly call [`InvalidateRect`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-invalidaterect) via [`Update`](https://github.com/microsoft/accessibility-insights-windows/blob/effa0a9d0958e5188877dc5e2c5f183043fc9ced/src/AccessibilityInsights.SharedUx/Highlighting/TextTip.cs#L159), or if it's [raised implicitly due to window resize](https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-erasebkgnd)
- The `Highlighter.IsVisible` setter explicitly calls `Update` via [`LoadHighlighterMode`](https://github.com/microsoft/accessibility-insights-windows/blob/effa0a9d0958e5188877dc5e2c5f183043fc9ced/src/AccessibilityInsights.SharedUx/Highlighting/Highlighter.cs#L68).
- However, in `main`, `Highlighter.IsVisible` is set *before* `Highlighter.SetText` is called. This is problematic when the tooltip size stays constant, because [`SetWindowPos`](https://github.com/microsoft/accessibility-insights-windows/blob/effa0a9d0958e5188877dc5e2c5f183043fc9ced/src/AccessibilityInsights.SharedUx/Highlighting/TextTip.cs#L226) then won't trigger `WndProc` implicitly with `WM_ERASEBKGND` after the text change.
- The text 'lags one behind' because `Highlighter.SetText` is called at the end of [`SetElementInternal`](https://github.com/microsoft/accessibility-insights-windows/blob/effa0a9d0958e5188877dc5e2c5f183043fc9ced/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs#L85). The explicit `Update` call occurs the next time around.

We fix this by moving `Highlighter.IsVisible = true` to the end, after all rectangle & text changes. Then these changes are reflected in `LoadHighlighterMode` > `Update`.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 1123
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



