### PR TITLE
fix: Update Automated Checks GroupItem HelpText to reflect IsExpanded state

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -275,12 +275,11 @@
                                                 <Binding Path="Tag" RelativeSource="{RelativeSource Self}"/>
                                             </MultiBinding>
                                         </Setter.Value>
-                                    </Setter>
-                                    <Setter Property="AutomationProperties.HelpText" Value="{x:Static Properties:Resources.lvResultsListViewHelpText}"/>
+                                </Setter>
                                     <Setter Property="Template">
                                         <Setter.Value>
                                             <ControlTemplate>
-                                                <local:CustomExpander IsExpanded="False" KeyboardNavigation.DirectionalNavigation="Local" 
+                                                <local:CustomExpander x:Name="expander" IsExpanded="False" KeyboardNavigation.DirectionalNavigation="Local" 
                                                           RequestBringIntoView="Expander_RequestBringIntoView" Collapsed="Expander_Collapsed" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}">
                                                     <local:CustomExpander.Header>
                                                         <StackPanel Focusable="False" Orientation="Horizontal" Height="20">
@@ -293,6 +292,14 @@
                                                     </local:CustomExpander.Header>
                                                     <ItemsPresenter/>
                                                 </local:CustomExpander>
+                                                <ControlTemplate.Triggers>
+                                                    <Trigger SourceName="expander" Property="IsExpanded" Value="True">
+                                                        <Setter Property="AutomationProperties.HelpText" Value="{x:Static Properties:Resources.lvResultsListViewHelpTextExpanded}"/>
+                                                    </Trigger>
+                                                    <Trigger SourceName="expander" Property="IsExpanded" Value="False">
+                                                        <Setter Property="AutomationProperties.HelpText" Value="{x:Static Properties:Resources.lvResultsListViewHelpTextCollapsed}"/>
+                                                    </Trigger>
+                                                </ControlTemplate.Triggers>
                                             </ControlTemplate>
                                         </Setter.Value>
                                     </Setter>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2541,9 +2541,18 @@ namespace AccessibilityInsights.SharedUx.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Press right arrow key to expand, enter or space to toggle children highlighting.
         /// </summary>
-        public static string lvResultsListViewHelpText {
+        public static string lvResultsListViewHelpTextCollapsed {
             get {
-                return ResourceManager.GetString("lvResultsListViewHelpText", resourceCulture);
+                return ResourceManager.GetString("lvResultsListViewHelpTextCollapsed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Press left arrow key to collapse, enter or space to toggle children highlighting.
+        /// </summary>
+        public static string lvResultsListViewHelpTextExpanded {
+            get {
+                return ResourceManager.GetString("lvResultsListViewHelpTextExpanded", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -387,8 +387,11 @@
   <data name="lvResultsListViewAutomationPropertiesName" xml:space="preserve">
     <value>{1} errors - {0}, {2} children highlighted</value>
   </data>
-  <data name="lvResultsListViewHelpText" xml:space="preserve">
+  <data name="lvResultsListViewHelpTextCollapsed" xml:space="preserve">
     <value>Press right arrow key to expand, enter or space to toggle children highlighting</value>
+  </data>
+  <data name="lvResultsListViewHelpTextExpanded" xml:space="preserve">
+    <value>Press left arrow key to collapse, enter or space to toggle children highlighting</value>
   </data>
   <data name="lblCongratsContent" xml:space="preserve">
     <value>Congratulations</value>


### PR DESCRIPTION
#### Details
Currently, the HelpText for the GroupItems in the Automated Checks ListView is always "Press right arrow key to expand, enter or space to toggle children highlighting", regardless of expanded/collapsed state. With this PR, it will now be "Press left arrow key to collapse, enter or space to toggle children highlighting" when the items are expanded. 

Example of NVDA reading these items now:
- Collapsed:
> 2 errors - A button must not support both the Invoke and Toggle patterns., all children highlighted  grouping  collapsed Press right arrow key to expand, enter or space to toggle children highlighting  1 of 6

- Expanded:
> 2 errors - A button must not support both the Invoke and Toggle patterns., some children highlighted  grouping  expanded  Press left arrow key to collapse, enter or space to toggle children highlighting  1 of 6


##### Motivation
Addresses ADO 1750592

##### Context
- It took a few tries to find the right place to put the `Trigger`

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 1750592
- [n/a] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



