### PR TITLE
feat(compliance-may21): move text/content strings to resources files

### DIFF
--- a/src/AccessibilityInsights.SharedUx/ActionViews/GeneralActionView.xaml
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/GeneralActionView.xaml
@@ -70,7 +70,7 @@
             <Label x:Name="lbDelay" Grid.Column="0" VerticalAlignment="Center" Content="{x:Static properties:Resources.lbDelayContent}"/>
             <TextBox x:Name="tbDelay" Grid.Column="1"
                      Margin="5" AutomationProperties.LabeledBy="{Binding ElementName=lbDelay}"
-                     Text="{x:Static properties:Resources.Delay_In_Seconds_Default}" PreviewTextInput="tbDelay_PreviewTextInput"/>
+                     Text="{x:Static properties:Resources.ActionsDefaultDelayInSeconds}" PreviewTextInput="tbDelay_PreviewTextInput"/>
             <Button x:Name="btnAction" Grid.Column="2" Width="70" Content="{x:Static properties:Resources.btnActionContent}"
                     AutomationProperties.Name="{x:Static properties:Resources.btnActionAutomationPropertiesName}" Click="Button_Click"
                     Margin="5"/>

--- a/src/AccessibilityInsights.SharedUx/ActionViews/GeneralActionView.xaml
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/GeneralActionView.xaml
@@ -70,7 +70,7 @@
             <Label x:Name="lbDelay" Grid.Column="0" VerticalAlignment="Center" Content="{x:Static properties:Resources.lbDelayContent}"/>
             <TextBox x:Name="tbDelay" Grid.Column="1"
                      Margin="5" AutomationProperties.LabeledBy="{Binding ElementName=lbDelay}"
-                     Text="0" PreviewTextInput="tbDelay_PreviewTextInput"/>
+                     Text="{x:Static properties:Resources.Delay_In_Seconds_Default}" PreviewTextInput="tbDelay_PreviewTextInput"/>
             <Button x:Name="btnAction" Grid.Column="2" Width="70" Content="{x:Static properties:Resources.btnActionContent}"
                     AutomationProperties.Name="{x:Static properties:Resources.btnActionAutomationPropertiesName}" Click="Button_Click"
                     Margin="5"/>

--- a/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml
@@ -73,7 +73,7 @@
             <TextBox x:Name="tbDelay" Grid.Column="1"
                      Margin="5"
                      VerticalContentAlignment="Center"
-                     Text="0" AutomationProperties.LabeledBy="{Binding ElementName=lbDelay}"
+                     Text="{x:Static Properties:Resources.Delay_In_Seconds_Default}" AutomationProperties.LabeledBy="{Binding ElementName=lbDelay}"
                      PreviewTextInput="tbDelay_PreviewTextInput"/>
             <Button x:Name="btnAction" Grid.Column="2" Width="70" Content="{x:Static Properties:Resources.btnActionContent}"
                     AutomationProperties.Name="{x:Static Properties:Resources.btnActionAutomationPropertiesName}" Click="btnRun_Click"

--- a/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml
@@ -73,7 +73,7 @@
             <TextBox x:Name="tbDelay" Grid.Column="1"
                      Margin="5"
                      VerticalContentAlignment="Center"
-                     Text="{x:Static Properties:Resources.Delay_In_Seconds_Default}" AutomationProperties.LabeledBy="{Binding ElementName=lbDelay}"
+                     Text="{x:Static Properties:Resources.ActionsDefaultDelayInSeconds}" AutomationProperties.LabeledBy="{Binding ElementName=lbDelay}"
                      PreviewTextInput="tbDelay_PreviewTextInput"/>
             <Button x:Name="btnAction" Grid.Column="2" Width="70" Content="{x:Static Properties:Resources.btnActionContent}"
                     AutomationProperties.Name="{x:Static Properties:Resources.btnActionAutomationPropertiesName}" Click="btnRun_Click"

--- a/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml
@@ -61,7 +61,7 @@
             <Label x:Name="lbDelay" Grid.Column="0" VerticalAlignment="Center" Content="{x:Static Properties:Resources.lbDelayContent}"/>
             <TextBox x:Name="tbDelay" Grid.Column="1"
                      Margin="5" AutomationProperties.LabeledBy="{Binding ElementName=lbDelay}"
-                     Text="{x:Static Properties:Resources.Delay_In_Seconds_Default}" PreviewTextInput="tbDelay_PreviewTextInput"/>
+                     Text="{x:Static Properties:Resources.ActionsDefaultDelayInSeconds}" PreviewTextInput="tbDelay_PreviewTextInput"/>
             <Button x:Name="btnAction" Grid.Column="2" Width="70" Content="{x:Static Properties:Resources.btnActionContent}"
                     AutomationProperties.Name="{x:Static Properties:Resources.btnActionAutomationPropertiesName}" Click="Button_Click"
                     Margin="5"/>

--- a/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml
@@ -61,7 +61,7 @@
             <Label x:Name="lbDelay" Grid.Column="0" VerticalAlignment="Center" Content="{x:Static Properties:Resources.lbDelayContent}"/>
             <TextBox x:Name="tbDelay" Grid.Column="1"
                      Margin="5" AutomationProperties.LabeledBy="{Binding ElementName=lbDelay}"
-                     Text="0" PreviewTextInput="tbDelay_PreviewTextInput"/>
+                     Text="{x:Static Properties:Resources.Delay_In_Seconds_Default}" PreviewTextInput="tbDelay_PreviewTextInput"/>
             <Button x:Name="btnAction" Grid.Column="2" Width="70" Content="{x:Static Properties:Resources.btnActionContent}"
                     AutomationProperties.Name="{x:Static Properties:Resources.btnActionAutomationPropertiesName}" Click="Button_Click"
                     Margin="5"/>

--- a/src/AccessibilityInsights.SharedUx/Controls/DisplayCountControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/DisplayCountControl.xaml
@@ -10,6 +10,6 @@
              d:DesignHeight="300" d:DesignWidth="300"
              AutomationProperties.Name="{x:Static Properties:Resources.DisplayCountControlAutomationName}">
     <Grid>
-        <TextBlock x:Name="lbCount" FontSize="100" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="Blue" Text="5" FontWeight="Bold" Background="Transparent" AutomationProperties.LiveSetting="Polite"/>
+        <TextBlock x:Name="lbCount" FontSize="100" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="Blue" Text="{x:Static Properties:Resources.DisplayCount}" FontWeight="Bold" Background="Transparent" AutomationProperties.LiveSetting="Polite"/>
     </Grid>
 </UserControl>

--- a/src/AccessibilityInsights.SharedUx/Controls/DisplayCountControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/DisplayCountControl.xaml
@@ -10,6 +10,6 @@
              d:DesignHeight="300" d:DesignWidth="300"
              AutomationProperties.Name="{x:Static Properties:Resources.DisplayCountControlAutomationName}">
     <Grid>
