### PR TITLE
fix: Use underlines for hyperlinks

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/PrivacyLearnMore.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PrivacyLearnMore.xaml
@@ -14,8 +14,7 @@
                 AutomationProperties.Name="{x:Static Properties:Resources.PrivacyLearnMoreLink}" 
                 NavigateUri="https://privacy.microsoft.com/en-US/privacystatement" 
                 RequestNavigate="Hyperlink_RequestNavigate" 
-                FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 
-                TextDecorations="None">
+                FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">
         <Hyperlink.Style>
             <Style TargetType="Hyperlink" BasedOn="{StaticResource {x:Type Hyperlink}}">
                 <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonLinkFGBrush}"/>

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/AboutTabControl.xaml
@@ -20,7 +20,7 @@
         <TextBlock Padding="0" FontSize="14" Margin="0,5,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlVersion" AutomationProperties.Name="{Binding Path=VersionInfoLabel, Mode=OneWay}" 
                     Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 
-                    NavigateUri="{Binding Path=VersionInfoUri}" TextDecorations="None" Style="{StaticResource hLink}">
+                    NavigateUri="{Binding Path=VersionInfoUri}" Style="{StaticResource hLink}">
                 <Run Text="{Binding Path=VersionInfoLabel, Mode=OneWay}" />
             </Hyperlink>
         </TextBlock>
@@ -30,21 +30,21 @@
         <TextBlock Padding="0" FontSize="14" Margin="0,32,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlHelp" AutomationProperties.Name="{x:Static Properties:Resources.hlHelpName}" 
                        Click="HyperLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 
-                       NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077919" TextDecorations="None" Style="{StaticResource hLink}">
+                       NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077919" Style="{StaticResource hLink}">
                 <Run Text="{x:Static Properties:Resources.hlHelpName}" />
             </Hyperlink>
         </TextBlock>
         <TextBlock Padding="0" FontSize="14" Margin="0,8,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlTerms" AutomationProperties.Name="{x:Static Properties:Resources.hlTermsName}" 
                        Click="FileLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 
-                       NavigateUri="eula.rtf" TextDecorations="None" Style="{StaticResource hLink}">
+                       NavigateUri="eula.rtf" Style="{StaticResource hLink}">
                 <Run Text="{x:Static Properties:Resources.hlTermsName}" />
             </Hyperlink>
         </TextBlock>
         <TextBlock Padding="0" FontSize="14" Margin="0,8,0,0" HorizontalAlignment="Left">
             <Hyperlink x:Name="hlNotices" AutomationProperties.Name="{x:Static Properties:Resources.hlThirdpartyNoticesName}" 
                        Click="FileLink_Click" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" 
-                       NavigateUri="thirdpartynotices.html" TextDecorations="None" AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.SettingsThirdPartyNoticesHyperlink}" Style="{StaticResource hLink}">
+                       NavigateUri="thirdpartynotices.html" AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.SettingsThirdPartyNoticesHyperlink}" Style="{StaticResource hLink}">
                 <Run Text="{x:Static Properties:Resources.hlThirdpartyNoticesName}" />
             </Hyperlink>
         </TextBlock>

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml
@@ -25,7 +25,7 @@
                         TextWrapping="Wrap" Margin="0 0 0 15" Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}" Focusable="True">
                 <Run Text="{x:Static Properties:Resources.connectionInstrText}"/>
                <TextBlock>
-                    <Hyperlink Name="hlLink" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" TextDecorations="None" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2075269" Style="{StaticResource hLink}">
+                    <Hyperlink Name="hlLink" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2075269" Style="{StaticResource hLink}">
                         <Run Text="{x:Static Properties:Resources.issueFilingLink}"/>
                     </Hyperlink><Run Text="{x:Static Properties:Resources.SentenceEndPeriod}"/>
                 </TextBlock>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -45,7 +45,7 @@
                 <Run FontSize="{DynamicResource StandardTextSize}" Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}" Text="{x:Static Properties:Resources.ColorContrast_IntroRun}" />
                 <Hyperlink
                     AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_IntroLink}" Click="hlLearnAboutColorContrast_Click" Style="{StaticResource hLink}" Name="hlLearnMore">
-                    <Run Text="{x:Static Properties:Resources.ColorContrast_IntroLink}" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" />
+                    <Run Text="{x:Static Properties:Resources.ColorContrast_IntroLink}" />
                 </Hyperlink>
                 </TextBlock>
                 <Grid Grid.Row="2" Grid.ColumnSpan="2" Height="24" Margin="0,16,0,0" VerticalAlignment="Top">

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml
@@ -44,8 +44,8 @@
                 <TextBlock Grid.Row="1" FontSize="{DynamicResource StandardTextSize}" Margin="0,0,0,0" TextWrapping="Wrap" Grid.ColumnSpan="2" VerticalAlignment="Center">
                 <Run FontSize="{DynamicResource StandardTextSize}" Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}" Text="{x:Static Properties:Resources.ColorContrast_IntroRun}" />
                 <Hyperlink
