### PR TITLE
feat(custom-uia): Add telemetry for custom UIA property count

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryAction.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryAction.cs
@@ -50,6 +50,8 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         ColorContrast_Click_HexChange,
 
         ReleaseChannel_ChangeConsidered,
+
+        Custom_UIA,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryBuffer.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryBuffer.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace AccessibilityInsights.SharedUx.Telemetry
+{
+    /// <summary>
+    /// Class to buffer telemetry events prior to telemetry initialization, then play them back after
+    /// initialization if telemetry is enabled.
+    /// </summary>
+    public class TelemetryBuffer
+    {
+        private readonly List<Func<TelemetryEvent>> _eventFactoryList = new List<Func<TelemetryEvent>>();
+
+        public void AddEventFactory(Func<TelemetryEvent> eventFactory)
+        {
+            if (eventFactory == null)
+                throw new ArgumentNullException(nameof(eventFactory));
+
+            _eventFactoryList.Add(eventFactory);
+        }
+
+        public void ProcessEventFactories(Action<TelemetryEvent> processor)
+        {
+            if (processor == null)
+                throw new ArgumentNullException(nameof(processor));
+
+            foreach(Func<TelemetryEvent> eventFactory in _eventFactoryList)
+            {
+                processor(eventFactory());
+            }
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
@@ -38,5 +38,6 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         ReleaseChannelConsidered,
         IssueReporter,
         InstalledDotNetFrameworkVersion,
+        CustomUIAPropertyCount,
     }
 }

--- a/src/AccessibilityInsights.SharedUxTests/Telemetry/TelemetryBufferUnitTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Telemetry/TelemetryBufferUnitTests.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using AccessibilityInsights.SharedUx.Telemetry;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+
+namespace AccessibilityInsights.SharedUXTests.Telemetry
+{
+    [TestClass]
+    public class TelemetryBufferUnitTests
+    {
+        private TelemetryBuffer _testSubject;
+
+        [TestInitialize]
+        public void BeforeEachTest()
+        {
+            _testSubject = new TelemetryBuffer();
+        }
+
+        [TestMethod]
+        [Timeout(2000)]
+        public void AddEventFactory_FactoryIsNull_ThrowsArgumentNullException()
+        {
+            ArgumentNullException e = Assert.ThrowsException<ArgumentNullException>(() => _testSubject.AddEventFactory(null));
+            Assert.AreEqual("eventFactory", e.ParamName);
+        }
+
+        [TestMethod]
+        [Timeout(2000)]
+        public void AddEventFactory_FactoryIsNotNull_SavesFactoryWithoutInvokingIt()
+        {
+            _testSubject.AddEventFactory(() => { Assert.Fail("Factory should not be invoked"); return null; });
+        }
+
+        [TestMethod]
+        [Timeout(2000)]
+        public void ProcessEventFactories_ProcessorIsNull_ThrowsArgumentNullException()
+        {
+            ArgumentNullException e = Assert.ThrowsException<ArgumentNullException>(() => _testSubject.ProcessEventFactories(null));
+            Assert.AreEqual("processor", e.ParamName);
+        }
+
+        [TestMethod]
+        [Timeout(2000)]
+        public void ProcessEventFactories_ProcessorIsNotNull_NoEvents_ProcessorIsNotInvoked()
+        {
+            _testSubject.ProcessEventFactories((_) => Assert.Fail("Processor should not be invoked"));
+        }
+
+        [TestMethod]
+        [Timeout(2000)]
+        public void ProcessEventFactories_ProcessorIsNotNull_HasEvents_ProcessorIsInvokedInOrder()
+        {
+            const TelemetryAction action1 = TelemetryAction.Event_Load;
+            const TelemetryAction action2 = TelemetryAction.Event_Save;
+            List<TelemetryEvent> receivedTelemetryEvents = new List<TelemetryEvent>();
+
+            _testSubject.AddEventFactory(() => new TelemetryEvent(action1, new Dictionary<TelemetryProperty, string>()));
+            _testSubject.AddEventFactory(() => new TelemetryEvent(action2, new Dictionary<TelemetryProperty, string>()));
+
+            _testSubject.ProcessEventFactories((telemetryEvent) => receivedTelemetryEvents.Add(telemetryEvent));
+
+            Assert.AreEqual(2, receivedTelemetryEvents.Count);
+            Assert.AreEqual(action1, receivedTelemetryEvents[0].Action);
+            Assert.AreEqual(action2, receivedTelemetryEvents[1].Action);
+        }
+    }
+}

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -150,15 +150,17 @@ namespace AccessibilityInsights
 
         public MainWindow()
         {
+            TelemetryBuffer telemetryBuffer = new TelemetryBuffer();
+
             SystemEvents.UserPreferenceChanging += SystemEvents_UserPreferenceChanging;
 
             SetColorTheme();
 
-            ///in case we need to do any debugging with elevated app
+            // in case we need to do any debugging with elevated app
             SupportDebugging();
 
             // create necessary config folders & their internal config files
-            PopulateConfigurations();
+            PopulateConfigurations(telemetryBuffer);
 
             SetFontSize();
 
@@ -173,7 +175,7 @@ namespace AccessibilityInsights
             this.TreeNavigator = new TreeNavigator(this);
             this.TreeNavigator.SelectionChanged += this.HandleTargetSelectionChanged;
 
-            InitTelemetry();
+            InitTelemetry(telemetryBuffer);
 
             InitPanes();
         }
@@ -181,7 +183,7 @@ namespace AccessibilityInsights
         /// <summary>
         /// Set up some context properties like installation id, app version, session id
         /// </summary>
-        private static void InitTelemetry()
+        private static void InitTelemetry(TelemetryBuffer telemetryBuffer)
         {
             var configFolder = ConfigurationManager.GetDefaultInstance().SettingsProvider.ConfigurationFolderPath;
             // Initialize user info from file if it exists, reset if needed, and re-serialize
@@ -192,6 +194,7 @@ namespace AccessibilityInsights
             Logger.AddOrUpdateContextProperty(TelemetryProperty.SessionType, "Desktop");
             Logger.AddOrUpdateContextProperty(TelemetryProperty.ReleaseChannel, ConfigurationManager.GetDefaultInstance().AppConfig.ReleaseChannel.ToString());
             Logger.PublishTelemetryEvent(Misc.TelemetryEventFactory.ForMainWindowStartup());
+            telemetryBuffer.ProcessEventFactories(Logger.PublishTelemetryEvent);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -113,6 +113,7 @@ namespace AccessibilityInsights
                 if (config?.Properties != null)
                 {
                     CustomUIAAction.RegisterCustomProperties(config.Properties);
+                    Logger.PublishTelemetryEvent(TelemetryEventFactory.ForCustomUIAPropertyCount(config.Properties.Length));
                 }
             }
         }

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -103,7 +103,7 @@ namespace AccessibilityInsights
         }
 
         /// <summary>Load and register for custom UI Automation properties if a configuration file exists.</summary>
