### PR TITLE
fix: Ensure windows bounds at all zoom levels

### DIFF
--- a/src/AccessibilityInsights.sln
+++ b/src/AccessibilityInsights.sln
@@ -82,6 +82,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomActions", "Accessibil
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomActionsUnitTests", "AccessibilityInsights.CustomActionsUnitTests\CustomActionsUnitTests.csproj", "{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AccessibilityInsightsUnitTests", "AccessibilityInsightsUnitTests\AccessibilityInsightsUnitTests.csproj", "{757A7A71-E939-43DB-B7D3-4EC30347368B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -496,6 +498,24 @@ Global
 		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.SignedRelease|x64.ActiveCfg = Release|Any CPU
 		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.SignedRelease|x64.Build.0 = Release|Any CPU
 		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E}.SignedRelease|x86.ActiveCfg = Release|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.Debug|x64.Build.0 = Debug|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.Debug|x86.Build.0 = Debug|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.Release|x64.ActiveCfg = Release|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.Release|x64.Build.0 = Release|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.Release|x86.ActiveCfg = Release|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.Release|x86.Build.0 = Release|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.SignedRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.SignedRelease|Any CPU.Build.0 = Release|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.SignedRelease|x64.ActiveCfg = Release|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.SignedRelease|x64.Build.0 = Release|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.SignedRelease|x86.ActiveCfg = Release|Any CPU
+		{757A7A71-E939-43DB-B7D3-4EC30347368B}.SignedRelease|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -524,6 +544,7 @@ Global
 		{01426834-55CE-4942-8445-194E4E1BE22A} = {C23FB215-D2F6-454D-BD08-7736562CDFB3}
 		{5838601C-D9EB-4198-9608-5F93735A04E4} = {2190F103-4B22-43FE-A047-093356B1007A}
 		{3AB5DE55-FD68-40C2-A1AC-2F4422C75A5E} = {2190F103-4B22-43FE-A047-093356B1007A}
+		{757A7A71-E939-43DB-B7D3-4EC30347368B} = {809F77B0-82E0-4990-A9A4-4806157385E9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {25101A75-9178-4066-B360-E932959B9758}

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -422,6 +422,23 @@ namespace AccessibilityInsights
                 SystemParameters.VirtualScreenWidth, SystemParameters.VirtualScreenHeight);
         }
 
+        /// <summary>
+        /// Return the first non-NaN number from an array of potentialNumbers.
+        /// Will return 0.0 if they're all NaN.
+        /// </summary>
+        private static double GetFirstNumber(double[] potentialNumbers)
+        {
+            foreach(double potentialNumber in potentialNumbers)
+            {
+                if (!double.IsNaN(potentialNumber))
+                {
+                    return potentialNumber;
+                }
+            }
+
+            return 0.0;
+        }
+
         internal static void EnsureWindowIsInVirtualScreenWithInjection(AppLayout layout,
             double windowTop, double windowLeft, double virtualLeft,
             double virtualTop, double virtualWidth, double virtualHeight)
@@ -431,8 +448,8 @@ namespace AccessibilityInsights
 
             if (layout != null)
             {
-                layout.Top = double.IsNaN(layout.Top) ? windowTop : layout.Top;
-                layout.Left = double.IsNaN(layout.Left) ? windowLeft : layout.Left;
+                layout.Top = GetFirstNumber(new double[] { layout.Top, windowTop, 200.0 });
+                layout.Left = GetFirstNumber(new double[] { layout.Left, windowLeft, 200.0 });
 
                 double top = layout.Top;
                 double left = layout.Left;
@@ -468,7 +485,7 @@ namespace AccessibilityInsights
                 {
                     layout.Top = virtualBottom - layout.Height;
                 }
-                if (top < virtualTop)
+                else if (top < virtualTop)
                 {
                     layout.Top = virtualTop;
                 }

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -423,10 +423,10 @@ namespace AccessibilityInsights
         }
 
         /// <summary>