-        <TextBlock x:Name="lbCount" FontSize="100" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="Blue" Text="{x:Static Properties:Resources.DisplayCount}" FontWeight="Bold" Background="Transparent" AutomationProperties.LiveSetting="Polite"/>
+        <TextBlock x:Name="lbCount" FontSize="100" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="Blue" FontWeight="Bold" Background="Transparent" AutomationProperties.LiveSetting="Polite"/>
     </Grid>
 </UserControl>

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -147,7 +147,7 @@
             <Run Text="{x:Static Properties:Resources.tbIntroTextSelectEventRecord}"/>
             <fabric:FabricIconControl GlyphName="CircleFill" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-3" Foreground="{DynamicResource ResourceKey=EventStartBrush}" FontStyle="Normal" ShowInControlView="False"/>
             <Run Text="{x:Static Properties:Resources.tbIntroTextStartRecording}"/>
-            <Run Name="runHkRecord"/><Run Text="."/>
+            <Run Name="runHkRecord"/><Run Text="{x:Static Properties:Resources.SentenceEndPeriod}"/>
         </TextBlock>
         <ScrollViewer Name="svData" Grid.Row="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" Padding="2,0" Margin="-2,0">
             <customcontrols:CustomDataGrid x:Name="dgEvents" GotKeyboardFocus="dgEvents_GotKeyboardFocus"

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -136,19 +136,19 @@
                             <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRaw_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName1}">
                                 <MenuItem.Header>
-                                    <RadioButton x:Name="rbRaw" Content="_Raw" Loaded="mniRaw_Loaded" Click="rbRaw_Click" Focusable="False" />
+                                    <RadioButton x:Name="rbRaw" Content="{x:Static Properties:Resources.HierarchyControl_Raw}" Loaded="mniRaw_Loaded" Click="rbRaw_Click" Focusable="False" />
                                 </MenuItem.Header>
                             </MenuItem>
                             <MenuItem x:Name="mniControl" IsCheckable="False" Click="mniControl_Click" 
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniControlAutomationPropertiesName}">
                                 <MenuItem.Header>
-                                    <RadioButton x:Name="rbControl" Content="_Control" Loaded="mniControl_Loaded" Click="rbControl_Click" Focusable="False" />
+                                    <RadioButton x:Name="rbControl" Content="{x:Static Properties:Resources.HierarchyControl_Control}" Loaded="mniControl_Loaded" Click="rbControl_Click" Focusable="False" />
                                 </MenuItem.Header>
                             </MenuItem>
                             <MenuItem x:Name="mniContent" IsCheckable="False" Click="mniContent_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniContentAutomationPropertiesName1}">
                                 <MenuItem.Header>
-                                    <RadioButton x:Name="rbContent" Content="Con_tent" Loaded="mniContent_Loaded" Click="rbContent_Click" Focusable="False" />
+                                    <RadioButton x:Name="rbContent" Content="{x:Static Properties:Resources.HierarchyControl_Con_tent}" Loaded="mniContent_Loaded" Click="rbContent_Click" Focusable="False" />
                                 </MenuItem.Header>
                             </MenuItem>
                         </MenuItem>

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -148,7 +148,7 @@
                             <MenuItem x:Name="mniContent" IsCheckable="False" Click="mniContent_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniContentAutomationPropertiesName1}">
                                 <MenuItem.Header>
-                                    <RadioButton x:Name="rbContent" Content="{x:Static Properties:Resources.HierarchyControl_Con_tent}" Loaded="mniContent_Loaded" Click="rbContent_Click" Focusable="False" />
+                                    <RadioButton x:Name="rbContent" Content="{x:Static Properties:Resources.HierarchyControl_Content}" Loaded="mniContent_Loaded" Click="rbContent_Click" Focusable="False" />
                                 </MenuItem.Header>
                             </MenuItem>
                         </MenuItem>

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
@@ -83,7 +83,7 @@
                             <ListView.View>
                                 <GridView x:Name="gvRules">
                                     <GridViewColumn>
-                                        <GridViewColumnHeader Content="Rule" IsTabStop="False" Focusable="True" FontSize="{DynamicResource StandardTextSize}" Background="Transparent" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                                        <GridViewColumnHeader Content="{x:Static Properties:Resources.ScannerResultControl_Rule}" IsTabStop="False" Focusable="True" FontSize="{DynamicResource StandardTextSize}" Background="Transparent" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                                         <GridViewColumn.CellTemplate>
                                             <DataTemplate>
                                                 <StackPanel Orientation="Horizontal">
@@ -118,7 +118,7 @@
                                         </GridViewColumn.CellTemplate>
                                     </GridViewColumn>
                                     <GridViewColumn Width="{Binding BugColumnWidth}">
-                                        <GridViewColumnHeader Visibility="{Binding BugColumnVisibility}" Content="Issue" IsTabStop="False" Focusable="True" FontSize="{DynamicResource StandardTextSize}" Background="Transparent" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                                        <GridViewColumnHeader Visibility="{Binding BugColumnVisibility}" Content="{x:Static Properties:Resources.ScannerResultControl_Issue}" IsTabStop="False" Focusable="True" FontSize="{DynamicResource StandardTextSize}" Background="Transparent" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                                         <GridViewColumn.CellTemplate>
                                             <DataTemplate>
                                                 <StackPanel Orientation="Horizontal" MinWidth="200">

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
@@ -180,7 +180,7 @@
                     <Label Name="lblDelay" Margin="0,5,0,0" Content="{x:Static Properties:Resources.lblDelayContent}" Padding="0" Style="{StaticResource LblText}" Target="{Binding ElementName=tbMouseDelay}"/>
                     <TextBox Name="tbMouseDelay" Height="26" Width="38" Margin="5,0,5,0" PreviewTextInput="textboxMouseDelay_PreviewTextInput" MaxLines="1" MaxLength="4" 
                      VerticalContentAlignment="Center" HorizontalContentAlignment="Right" Style="{StaticResource TxtBxText}" AutomationProperties.Name="{x:Static Properties:Resources.tbMouseDelayAutomationName}" TextChanged="tbMouseDelay_TextChanged"/>
-                    <Label Content="milliseconds" Margin="0,5,0,0" Padding="0" Style="{StaticResource LblText}"/>
+                    <Label Content="{x:Static Properties:Resources.ApplicationSettingsControl_milliseconds}" Margin="0,5,0,0" Padding="0" Style="{StaticResource LblText}"/>
                 </StackPanel>
             </Grid>
         </Grid>
@@ -236,7 +236,7 @@
                     <ColumnDefinition Width="151"/>
                     <ColumnDefinition Width="180"/>
                 </Grid.ColumnDefinitions>
-                <Label Name="lblFontSizeLabel" Grid.Column="0" Content="Font Size" Padding="0" Style="{StaticResource LblText}" VerticalAlignment="Center"/>
+                <Label Name="lblFontSizeLabel" Grid.Column="0" Content="{x:Static Properties:Resources.ApplicationSettingsControl_fontsize}" Padding="0" Style="{StaticResource LblText}" VerticalAlignment="Center"/>
                 <ComboBox Grid.Column="2" x:Name ="fontSizeComboBox"
                           SelectedIndex="{Binding FontSize}"
                           AutomationProperties.Name="{x:Static Properties:Resources.fontSizeComboBoxAutomationPropertiesName}"

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
@@ -236,7 +236,7 @@
                     <ColumnDefinition Width="151"/>
                     <ColumnDefinition Width="180"/>
                 </Grid.ColumnDefinitions>
