### PR TITLE
fix: Revise repo link help text to be more helpful

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
@@ -160,7 +160,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Repo link.
+        ///   Looks up a localized string similar to Azure Boards link.
         /// </summary>
         public static string ServerComboBoxAutomationPropertiesName {
             get {

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -124,7 +124,7 @@
     <value>)</value>
   </data>
   <data name="ServerComboBoxAutomationPropertiesName" xml:space="preserve">
-    <value>Repo link</value>
+    <value>Azure Boards link</value>
   </data>
   <data name="ConnectionDescriptionItalicized" xml:space="preserve">
     <value>https://dev.azure.com/fabrikam</value>

--- a/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.Designer.cs
@@ -141,7 +141,7 @@ namespace AccessibilityInsights.Extensions.GitHub.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Repo link.
+        ///   Looks up a localized string similar to GitHub repo link.
         /// </summary>
         public static string RepoLinkAutomationName {
             get {

--- a/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.GitHub/Properties/Resources.resx
@@ -184,6 +184,6 @@ This accessibility issue was found using Accessibility Insights for Windows, a t
     <value>Invalid GitHub Link Format!</value>
   </data>
   <data name="RepoLinkAutomationName" xml:space="preserve">
-    <value>Repo link</value>
+    <value>GitHub repo link</value>
   </data>
 </root>


### PR DESCRIPTION
#### Details

Adjust the help text for GitHub and ADO issue filing to be slightly more descriptive, but still be succinct.

##### Motivation

Address TT bug

##### Screenshots
Type of issues | Screenshot
--- | ---
ADO (Azure Boards) | ![image](https://user-images.githubusercontent.com/45672944/134042497-1733583b-ffa9-46ec-9347-2830aaad6d7f.png)
GitHub | ![image](https://user-images.githubusercontent.com/45672944/134042530-64d74200-0906-4a88-bfab-5ab9c7e7a900.png)

Note that the help text is shorter than the text that appears directly above the edit control. This is _intentional_, since reading the full line actually reduces the usability of the control when an AT is used. The text we settled on is long enough to describe what the control does, but is succinct enough to not get in the way.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue - [1868521](https://mseng.visualstudio.com/DefaultCollection/1ES/_workitems/edit/1868521)
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