-        /// Return the first non-NaN number from an array of potentialNumbers.
+        /// Return the first defined number from an array of potentialNumbers.
         /// Will return 0.0 if they're all NaN.
         /// </summary>
-        private static double GetFirstNumber(double[] potentialNumbers)
+        private static double GetFirstDefinedNumber(double[] potentialNumbers)
         {
             foreach(double potentialNumber in potentialNumbers)
             {
@@ -436,7 +436,7 @@ namespace AccessibilityInsights
                 }
             }
 
-            return 0.0;
+            return 0.0; // Our ultimate fallback value
         }
 
         internal static void EnsureWindowIsInVirtualScreenWithInjection(AppLayout layout,
@@ -448,8 +448,9 @@ namespace AccessibilityInsights
 
             if (layout != null)
             {
-                layout.Top = GetFirstNumber(new double[] { layout.Top, windowTop, 200.0 });
-                layout.Left = GetFirstNumber(new double[] { layout.Left, windowLeft, 200.0 });
+                const double fallbackWindowPosition = 200.0;
+                layout.Top = GetFirstDefinedNumber(new double[] { layout.Top, windowTop, fallbackWindowPosition });
+                layout.Left = GetFirstDefinedNumber(new double[] { layout.Left, windowLeft, fallbackWindowPosition });
 
                 double top = layout.Top;
                 double left = layout.Left;

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interop;
+using System.Windows.Media;
 using System.Windows.Shell;
 
 namespace AccessibilityInsights
@@ -91,9 +92,8 @@ namespace AccessibilityInsights
         /// </summary>
         private void UpdateMainWindowLayout()
         {
-            var layout = ConfigurationManager.GetDefaultInstance().AppLayout;
-
-            FixWindowPositionForStartup();
+            AppLayout layout = ConfigurationManager.GetDefaultInstance().AppLayout;
+            EnsureWindowIsInVirtualScreen(layout);
 
             this.Top = layout.Top;
             this.Left = layout.Left;
@@ -411,45 +411,66 @@ namespace AccessibilityInsights
         }
 
         /// <summary>
-        /// Sets window position to avoid opening window offscreen. Modelled after explorer's behavior
-        /// If fully offscreen, open in default position
-        /// If partially offscreen, move onscreen
+        /// Make sure that the app layout is fully within the virtual screen, including resizing it
+        /// if necessary.
         /// </summary>
-        /// <returns></returns>
-        private void FixWindowPositionForStartup()
+        /// <param name="layout">The layout. Its position will be modified only if necessary</param>
+        private void EnsureWindowIsInVirtualScreen(AppLayout layout)
         {
-            var layout = ConfigurationManager.GetDefaultInstance().AppLayout;
+            EnsureWindowIsInVirtualScreenWithInjection(layout, this.Top, this.Left,
+                SystemParameters.VirtualScreenLeft, SystemParameters.VirtualScreenTop,
+                SystemParameters.VirtualScreenWidth, SystemParameters.VirtualScreenHeight);
+        }
+
+        internal static void EnsureWindowIsInVirtualScreenWithInjection(AppLayout layout,
+            double windowTop, double windowLeft, double virtualLeft,
+            double virtualTop, double virtualWidth, double virtualHeight)
+        {
+            double virtualRight = virtualLeft + virtualWidth;
+            double virtualBottom = virtualTop + virtualHeight;
 
             if (layout != null)
             {
-                // If the window is completely offscreen, open it in default location
-                if ((layout.Left <= SystemParameters.VirtualScreenLeft - layout.Width) ||
-                        (layout.Top <= SystemParameters.VirtualScreenTop - layout.Height) ||
-                        (SystemParameters.VirtualScreenLeft + SystemParameters.VirtualScreenWidth <= layout.Left) ||
-                        (SystemParameters.VirtualScreenTop + SystemParameters.VirtualScreenHeight <= layout.Top))
-                {
-                    layout.Top = this.Top;
-                    layout.Left = this.Left;
-                }
-                else // if the window is partially offscreen, move it the appropriate vertical and/or horizontal distance to become fully onscreen
-                {
-                    if (layout.Left < SystemParameters.VirtualScreenLeft)
-                    {
-                        layout.Left = SystemParameters.VirtualScreenLeft;
-                    }
-                    else if (SystemParameters.VirtualScreenLeft + SystemParameters.VirtualScreenWidth - layout.Width < layout.Left)
-                    {
-                        layout.Left = SystemParameters.VirtualScreenLeft + SystemParameters.VirtualScreenWidth - layout.Width;
-                    }
+                layout.Top = double.IsNaN(layout.Top) ? windowTop : layout.Top;
+                layout.Left = double.IsNaN(layout.Left) ? windowLeft : layout.Left;
 
-                    if (layout.Top < SystemParameters.VirtualScreenTop)
-                    {
-                        layout.Top = SystemParameters.VirtualScreenTop;
-                    }
-                    else if (SystemParameters.VirtualScreenTop + SystemParameters.VirtualScreenHeight - layout.Height < layout.Top)
-                    {
-                        layout.Top = SystemParameters.VirtualScreenTop + SystemParameters.VirtualScreenHeight - layout.Height;
-                    }
+                double top = layout.Top;
+                double left = layout.Left;
+                double right = left + layout.Width;
+                double bottom = top + layout.Height;
+
+                // If the window is completely offscreen, open it in default location
+                if ((right <= virtualLeft) ||
+                    (bottom <= virtualTop) ||
+                    (left >= virtualRight) ||
+                    (top >= virtualBottom))
+                {
+                    top = layout.Top = windowTop;
+                    left = layout.Left = windowLeft;
+                }
+
+                // Adjust the window extents to keep it fully within the virtual screen
+                layout.Width = Math.Min(layout.Width, virtualWidth);
+                layout.Height = Math.Min(layout.Height, virtualHeight);
+                right = left + layout.Width;
+                bottom = top + layout.Height;
+
+                if (right > virtualRight)
+                {
+                    layout.Left = virtualRight - layout.Width;
+                }
+                else if (left < virtualLeft)
+                {
+                    layout.Left = virtualLeft;
+                }
+
+                if (bottom > virtualBottom)
+                {
+                    layout.Top = virtualBottom - layout.Height;
+                }
+                if (top < virtualTop)
+                {
+                    layout.Top = virtualTop;
                 }
             }
         }

--- a/src/AccessibilityInsights/Properties/AssemblyInfo.cs
+++ b/src/AccessibilityInsights/Properties/AssemblyInfo.cs
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Diagnostics.CodeAnalysis;
+
 using System.Reflection;
 using System.Resources;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 
@@ -41,3 +42,9 @@ using System.Windows;
                                               // app, or any theme specific resource dictionaries)
 )]
 [assembly: NeutralResourcesLanguage("en-US")]
+
+#if ENABLE_SIGNING
+[assembly: InternalsVisibleTo("AccessibilityInsightsUnitTests,PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+#else
+[assembly: InternalsVisibleTo("AccessibilityInsightsUnitTests")]
+#endif

--- a/src/AccessibilityInsightsUnitTests/AccessibilityInsightsUnitTests.csproj
+++ b/src/AccessibilityInsightsUnitTests/AccessibilityInsightsUnitTests.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>AccessibilityInsightsUnitTests</AssemblyName>
+    <RootNamespace>AccessibilityInsightsUnitTests</RootNamespace>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <Import Project="..\..\build\NetFrameworkTest.targets" />
+
+  <ItemGroup>
+    <PackageReference Include="Codecov" Version="1.13.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AccessibilityInsights.SharedUx\SharedUx.csproj" />
+    <ProjectReference Include="..\AccessibilityInsights\AccessibilityInsights.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/AccessibilityInsightsUnitTests/MainWindowHelpers/InitializeUnitTests.cs
+++ b/src/AccessibilityInsightsUnitTests/MainWindowHelpers/InitializeUnitTests.cs
@@ -100,7 +100,7 @@ namespace AccessibilityInsightsUnitTests.MainWindowHelpers
             MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
                 VirtualLeft, VirtualTop, VirtualWidth, VirtualHeight);
 
-            Assert.AreEqual(VirtualHeight - oldHeight, layout.Top);
+            Assert.AreEqual(VirtualTop + VirtualHeight - oldHeight, layout.Top);
             Assert.AreEqual(oldLeft, layout.Left);
             Assert.AreEqual(oldWidth, layout.Width);
             Assert.AreEqual(oldHeight, layout.Height);
@@ -119,7 +119,7 @@ namespace AccessibilityInsightsUnitTests.MainWindowHelpers
                 VirtualLeft, VirtualTop, VirtualWidth, VirtualHeight);
 
             Assert.AreEqual(oldTop, layout.Top);
-            Assert.AreEqual(VirtualWidth - oldWidth, layout.Left);
+            Assert.AreEqual(VirtualLeft + VirtualWidth - oldWidth, layout.Left);
             Assert.AreEqual(oldWidth, layout.Width);
             Assert.AreEqual(oldHeight, layout.Height);
         }