-        private static void InitCustomUIA(string ConfigurationFolderPath)
+        private static void InitCustomUIA(string ConfigurationFolderPath, TelemetryBuffer telemetryBuffer)
         {
             const string ConfigurationFileName = "CustomUIA.json";
             string path = Path.Combine(ConfigurationFolderPath, ConfigurationFileName);
@@ -113,7 +113,7 @@ namespace AccessibilityInsights
                 if (config?.Properties != null)
                 {
                     CustomUIAAction.RegisterCustomProperties(config.Properties);
-                    Logger.PublishTelemetryEvent(TelemetryEventFactory.ForCustomUIAPropertyCount(config.Properties.Length));
+                    telemetryBuffer.AddEventFactory(() => TelemetryEventFactory.ForCustomUIAPropertyCount(config.Properties.Length));
                 }
             }
         }
@@ -121,7 +121,7 @@ namespace AccessibilityInsights
         /// <summary>
         /// Populate all configurations
         /// </summary>
-        private static void PopulateConfigurations()
+        private static void PopulateConfigurations(TelemetryBuffer telemetryBuffer)
         {
             var defaultPaths = FixedConfigSettingsProvider.CreateDefaultSettingsProvider();
             var configPathProvider = new FixedConfigSettingsProvider(
@@ -135,7 +135,7 @@ namespace AccessibilityInsights
             // Populate the App Config and Test Config
             ConfigurationManager.GetDefaultInstance(configPathProvider);
 
-            InitCustomUIA(configPathProvider.ConfigurationFolderPath);
+            InitCustomUIA(configPathProvider.ConfigurationFolderPath, telemetryBuffer);
 
             // based on customer feedback, we will set default selection mode to Element
             // when AccessibilityInsights starts up.

--- a/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
+++ b/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using AccessibilityInsights.SetupLibrary;
 using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.Win32;
@@ -122,6 +123,16 @@ namespace AccessibilityInsights.Misc
                     { TelemetryProperty.UIAccessEnabled, NativeMethods.IsRunningWithUIAccess().ToString(CultureInfo.InvariantCulture) },
                     { TelemetryProperty.InstalledDotNetFrameworkVersion, formattedDotNetFrameworkVersion }
                 });
+        }
+
+        public static TelemetryEvent ForCustomUIAPropertyCount(int count)
+        {
+            return new TelemetryEvent(TelemetryAction.Custom_UIA,
+                new Dictionary<TelemetryProperty, string>
+                {
+                    [TelemetryProperty.CustomUIAPropertyCount] = count.ToString(CultureInfo.InvariantCulture)
+                }
+            );
         }
     }
 }


### PR DESCRIPTION
#### Details
Add telemetry for number of registered custom UIA properties when telemetry and custom UIA are enabled.

##### Motivation
Part of custom UIA extensions feature (internal Microsoft access required to view).

#### Pull request checklist
- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.
