### PR TITLE
fix: Handle unhandled exception during update

### DIFF
--- a/src/AccessibilityInsights.SetupLibrary/REST/GitHubClient.cs
+++ b/src/AccessibilityInsights.SetupLibrary/REST/GitHubClient.cs
@@ -58,10 +58,10 @@ namespace AccessibilityInsights.SetupLibrary.REST
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 state.Status = TriState.Failure;
             }
+#pragma warning restore CA1031 // Do not catch general exception types
             finally
             {
                 stopwatch.Stop();
@@ -77,14 +77,17 @@ namespace AccessibilityInsights.SetupLibrary.REST
         {
             DownloadState state = e.UserState as DownloadState;
 
-            if (e.Cancelled || e.Error != null)
+            try
+            {
+                state.Stream.Write(e.Result, 0, e.Result.Length);
+                state.Status = TriState.Success;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception)
             {
                 state.Status = TriState.Failure;
-                return;
             }
-
-            state.Stream.Write(e.Result, 0, e.Result.Length);
-            state.Status = TriState.Success;
+#pragma warning restore CA1031 // Do not catch general exception types
         }
 
         private static void ProgressChanged(object sender, DownloadProgressChangedEventArgs e)

--- a/src/AccessibilityInsights.SetupLibrary/TriState.cs
+++ b/src/AccessibilityInsights.SetupLibrary/TriState.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace AccessibilityInsights.SetupLibrary
+{
+    public enum TriState
+    {
+        Unknown,
+        Success,
+        Failure,
+    }
+}


### PR DESCRIPTION
#### Details

Issue #1191 highlighted an error case that we overlooked. The root cause is that the code added to provide a progress indicator to the dialog didn't include handling for externally caused failure (network issue, etc.) or for user cancellation. In terms of the code, when the download failed, we get to https://github.com/microsoft/accessibility-insights-windows/blob/main/src/AccessibilityInsights.SetupLibrary/REST/GitHubClient.cs#L72 and access the value for `DownloadDataCompletedEventArgs.Result`. This indirectly calls into https://github.com/microsoft/referencesource/blob/master/System/compmod/system/componentmodel/AsyncCompletedEventArgs.cs#L60, where the `TargetInvocationException` gets thrown if an error occurred. Since the callback to DownloadCompleted is async, the exception is thrown outside the scope of our Exception handler at https://github.com/microsoft/accessibility-insights-windows/blob/main/src/AccessibilityInsights.SetupLibrary/REST/GitHubClient.cs#L58, and the app dies as a result.

My initial fix was to detect abnormal exits before touching the `DownloadDataCompletedEventArgs.Result`, so the exception never gets thrown. To do this, I replaced `bool DownloadState.Complete` with `TriState DownloadState.Status` and allowed the code that waited for completion to safely exit in all cases. Inside the `DownloadCompleted` method, I first checked for cases that would cause the `TargetInvocation` to get thrown. Upon further investigation, I discovered that if I forced the `ProgressChanged` method to set the Status flag to `TriState.Failure`, an error dialog would display for 15 seconds, then the app would be forcibly shut down. As it turns out, `DownloadCompleted` was still being called in this case but the Exception was being triggered by something unrelated to the `DownloadProgressChangedEventArgs` object. Because of this, I kept the `TriState` but changed `DownloadComplete` to contain a try/catch block, so we'd handle exceptions in all cases.

If the download completes successfully, then no exception is thrown. If the download fails for any reason, then we throw an `ArgumentException` about the uri, which produces the following error message (the application exits only after the user presses the OK button):

```
---------------------------
An error occurred during install
---------------------------
Unable to get contents from https://www.github.com/Microsoft/accessibility-insights-windows/releases/download/v1.1.1689.01.AccessibilityInsights.msi

Parameter name: uri
---------------------------
OK
---------------------------
```

##### Motivation

Address #1191 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
At some point in time, it might be worth improving the error message. I focused primarily on fixing the app crash.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
See details

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #1191 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



