### PR TITLE
fix: Make labels in About dialog focusable

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
@@ -55,7 +55,7 @@
         </TreeView>
         <Label x:Name="lbNoPattern" Content="{x:Static Properties:Resources.lbNoPatternContent}"
                    Grid.Row="1"
-                   Style="{DynamicResource LblFocusable}"
+                   Style="{DynamicResource LblFocusablePrimaryFG}"
                    VerticalAlignment="Center"
                    HorizontalAlignment="Center"/>
     </Grid>

--- a/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
@@ -55,7 +55,6 @@
         </TreeView>
         <Label x:Name="lbNoPattern" Content="{x:Static Properties:Resources.lbNoPatternContent}"
                    Grid.Row="1"
-                   Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"
                    Style="{DynamicResource LblFocusable}"
                    VerticalAlignment="Center"
                    HorizontalAlignment="Center"/>

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -15,8 +15,8 @@
         <ResourceDictionary Source="..\..\Resources\Styles.xaml"/>
     </UserControl.Resources>
     <StackPanel Margin="20,10,20,0">
-        <Label Padding="0" FontSize="20" FontWeight="Bold" Content="{x:Static Properties:Resources.LabelContentAccessibilityInsightsForWindows}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
-        <Label Padding="0" FontSize="14" Margin="0,5,0,0" Content="{x:Static Properties:Resources.LabelContentByMicrosoftCorporation}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+        <TextBlock Padding="0" FontSize="20" FontWeight="Bold" Text="{x:Static Properties:Resources.LabelContentAccessibilityInsightsForWindows}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" Focusable="True"/>
+        <TextBlock Padding="0" FontSize="14" Margin="0,5,0,0" Text="{x:Static Properties:Resources.LabelContentByMicrosoftCorporation}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" Focusable="True"/>
         <TextBlock Padding="0" FontSize="14" Margin="0,5,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlVersion" AutomationProperties.Name="{Binding Path=VersionInfoLabel, Mode=OneWay}" 
                     Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 
@@ -25,8 +25,8 @@
             </Hyperlink>
         </TextBlock>
         <TextBlock Text="{Binding Path=AxeVersion, StringFormat={x:Static Properties:Resources.AboutTabControl_AxeVersionFormat}}"
-               Style="{StaticResource tbHeaderDark}" Margin="0,5,0,0"/>
-        <Label Style="{StaticResource lblDark}" Margin="0,5,0,0" Content="{Binding Path=UIAccessStatus, Mode=OneWay}" />
+               Style="{StaticResource tbHeaderDark}" Margin="0,5,0,0" Focusable="True"/>
+        <TextBlock Style="{StaticResource tbHeaderDark}" Margin="0,5,0,0" Text="{Binding Path=UIAccessStatus, Mode=OneWay}" Focusable="True"/>
         <TextBlock Padding="0" FontSize="14" Margin="0,32,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlHelp" AutomationProperties.Name="{x:Static Properties:Resources.hlHelpName}" 
                        Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -15,8 +15,8 @@
         <ResourceDictionary Source="..\..\Resources\Styles.xaml"/>
     </UserControl.Resources>
     <StackPanel Margin="20,10,20,0">
-        <Label Padding="0" FontSize="20" FontWeight="Bold" Content="{x:Static Properties:Resources.LabelContentAccessibilityInsightsForWindows}" Style="{StaticResource LblFocusable}"/>
-        <Label Padding="0" FontSize="14" Margin="0,5,0,0" Content="{x:Static Properties:Resources.LabelContentByMicrosoftCorporation}" Style="{StaticResource LblFocusable}"/>
+        <Label Padding="0" FontSize="20" FontWeight="Bold" Content="{x:Static Properties:Resources.LabelContentAccessibilityInsightsForWindows}" Style="{StaticResource LblFocusablePrimaryFG}"/>
+        <Label Padding="0" FontSize="14" Margin="0,5,0,0" Content="{x:Static Properties:Resources.LabelContentByMicrosoftCorporation}" Style="{StaticResource LblFocusablePrimaryFG}"/>
         <TextBlock Padding="0" FontSize="14" Margin="0,5,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlVersion" AutomationProperties.Name="{Binding Path=VersionInfoLabel, Mode=OneWay}" 
                     Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 
@@ -26,7 +26,7 @@
         </TextBlock>
         <TextBlock Text="{Binding Path=AxeVersion, StringFormat={x:Static Properties:Resources.AboutTabControl_AxeVersionFormat}}"
                Style="{StaticResource TbFocusable}" Margin="0,5,0,0" Padding="0" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
-        <Label Style="{StaticResource LblFocusable}" Margin="0,5,0,0" Content="{Binding Path=UIAccessStatus, Mode=OneWay}" Padding="0"/>
+        <Label Style="{StaticResource LblFocusablePrimaryFG}" Margin="0,5,0,0" Content="{Binding Path=UIAccessStatus, Mode=OneWay}" Padding="0"/>
         <TextBlock Padding="0" FontSize="14" Margin="0,32,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlHelp" AutomationProperties.Name="{x:Static Properties:Resources.hlHelpName}" 
                        Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -26,7 +26,7 @@
         </TextBlock>
         <TextBlock Text="{Binding Path=AxeVersion, StringFormat={x:Static Properties:Resources.AboutTabControl_AxeVersionFormat}}"
                Style="{StaticResource TbFocusable}" Margin="0,5,0,0" Padding="0" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
