### PR TITLE
fix: Make selected menu item bold

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1226,6 +1226,7 @@
                             <Setter TargetName="Border" Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
                             <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
                             <Setter TargetName="fbIcn" Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
+                            <Setter Property="FontWeight" Value="Bold"/>
                         </Trigger>
                         <Trigger Property="IsHighlighted" Value="false">
                             <Setter TargetName="fbIcn" Property="Foreground" Value="{DynamicResource ResourceKey=IconBrush}"/>


### PR DESCRIPTION
#### Details

Make selected menu items bold to satisfy WCAG 1.4.1 requirements. According to https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/visual-audio-contrast-without-color.html, there are multiple ways to satisfy this requirement. One of these ways is https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/G182, which states:

To use this technique, an author incorporates a visual cue in addition to color for each place where color alone is used to convey information. Visual cues can take many forms including changes to the font style, the addition of underlines, bold, or italics, or changes to the font size.

Our color palette in Dark and HC modes are very limited, so we're taking the approach of making the selected popup menu item bold, so that color isn't the only distinguishing attribute. The results appear in the GIF wall below.

##### Motivation

Address TT bug

##### GIF wall
These GIF's all go through the same sequence--starting with a selected item, use the keyboard to explore the menu and show the menu items in selected and non-selected state, then work back to the starting point.

Mode | GIF
--- | ---
Light | ![boldmenu-light](https://user-images.githubusercontent.com/45672944/133859906-021d03da-02a6-4152-bdf4-a11dde7eb94c.gif)
Dark | ![boldmenu-dark](https://user-images.githubusercontent.com/45672944/133859923-968088e7-51c4-4d34-90bc-22f809c315a0.gif)
HC 1 | ![boldmenu-hc-1](https://user-images.githubusercontent.com/45672944/133860023-96df2270-d9e5-4506-815d-42125c339383.gif)
HC 2 | ![boldmenu-hc-2](https://user-images.githubusercontent.com/45672944/133860055-5fd8354c-464b-49cd-9e38-5000c298a163.gif)
HC Black | ![boldmenu-hc-black](https://user-images.githubusercontent.com/45672944/133860081-33628cf4-69fb-400a-a084-912620524841.gif)
HC White | ![boldmenu-hc-white](https://user-images.githubusercontent.com/45672944/133860092-3e234b8c-41e8-4b79-ae99-81bddee47976.gif)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue - [1868536](https://mseng.visualstudio.com/DefaultCollection/1ES/_workitems/edit/1868536)
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



