### PR TITLE
chore: Replace ADO dialog with simple error dialog

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/AdoNotSupportedDialog.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/AdoNotSupportedDialog.xaml
@@ -1,0 +1,19 @@
+﻿<!-- Copyright (c) Microsoft. All rights reserved.
+     Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
+<Window x:Class="AccessibilityInsights.Extensions.AzureDevOps.FileIssue.AdoNotSupportedDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="Accessibility Insights for Windows" Height="220" Width="300" WindowStartupLocation="CenterScreen" WindowStyle="ToolWindow">
+<Grid>
+        <TextBlock Name="tbInstructions" Width="Auto" Height="Auto" TextWrapping="Wrap" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" >
+            <!-- Non-standard breaks around the hyperlink at to intentionaly to avoid whitespace around the link -->
+            <Run Text="Bug filing for AzureDevOps is not currently supported. This issue is being tracked at"/>
+            <Hyperlink NavigateUri="https://github.com/microsoft/accessibility-insights-windows/issues/1167" Click="Hyperlink_Click">
+                        <Run Text="https://github.com/microsoft/accessibility-insights-windows/issues/1167"/></Hyperlink><Run Text=". Please refer to that issue to learn the most recent state of the problem." />
+        </TextBlock>
+        <Button Content="OK" IsDefault="True" HorizontalAlignment="Center" Margin="0,10" VerticalAlignment="Bottom" Width="75" Click="Button_Click"/>
+    </Grid>
+</Window>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/AdoNotSupportedDialog.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/AdoNotSupportedDialog.xaml
@@ -9,7 +9,7 @@
         Title="Accessibility Insights for Windows" Height="220" Width="300" WindowStartupLocation="CenterScreen" WindowStyle="ToolWindow">
 <Grid>
         <TextBlock Name="tbInstructions" Width="Auto" Height="Auto" TextWrapping="Wrap" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" >
-            <!-- Non-standard breaks around the hyperlink at to intentionaly to avoid whitespace around the link -->
+            <!-- Non-standard breaks around the hyperlink are intentional to avoid whitespace around the link -->
             <Run Text="Bug filing for AzureDevOps is not currently supported. This issue is being tracked at"/>
             <Hyperlink NavigateUri="https://github.com/microsoft/accessibility-insights-windows/issues/1167" Click="Hyperlink_Click">
                         <Run Text="https://github.com/microsoft/accessibility-insights-windows/issues/1167"/></Hyperlink><Run Text=". Please refer to that issue to learn the most recent state of the problem." />

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/AdoNotSupportedDialog.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/AdoNotSupportedDialog.xaml.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using AccessibilityInsights.Extensions.Helpers;
+using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Documents;
+
+namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
+{
+    /// <summary>
+    /// Interaction logic for AdoNotSupportedDialog.xaml
+    /// </summary>
+    public partial class AdoNotSupportedDialog : Window
+    {
+        public AdoNotSupportedDialog()
+        {
+            InitializeComponent();
+        }
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        private void Hyperlink_Click(object sender, RoutedEventArgs e)
+        {
+            var uri = ((Hyperlink)sender).NavigateUri;
+
+            try
+            {
+                Process.Start(uri.AbsoluteUri);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+            {
+                ex.ReportException();
+                // silently ignore.
+            }
+#pragma warning restore CA1031 // Do not catch general exception types
+        }
+    }
+}

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/AdoNotSupportedDialog.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/AdoNotSupportedDialog.xaml.cs
@@ -14,9 +14,10 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
     /// </summary>
     public partial class AdoNotSupportedDialog : Window
     {
-        public AdoNotSupportedDialog()
+        public AdoNotSupportedDialog(bool onTop)
         {
             InitializeComponent();
+            Topmost = onTop;
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/FileIssueHelpers.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/FileIssueHelpers.cs
@@ -298,7 +298,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
 
             return dlg.IssueId;
 #else
-            var dlg = new AdoNotSupportedDialog();
+            var dlg = new AdoNotSupportedDialog(onTop);
             dlg.ShowDialog();
             return null;
 #endif

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/FileIssueHelpers.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/FileIssueHelpers.cs
@@ -298,10 +298,8 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
 
             return dlg.IssueId;
 #else
-            if (MessageBoxResult.Yes ==  MessageBox.Show("Bug filing to Azure DevOps is not currently supported. This issue is tracked at https://github.com/microsoft/accessibility-insights-windows/issues/1167. Would you like to open the issue tracking this problem?", "Accessibility Insights for Windows", MessageBoxButton.YesNo))
-            {
-                Process.Start("https://github.com/microsoft/accessibility-insights-windows/issues/1167");
-            }
+            var dlg = new AdoNotSupportedDialog();
+            dlg.ShowDialog();
             return null;
 #endif
         }

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/FileIssueHelpers.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/FileIssueHelpers.cs
@@ -6,12 +6,14 @@ using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
 using mshtml;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Windows;
 using static System.FormattableString;
 
 namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
@@ -283,8 +285,10 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
         /// Change the configuration zoom level for the embedded browser
         /// </summary>
         /// <param name="url"></param>
+#pragma warning disable CA1801 // Review unused parameters
         private static int? FileIssueWindow(Uri url, bool onTop, int zoomLevel, Action<int> updateZoom)
         {
+#if ADO_HAS_BEEN_FIXED
             System.Diagnostics.Trace.WriteLine(Invariant($"Url is {url.AbsoluteUri.Length} long: {url}"));
             IEBrowserEmulation.SetFeatureControls();
             var dlg = new IssueFileForm(url, onTop, zoomLevel, updateZoom);
@@ -293,7 +297,15 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
             dlg.ShowDialog();
 
             return dlg.IssueId;
+#else
+            if (MessageBoxResult.Yes ==  MessageBox.Show("Bug filing to Azure DevOps is not currently supported. This issue is tracked at https://github.com/microsoft/accessibility-insights-windows/issues/1167. Would you like to open the issue tracking this problem?", "Accessibility Insights for Windows", MessageBoxButton.YesNo))
+            {
+                Process.Start("https://github.com/microsoft/accessibility-insights-windows/issues/1167");
+            }
+            return null;
+#endif
         }
+#pragma warning restore CA1801 // Review unused parameters
 
         /// <summary>
         /// Creates a temp file with the given extension and returns its path


### PR DESCRIPTION
#### Details

ADO bug filing has recently stopped working (see #1167). We need to investigate a long-term strategy here, but we've agreed to a short-term strategy of warning uses who attempt to use ADO bug filing that it's unavailable and provide information to learn more about the current state. 

##### Motivation

Educate the user about #1167 

##### Interim User Experience
When the user clicks on the "File Issue" button using ADO, the following dialog is presented:
![image](https://user-images.githubusercontent.com/45672944/128087977-c7fffe4c-2aee-47e2-9323-d9d70edefdd9.png)

If the user clicks on the link, the issue is opened. The dialog goes away when the user clicks the OK button (which is also the default button)

![ado-warning-2](https://user-images.githubusercontent.com/45672944/128087669-91c0205f-368f-442d-93a4-df7c7b5c8c45.gif)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
We considered just using MessageBox but decided that the experience was less than we wanted it to be.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ado fails] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #1167 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



