### PR TITLE
fix: Clearer keyboard focus indicator for tabstops list

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -504,6 +504,9 @@
         <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}" />
     </Style>
     <Style x:Key="lviTabStops" TargetType="{x:Type ListViewItem}">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="2,0"/>
         <Style.Triggers>
             <Trigger Property="IsSelected" Value="False">
                 <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
@@ -516,6 +519,11 @@
                 <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TSRowSelectedFGBrush}"/>
                 <Setter Property="Background" Value="{DynamicResource ResourceKey=TSRowSelectedBGBrush}"/>
                 <Setter Property="FontWeight" Value="Bold"/>
+            </Trigger>
+            <Trigger Property="IsFocused" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource ResourceKey=PrimaryBGBrush}"/>
+                <Setter Property="BorderThickness" Value="2"/>
+                <Setter Property="Margin" Value="1, 1, 2, 1" />
             </Trigger>
         </Style.Triggers>
     </Style>


### PR DESCRIPTION
#### Details

The keyboard focus indicator in the tabstops list doesn't match updated WCAG requirements. Our color palette is pretty minimal in dark and HC modes, so we fix this by enabling a stronger system focus indicator, then we make it stand out by adding a contrasting border inside the focus indicator.

##### Motivation

Address TT bug

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

##### GIF wall
These are all the same sequence where we use the keyboard to move between some items in the list, then tab to the nav bar, shift-tab back to the list, the move back to our starting point.

Mode | GIF
--- | ---
Light | ![tabstops-light](https://user-images.githubusercontent.com/45672944/133855667-9563a4b7-b0d9-4c06-b1b4-7379e988c963.gif)
Dark | ![tabstops-dark](https://user-images.githubusercontent.com/45672944/133855712-ad7c6db8-aa73-4f14-8fb8-5ff4af34da9b.gif)
HC 1 | ![tabstops-hc-1](https://user-images.githubusercontent.com/45672944/133855747-d2d739b9-0c11-42e0-ada1-8896125a8185.gif)
HC 2 | ![tabstops-hc-2](https://user-images.githubusercontent.com/45672944/133855780-fb62ee2c-b70f-4b37-aceb-55d2ec08e952.gif)
HC Black | ![tabstops-hc-black](https://user-images.githubusercontent.com/45672944/133855801-c986b0ad-8ce6-4f76-a9f5-7ace3f232a07.gif)
HC White | ![tabstops-hc-white](https://user-images.githubusercontent.com/45672944/133855822-a234c00e-4230-480f-aba8-b2d1687bbed5.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue - [1868532](https://mseng.visualstudio.com/DefaultCollection/1ES/_workitems/edit/1868532)
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