-                    TextDecorations="{x:Null}" AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_IntroLink}" Click="hlLearnAboutColorContrast_Click" Style="{StaticResource hLink}" Name="hlLearnMore">
-                    <Run Text="{x:Static Properties:Resources.ColorContrast_IntroLink}" />
+                    AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_IntroLink}" Click="hlLearnAboutColorContrast_Click" Style="{StaticResource hLink}" Name="hlLearnMore">
+                    <Run Text="{x:Static Properties:Resources.ColorContrast_IntroLink}" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" />
                 </Hyperlink>
                 </TextBlock>
                 <Grid Grid.Row="2" Grid.ColumnSpan="2" Height="24" Margin="0,16,0,0" VerticalAlignment="Top">
@@ -202,7 +202,7 @@
                         <TextBlock  Margin="0 0 0 8">
                             <!--  Non-standard line breaks around the hyperlink are intentional to avoid whitespaces around the link -->
                             <Run Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}" Text="{x:Static Properties:Resources.ColorContrast_RequiresRegularSizePre}"/><Hyperlink
-                                TextDecorations="{x:Null}" AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" Click="hlWCAG_1_4_3_Click" Style="{StaticResource hLink}">
+                                AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" Click="hlWCAG_1_4_3_Click" Style="{StaticResource hLink}">
                                 <Run Text="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" />
                             </Hyperlink><Run Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}" Text="{x:Static Properties:Resources.ColorContrast_RequiresRegularSizePost}" />
                         </TextBlock>
@@ -261,7 +261,7 @@
                         <TextBlock  Margin="0 0 0 8">
                             <!--  Non-standard line breaks around the hyperlink are intentional to avoid whitespaces around the link -->
                             <Run Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}" Text="{x:Static Properties:Resources.ColorContrast_RequiresLargeSizePre}" /><Hyperlink
-                                TextDecorations="{x:Null}" AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" Click="hlWCAG_1_4_3_Click" Style="{StaticResource hLink}">
+                                AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" Click="hlWCAG_1_4_3_Click" Style="{StaticResource hLink}">
                                 <Run Text="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_3}" />
                             </Hyperlink><Run Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}" Text="{x:Static Properties:Resources.ColorContrast_RequiresLargeSizePost}" />
                         </TextBlock>
@@ -332,7 +332,7 @@
                         <TextBlock  Margin="0 0 0 8">
                             <!--  Non-standard line breaks around the hyperlink are intentional to avoid whitespaces around the link -->
                             <Run Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}" Text="{x:Static Properties:Resources.ColorContrast_RequiresNonTextObjectsPre}" /><Hyperlink
-                                TextDecorations="{x:Null}" AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_11}" Click="hlWCAG_1_4_11_Click" Style="{StaticResource hLink}">
+                                AutomationProperties.Name="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_11}" Click="hlWCAG_1_4_11_Click" Style="{StaticResource hLink}">
                                 <Run Text="{x:Static Properties:Resources.ColorContrast_TextBlock_WCAG_1_4_11}" />
                             </Hyperlink><Run Foreground="{DynamicResource ResourceKey=SecondaryFGBrush}" Text="{x:Static Properties:Resources.ColorContrast_RequiresNonTextObjectsPost}" />
                             <Border Margin="6,0,0,-7" VerticalAlignment="Center" Background="{DynamicResource ResourceKey=BubbleBGBrush}" CornerRadius="10">

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml
@@ -44,7 +44,7 @@
             </TextBlock>
             <TextBlock Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,0,0,10" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}">
                 <Run FontWeight="SemiBold" FontSize="{DynamicResource ConstXLTextSize}" Text="{x:Static Properties:Resources.RunTextTabStops}" />
-                <Hyperlink TextDecorations="{x:Null}" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"
+                <Hyperlink FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"
                            NavigateUri="https://go.microsoft.com/fwlink/?linkid=2080645" RequestNavigate="Hyperlink_RequestNavigate"
                            Style="{StaticResource hLink}">
                     <Run Text="{x:Static Properties:Resources.TabStopsControl_TabStopsLink}"/>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -50,7 +50,7 @@
                     <Run Text="{x:Static properties:Resources.LabelContentAccessibilityInsightsForWindows}" FontSize="24"/>
                     <LineBreak/>
                     <LineBreak/>
-                    <Hyperlink x:Name="hlVersion" TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="{Binding Path=AppVersionUri, Mode=OneWay}"
+                    <Hyperlink x:Name="hlVersion" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="{Binding Path=AppVersionUri, Mode=OneWay}"
                                 AutomationProperties.Name="{Binding Path=VersionInfoLabel, Mode=OneWay}" Style="{StaticResource hLink}">
                         <Run Text="{Binding Path=VersionInfoLabel, Mode=OneWay}" FontSize="12"/>
                     </Hyperlink>