-                <Label Name="lblFontSizeLabel" Grid.Column="0" Content="{x:Static Properties:Resources.ApplicationSettingsControl_fontsize}" Padding="0" Style="{StaticResource LblText}" VerticalAlignment="Center"/>
+                <Label Name="lblFontSizeLabel" Grid.Column="0" Content="{x:Static Properties:Resources.ApplicationSettingsControl_Fontsize}" Padding="0" Style="{StaticResource LblText}" VerticalAlignment="Center"/>
                 <ComboBox Grid.Column="2" x:Name ="fontSizeComboBox"
                           SelectedIndex="{Binding FontSize}"
                           AutomationProperties.Name="{x:Static Properties:Resources.fontSizeComboBoxAutomationPropertiesName}"

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml
@@ -27,7 +27,7 @@
                <TextBlock>
                     <Hyperlink Name="hlLink" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" TextDecorations="None" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2075269" Style="{StaticResource hLink}">
                         <Run Text="{x:Static Properties:Resources.issueFilingLink}"/>
-                    </Hyperlink><Run Text="."/>
+                    </Hyperlink><Run Text="{x:Static Properties:Resources.SentenceEndPeriod}"/>
                 </TextBlock>
             </TextBlock>
             <StackPanel Grid.Row="2" x:Name="availableIssueReporters">

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -108,7 +108,7 @@
                             </GridViewColumn>
                             <GridViewColumn x:Name="gvcElement" Width="Auto">
                                 <local:CustomGridViewColumnHeader Style="{StaticResource gvchAutomatedChecks}" Focusable="True" SizeChanged="CustomGridViewColumnHeader_SizeChanged">
-                                    <Label Content="{x:Static Properties:Resources.AutomatedChecksControl_Element_Path}" VerticalAlignment="Center" Style="{StaticResource lblFaint}"/>
+                                    <Label Content="{x:Static Properties:Resources.AutomatedChecksControl_ElementPath}" VerticalAlignment="Center" Style="{StaticResource lblFaint}"/>
                                 </local:CustomGridViewColumnHeader>
                                 <GridViewColumn.CellTemplate>
                                     <DataTemplate>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -108,7 +108,7 @@
                             </GridViewColumn>
                             <GridViewColumn x:Name="gvcElement" Width="Auto">
                                 <local:CustomGridViewColumnHeader Style="{StaticResource gvchAutomatedChecks}" Focusable="True" SizeChanged="CustomGridViewColumnHeader_SizeChanged">
-                                    <Label Content="Element path" VerticalAlignment="Center" Style="{StaticResource lblFaint}"/>
+                                    <Label Content="{x:Static Properties:Resources.AutomatedChecksControl_Element_Path}" VerticalAlignment="Center" Style="{StaticResource lblFaint}"/>
                                 </local:CustomGridViewColumnHeader>
                                 <GridViewColumn.CellTemplate>
                                     <DataTemplate>
@@ -120,7 +120,7 @@
                             </GridViewColumn>
                             <GridViewColumn Width="Auto">
                                 <local:CustomGridViewColumnHeader Style="{StaticResource gvchAutomatedChecks}" Focusable="True">
-                                    <Label Visibility="{Binding BugColumnVisibility}" Content="Issue" VerticalAlignment="Center" Style="{StaticResource lblFaint}"/>
+                                    <Label Visibility="{Binding BugColumnVisibility}" Content="{x:Static Properties:Resources.AutomatedChecksControl_Issue}" VerticalAlignment="Center" Style="{StaticResource lblFaint}"/>
                                 </local:CustomGridViewColumnHeader>
                                 <GridViewColumn.CellTemplate>
                                     <DataTemplate>
@@ -285,10 +285,10 @@
                                                     <local:CustomExpander.Header>
                                                         <StackPanel Focusable="False" Orientation="Horizontal" Height="20">
                                                             <Label Content="{Binding Path=Items[0].Description}" Style="{StaticResource lblRowStyle}" VerticalAlignment="Center" />
-                                                            <Label Content="(" Style="{StaticResource lblRowStyle}" Margin="4,0,0,0" VerticalAlignment="Center" />
+                                                            <Label Content="{x:Static Properties:Resources.AutomatedChecksControl_OpenParenthesis}" Style="{StaticResource lblRowStyle}" Margin="4,0,0,0" VerticalAlignment="Center" />
                                                             <fabric:FabricIconControl VerticalAlignment="Bottom" Margin="1,2" GlyphName="{Binding Path=Items[0].GlyphName}" Foreground="{DynamicResource ResourceKey=HLbrushRed}" GlyphSize="Custom" FontSize="14"/>
                                                             <Label Content="{Binding ItemCount}" Style="{StaticResource lblRowStyle}" VerticalAlignment="Center" />
-                                                            <Label Content=")" Style="{StaticResource lblRowStyle}"  VerticalAlignment="Center" />
+                                                            <Label Content="{x:Static Properties:Resources.AutomatedChecksControl_CloseParenthesis}" Style="{StaticResource lblRowStyle}"  VerticalAlignment="Center" />
                                                         </StackPanel>
                                                     </local:CustomExpander.Header>
                                                     <ItemsPresenter/>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml
@@ -58,7 +58,7 @@
             <RichTextBox Margin="-4,0,0,0" Grid.Row="5" Grid.Column="1" Style="{StaticResource ResourceKey=RtbReadonlyText}" Name="rtbInstructions" AutomationProperties.LabeledBy="{Binding ElementName=tabIntro}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}">
                 <FlowDocument LineHeight="6"/>
             </RichTextBox>
-            <Label Name="lblResults" Grid.Row="7" Grid.Column="1" Content="Recorded order results" Style="{StaticResource lblHeader}" HorizontalAlignment="Left"/>
+            <Label Name="lblResults" Grid.Row="7" Grid.Column="1" Content="{x:Static Properties:Resources.TabStopControl_Recorded_order_results}" Style="{StaticResource lblHeader}" HorizontalAlignment="Left"/>
             <ListView x:Name="lvElements" 
                 Margin="0"
                 VerticalAlignment="Stretch"

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml
@@ -58,7 +58,7 @@
             <RichTextBox Margin="-4,0,0,0" Grid.Row="5" Grid.Column="1" Style="{StaticResource ResourceKey=RtbReadonlyText}" Name="rtbInstructions" AutomationProperties.LabeledBy="{Binding ElementName=tabIntro}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}">
                 <FlowDocument LineHeight="6"/>
             </RichTextBox>
