### PR TITLE
fix: Allow tooltips to display until the user takes action

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Behaviors/KeyboardToolTipButtonBehavior.cs
+++ b/src/AccessibilityInsights.SharedUx/Behaviors/KeyboardToolTipButtonBehavior.cs
@@ -60,18 +60,6 @@ namespace AccessibilityInsights.SharedUx.Behaviors
                     tt.Placement = PlacementMode.Left;
                     tt.PlacementRectangle = new Rect(0, (sender as Control).Height + 5, 0, 0);
                     tt.IsOpen = true;
-
-                    // set up a timer to clear the tooltip after 5 secs if focus has not been changed
-                    DispatcherTimer timer = new DispatcherTimer() { Interval = TimeSpan.FromSeconds(5) };
-                    timer.Tick += delegate (object _sender, EventArgs _e)
-                    {
-                        ((DispatcherTimer)timer).Stop();
-                        if (tt.IsOpen)
-                        {
-                            tt.IsOpen = false;
-                        }
-                    };
-                    timer.Start();
                 }
             }
         }

--- a/src/AccessibilityInsights/App.xaml.cs
+++ b/src/AccessibilityInsights/App.xaml.cs
@@ -116,9 +116,9 @@ namespace AccessibilityInsights
             }
 
             // WPF hides tooltips after a few seconds, which is bad for accessibility.
-            // Override the default for the longest possible value.
+            // Override the default to 1 day
             ToolTipService.ShowDurationProperty.OverrideMetadata(typeof(UIElement),
-                new FrameworkPropertyMetadata(int.MaxValue));
+                new FrameworkPropertyMetadata((int)TimeSpan.FromDays(1).TotalMilliseconds));
         }
     }
 }

--- a/src/AccessibilityInsights/App.xaml.cs
+++ b/src/AccessibilityInsights/App.xaml.cs
@@ -5,6 +5,7 @@ using AccessibilityInsights.SharedUx.Highlighting;
 using System;
 using System.Collections.Generic;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -106,13 +107,18 @@ namespace AccessibilityInsights
             Resources.MergedDictionaries.Add(this.fontResourceDictionary);
         }
 
-        // Stackoverflow: https://stackoverflow.com/questions/4951058/software-rendering-mode-wpf answer by Matt Varblow
         protected override void OnStartup(StartupEventArgs e)
         {
+            // StackOverflow: https://stackoverflow.com/questions/4951058/software-rendering-mode-wpf answer by Matt Varblow
             if (DisableHardwareRendering)
             {
                 RenderOptions.ProcessRenderMode = RenderMode.SoftwareOnly;
             }
+
+            // WPF hides tooltips after a few seconds, which is bad for accessibility.
+            // Override the default for the longest possible value.
+            ToolTipService.ShowDurationProperty.OverrideMetadata(typeof(UIElement),
+                new FrameworkPropertyMetadata(int.MaxValue));
         }
     }
 }


### PR DESCRIPTION
#### Details

The current code hides tooltips after 5 seconds, which violates current accessibility requirements. Change the code to display them until the user takes some action that would dismiss them.

We actually had code that was hardcoded to a 5 second dismissal of the tooltips, but 5 seconds also seems to be the default value from WPF. I found no way to tell WPF not to hide tooltips at all, but I was able to set the duration to int.MaxValue

##### Motivation

Address trusted tester bug

##### Screenshots

These screenshots only show the tooltip for about 15 seconds, but it will last much longer. In fact, int.MaxValue in milliseconds represents about 24 days of actual time...

Old | New
--- | ---
![Tooltip-Timer](https://user-images.githubusercontent.com/45672944/132902595-73f28d0b-7596-44e8-962f-6a7a9d4ded34.gif) | ![Tooltip-Indefinite](https://user-images.githubusercontent.com/45672944/132902612-c58dd479-da09-4423-9211-1be5b0266cb1.gif)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue - [1869230](https://mseng.visualstudio.com/DefaultCollection/1ES/_workitems/edit/1869230)
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