@@ -226,7 +226,7 @@ namespace AccessibilityInsightsUnitTests.MainWindowHelpers
         public void EnsureWindowIsInVirtualScreenWithInjection_DefaultValues_VirtualScreenTooSmall_UsesFullVirtualScreen()
         {
             var layout = GetInitialConfig();
-            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, double.NaN, double.NaN,
                 VirtualLeft, VirtualTop, SmallVirtualWidth, SmallVirtualHeight);
 
             Assert.AreEqual(VirtualTop, layout.Top);

--- a/src/AccessibilityInsightsUnitTests/MainWindowHelpers/InitializeUnitTests.cs
+++ b/src/AccessibilityInsightsUnitTests/MainWindowHelpers/InitializeUnitTests.cs
@@ -1,0 +1,254 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using AccessibilityInsights;
+using AccessibilityInsights.SharedUx.Settings;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AccessibilityInsightsUnitTests.MainWindowHelpers
+{
+    [TestClass]
+    public class InitializeUnitTests
+    {
+        const double DefaultTop = 60.0;
+        const double DefaultLeft = 80.0;
+        const double DefaultHeight = 720.0;
+        const double DefaultWidth = 870.0;
+        const double VirtualLeft = -1.0;
+        const double VirtualTop = -1.0;
+        const double VirtualWidth = 1920.0;
+        const double VirtualHeight = 1080.0;
+        const double SmallVirtualWidth = 640;   // 1280 x 1024 at 200% zoom
+        const double SmallVirtualHeight = 512;  // 1280 x 1024 at 200% zoom
+
+        [TestMethod]
+        public void EnsureWindowIsInVirtualScreenWithInjection_DefaultValues_ValuesFit_UsesDefaultValues()
+        {
+            var layout = GetInitialConfig();
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+                VirtualLeft, VirtualTop, VirtualWidth, VirtualHeight);
+
+            Assert.AreEqual(DefaultTop, layout.Top);
+            Assert.AreEqual(DefaultLeft, layout.Left);
+            Assert.AreEqual(DefaultWidth, layout.Width);
+            Assert.AreEqual(DefaultHeight, layout.Height);
+        }
+
+        [TestMethod]
+        public void EnsureWindowIsInVirtualScreenWithInjection_SavedValues_ValuesFit_UsesSavedValues()
+        {
+            const double oldTop = 80;
+            const double oldLeft = 90;
+            const double oldWidth = 1000;
+            const double oldHeight = 900;
+
+            var layout = GetInitialConfig(oldTop, oldLeft, oldHeight, oldWidth);
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+                VirtualLeft, VirtualTop, VirtualWidth, VirtualHeight);
+
+            Assert.AreEqual(oldTop, layout.Top);
+            Assert.AreEqual(oldLeft, layout.Left);
+            Assert.AreEqual(oldWidth, layout.Width);
+            Assert.AreEqual(oldHeight, layout.Height);
+        }
+
+        [TestMethod]
+        public void EnsureWindowIsInVirtualScreenWithInjection_SavedValuesStraddleTopEdgeOfVirtualScreen_IsOnScreen()
+        {
+            const double oldTop = VirtualTop - 1;
+            const double oldLeft = 90;
+            const double oldWidth = 1000;
+            const double oldHeight = 900;
+
+            var layout = GetInitialConfig(oldTop, oldLeft, oldHeight, oldWidth);
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+                VirtualLeft, VirtualTop, VirtualWidth, VirtualHeight);
+
+            Assert.AreEqual(VirtualTop, layout.Top);
+            Assert.AreEqual(oldLeft, layout.Left);
+            Assert.AreEqual(oldWidth, layout.Width);
+            Assert.AreEqual(oldHeight, layout.Height);
+        }
+
+        [TestMethod]
+        public void EnsureWindowIsInVirtualScreenWithInjection_SavedValuesStraddleLeftEdgeOfVirtualScreen_IsOnScreen()
+        {
+            const double oldTop = 80;
+            const double oldLeft = VirtualLeft - 1;
+            const double oldWidth = 1000;
+            const double oldHeight = 900;
+
+            var layout = GetInitialConfig(oldTop, oldLeft, oldHeight, oldWidth);
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+                VirtualLeft, VirtualTop, VirtualWidth, VirtualHeight);
+
+            Assert.AreEqual(oldTop, layout.Top);
+            Assert.AreEqual(VirtualLeft, layout.Left);
+            Assert.AreEqual(oldWidth, layout.Width);
+            Assert.AreEqual(oldHeight, layout.Height);
+        }
+
+        [TestMethod]
+        public void EnsureWindowIsInVirtualScreenWithInjection_SavedValuesStraddleBottomEdgeOfVirtualScreen_IsOnScreen()
+        {
+            const double oldTop = VirtualTop + VirtualHeight - 1;
+            const double oldLeft = 90;
+            const double oldWidth = 1000;
+            const double oldHeight = 900;
+
+            var layout = GetInitialConfig(oldTop, oldLeft, oldHeight, oldWidth);
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+                VirtualLeft, VirtualTop, VirtualWidth, VirtualHeight);
+
+            Assert.AreEqual(VirtualHeight - oldHeight, layout.Top);
+            Assert.AreEqual(oldLeft, layout.Left);
+            Assert.AreEqual(oldWidth, layout.Width);
+            Assert.AreEqual(oldHeight, layout.Height);
+        }
+
+        [TestMethod]
+        public void EnsureWindowIsInVirtualScreenWithInjection_SavedValuesStraddleRightEdgeOfVirtualScreen_IsOnScreen()
+        {
+            const double oldTop = 80;
+            const double oldLeft = VirtualLeft + VirtualWidth - 1;
+            const double oldWidth = 1000;
+            const double oldHeight = 900;
+
+            var layout = GetInitialConfig(oldTop, oldLeft, oldHeight, oldWidth);
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+                VirtualLeft, VirtualTop, VirtualWidth, VirtualHeight);
+
+            Assert.AreEqual(oldTop, layout.Top);
+            Assert.AreEqual(VirtualWidth - oldWidth, layout.Left);
+            Assert.AreEqual(oldWidth, layout.Width);
+            Assert.AreEqual(oldHeight, layout.Height);
+        }
+
+        [TestMethod]
+        public void EnsureWindowIsInVirtualScreenWithInjection_SavedValuesBeyondTopEdgeOfVirtualScreen_IsOnScreen()
+        {
+            const double oldLeft = 90;
+            const double oldWidth = 1000;
+            const double oldHeight = 900;
+            const double oldTop = VirtualTop - oldHeight - 1;
+
+            var layout = GetInitialConfig(oldTop, oldLeft, oldHeight, oldWidth);
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+                VirtualLeft, VirtualTop, VirtualWidth, VirtualHeight);
+
+            Assert.AreEqual(DefaultTop, layout.Top);
+            Assert.AreEqual(DefaultLeft, layout.Left);
+            Assert.AreEqual(oldWidth, layout.Width);
+            Assert.AreEqual(oldHeight, layout.Height);
+        }
+
+        [TestMethod]
+        public void EnsureWindowIsInVirtualScreenWithInjection_SavedValuesBeyondLeftEdgeOfVirtualScreen_IsOnScreen()
+        {
+            const double oldTop = 80;
+            const double oldWidth = 1000;
+            const double oldHeight = 900;
+            const double oldLeft = VirtualLeft - oldWidth - 1;
+
+            var layout = GetInitialConfig(oldTop, oldLeft, oldHeight, oldWidth);
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+                VirtualLeft, VirtualTop, VirtualWidth, VirtualHeight);
+
+            Assert.AreEqual(DefaultTop, layout.Top);
+            Assert.AreEqual(DefaultLeft, layout.Left);
+            Assert.AreEqual(oldWidth, layout.Width);
+            Assert.AreEqual(oldHeight, layout.Height);
+        }
+
+        [TestMethod]
+        public void EnsureWindowIsInVirtualScreenWithInjection_SavedValuesBeyondBottomEdgeOfVirtualScreen_IsOnScreen()
+        {
+            const double oldTop = VirtualTop + VirtualHeight + 1;
+            const double oldLeft = 90;
+            const double oldWidth = 1000;
+            const double oldHeight = 900;
+
+            var layout = GetInitialConfig(oldTop, oldLeft, oldHeight, oldWidth);
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+                VirtualLeft, VirtualTop, VirtualWidth, VirtualHeight);
+
+            Assert.AreEqual(DefaultTop, layout.Top);
+            Assert.AreEqual(DefaultLeft, layout.Left);
+            Assert.AreEqual(oldWidth, layout.Width);
+            Assert.AreEqual(oldHeight, layout.Height);
+        }
+
+        [TestMethod]
+        public void EnsureWindowIsInVirtualScreenWithInjection_SavedValuesBeyondRightEdgeOfVirtualScreen_IsOnScreen()
+        {
+            const double oldTop = 80;
+            const double oldLeft = VirtualLeft + VirtualWidth + 1;
+            const double oldWidth = 1000;
+            const double oldHeight = 900;
+
+            var layout = GetInitialConfig(oldTop, oldLeft, oldHeight, oldWidth);
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+                VirtualLeft, VirtualTop, VirtualWidth, VirtualHeight);
+
+            Assert.AreEqual(DefaultTop, layout.Top);
+            Assert.AreEqual(DefaultLeft, layout.Left);
+            Assert.AreEqual(oldWidth, layout.Width);
+            Assert.AreEqual(oldHeight, layout.Height);
+        }
+
+        [TestMethod]
+        public void EnsureWindowIsInVirtualScreenWithInjection_DefaultValues_VirtualScreenTooNarrow_UsesFullVirtualScreenWidth()
+        {
+            var layout = GetInitialConfig();
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+                VirtualLeft, VirtualTop, SmallVirtualWidth, VirtualHeight);
+
+            Assert.AreEqual(DefaultTop, layout.Top);
+            Assert.AreEqual(VirtualLeft, layout.Left);
+            Assert.AreEqual(SmallVirtualWidth, layout.Width);
+            Assert.AreEqual(DefaultHeight, layout.Height);
+        }
+
+        [TestMethod]
+        public void EnsureWindowIsInVirtualScreenWithInjection_DefaultValues_VirtualScreenTooShort_UsesFullVirtualScreenHeight()
+        {
+            var layout = GetInitialConfig();
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+                VirtualLeft, VirtualTop, VirtualWidth, SmallVirtualHeight);
+
+            Assert.AreEqual(VirtualTop, layout.Top);
+            Assert.AreEqual(DefaultLeft, layout.Left);
+            Assert.AreEqual(DefaultWidth, layout.Width);
+            Assert.AreEqual(SmallVirtualHeight, layout.Height);
+        }
+
+        [TestMethod]
+        public void EnsureWindowIsInVirtualScreenWithInjection_DefaultValues_VirtualScreenTooSmall_UsesFullVirtualScreen()
+        {
+            var layout = GetInitialConfig();
+            MainWindow.EnsureWindowIsInVirtualScreenWithInjection(layout, DefaultTop, DefaultLeft,
+                VirtualLeft, VirtualTop, SmallVirtualWidth, SmallVirtualHeight);
+
+            Assert.AreEqual(VirtualTop, layout.Top);
+            Assert.AreEqual(VirtualLeft, layout.Left);
+            Assert.AreEqual(SmallVirtualWidth, layout.Width);
+            Assert.AreEqual(SmallVirtualHeight, layout.Height);
+        }
+
+        private AppLayout GetInitialConfig(double? top = null, double? left = null, double? height = null, double? width = null)
+        {
+            var layout = new AppLayout(double.NaN, double.NaN);
+
+            if (top.HasValue)
+                layout.Top = top.Value;
+            if (left.HasValue)
+                layout.Left = left.Value;
+            if (height.HasValue)
+                layout.Height = height.Value;
+            if (width.HasValue)
+                layout.Width = width.Value;
+
+            return layout;
+        }
+    }
+}


