### PR TITLE
fix: Correct incorrect document link

### DIFF
--- a/docs/TelemetryOverview.md
+++ b/docs/TelemetryOverview.md
@@ -49,4 +49,4 @@ catch (Exception e)
 All telemetry (including reported exceptions) is under user control. When the application starts the first time, the user is allowed to enable or disable telemetry. The user can change this option at any time via the settings page.
 
 ### More details
-More details are available in the [Telemetry Details Documentation](./TelemeryDetails.md)
+More details are available in the [Telemetry Details Documentation](./TelemetryDetails.md)


### PR DESCRIPTION
#### Details

There's a typo in the link from `TelemetryOverview.md` to `TelemetryDetails.md`, so the link doesn't work. This fixes the typo.

##### Motivation

Links should work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? 
- [docs only] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