-            <Label Name="lblResults" Grid.Row="7" Grid.Column="1" Content="{x:Static Properties:Resources.TabStopControl_Recorded_order_results}" Style="{StaticResource lblHeader}" HorizontalAlignment="Left"/>
+            <Label Name="lblResults" Grid.Row="7" Grid.Column="1" Content="{x:Static Properties:Resources.TabStopControl_RecordedOrderResults}" Style="{StaticResource lblHeader}" HorizontalAlignment="Left"/>
             <ListView x:Name="lvElements" 
                 Margin="0"
                 VerticalAlignment="Stretch"

--- a/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
@@ -139,7 +139,7 @@
                                                 </Style>
                                             </TextBlock.Style>
                                         </TextBlock>
-                                        <Button Grid.Column="2" Content="Details" Visibility="{Binding Path=DetailsVisibility}" Command="{Binding ClickCommand}" Margin="0,0,5,0" Style="{StaticResource btnLink}"/>
+                                        <Button Grid.Column="2" Content="{x:Static Properties:Resources.TextRangeControl_Details}" Visibility="{Binding Path=DetailsVisibility}" Command="{Binding ClickCommand}" Margin="0,0,5,0" Style="{StaticResource btnLink}"/>
                                     </Grid>
                                 </DataTemplate>
                             </GridViewColumn.CellTemplate>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/MoveTextRangeDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/MoveTextRangeDialog.xaml
@@ -74,9 +74,9 @@
                    VerticalAlignment="Stretch"
                    AutomationProperties.Name="{x:Static Properties:Resources.tbResultAutomationPropertiesName}"/>
         <StackPanel Orientation="Horizontal" Margin="0,10,0,0" Grid.Row="5" HorizontalAlignment="Right">
-            <Button x:Name="btnAction"  Width="60" Content="Run"
+            <Button x:Name="btnAction"  Width="60" Content="{x:Static Properties:Resources.MoveTextRangeDialog_Run}"
                     AutomationProperties.Name="{x:Static Properties:Resources.btnActionAutomationPropertiesNameMethod}" Click="btnAction_Click"/>
-            <Button Grid.Row="5" Margin="20,0,0,0" Width="60" Content="Close" IsDefault="True" IsCancel="True"/>
+            <Button Grid.Row="5" Margin="20,0,0,0" Width="60" Content="{x:Static Properties:Resources.MoveTextRangeDialog_Close}" IsDefault="True" IsCancel="True"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -123,7 +123,7 @@
                         <Run Text="{x:Static properties:Resources.StartupModeControl_shortcutsDescription}"/>
                     </TextBlock>
                     <Border Grid.Row="3" Grid.Column="1" Style="{StaticResource BrdrKey}" VerticalAlignment="Center">
-                        <Label Name="lblEventHk" Style="{StaticResource LblKey}" Content="Shift + F6" Padding="3,6">
+                        <Label Name="lblEventHk" Style="{StaticResource LblKey}" Content="{x:Static properties:Resources.StartUpModeControl_ShiftF6}" Padding="3,6">
                             <AutomationProperties.Name>
                                 <MultiBinding StringFormat="{}{0} {1}">
                                     <Binding RelativeSource="{RelativeSource Self}" Path="Content"/>
@@ -134,7 +134,7 @@
                     </Border>
                     <TextBlock Name="txtEventHk" Style="{StaticResource TbBaseWrap}" Grid.Row="3" Grid.Column="3" Text="{x:Static properties:Resources.toggleEventText}" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
                     <Border Grid.Row="5" Grid.Column="1" Style="{StaticResource BrdrKey}" VerticalAlignment="Center">
-                        <Label Name="lblTestHk" Style="{StaticResource LblKey}" Content="Shift + F8" Padding="3,6">
+                        <Label Name="lblTestHk" Style="{StaticResource LblKey}" Content="{x:Static properties:Resources.StartUpModeControl_ShiftF8}" Padding="3,6">
                             <AutomationProperties.Name>
                                 <MultiBinding StringFormat="{}{0} {1}">
                                     <Binding RelativeSource="{RelativeSource Self}" Path="Content"/>
@@ -145,7 +145,7 @@
                     </Border>
                     <TextBlock Name="txtTesttHk" Style="{StaticResource TbBaseWrap}" Grid.Row="5" Grid.Column="3" Text="{x:Static properties:Resources.runSelectedTestText}" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
                     <Border Grid.Row="7" Grid.Column="1" Style="{StaticResource BrdrKey}" Height="32" VerticalAlignment="Center">
-                        <Label Name="lblActivateHk" Style="{StaticResource LblKey}" Content="Shift + F9" Padding="3,6">
+                        <Label Name="lblActivateHk" Style="{StaticResource LblKey}" Content="{x:Static properties:Resources.StartUpModeControl_ShiftF9}" Padding="3,6">
                             <AutomationProperties.Name>
                                 <MultiBinding StringFormat="{}{0} {1}">
                                     <Binding RelativeSource="{RelativeSource Self}" Path="Content"/>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -107,6 +107,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Font Size.