-        <Label Margin="0,5,0,0" Content="{Binding Path=UIAccessStatus, Mode=OneWay}" Style="{StaticResource LblFocusable}" Padding="0"/>
+        <Label Style="{StaticResource LblFocusable}" Margin="0,5,0,0" Content="{Binding Path=UIAccessStatus, Mode=OneWay}" Padding="0"/>
         <TextBlock Padding="0" FontSize="14" Margin="0,32,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlHelp" AutomationProperties.Name="{x:Static Properties:Resources.hlHelpName}" 
                        Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -15,8 +15,8 @@
         <ResourceDictionary Source="..\..\Resources\Styles.xaml"/>
     </UserControl.Resources>
     <StackPanel Margin="20,10,20,0">
-        <TextBlock Padding="0" FontSize="20" FontWeight="Bold" Text="{x:Static Properties:Resources.LabelContentAccessibilityInsightsForWindows}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" Focusable="True"/>
-        <TextBlock Padding="0" FontSize="14" Margin="0,5,0,0" Text="{x:Static Properties:Resources.LabelContentByMicrosoftCorporation}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}" Focusable="True"/>
+        <Label Padding="0" FontSize="20" FontWeight="Bold" Content="{x:Static Properties:Resources.LabelContentAccessibilityInsightsForWindows}" Style="{StaticResource LblFocusable}"/>
+        <Label Padding="0" FontSize="14" Margin="0,5,0,0" Content="{x:Static Properties:Resources.LabelContentByMicrosoftCorporation}" Style="{StaticResource LblFocusable}"/>
         <TextBlock Padding="0" FontSize="14" Margin="0,5,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlVersion" AutomationProperties.Name="{Binding Path=VersionInfoLabel, Mode=OneWay}" 
                     Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 
@@ -25,8 +25,8 @@
             </Hyperlink>
         </TextBlock>
         <TextBlock Text="{Binding Path=AxeVersion, StringFormat={x:Static Properties:Resources.AboutTabControl_AxeVersionFormat}}"
-               Style="{StaticResource tbHeaderDark}" Margin="0,5,0,0" Focusable="True"/>
-        <TextBlock Style="{StaticResource tbHeaderDark}" Margin="0,5,0,0" Text="{Binding Path=UIAccessStatus, Mode=OneWay}" Focusable="True"/>
+               Style="{StaticResource TbFocusable}" Margin="0,5,0,0" Padding="0" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+        <Label Margin="0,5,0,0" Content="{Binding Path=UIAccessStatus, Mode=OneWay}" Style="{StaticResource LblFocusable}" Padding="0"/>
         <TextBlock Padding="0" FontSize="14" Margin="0,32,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlHelp" AutomationProperties.Name="{x:Static Properties:Resources.hlHelpName}" 
                        Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -211,6 +211,8 @@
         <Setter Property="Focusable" Value="True"/>
         <Setter Property="KeyboardNavigation.IsTabStop" Value="True"/>
         <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
+    </Style>
+    <Style TargetType="{x:Type Label}" x:Key="LblFocusablePrimaryFG" BasedOn="{StaticResource ResourceKey=LblFocusable}">
         <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="TxtTelemetrySettingInfo">

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -211,6 +211,7 @@
         <Setter Property="Focusable" Value="True"/>
         <Setter Property="KeyboardNavigation.IsTabStop" Value="True"/>
         <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="TxtTelemetrySettingInfo">
         <Setter Property="FontSize" Value="10"/>


### PR DESCRIPTION
#### Details

Convert labels in the About dialog to focusable text to they're more accessible via NVDA & Narrator

##### Motivation

Addresses issue found in trusted tester pass

##### Wall of GIF's
Mode | GIF
--- | ---
Light | ![focusable-light](https://user-images.githubusercontent.com/45672944/131548947-78c4c061-55dd-46f9-935b-6b392f61fa85.gif)
Dark | ![focusable-dark](https://user-images.githubusercontent.com/45672944/131548987-eb4136fe-205b-4fa7-841b-50f76f3abcdf.gif)
HC 1 | ![focusable-hc-1](https://user-images.githubusercontent.com/45672944/131549017-406b371f-4e30-424e-aef0-a1bce445fcf0.gif)
HC 2 | ![focusable-hc-2](https://user-images.githubusercontent.com/45672944/131549050-6d265d6c-cffa-473c-88ca-0230109ff014.gif)
HC Black | ![focusable-hc-black](https://user-images.githubusercontent.com/45672944/131549076-1c72da64-b5fb-4d6a-b72a-fe1cd65346cd.gif)
HC White | ![focusable-hc-white](https://user-images.githubusercontent.com/45672944/131549118-154897ff-6993-4f22-9fc6-f5143f4e7154.gif)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
I noticed that all cases where we used the LblFocusable style also set the Foreground color. I didn' t want to couple the color with the foreground, so I created a new style that combines them, then used that style in all places that used to use LblFocusable.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - [1868875](https://dev.azure.com/mseng/1ES/_workitems/edit/1868875)
- [x] Includes UI changes? No visual distinction
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