### PR DESCRIPTION
#### Details

Our window positioning code has some problems:
1. It never resizes the window, even if it's tool big to fit on screen
2. It fails to handle cases where the window position is `double.NaN` (which happens on first boot). As documented at https://docs.microsoft.com/en-us/dotnet/api/system.double.nan?view=net-5.0, comparing `double.NaN` to any other value (except `double.NaN`) will return false, and this is breaking the current code.

Because of these problems, it's possible to have parts of the app inaccessible on first boot at 200% zoom.

The fix is to rework the code that sets the initial window position so that the entire app is always in the virtual window, even if we need to resize the window (old code could only reposition, not resize). I also added some unit tests to make it easier to exercise the various pathways. This meant adding a new project to contain these unit test, but hopefully future changes to this project will also include unit tests. If we were to omit the unit tests, we'd only have modify 1 file.

##### Motivation

Address bug from trusted tester pass

##### Screenshots
These were all captured on first boot with 200% zoom on a 1280x1024 display (the highest zoom/smallest size that we support), run after deleting all config files (so it simulates the first boot experience):

View | Screenshot
--- | ---
Telemetry | ![image](https://user-images.githubusercontent.com/45672944/133530960-593071c6-9999-431f-b1a4-0106cc4b8fc9.png)
Welcome | ![image](https://user-images.githubusercontent.com/45672944/133530998-905a5071-53cc-4cc7-95a6-be03b92d10ac.png)
Live Inspect | ![image](https://user-images.githubusercontent.com/45672944/133531034-1d9f4561-5a34-4a03-8de8-91608b7f7b28.png)
About dialog | ![image](https://user-images.githubusercontent.com/45672944/133531053-741a17f4-179b-4c49-ac4a-e624f18dbc9d.png)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
There was some discussion of adding a ScrollViewer inside the About page. Looking at the other pages (Connection and Settings), though, neither of those has a ScrollViewer, so it's coming from external. To test this, I (locally) forced the About dialog to extend beyond the window size, and the ScrollBar appeared without any need to explicitly specify it. Since it's not needed, I left it out of the final PR and just focused on the window positioning.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue - [1868538](https://mseng.visualstudio.com/DefaultCollection/1ES/_workitems/edit/1868538)
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