+        /// </summary>
+        public static string ApplicationSettingsControl_fontsize {
+            get {
+                return ResourceManager.GetString("ApplicationSettingsControl_fontsize", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select Highlighter Mode.
         /// </summary>
         public static string ApplicationSettingsControl_HighlighterModeComboboxAutomationName {
@@ -121,6 +130,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string ApplicationSettingsControl_KeyboardIconAutomationName {
             get {
                 return ResourceManager.GetString("ApplicationSettingsControl_KeyboardIconAutomationName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to milliseconds.
+        /// </summary>
+        public static string ApplicationSettingsControl_milliseconds {
+            get {
+                return ResourceManager.GetString("ApplicationSettingsControl_milliseconds", resourceCulture);
             }
         }
         
@@ -148,6 +166,42 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string AutomatedChecksControl_btnFileBug_Click_File_Issue_Configure {
             get {
                 return ResourceManager.GetString("AutomatedChecksControl_btnFileBug_Click_File_Issue_Configure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ).
+        /// </summary>
+        public static string AutomatedChecksControl_CloseParenthesis {
+            get {
+                return ResourceManager.GetString("AutomatedChecksControl_CloseParenthesis", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Element path.
+        /// </summary>
+        public static string AutomatedChecksControl_Element_Path {
+            get {
+                return ResourceManager.GetString("AutomatedChecksControl_Element_Path", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Issue.
+        /// </summary>
+        public static string AutomatedChecksControl_Issue {
+            get {
+                return ResourceManager.GetString("AutomatedChecksControl_Issue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (.
+        /// </summary>
+        public static string AutomatedChecksControl_OpenParenthesis {
+            get {
+                return ResourceManager.GetString("AutomatedChecksControl_OpenParenthesis", resourceCulture);
             }
         }
         
@@ -1317,6 +1371,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 0.
+        /// </summary>
+        public static string Delay_In_Seconds_Default {
+            get {
+                return ResourceManager.GetString("Delay_In_Seconds_Default", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Parameters.
         /// </summary>
         public static string dgParamsAutomationName {
@@ -1367,6 +1430,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string dgReturnAutomationPropertiesName {
             get {
                 return ResourceManager.GetString("dgReturnAutomationPropertiesName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 5.
+        /// </summary>
+        public static string DisplayCount {
+            get {
+                return ResourceManager.GetString("DisplayCount", resourceCulture);
             }
         }
         
@@ -1788,6 +1860,24 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Con_tent.
+        /// </summary>
+        public static string HierarchyControl_Con_tent {
+            get {
+                return ResourceManager.GetString("HierarchyControl_Con_tent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Control.
+        /// </summary>
+        public static string HierarchyControl_Control {
+            get {
+                return ResourceManager.GetString("HierarchyControl_Control", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not find the selected item, the bug filing is canceled..
         /// </summary>
         public static string HierarchyControl_FileBug_Could_not_find_the_selected_item__the_bug_filing_is_canceled {
@@ -1812,6 +1902,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string HierarchyControl_PopulateHierarchyTree_No_data_to_populate_hierarchy {
             get {
                 return ResourceManager.GetString("HierarchyControl_PopulateHierarchyTree_No_data_to_populate_hierarchy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _RawForReals.
+        /// </summary>
+        public static string HierarchyControl_Raw {
+            get {
+                return ResourceManager.GetString("HierarchyControl_Raw", resourceCulture);
             }
         }
         
@@ -2890,11 +2989,29 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Close.
+        /// </summary>
+        public static string MoveTextRangeDialog_Close {
+            get {
+                return ResourceManager.GetString("MoveTextRangeDialog_Close", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to HResult: 0x{0:X8}.
         /// </summary>
         public static string MoveTextRangeDialog_GetExceptionString_HResult_0x_0_X8 {
             get {
                 return ResourceManager.GetString("MoveTextRangeDialog_GetExceptionString_HResult_0x_0_X8", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run.
+        /// </summary>
+        public static string MoveTextRangeDialog_Run {
+            get {
+                return ResourceManager.GetString("MoveTextRangeDialog_Run", resourceCulture);
             }
         }
         
@@ -3310,11 +3427,29 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Issue.
+        /// </summary>
+        public static string ScannerResultControl_Issue {
+            get {
+                return ResourceManager.GetString("ScannerResultControl_Issue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There were no failures..
         /// </summary>
         public static string ScannerResultControl_noFailures {
             get {
                 return ResourceManager.GetString("ScannerResultControl_noFailures", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rule.
+        /// </summary>
+        public static string ScannerResultControl_Rule {
+            get {
+                return ResourceManager.GetString("ScannerResultControl_Rule", resourceCulture);
             }
         }
         
@@ -3378,6 +3513,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string secondChooserAutomationPropertiesName {
             get {
                 return ResourceManager.GetString("secondChooserAutomationPropertiesName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ..
+        /// </summary>
+        public static string SentenceEndPeriod {
+            get {
+                return ResourceManager.GetString("SentenceEndPeriod", resourceCulture);
             }
         }
         
@@ -3571,6 +3715,33 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Shift + F6.
+        /// </summary>
+        public static string StartUpModeControl_ShiftF6 {
+            get {
+                return ResourceManager.GetString("StartUpModeControl_ShiftF6", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Shift + F8.
+        /// </summary>
+        public static string StartUpModeControl_ShiftF8 {
+            get {
+                return ResourceManager.GetString("StartUpModeControl_ShiftF8", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Shift + F9.
+        /// </summary>
+        public static string StartUpModeControl_ShiftF9 {
+            get {
+                return ResourceManager.GetString("StartUpModeControl_ShiftF9", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to These keystrokes are default, but you can customize your shortcut keystrokes in settings..
         /// </summary>
         public static string StartupModeControl_shortcutsDescription {
@@ -3648,6 +3819,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string tabPropertiesAutomationPropertiesName {
             get {
                 return ResourceManager.GetString("tabPropertiesAutomationPropertiesName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Recorded order results.
+        /// </summary>
+        public static string TabStopControl_Recorded_order_results {
+            get {
+                return ResourceManager.GetString("TabStopControl_Recorded_order_results", resourceCulture);
             }
         }
         
@@ -4116,6 +4296,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string TextRangeActionView_ExecuteAction_Succeeded {
             get {
                 return ResourceManager.GetString("TextRangeActionView_ExecuteAction_Succeeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Details.
+        /// </summary>
+        public static string TextRangeControl_Details {
+            get {
+                return ResourceManager.GetString("TextRangeControl_Details", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -70,6 +70,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 0.
+        /// </summary>
+        public static string ActionsDefaultDelayInSeconds {
+            get {
+                return ResourceManager.GetString("ActionsDefaultDelayInSeconds", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to passed value is not supported type..
         /// </summary>
         public static string ActionViewModelConverter_Convert_passed_value_is_not_supported_type {
@@ -109,9 +118,9 @@ namespace AccessibilityInsights.SharedUx.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Font Size.
         /// </summary>
-        public static string ApplicationSettingsControl_fontsize {
+        public static string ApplicationSettingsControl_Fontsize {
             get {
-                return ResourceManager.GetString("ApplicationSettingsControl_fontsize", resourceCulture);
+                return ResourceManager.GetString("ApplicationSettingsControl_Fontsize", resourceCulture);
             }
         }
         
@@ -181,9 +190,9 @@ namespace AccessibilityInsights.SharedUx.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Element path.
         /// </summary>
-        public static string AutomatedChecksControl_Element_Path {
+        public static string AutomatedChecksControl_ElementPath {
             get {
-                return ResourceManager.GetString("AutomatedChecksControl_Element_Path", resourceCulture);
+                return ResourceManager.GetString("AutomatedChecksControl_ElementPath", resourceCulture);
             }
         }
         
@@ -1371,15 +1380,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 0.
-        /// </summary>
-        public static string Delay_In_Seconds_Default {
-            get {
-                return ResourceManager.GetString("Delay_In_Seconds_Default", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Parameters.
         /// </summary>
         public static string dgParamsAutomationName {
@@ -1862,9 +1862,9 @@ namespace AccessibilityInsights.SharedUx.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Con_tent.
         /// </summary>
-        public static string HierarchyControl_Con_tent {
+        public static string HierarchyControl_Content {
             get {
-                return ResourceManager.GetString("HierarchyControl_Con_tent", resourceCulture);
+                return ResourceManager.GetString("HierarchyControl_Content", resourceCulture);
             }
         }
         
@@ -3825,9 +3825,9 @@ namespace AccessibilityInsights.SharedUx.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Recorded order results.
         /// </summary>
-        public static string TabStopControl_Recorded_order_results {
+        public static string TabStopControl_RecordedOrderResults {
             get {
-                return ResourceManager.GetString("TabStopControl_Recorded_order_results", resourceCulture);
+                return ResourceManager.GetString("TabStopControl_RecordedOrderResults", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1906,7 +1906,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _RawForReals.
+        ///   Looks up a localized string similar to _Raw.
         /// </summary>
         public static string HierarchyControl_Raw {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -135,6 +135,7 @@
   <data name="lbDelayContent" xml:space="preserve">
     <value>Delay in sec</value>
   </data>
+  
   <data name="tbResultAutomationPropertiesName" xml:space="preserve">
     <value>Execution result</value>
   </data>
@@ -147,7 +148,7 @@
   <data name="GeneralActionView_Button_Click_Input_should_be_int_value_greater_than_equal_to_0" xml:space="preserve">
     <value>Input should be int value greater than or equal to 0.</value>
   </data>
-  <data name="Delay_In_Seconds_Default" xml:space="preserve">
+  <data name="ActionsDefaultDelayInSeconds" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="GeneralActionView_ExecuteAction_Execution_result_passed" xml:space="preserve">
@@ -1527,7 +1528,7 @@ Do you want to change the channel? </value>
   <data name="AutomatedChecksControl_RuleSourceLabel" xml:space="preserve">
     <value>Rule source</value>
   </data>
-  <data name="ApplicationSettingsControl_fontsize" xml:space="preserve">
+  <data name="ApplicationSettingsControl_Fontsize" xml:space="preserve">
     <value>Font Size</value>
   </data>
   <data name="ApplicationSettingsControl_milliseconds" xml:space="preserve">
@@ -1539,7 +1540,7 @@ Do you want to change the channel? </value>
   <data name="HierarchyControl_Control" xml:space="preserve">
     <value>_Control</value>
   </data>
-  <data name="HierarchyControl_Con_tent" xml:space="preserve">
+  <data name="HierarchyControl_Content" xml:space="preserve">
     <value>Con_tent</value>
   </data>
   <data name="HierarchyControl_Raw" xml:space="preserve">
@@ -1557,7 +1558,7 @@ Do you want to change the channel? </value>
   <data name="AutomatedChecksControl_CloseParenthesis" xml:space="preserve">
     <value>)</value>
   </data>
-  <data name="AutomatedChecksControl_Element_Path" xml:space="preserve">
+  <data name="AutomatedChecksControl_ElementPath" xml:space="preserve">
     <value>Element path</value>
   </data>
   <data name="AutomatedChecksControl_Issue" xml:space="preserve">
@@ -1581,7 +1582,7 @@ Do you want to change the channel? </value>
   <data name="StartUpModeControl_ShiftF9" xml:space="preserve">
     <value>Shift + F9</value>
   </data>
-  <data name="TabStopControl_Recorded_order_results" xml:space="preserve">
+  <data name="TabStopControl_RecordedOrderResults" xml:space="preserve">
     <value>Recorded order results</value>
   </data>
   <data name="TextRangeControl_Details" xml:space="preserve">

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1544,7 +1544,7 @@ Do you want to change the channel? </value>
     <value>Con_tent</value>
   </data>
   <data name="HierarchyControl_Raw" xml:space="preserve">
-    <value>_RawForReals</value>
+    <value>_Raw</value>
   </data>
   <data name="ScannerResultControl_Issue" xml:space="preserve">
     <value>Issue</value>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -147,6 +147,9 @@
   <data name="GeneralActionView_Button_Click_Input_should_be_int_value_greater_than_equal_to_0" xml:space="preserve">
     <value>Input should be int value greater than or equal to 0.</value>
   </data>
+  <data name="Delay_In_Seconds_Default" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="GeneralActionView_ExecuteAction_Execution_result_passed" xml:space="preserve">
     <value>Execution result passed</value>
   </data>
@@ -1523,5 +1526,65 @@ Do you want to change the channel? </value>
   </data>
   <data name="AutomatedChecksControl_RuleSourceLabel" xml:space="preserve">
     <value>Rule source</value>
+  </data>
+  <data name="ApplicationSettingsControl_fontsize" xml:space="preserve">
+    <value>Font Size</value>
+  </data>
+  <data name="ApplicationSettingsControl_milliseconds" xml:space="preserve">
+    <value>milliseconds</value>
+  </data>
+  <data name="DisplayCount" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="HierarchyControl_Control" xml:space="preserve">
+    <value>_Control</value>
+  </data>
+  <data name="HierarchyControl_Con_tent" xml:space="preserve">
+    <value>Con_tent</value>
+  </data>
+  <data name="HierarchyControl_Raw" xml:space="preserve">
+    <value>_RawForReals</value>
+  </data>
+  <data name="ScannerResultControl_Issue" xml:space="preserve">
+    <value>Issue</value>
+  </data>
+  <data name="ScannerResultControl_Rule" xml:space="preserve">
+    <value>Rule</value>
+  </data>
+  <data name="SentenceEndPeriod" xml:space="preserve">
+    <value>.</value>
+  </data>
+  <data name="AutomatedChecksControl_CloseParenthesis" xml:space="preserve">
+    <value>)</value>
+  </data>
+  <data name="AutomatedChecksControl_Element_Path" xml:space="preserve">
+    <value>Element path</value>
+  </data>
+  <data name="AutomatedChecksControl_Issue" xml:space="preserve">
+    <value>Issue</value>
+  </data>
+  <data name="AutomatedChecksControl_OpenParenthesis" xml:space="preserve">
+    <value>(</value>
+  </data>
+  <data name="MoveTextRangeDialog_Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="MoveTextRangeDialog_Run" xml:space="preserve">
+    <value>Run</value>
+  </data>
+  <data name="StartUpModeControl_ShiftF6" xml:space="preserve">
+    <value>Shift + F6</value>
+  </data>
+  <data name="StartUpModeControl_ShiftF8" xml:space="preserve">
+    <value>Shift + F8</value>
+  </data>
+  <data name="StartUpModeControl_ShiftF9" xml:space="preserve">
+    <value>Shift + F9</value>
+  </data>
+  <data name="TabStopControl_Recorded_order_results" xml:space="preserve">
+    <value>Recorded order results</value>
+  </data>
+  <data name="TextRangeControl_Details" xml:space="preserve">
+    <value>Details</value>
   </data>
 </root>

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -458,7 +458,7 @@
                                                 <MenuItem.Header>
                                                     <TextBlock Name="tbTimer">
                                                     <Run Text="{x:Static properties:Resources.tbTimerText1}"/>
-                                                    <TextBox TextChanged="tbxTimer_TextChanged" Name="tbxTimer" PreviewTextInput="tbxTimer_PreviewTextInput" Text="{x:Static properties:Resources.MainWindow_NumberFive}" MaxLength="2" FontSize="11" Width="16" Margin="2,-4" 
+                                                    <TextBox TextChanged="tbxTimer_TextChanged" Name="tbxTimer" PreviewTextInput="tbxTimer_PreviewTextInput" Text="{x:Static properties:Resources.MainWindow_DefaultTimerDelayInSeconds}" MaxLength="2" FontSize="11" Width="16" Margin="2,-4" 
                                                              AutomationProperties.LabeledBy="{Binding RelativeSource={RelativeSource AncestorType={x:Type TextBlock}}}"/>
                                                     <Run Text="{x:Static properties:Resources.tbTimerText2}"/>
                                                     </TextBlock>

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -244,7 +244,7 @@
                                     <ToolTip Content="{x:Static properties:Resources.btnHelpToolTip}" />
                                 </Button.ToolTip>
                                 <Grid>
-                                    <AccessText Text="_?" Opacity="0"/>
+                                    <AccessText Text="{x:Static properties:Resources.MainWindow_QuestionMark}" Opacity="0"/>
                                     <fabric:FabricIconControl GlyphName="Unknown" GlyphSize="Small" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=WindowBorderTextBrush}"/>
                                 </Grid>
                             </Button>
@@ -458,7 +458,7 @@
                                                 <MenuItem.Header>
                                                     <TextBlock Name="tbTimer">
                                                     <Run Text="{x:Static properties:Resources.tbTimerText1}"/>
-                                                    <TextBox TextChanged="tbxTimer_TextChanged" Name="tbxTimer" PreviewTextInput="tbxTimer_PreviewTextInput" Text="5" MaxLength="2" FontSize="11" Width="16" Margin="2,-4" 
+                                                    <TextBox TextChanged="tbxTimer_TextChanged" Name="tbxTimer" PreviewTextInput="tbxTimer_PreviewTextInput" Text="{x:Static properties:Resources.MainWindow_NumberFive}" MaxLength="2" FontSize="11" Width="16" Margin="2,-4" 
                                                              AutomationProperties.LabeledBy="{Binding RelativeSource={RelativeSource AncestorType={x:Type TextBlock}}}"/>
                                                     <Run Text="{x:Static properties:Resources.tbTimerText2}"/>
                                                     </TextBlock>
@@ -486,12 +486,12 @@
                         </DockPanel>
                         <StackPanel Margin="0" Background="{DynamicResource ResourceKey=PrimaryBGBrush}" Name="spBreadcrumbs" Orientation="Horizontal" Height="34" Grid.Row="1" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabNavigation="Once">
                             <Button FontSize="{StaticResource ConstXLTextSize}" Name="btnCrumbOne" Style="{StaticResource btnLink}" 
-                                    Content="One" Click="btnCrumbOne_Click" Margin="8,0,0,0" VerticalAlignment="Center"
+                                    Content="{x:Static properties:Resources.MainWindow_One}" Click="btnCrumbOne_Click" Margin="8,0,0,0" VerticalAlignment="Center"
                                     AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinBreadCrumbOneButton}"/>
                             <TextBlock FontSize="{StaticResource ConstXLTextSize}" Name="tbCrumbOne" Style="{StaticResource TbFocusable}" Margin="8,0,0,0" Text="Three" VerticalAlignment="Center" Height="Auto"/>
                             <fabric:FabricIconControl Name="ctrlFabCrumbOne" GlyphName="ChevronRight" GlyphSize="Small" Margin="4,2,4,0" Foreground="{DynamicResource ResourceKey=IconBrush}" VerticalAlignment="Center"/>
                             <Button FontSize="{StaticResource ConstXLTextSize}" Name="btnCrumbTwo" Style="{StaticResource btnLink}"
-                                    Content="Two" Click="btnCrumbTwo_Click" VerticalAlignment="Center"
+                                    Content="{x:Static properties:Resources.MainWindow_Two}" Click="btnCrumbTwo_Click" VerticalAlignment="Center"
                                     AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinBreadCrumbTwoButton}"/>
                             <TextBlock FontSize="{StaticResource ConstXLTextSize}" Name="tbCrumbTwo" Style="{StaticResource TbFocusable}" Text="Three" VerticalAlignment="Center" Height="Auto"/>
                             <fabric:FabricIconControl Name="ctrlFabCrumbTwo" GlyphName="ChevronRight" GlyphSize="Small" Foreground="{DynamicResource ResourceKey=IconBrush}" Margin="4,2,4,0" VerticalAlignment="Center"/>

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml
@@ -44,11 +44,11 @@
                 <StackPanel Name="spInstructions" Grid.Row="1" KeyboardNavigation.IsTabStop="True">
                     <TextBlock Name="tbInstructions" Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
                         <Run Text="{x:Static properties:Resources.LiveModeControl_HoverOverElement}"/>
-                        <Run Name="runHkActivate"/><Run Text="."/>
+                        <Run Name="runHkActivate"/><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
                         <TextBlock TextWrapping="Wrap">
                             <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2075123" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
                                  <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreInspect}"/>
-                            </Hyperlink><Run Text="."/>
+                            </Hyperlink><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
                         </TextBlock>
                     </TextBlock>
 
@@ -56,11 +56,11 @@
                         <Run Text="{x:Static properties:Resources.LiveModeControl_RunAutomatedChecks}"/>
                         <fabric:FabricIconControl GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" FontStyle="Normal" ShowInControlView="False"/>
                         <Run Text="{x:Static properties:Resources.LiveModeControl_FocusOnElement}"/>
-                        <Run Name="runHkTest"/><Run Text="."/>
+                        <Run Name="runHkTest"/><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
                         <TextBlock TextWrapping="Wrap">
                             <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077027" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
                                  <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreAutomated}" />
-                            </Hyperlink><Run Text="."/>
+                            </Hyperlink><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
                         </TextBlock>
                     </TextBlock>
 

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
@@ -393,7 +393,7 @@ namespace AccessibilityInsights.Modes
                 var se = this.ctrlHierarchy.SelectedElement ?? this.ElementContext.Element;
 
                 // glimpse
-                sb.AppendFormat(CultureInfo.InvariantCulture, Properties.Resources.SnapshotModeControl_Glimpse + ": {0}", se.Glimpse);
+                sb.AppendFormat(CultureInfo.CurrentCulture, Properties.Resources.SnapshotModeControl_GlimpseFormat, se.Glimpse);
                 sb.AppendLine();
                 sb.AppendLine();
 

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
@@ -393,11 +393,11 @@ namespace AccessibilityInsights.Modes
                 var se = this.ctrlHierarchy.SelectedElement ?? this.ElementContext.Element;
 
                 // glimpse
-                sb.AppendFormat(CultureInfo.InvariantCulture, "Glimpse: {0}", se.Glimpse);
+                sb.AppendFormat(CultureInfo.InvariantCulture, Properties.Resources.SnapshotModeControl_Glimpse + ": {0}", se.Glimpse);
                 sb.AppendLine();
                 sb.AppendLine();
 
-                sb.AppendLine("Available properties");
+                sb.AppendLine(Properties.Resources.SnapshotModeControl_AvailableProperties);
                 // properties
                 foreach (var p in se.Properties)
                 {
@@ -407,7 +407,7 @@ namespace AccessibilityInsights.Modes
 
                 sb.AppendLine();
 
-                sb.AppendLine("Available patterns:");
+                sb.AppendLine(Properties.Resources.SnapshotModeControl_AvailablePatterns + ":");
                 // patterns
                 foreach (var pt in se.Patterns)
                 {

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
@@ -407,7 +407,7 @@ namespace AccessibilityInsights.Modes
 
                 sb.AppendLine();
 
-                sb.AppendLine(Properties.Resources.SnapshotModeControl_AvailablePatterns + ":");
+                sb.AppendLine(Properties.Resources.SnapshotModeControl_AvailablePatterns);
                 // patterns
                 foreach (var pt in se.Patterns)
                 {

--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml
@@ -62,12 +62,12 @@
                 <Run Text="{x:Static properties:Resources.TestModeControl_HoverAndTest}"/>
                 <fabric:FabricIconControl GlyphName="TestBeaker" GlyphSize="Custom" FontSize="{DynamicResource StandardTextSize}" Margin="0,-2" Foreground="{DynamicResource ResourceKey=IconBrush}" FontStyle="Normal" ShowInControlView="False"/>
                 <Run Text="{x:Static properties:Resources.LiveModeControl_FocusOnElement}"/>
-                <Run Name="runHotkey"/><Run Text="."/>
+                <Run Name="runHotkey"/><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
                 <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077027" RequestNavigate="Hyperlink_RequestNavigate"
                             FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">
                     <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreAutomated}"/>
                 </Hyperlink>
-                <Run Text="."/>
+                <Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
             </TextBlock>
             <TextBlock Grid.Row="2" Text="{x:Static properties:Resources.AutomatedChecksRole}" Style="{StaticResource TbFocusableCenter}" MinWidth="40"/>
         </Grid>

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -745,6 +745,33 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 5.
+        /// </summary>
+        public static string MainWindow_NumberFive {
+            get {
+                return ResourceManager.GetString("MainWindow_NumberFive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to One.
+        /// </summary>
+        public static string MainWindow_One {
+            get {
+                return ResourceManager.GetString("MainWindow_One", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _?.
+        /// </summary>
+        public static string MainWindow_QuestionMark {
+            get {
+                return ResourceManager.GetString("MainWindow_QuestionMark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An update is available..
         /// </summary>
         public static string MainWindow_ShowUpgradeDialog_An_update_is_available {
@@ -759,6 +786,15 @@ namespace AccessibilityInsights.Properties {
         public static string MainWindow_ShowUpgradeDialog_An_update_is_required {
             get {
                 return ResourceManager.GetString("MainWindow_ShowUpgradeDialog_An_update_is_required", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Two.
+        /// </summary>
+        public static string MainWindow_Two {
+            get {
+                return ResourceManager.GetString("MainWindow_Two", resourceCulture);
             }
         }
         
@@ -907,6 +943,15 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ..
+        /// </summary>
+        public static string SentenceEndPeriod {
+            get {
+                return ResourceManager.GetString("SentenceEndPeriod", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Only the first {0:N0} elements are being scanned. You will not be able to save the results or file any bugs from this scan..
         /// </summary>
         public static string SetElementCultureInfoFormatMessage {
@@ -930,6 +975,33 @@ namespace AccessibilityInsights.Properties {
         public static string SetElementInspectTestDetail {
             get {
                 return ResourceManager.GetString("SetElementInspectTestDetail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Available patterns.
+        /// </summary>
+        public static string SnapshotModeControl_AvailablePatterns {
+            get {
+                return ResourceManager.GetString("SnapshotModeControl_AvailablePatterns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Available properties.
+        /// </summary>
+        public static string SnapshotModeControl_AvailableProperties {
+            get {
+                return ResourceManager.GetString("SnapshotModeControl_AvailableProperties", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Glimpse.
+        /// </summary>
+        public static string SnapshotModeControl_Glimpse {
+            get {
+                return ResourceManager.GetString("SnapshotModeControl_Glimpse", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -979,7 +979,7 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Available patterns.
+        ///   Looks up a localized string similar to Available patterns:.
         /// </summary>
         public static string SnapshotModeControl_AvailablePatterns {
             get {

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -747,9 +747,9 @@ namespace AccessibilityInsights.Properties {
         /// <summary>
         ///   Looks up a localized string similar to 5.
         /// </summary>
-        public static string MainWindow_NumberFive {
+        public static string MainWindow_DefaultTimerDelayInSeconds {
             get {
-                return ResourceManager.GetString("MainWindow_NumberFive", resourceCulture);
+                return ResourceManager.GetString("MainWindow_DefaultTimerDelayInSeconds", resourceCulture);
             }
         }
         
@@ -997,11 +997,11 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Glimpse.
+        ///   Looks up a localized string similar to Glimpse: {0}.
         /// </summary>
-        public static string SnapshotModeControl_Glimpse {
+        public static string SnapshotModeControl_GlimpseFormat {
             get {
-                return ResourceManager.GetString("SnapshotModeControl_Glimpse", resourceCulture);
+                return ResourceManager.GetString("SnapshotModeControl_GlimpseFormat", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -546,10 +546,10 @@ Please ensure that you are opening a valid test file using the most recent relea
   <data name="SnapshotModeControl_AvailableProperties" xml:space="preserve">
     <value>Available properties</value>
   </data>
-  <data name="SnapshotModeControl_Glimpse" xml:space="preserve">
-    <value>Glimpse</value>
+  <data name="SnapshotModeControl_GlimpseFormat" xml:space="preserve">
+    <value>Glimpse: {0}</value>
   </data>
-  <data name="MainWindow_NumberFive" xml:space="preserve">
+  <data name="MainWindow_DefaultTimerDelayInSeconds" xml:space="preserve">
     <value>5</value>
   </data>
   <data name="MainWindow_One" xml:space="preserve">

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -541,7 +541,7 @@ Please ensure that you are opening a valid test file using the most recent relea
     <value>.</value>
   </data>
   <data name="SnapshotModeControl_AvailablePatterns" xml:space="preserve">
-    <value>Available patterns</value>
+    <value>Available patterns:</value>
   </data>
   <data name="SnapshotModeControl_AvailableProperties" xml:space="preserve">
     <value>Available properties</value>

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -537,4 +537,28 @@ Please ensure that you are opening a valid test file using the most recent relea
   <data name="RequiredUpdateFailedUnknown" xml:space="preserve">
     <value>There was a problem updating the application. Because this is a required update, the app will be shut down. Please check your internet connection and try again.</value>
   </data>
+  <data name="SentenceEndPeriod" xml:space="preserve">
+    <value>.</value>
+  </data>
+  <data name="SnapshotModeControl_AvailablePatterns" xml:space="preserve">
+    <value>Available patterns</value>
+  </data>
+  <data name="SnapshotModeControl_AvailableProperties" xml:space="preserve">
+    <value>Available properties</value>
+  </data>
+  <data name="SnapshotModeControl_Glimpse" xml:space="preserve">
+    <value>Glimpse</value>
+  </data>
+  <data name="MainWindow_NumberFive" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="MainWindow_One" xml:space="preserve">
+    <value>One</value>
+  </data>
+  <data name="MainWindow_QuestionMark" xml:space="preserve">
+    <value>_?</value>
+  </data>
+  <data name="MainWindow_Two" xml:space="preserve">
+    <value>Two</value>
+  </data>
 </root>


### PR DESCRIPTION
#### Details

Moves strings/text to resources files.

##### Motivation

Compliance feature work.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



