### PR TITLE
fix: Add themed styling to properties search bar

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
@@ -24,10 +24,9 @@
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="{Binding Path=Width, 
-           RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UIElement},Mode=OneWayToSource}"/>
+                    <ColumnDefinition Width="{Binding Path=Width, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UIElement},Mode=OneWayToSource}"/>
                 </Grid.ColumnDefinitions>
-                <Border Background="{DynamicResource ResourceKey=DataGridBGBrush}" x:Name="dpFilter" Grid.Row="0" HorizontalAlignment="Stretch" BorderBrush="LightGray" BorderThickness="0" Height="24" Margin="4,0,2,5">
+                <Border Background="{DynamicResource ResourceKey=DataGridBGBrush}" x:Name="dpFilter" Grid.Row="0" HorizontalAlignment="Stretch" BorderBrush="LightGray" BorderThickness="0" Height="28" Margin="4,0,2,5">
                     <DockPanel>
                         <controls:FabricIconControl GlyphName="Search" GlyphSize="Custom" FontSize="18" Margin="5,0,5,0" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=SearchAndIconForegroundBrush}" ShowInControlView="False"/>
                         <controls:PlaceholderTextBox x:Name="textboxSearch" TextChanged="textboxSearch_TextChanged"
@@ -38,6 +37,8 @@
                                     Background="Transparent" Placeholder="{x:Static Properties:Resources.tbSearchText}">
                             <controls:PlaceholderTextBox.Style>
                                 <Style TargetType="{x:Type controls:PlaceholderTextBox}" BasedOn="{StaticResource ResourceKey=PlaceholderTextBox}">
+                                    <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                                    <Setter Property="CaretBrush" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding Text, ElementName=textboxSearch}" Value="">
                                             <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SearchAndIconForegroundBrush}"/>
@@ -46,7 +47,7 @@
                                 </Style>
                             </controls:PlaceholderTextBox.Style>
                         </controls:PlaceholderTextBox>
-                    </DockPanel>                        
+                    </DockPanel>
                 </Border>
                 <customcontrols:CustomListView
                     x:Name="lvProperties" Grid.Row="2"


### PR DESCRIPTION
#### Details

Fix styling details that were missed on the properties search dialog. This includes setting the foreground and caret colors, as well as making the containing control tall enough to not clip the top part of the focus rectangle.

GIF wall with fix in place (Note that the blue highlight in HC2 is just because I happened to have that item selected and is unrelated to the change):
Mode | GIF
--- | ---
Light | ![search-light](https://user-images.githubusercontent.com/45672944/125844294-860b8d2f-7b2a-4c1a-9848-064bc9561a62.gif)
Dark | ![search-dark](https://user-images.githubusercontent.com/45672944/125844325-4b9ac1d3-95a4-4fd1-8d96-bc62f5011ccf.gif)
HC 1 | ![search-hc1](https://user-images.githubusercontent.com/45672944/125844346-4d5d7558-4a24-46b3-9044-4a5dd65f4d4d.gif)
HC 2 | ![search-hc2](https://user-images.githubusercontent.com/45672944/125844359-3c7894f8-edf5-4eb9-b2a1-0080419562c6.gif)
HC Black | ![search-hcblack](https://user-images.githubusercontent.com/45672944/125844377-e2506b3f-a028-4630-97f8-34d5f433328e.gif)
HC White | ![search-hcwhite](https://user-images.githubusercontent.com/45672944/125844394-29969fd3-3dd0-47bc-a119-3890f4bdfeac.gif)


##### Motivation

Address issue #1149 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
At some point, we might want to walk through the code with a design of consolidating more settings into global styles.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #1149
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



