### PR TITLE
chore: Update telemetry docs to include Custom_UIA event

### DIFF
--- a/docs/TelemetryDetails.md
+++ b/docs/TelemetryDetails.md
@@ -22,6 +22,13 @@ Additional properties: None.
 Trigger: The user enters a value in a hex dialog in the Color Contrast view.  
 Additional properties: None.
 
+#### Custom_UIA
+Trigger: The application was configured with a `CustomUIA.json` file as described in the [online documentation](https://accessibilityinsights.io/docs/en/windows/reference/faq/#does-accessibility-insights-for-windows-support-custom-ui-automation-properties).  
+Additional properties:
+Name | Value 
+--- | ---
+CustomUIAPropertyCount | The count of custom UIA properties that were defined in the `CustomUIA.json` file.
+
 #### Event_Load
 Trigger: The user successfully opens a previously-saved A11yEvents file.  
 Additional properties: None.

--- a/docs/TelemetryDetails.md
+++ b/docs/TelemetryDetails.md
@@ -23,7 +23,7 @@ Trigger: The user enters a value in a hex dialog in the Color Contrast view.
 Additional properties: None.
 
 #### Custom_UIA
-Trigger: The application was configured with a `CustomUIA.json` file as described in the [online documentation](https://accessibilityinsights.io/docs/en/windows/reference/faq/#does-accessibility-insights-for-windows-support-custom-ui-automation-properties).  
+Trigger: The application was configured with a `CustomUIA.json` file as described in the [online documentation](https://accessibilityinsights.io/docs/en/windows/reference/faq/#does-accessibility-insights-for-windows-support-custom-ui-automation-properties). This event is sent _only_ if a valid `Custom_UIA.json` exists.
 Additional properties:
 Name | Value 
 --- | ---


### PR DESCRIPTION
#### Details

In #1162, we added telemetry without updating the corresponding documentation. This updates the documentation 

##### Motivation

Keep docs in sync with code.

##### Telemetry sample
Here's slightly redacted output of an actual event in telemetry--note that the value for the `customDimensions` property is a json-formatted object, and that `CustomUIAPropertyCount` is a property on that object:

Property | Value
--- | ---
name | Custom_UIA
itemType | customEvent
customDimensions | {"ReleaseChannel":"Canary","InstallationID":"4d05726d-3e0f-43e1-83c2-0aefa1709636","AppSessionID":"ff1dc94a-ef9e-4e66-a5c4-d13fd156d0b9","SessionType":"Desktop","Version":"1.1.1667.1","CustomUIAPropertyCount":"9"}

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



