### PR TITLE
fix: Show correct keyboard shortcut in startup screen

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -123,7 +123,7 @@
                         <Run Text="{x:Static properties:Resources.StartupModeControl_shortcutsDescription}"/>
                     </TextBlock>
                     <Border Grid.Row="3" Grid.Column="1" Style="{StaticResource BrdrKey}" VerticalAlignment="Center">
-                        <Label Name="lblEventHk" Style="{StaticResource LblKey}" Content="{x:Static properties:Resources.StartUpModeControl_ShiftF6}" Padding="3,6">
+                        <Label Name="lblEventHk" Style="{StaticResource LblKey}" Content="{x:Static properties:Resources.StartUpModeControl_ShiftF7}" Padding="3,6">
                             <AutomationProperties.Name>
                                 <MultiBinding StringFormat="{}{0} {1}">
                                     <Binding RelativeSource="{RelativeSource Self}" Path="Content"/>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3516,11 +3516,11 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Shift + F6.
+        ///   Looks up a localized string similar to Shift + F7.
         /// </summary>
-        public static string StartUpModeControl_ShiftF6 {
+        public static string StartUpModeControl_ShiftF7 {
             get {
-                return ResourceManager.GetString("StartUpModeControl_ShiftF6", resourceCulture);
+                return ResourceManager.GetString("StartUpModeControl_ShiftF7", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1500,8 +1500,8 @@ Do you want to change the channel? </value>
   <data name="MoveTextRangeDialog_Run" xml:space="preserve">
     <value>Run</value>
   </data>
-  <data name="StartUpModeControl_ShiftF6" xml:space="preserve">
-    <value>Shift + F6</value>
+  <data name="StartUpModeControl_ShiftF7" xml:space="preserve">
+    <value>Shift + F7</value>
   </data>
   <data name="StartUpModeControl_ShiftF8" xml:space="preserve">
     <value>Shift + F8</value>


### PR DESCRIPTION
#### Details

The startup screen currently shows Shift+F6 as the shortcut for event recording. The correct value, shown in both the control panel in the [documented shortcuts](https://accessibilityinsights.io/docs/en/windows/reference/keyboard/#live-inspect)), as well as proven by direct testing, is Shift+F7

##### Motivation

Show correct information

##### Screenshots
Before change | After change
--- | ---
![image](https://user-images.githubusercontent.com/45672944/127051317-4a28d3e3-4e9c-48b8-9f16-94bdc2ca95fe.png)  | ![image](https://user-images.githubusercontent.com/45672944/127051254-6f09ccc2-76c4-43cd-ad74-0e6efa769c72.png)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
I renamed the string name for consistency with the content

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



