### PR TITLE
chore: Remove unused resource strings from SharedUx assembly

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3152,15 +3152,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Check color contrast:.
-        /// </summary>
-        public static string RunTextColorContrast {
-            get {
-                return ResourceManager.GetString("RunTextColorContrast", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Quickly find accessibility issues with FastPass:.
         /// </summary>
         public static string RunTextFastPass {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -521,15 +521,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Next.
-        /// </summary>
-        public static string btnNextAutomationPropertiesName {
-            get {
-                return ResourceManager.GetString("btnNextAutomationPropertiesName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Ok.
         /// </summary>
         public static string btnOkContent {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1580,15 +1580,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Learn more about bug filing..
-        /// </summary>
-        public static string FileBugLink {
-            get {
-                return ResourceManager.GetString("FileBugLink", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to first color.
         /// </summary>
         public static string firstChooserAutomationPropertiesName {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1580,15 +1580,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Learn more about FastPass..
-        /// </summary>
-        public static string FastPassLink {
-            get {
-                return ResourceManager.GetString("FastPassLink", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Learn more about bug filing..
         /// </summary>
         public static string FileBugLink {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1963,15 +1963,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Learn more about Inspect..
-        /// </summary>
-        public static string InspectModeLink {
-            get {
-                return ResourceManager.GetString("InspectModeLink", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Invalid link {0}.
         /// </summary>
         public static string InvalidLink {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3181,15 +3181,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Identify accessibility issues caused by low color contrast..
-        /// </summary>
-        public static string RunTextManualColorTest {
-            get {
-                return ResourceManager.GetString("RunTextManualColorTest", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to You can change this choice anytime under Settings..
         /// </summary>
         public static string RunTextPrivacyStatement {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3152,15 +3152,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Quickly find accessibility issues with FastPass:.
-        /// </summary>
-        public static string RunTextFastPass {
-            get {
-                return ResourceManager.GetString("RunTextFastPass", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to File bugs:.
         /// </summary>
         public static string RunTextFileBugs {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3079,15 +3079,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Progress Loading Ring.
-        /// </summary>
-        public static string ProgressRingControlAutomationPropertiesName {
-            get {
-                return ResourceManager.GetString("ProgressRingControlAutomationPropertiesName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Properties.
         /// </summary>
         public static string propertiesLabelContent {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3756,15 +3756,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to What&apos;s new.
-        /// </summary>
-        public static string tbTitleText {
-            get {
-                return ResourceManager.GetString("tbTitleText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Get started.
         /// </summary>
         public static string tbVideoText1 {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3181,15 +3181,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Inspect the live UI Automation tree using Inspect mode..
-        /// </summary>
-        public static string RunTextInspectLiveUIATree {
-            get {
-                return ResourceManager.GetString("RunTextInspectLiveUIATree", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Verify an element has the expected UI Automation properties:.
         /// </summary>
         public static string RunTextInspectMode {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2062,15 +2062,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Loading....
-        /// </summary>
-        public static string LabelContentLoading {
-            get {
-                return ResourceManager.GetString("LabelContentLoading", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Other options.
         /// </summary>
         public static string LabelContentOtherOptions {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -521,15 +521,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Refresh.
-        /// </summary>
-        public static string btnRefreshAutomationPropertiesName {
-            get {
-                return ResourceManager.GetString("btnRefreshAutomationPropertiesName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Update range.
         /// </summary>
         public static string btnRefreshAutomationPropertiesNameUpdateRange {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3693,15 +3693,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to FastPass is a lightweight, two-step process that helps developers identify common, high-impact accessibility issues in less than 5 minutes..
-        /// </summary>
-        public static string tbFastPassInfoText {
-            get {
-                return ResourceManager.GetString("tbFastPassInfoText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Select the events to listen to in the Configuration tab, and select Record.
         /// </summary>
         public static string tbIntroTextSelectEventRecord {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -747,15 +747,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Learn more about checking color contrast..
-        /// </summary>
-        public static string CCALink {
-            get {
-                return ResourceManager.GetString("CCALink", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Do not change channel.
         /// </summary>
         public static string ChangeChannelContainedDialog_BtnExit {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3079,16 +3079,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Software\Microsoft\Windows NT\CurrentVersion\AccessibilityTemp.
-        /// </summary>
-        public static string ProgressRingControl_IsInternalScreenReaderActive_Software_Microsoft_Windows_NT_CurrentVersion_AccessibilityTemp {
-            get {
-                return ResourceManager.GetString("ProgressRingControl_IsInternalScreenReaderActive_Software_Microsoft_Windows_NT_Cu" +
-                        "rrentVersion_AccessibilityTemp", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Progress Loading Ring.
         /// </summary>
         public static string ProgressRingControlAutomationPropertiesName {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3181,15 +3181,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Verify an element has the expected UI Automation properties:.
-        /// </summary>
-        public static string RunTextInspectMode {
-            get {
-                return ResourceManager.GetString("RunTextInspectMode", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Can’t fix a bug right now? Log the bug in Azure Boards, complete with a snapshot file..
         /// </summary>
         public static string RunTextLogBugsIn {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2836,15 +2836,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Microsoft Accessibility Insights.
-        /// </summary>
-        public static string MessageDialogWindowTitle {
-            get {
-                return ResourceManager.GetString("MessageDialogWindowTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Bring Accessibility Insights for Windows to the foreground or minimize it..
         /// </summary>
         public static string minmizeOrActivateWindowText {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3181,15 +3181,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Can’t fix a bug right now? Log the bug in Azure Boards, complete with a snapshot file..
-        /// </summary>
-        public static string RunTextLogBugsIn {
-            get {
-                return ResourceManager.GetString("RunTextLogBugsIn", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Identify accessibility issues caused by low color contrast..
         /// </summary>
         public static string RunTextManualColorTest {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -332,15 +332,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to OK.
-        /// </summary>
-        public static string btnCloseAutomationPropertiesName1 {
-            get {
-                return ResourceManager.GetString("btnCloseAutomationPropertiesName1", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to _Close.
         /// </summary>
         public static string btnCloseContent {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3507,15 +3507,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to go to the latest release notes.
-        /// </summary>
-        public static string StartupModeControl_latestReleaseNotes {
-            get {
-                return ResourceManager.GetString("StartupModeControl_latestReleaseNotes", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to More guidance and tutorials.
         /// </summary>
         public static string StartupModeControl_moreGuidanceText {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3152,15 +3152,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File bugs:.
-        /// </summary>
-        public static string RunTextFileBugs {
-            get {
-                return ResourceManager.GetString("RunTextFileBugs", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to By opting into telemetry, you.
         /// </summary>
         public static string RunTextHelpCommunity1 {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2512,15 +2512,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to page.
-        /// </summary>
-        public static string LocalizedControlType_Page {
-            get {
-                return ResourceManager.GetString("LocalizedControlType_Page", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Telemetry was lost! Exceptions were flushed from ReportExceptionBuffer, but the telemetry sink was not open..
         /// </summary>
         public static string LostExceptionTelemetry {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1389,15 +1389,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 5.
-        /// </summary>
-        public static string DisplayCount {
-            get {
-                return ResourceManager.GetString("DisplayCount", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Display Delay count.
         /// </summary>
         public static string DisplayCountControlAutomationName {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -135,7 +135,6 @@
   <data name="lbDelayContent" xml:space="preserve">
     <value>Delay in sec</value>
   </data>
-  
   <data name="tbResultAutomationPropertiesName" xml:space="preserve">
     <value>Execution result</value>
   </data>
@@ -342,9 +341,6 @@
   </data>
   <data name="lblIssueFiling" xml:space="preserve">
     <value>Issue Filing</value>
-  </data>
-  <data name="btnNextAutomationPropertiesName" xml:space="preserve">
-    <value>Next</value>
   </data>
   <data name="RunTextFastPass" xml:space="preserve">
     <value>Quickly find accessibility issues with FastPass:</value>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -479,9 +479,6 @@
   <data name="tbTitleText" xml:space="preserve">
     <value>What's new</value>
   </data>
-  <data name="tbFastPassInfoText" xml:space="preserve">
-    <value>FastPass is a lightweight, two-step process that helps developers identify common, high-impact accessibility issues in less than 5 minutes.</value>
-  </data>
   <data name="MultiBindingStringFormattbFastPass" xml:space="preserve">
     <value>{0} in less than {1}</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -512,9 +512,6 @@
   <data name="RunTextManualColorTest" xml:space="preserve">
     <value>Identify accessibility issues caused by low color contrast.</value>
   </data>
-  <data name="CCALink" xml:space="preserve">
-    <value>Learn more about checking color contrast.</value>
-  </data>
   <data name="ColorChooserAutomationPropertiesName" xml:space="preserve">
     <value>Color chooser</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -749,9 +749,6 @@
   <data name="StartupModeControl_moreGuidanceText" xml:space="preserve">
     <value>More guidance and tutorials</value>
   </data>
-  <data name="StartupModeControl_latestReleaseNotes" xml:space="preserve">
-    <value>go to the latest release notes</value>
-  </data>
   <data name="StartUpModeControlAutomationPropertiesName" xml:space="preserve">
     <value>Welcome page</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -479,9 +479,6 @@
   <data name="tbTitleText" xml:space="preserve">
     <value>What's new</value>
   </data>
-  <data name="RunTextInspectMode" xml:space="preserve">
-    <value>Verify an element has the expected UI Automation properties:</value>
-  </data>
   <data name="tbFastPassInfoText" xml:space="preserve">
     <value>FastPass is a lightweight, two-step process that helps developers identify common, high-impact accessibility issues in less than 5 minutes.</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -491,9 +491,6 @@
   <data name="tbFastPassInfoText" xml:space="preserve">
     <value>FastPass is a lightweight, two-step process that helps developers identify common, high-impact accessibility issues in less than 5 minutes.</value>
   </data>
-  <data name="FastPassLink" xml:space="preserve">
-    <value>Learn more about FastPass.</value>
-  </data>
   <data name="MultiBindingStringFormattbFastPass" xml:space="preserve">
     <value>{0} in less than {1}</value>
   </data>
@@ -1502,9 +1499,6 @@ Do you want to change the channel? </value>
   </data>
   <data name="ApplicationSettingsControl_milliseconds" xml:space="preserve">
     <value>milliseconds</value>
-  </data>
-  <data name="DisplayCount" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="HierarchyControl_Control" xml:space="preserve">
     <value>_Control</value>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1002,9 +1002,6 @@
   <data name="MessageDialogWindowTitle" xml:space="preserve">
     <value>Microsoft Accessibility Insights</value>
   </data>
-  <data name="btnCloseAutomationPropertiesName1" xml:space="preserve">
-    <value>OK</value>
-  </data>
   <data name="MoveTextRangeDialogWindowTitle" xml:space="preserve">
     <value>Move/Compare TextRange...</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -491,9 +491,6 @@
   <data name="MultiBindingStringFormattbFastPass" xml:space="preserve">
     <value>{0} in less than {1}</value>
   </data>
-  <data name="RunTextFileBugs" xml:space="preserve">
-    <value>File bugs:</value>
-  </data>
   <data name="RunTextLogBugsIn" xml:space="preserve">
     <value>Can’t fix a bug right now? Log the bug in Azure Boards, complete with a snapshot file.</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -749,9 +749,6 @@
   <data name="lbNoPatternContent" xml:space="preserve">
     <value>No available pattern...</value>
   </data>
-  <data name="ProgressRingControlAutomationPropertiesName" xml:space="preserve">
-    <value>Progress Loading Ring</value>
-  </data>
   <data name="PropertyInfoControlAutomationPropertiesName" xml:space="preserve">
     <value>Selected Element Properties</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -752,9 +752,6 @@
   <data name="ProgressRingControlAutomationPropertiesName" xml:space="preserve">
     <value>Progress Loading Ring</value>
   </data>
-  <data name="ProgressRingControl_IsInternalScreenReaderActive_Software_Microsoft_Windows_NT_CurrentVersion_AccessibilityTemp" xml:space="preserve">
-    <value>Software\Microsoft\Windows NT\CurrentVersion\AccessibilityTemp</value>
-  </data>
   <data name="PropertyInfoControlAutomationPropertiesName" xml:space="preserve">
     <value>Selected Element Properties</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -485,9 +485,6 @@
   <data name="MultiBindingStringFormattbFastPass" xml:space="preserve">
     <value>{0} in less than {1}</value>
   </data>
-  <data name="RunTextLogBugsIn" xml:space="preserve">
-    <value>Can’t fix a bug right now? Log the bug in Azure Boards, complete with a snapshot file.</value>
-  </data>
   <data name="RunTextManualColorTest" xml:space="preserve">
     <value>Identify accessibility issues caused by low color contrast.</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -752,9 +752,6 @@
   <data name="ProgressRingControlAutomationPropertiesName" xml:space="preserve">
     <value>Progress Loading Ring</value>
   </data>
-  <data name="LabelContentLoading" xml:space="preserve">
-    <value>Loading...</value>
-  </data>
   <data name="ProgressRingControl_IsInternalScreenReaderActive_Software_Microsoft_Windows_NT_CurrentVersion_AccessibilityTemp" xml:space="preserve">
     <value>Software\Microsoft\Windows NT\CurrentVersion\AccessibilityTemp</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -818,9 +818,6 @@
   <data name="tbVideoText2" xml:space="preserve">
     <value>Learn about Accessibility Insights for Windows with this 4-minute introductory video.</value>
   </data>
-  <data name="LocalizedControlType_Page" xml:space="preserve">
-    <value>page</value>
-  </data>
   <data name="btnVideo_ClickException" xml:space="preserve">
     <value>Failed to start the video. please use this URL to open page.
  {0}</value>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -485,9 +485,6 @@
   <data name="MultiBindingStringFormattbFastPass" xml:space="preserve">
     <value>{0} in less than {1}</value>
   </data>
-  <data name="RunTextManualColorTest" xml:space="preserve">
-    <value>Identify accessibility issues caused by low color contrast.</value>
-  </data>
   <data name="ColorChooserAutomationPropertiesName" xml:space="preserve">
     <value>Color chooser</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -479,9 +479,6 @@
   <data name="tbTitleText" xml:space="preserve">
     <value>What's new</value>
   </data>
-  <data name="RunTextInspectLiveUIATree" xml:space="preserve">
-    <value>Inspect the live UI Automation tree using Inspect mode.</value>
-  </data>
   <data name="RunTextInspectMode" xml:space="preserve">
     <value>Verify an element has the expected UI Automation properties:</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -996,9 +996,6 @@
   <data name="TextBlockTextPressEscabeToCancel" xml:space="preserve">
     <value>Press Escape to cancel.</value>
   </data>
-  <data name="MessageDialogWindowTitle" xml:space="preserve">
-    <value>Microsoft Accessibility Insights</value>
-  </data>
   <data name="MoveTextRangeDialogWindowTitle" xml:space="preserve">
     <value>Move/Compare TextRange...</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -500,9 +500,6 @@
   <data name="RunTextLogBugsIn" xml:space="preserve">
     <value>Can’t fix a bug right now? Log the bug in Azure Boards, complete with a snapshot file.</value>
   </data>
-  <data name="RunTextColorContrast" xml:space="preserve">
-    <value>Check color contrast:</value>
-  </data>
   <data name="RunTextManualColorTest" xml:space="preserve">
     <value>Identify accessibility issues caused by low color contrast.</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -342,9 +342,6 @@
   <data name="lblIssueFiling" xml:space="preserve">
     <value>Issue Filing</value>
   </data>
-  <data name="RunTextFastPass" xml:space="preserve">
-    <value>Quickly find accessibility issues with FastPass:</value>
-  </data>
   <data name="RunTextTabStops" xml:space="preserve">
     <value>Tab Stops</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -500,9 +500,6 @@
   <data name="RunTextLogBugsIn" xml:space="preserve">
     <value>Can’t fix a bug right now? Log the bug in Azure Boards, complete with a snapshot file.</value>
   </data>
-  <data name="FileBugLink" xml:space="preserve">
-    <value>Learn more about bug filing.</value>
-  </data>
   <data name="RunTextColorContrast" xml:space="preserve">
     <value>Check color contrast:</value>
   </data>
@@ -1339,9 +1336,6 @@ We collect anonymized data to identify the top accessibility issues found by use
   </data>
   <data name="lblAutoDetectContent" xml:space="preserve">
     <value>Auto detect contrast ratio</value>
-  </data>
-  <data name="InspectModeLink" xml:space="preserve">
-    <value>Learn more about Inspect.</value>
   </data>
   <data name="ColorContrast_AutoDetectGuidance" xml:space="preserve">
     <value>Auto-detection allows you to evaulate color contrast ratios by hovering over an element or setting the keyboard focus on it.</value>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1008,9 +1008,6 @@
   <data name="MoveTextRangeDialog_btnAction_Click_Return_0" xml:space="preserve">
     <value>Return: {0}</value>
   </data>
-  <data name="btnRefreshAutomationPropertiesName" xml:space="preserve">
-    <value>Refresh</value>
-  </data>
   <data name="PropertyConfigDialogWindowTitle" xml:space="preserve">
     <value>Properties Configuration</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -476,9 +476,6 @@
   <data name="TabStopControl_StartRecordingEvent_NoSelection" xml:space="preserve">
     <value>No element is selected yet. please select first!!</value>
   </data>
-  <data name="tbTitleText" xml:space="preserve">
-    <value>What's new</value>
-  </data>
   <data name="MultiBindingStringFormattbFastPass" xml:space="preserve">
     <value>{0} in less than {1}</value>
   </data>


### PR DESCRIPTION
#### Details

The SharedUx assembly has several strings that have been either removed completely or migrated into other assemblies, but the string resources never got removed. We noticed a few of these while working on #1126 and #1127, but deferred the cleanup until a later change. This PR is intentionally broken up into one change per resource, if that makes it simpler to review.

##### Motivation

Remove unused stuff

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
I found some misspellings and strings with awkward names, but it would be cleaner to remove the chaff before trying to change anything else.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



