### PR TITLE
fix: Update pattern content to reflect interface changes

### DIFF
--- a/src/AccessibilityInsights.SharedUx/ViewModels/BaseActionViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/BaseActionViewModel.cs
@@ -141,13 +141,13 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// <returns></returns>
         internal static BaseActionViewModel GetActionViewModel(A11yPattern p, MethodInfo m)
         {
-            if (m.ReturnType == typeof(DesktopElement) || m.ReturnType == typeof(List<DesktopElement>))
+            if (m.ReturnType == typeof(DesktopElement) || m.ReturnType == typeof(IList<DesktopElement>))
             {
                 return new ReturnA11yElementsViewModel(p, m);
             }
             else if(m.ReturnType.Name != "IAccessible")
             {
-                if (m.ReturnType != typeof(TextRange) && m.ReturnType != typeof(List<TextRange>))
+                if (m.ReturnType != typeof(TextRange) && m.ReturnType != typeof(IList<TextRange>))
                 {
                     return new GeneralActionViewModel(p, m);
                 }


### PR DESCRIPTION
#### Details

Axe.Windows 1.0.7 changed a couple of return types from `List` to `IList`, but the code that maps the return type to a view didn't get updated. Issue #1138 was a direct result of that oversight.

##### Motivation

Address #1138, fix regression

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
It occurs to me that we might consider some E2E tests that exercise patterns, but that's out of scope for this change.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #1138
- [fixes regression] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



