### PR TITLE
fix: Add a handler to clear button tooltip when Escape is pressed

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Behaviors/KeyboardToolTipButtonBehavior.cs
+++ b/src/AccessibilityInsights.SharedUx/Behaviors/KeyboardToolTipButtonBehavior.cs
@@ -6,7 +6,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
-using System.Windows.Threading;
 
 namespace AccessibilityInsights.SharedUx.Behaviors
 {
@@ -25,6 +24,7 @@ namespace AccessibilityInsights.SharedUx.Behaviors
         {
             base.OnAttached();
 
+            AssociatedObject.AddHandler(Button.KeyDownEvent, new KeyEventHandler(CancelButtonTooltipOnEscape), true);
             AssociatedObject.AddHandler(Button.LostKeyboardFocusEvent, new KeyboardFocusChangedEventHandler(ClearButtonTooltip), true);
             AssociatedObject.AddHandler(Button.GotKeyboardFocusEvent, new KeyboardFocusChangedEventHandler(ShowButtonTooltip), true);
             AssociatedObject.AddHandler(Button.MouseEnterEvent, new MouseEventHandler(ButtonMouseEnter), true);
@@ -37,6 +37,14 @@ namespace AccessibilityInsights.SharedUx.Behaviors
             {
                 ToolTip tt = (ToolTip)(currentToolTipButton as Control).ToolTip;
                 tt.IsOpen = false;
+            }
+        }
+
+        private static void CancelButtonTooltipOnEscape(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                ClearButtonTooltip();
             }
         }
 


### PR DESCRIPTION
#### Details

#1192 Made tooltips stay visible indefinitely (instead of disappearing after 5 seconds). What was lacking, though, was a way to dismiss the tooltip to get it out of the way, and the bug was reactivated as a result. This PR adds a keyboard handler to dismiss the tooltip when the user presses Escape, as described in https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html.

##### Motivation

Fix trusted tester bug

##### Gif of feature in action
![esc-tooltips](https://user-images.githubusercontent.com/45672944/133510005-5ae8aafa-6ef1-4446-a95c-edd0d5dff83a.gif)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
Dismiss on escape was raised in the comments for #1192, but since the framework dismissed on Shift+Ctrl+F10, we believed that would suffice. To meet WCAG guidelines, we need something easier.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue - [1869230](https://mseng.visualstudio.com/1ES/_workitems/edit/1869230)
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