@@ -89,7 +89,7 @@
                     </Button>
                     <TextBlock Grid.Column="1" Grid.Row="3" Grid.ColumnSpan="3" TextWrapping="Wrap" Foreground="{DynamicResource ResourceKey=StartupFGBrush}" Padding="0"
                            FontWeight="Light" VerticalAlignment="Center" TextAlignment="Left" Margin="12,17,12,12">
-                        <Hyperlink x:Name="hlHelp" TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077919"
+                        <Hyperlink x:Name="hlHelp" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077919"
                                     AutomationProperties.Name="{x:Static properties:Resources.StartupModeControl_moreGuidanceText}" Style="{StaticResource hLink}">
                             <Run Text="{x:Static properties:Resources.StartupModeControl_moreGuidanceText}" FontSize="12" FontWeight="Light"/>
                         </Hyperlink>
@@ -156,7 +156,7 @@
                     </Border>
                     <TextBlock Name="txtActivateHk" Grid.Row="7" Grid.Column="3" Style="{StaticResource TbBaseWrap}" Text="{x:Static properties:Resources.minmizeOrActivateWindowText}" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
                     <TextBlock Grid.Row="8" Grid.ColumnSpan="8" Padding="16,4,0,10" TextWrapping="Wrap">
-                        <Hyperlink TextDecorations="None" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2073853"
+                        <Hyperlink FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2073853"
                                    AutomationProperties.Name="{Binding ElementName=shortcutsDescTxt, Path=Text}" Style="{StaticResource hLink}">
                             <Run x:Name="shortcutsDescTxt" Text="{x:Static properties:Resources.StartupModeControl_shortcutsLinkLabel}" FontSize="12" FontWeight="Light"/>
                         </Hyperlink>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TelemetryApproveContainedDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TelemetryApproveContainedDialog.xaml
@@ -36,7 +36,7 @@
             </Grid.ColumnDefinitions>
             <TextBlock Style="{StaticResource TxtTelemetryDialogText}" TextWrapping="Wrap" >
                     <Run Text="{x:Static properties:Resources.RunTextHelpCommunity1}"/>
-                    <Hyperlink x:Name="hlHelpCommunity" AutomationProperties.Name="{x:Static properties:Resources.RunTextHelpCommunity2}" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077765" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" TextDecorations="None" Style="{StaticResource hLink}"><Run Text="{x:Static properties:Resources.RunTextHelpCommunity2}" /></Hyperlink>
+                    <Hyperlink x:Name="hlHelpCommunity" AutomationProperties.Name="{x:Static properties:Resources.RunTextHelpCommunity2}" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077765" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}"><Run Text="{x:Static properties:Resources.RunTextHelpCommunity2}" /></Hyperlink>
                     <Run Text="{x:Static properties:Resources.RunTextHelpCommunity3}" />
             </TextBlock>
         </Grid>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -355,16 +355,11 @@
         <Setter Property="Padding" Value="0"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="tbLink">
+        <Setter Property="TextDecorations" Value="Underline"/>
         <Setter Property="Focusable" Value="True"/>
         <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
         <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ButtonLinkFGBrush}"/>
         <Style.Triggers>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="TextDecorations" Value="Underline"/>
-            </Trigger>
-            <Trigger Property="IsFocused" Value="True">
-                <Setter Property="TextDecorations" Value="Underline"/>
-            </Trigger>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Cursor" Value="Hand"/>
             </Trigger>


### PR DESCRIPTION
#### Details

In a recent trusted tester pass, a bug was filed about distinguishing hyperlinks only by color, since they had no underlines. This was a design decision made a long time ago, but since we've put underlines in some places in response to trusted tester bugs, I just went ahead and put underlines in all hyperlinks. More specifically, this involved 2 changes:

1. We were suppressing the underlines by overriding the **TextDecorations** property. The PR removes all of those overrides.
2. In the tbLink style, we were only setting the Underline style on mouse hover. This now sets the style all the time

##### Motivation

Address trusted tester bug

##### Screenshots
I'm just including the Color Contrast screen and the test results screen in the screenshots, even though the change impacts other places, as well:

Location | Before | After
--- | --- | ---
Color Contrast | ![image](https://user-images.githubusercontent.com/45672944/131761611-5fb68db1-f8e1-4aab-8493-ef3f332e6206.png) | ![CCA](https://user-images.githubusercontent.com/45672944/132068190-67ae1ec5-91a5-4ecb-ac56-0be7bc9654b4.png)
Test Results | ![No_Underlines](https://user-images.githubusercontent.com/45672944/132067850-31e0ee7e-ff9e-405d-b7ed-54a92a2b020a.png) | ![Underlines](https://user-images.githubusercontent.com/45672944/132067868-7b0e2240-e8e1-400a-9ffd-286b016129f1.png)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
The bug also makes a comment about color contrast ratio, but I checked with @ferBonnin who clarified that if we use underlines our current colors will be OK.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - [1868536](https://dev.azure.com/mseng/1ES/_workitems/edit/1868536)
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



