### PR TITLE
fix: Allow system administrators to suppress telemetry by policy

### DIFF
--- a/docs/TelemetryOverview.md
+++ b/docs/TelemetryOverview.md
@@ -45,8 +45,31 @@ catch (Exception e)
 }
 ```
 
-### User control
-All telemetry (including reported exceptions) is under user control. When the application starts the first time, the user is allowed to enable or disable telemetry. The user can change this option at any time via the settings page.
+### Control of Telemery
+Telemetry (including reported exceptions) can be disabled either by the computer's administrator or the current user.
+
+#### Administrative override
+An administrator can disable telemetry for all users of a system by adding a DWORD value the registry:
+
+```
+Key: HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Accessibility Insights for Windows  
+Name: DisableTelemetry
+Value (DWORD): 1
+```
+Here is the same data expressed as a Windows REG file:
+```
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Accessibility Insights for Windows]
+"DisableTelemetry"=dword:00000001
+```
+
+Setting this override will disable telemetry for _all_ users of the computer. Since telemetry is disabled systemwide, users are never asked to enable or disable telemetry. The overridden status is reflected in the settings page within the application.
+
+This override exists to support organizations who may be sensitive to any data being collected by outside systems. It is the responsibility of the organization to set this flag through external means.
+
+#### User Control
+If no [administrative override](#administrative-override) is set, then telemetry is controlled by each user. When the application starts the first time, the user is asked to enable or disable telemetry. The user can change this setting at any time via the settings page. If the [administrative override](#administrative-override) is later enabled, it will overide the telemetry selection for new application sessions for all users.
 
 ### More details
 More details are available in the [Telemetry Details Documentation](./TelemetryDetails.md)

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
@@ -263,7 +263,7 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="320"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock Grid.Row="0" Name ="telemetryDescription" Style="{StaticResource TxtTelemetrySettingInfo}" TextWrapping="Wrap">
+                    <TextBlock Grid.Row="0" Name="telemetryDescription" Style="{StaticResource TxtTelemetrySettingInfo}" TextWrapping="Wrap">
                         <Run Text="{x:Static Properties:Resources.TextBlockTelemetrySettingInfo}"/>
                         <LineBreak/>
                     </TextBlock>

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml
@@ -263,11 +263,11 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="320"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock Grid.Row="0" Style="{StaticResource TxtTelemetrySettingInfo}" TextWrapping="Wrap">
+                    <TextBlock Grid.Row="0" Name ="telemetryDescription" Style="{StaticResource TxtTelemetrySettingInfo}" TextWrapping="Wrap">
                         <Run Text="{x:Static Properties:Resources.TextBlockTelemetrySettingInfo}"/>
                         <LineBreak/>
                     </TextBlock>
-                    <sharedControls:PrivacyLearnMore Style="{StaticResource TxtTelemetrySettingInfo}" Grid.Row="1"/>
+                    <sharedControls:PrivacyLearnMore x:Name="privacyLearnMore" Style="{StaticResource TxtTelemetrySettingInfo}" Grid.Row="1"/>
                 </Grid>
                 <Grid Grid.Row="2" Margin="1,5,0,0">
                     <Grid.ColumnDefinitions>

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml.cs
@@ -6,6 +6,7 @@ using AccessibilityInsights.SetupLibrary;
 using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.SharedUx.Settings;
+using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.SharedUx.ViewModels;
 using System;
 using System.Collections.Generic;
@@ -71,6 +72,13 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
                 this.btnHotkeyToggle,
                 this.btnHotkeyToParent
             };
+            if (!TelemetryController.DoesGroupPolicyAllowTelemetry)
+            {
+                this.telemetryDescription.Text = Properties.Resources.ApplicationSettingsControl_TelemetryDisabledByAdministrator;
+                this.privacyLearnMore.Visibility = Visibility.Collapsed;
+                this.lblEnableTelemetryLabel.Visibility = Visibility.Collapsed;
+                this.tgbtnEnableTelemetry.Visibility = Visibility.Collapsed;
+            }
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TelemetryApproveContainedDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TelemetryApproveContainedDialog.xaml.cs
@@ -55,9 +55,9 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             DialogResult = ckbxAgreeToHelp.IsChecked ?? false;
 
             if (DialogResult)
-                TelemetryController.EnableTelemetry();
+                TelemetryController.OptIntoTelemetry();
             else
-                TelemetryController.DisableTelemetry();
+                TelemetryController.OptOutOfTelemetry();
 
             WaitHandle.Set();
         }

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -152,6 +152,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Telemetry has been disabled by an administrator of this computer..
+        /// </summary>
+        public static string ApplicationSettingsControl_TelemetryDisabledByAdministrator {
+            get {
+                return ResourceManager.GetString("ApplicationSettingsControl_TelemetryDisabledByAdministrator", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Application settings.
         /// </summary>
         public static string ApplicationSettingsControlAutomationName {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1548,4 +1548,7 @@ Do you want to change the channel? </value>
   <data name="closeDialogText" xml:space="preserve">
     <value>Close</value>
   </data>
+  <data name="ApplicationSettingsControl_TelemetryDisabledByAdministrator" xml:space="preserve">
+    <value>Telemetry has been disabled by an administrator of this computer.</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
@@ -631,7 +631,7 @@ namespace AccessibilityInsights.SharedUx.Settings
                 FontSize = FontSize.Standard,
                 HighlighterMode = HighlighterMode.HighlighterBeakerTooltip,
                 ShowAncestry = true,
-                EnableTelemetry = true,
+                EnableTelemetry = false,
                 ShowTelemetryDialog = true,
 
                 IsUnderElementScope = true,

--- a/src/AccessibilityInsights.SharedUx/Telemetry/ITelemetrySink.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/ITelemetrySink.cs
@@ -8,6 +8,11 @@ namespace AccessibilityInsights.SharedUx.Telemetry
     internal interface ITelemetrySink
     {
         /// <summary>
+        /// We allow group policy to disable telemetry. This takes precedence over user opt-in
+        /// </summary>
+        bool DoesGroupPolicyAllowTelemetry { get; }
+
+        /// <summary>
         /// Whether or not telemetry toggle button is enabled in the settings.
         /// </summary>
         bool IsTelemetryAllowed { get; set; }

--- a/src/AccessibilityInsights.SharedUx/Telemetry/ITelemetrySink.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/ITelemetrySink.cs
@@ -15,7 +15,7 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         /// <summary>
         /// Whether or not telemetry toggle button is enabled in the settings.
         /// </summary>
-        bool IsTelemetryAllowed { get; set; }
+        bool HasUserOptedIntoTelemetry { get; set; }
 
         /// <summary>
         /// Whether or not telemetry is enabled. Exposed to allow callers who do lots of

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryController.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryController.cs
@@ -10,21 +10,29 @@ namespace AccessibilityInsights.SharedUx.Telemetry
 
         public static void OptIntoTelemetry()
         {
-            // Open the telemetry sink
-            Sink.HasUserOptedIntoTelemetry = true;
+            if (DoesGroupPolicyAllowTelemetry)
+            {
+                // Open the telemetry sink
+                Sink.HasUserOptedIntoTelemetry = true;
 
-            // Begin listening for telemetry events
-            // This must be done after the low-level sink is opened above
-            // So that queued events get flushed to an open telemetry sink
-            EventTelemetrySink.Enable();
+                // Begin listening for telemetry events
+                // This must be done after the low-level sink is opened above
+                // So that queued events get flushed to an open telemetry sink
+                EventTelemetrySink.Enable();
 
-            AxeWindowsTelemetrySink.Enable();
+                AxeWindowsTelemetrySink.Enable();
+            }
         }
 
         public static void OptOutOfTelemetry()
         {
-            // Close the telemetry sink
-            Sink.HasUserOptedIntoTelemetry = false;
+            if (DoesGroupPolicyAllowTelemetry)
+            {
+                // Close the telemetry sink
+                Sink.HasUserOptedIntoTelemetry = false;
+            }
         }
+
+        public static bool DoesGroupPolicyAllowTelemetry => Sink.DoesGroupPolicyAllowTelemetry;
     } // class
 } // namespace

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryController.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryController.cs
@@ -10,27 +10,27 @@ namespace AccessibilityInsights.SharedUx.Telemetry
 
         public static void OptIntoTelemetry()
         {
-            if (DoesGroupPolicyAllowTelemetry)
-            {
-                // Open the telemetry sink
-                Sink.HasUserOptedIntoTelemetry = true;
+            if (!DoesGroupPolicyAllowTelemetry)
+                return;
 
-                // Begin listening for telemetry events
-                // This must be done after the low-level sink is opened above
-                // So that queued events get flushed to an open telemetry sink
-                EventTelemetrySink.Enable();
+            // Open the telemetry sink
+            Sink.HasUserOptedIntoTelemetry = true;
 
-                AxeWindowsTelemetrySink.Enable();
-            }
+            // Begin listening for telemetry events
+            // This must be done after the low-level sink is opened above
+            // So that queued events get flushed to an open telemetry sink
+            EventTelemetrySink.Enable();
+
+            AxeWindowsTelemetrySink.Enable();
         }
 
         public static void OptOutOfTelemetry()
         {
-            if (DoesGroupPolicyAllowTelemetry)
-            {
-                // Close the telemetry sink
-                Sink.HasUserOptedIntoTelemetry = false;
-            }
+            if (!DoesGroupPolicyAllowTelemetry)
+                return;
+
+            // Close the telemetry sink
+            Sink.HasUserOptedIntoTelemetry = false;
         }
 
         public static bool DoesGroupPolicyAllowTelemetry => Sink.DoesGroupPolicyAllowTelemetry;

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryController.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryController.cs
@@ -8,10 +8,10 @@ namespace AccessibilityInsights.SharedUx.Telemetry
     {
         private static readonly ITelemetrySink Sink = TelemetrySink.DefaultTelemetrySink;
 
-        public static void EnableTelemetry()
+        public static void OptIntoTelemetry()
         {
             // Open the telemetry sink
-            Sink.IsTelemetryAllowed = true;
+            Sink.HasUserOptedIntoTelemetry = true;
 
             // Begin listening for telemetry events
             // This must be done after the low-level sink is opened above
@@ -21,10 +21,10 @@ namespace AccessibilityInsights.SharedUx.Telemetry
             AxeWindowsTelemetrySink.Enable();
         }
 
-        public static void DisableTelemetry()
+        public static void OptOutOfTelemetry()
         {
             // Close the telemetry sink
-            Sink.IsTelemetryAllowed = false;
+            Sink.HasUserOptedIntoTelemetry = false;
         }
     } // class
 } // namespace

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetrySink.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetrySink.cs
@@ -20,7 +20,7 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         /// <summary>
         /// Holds the production TelemetrySink object
         /// </summary>
-        internal static ITelemetrySink DefaultTelemetrySink { get; } = new TelemetrySink(Container.GetDefaultInstance()?.Telemetry, ReadGroupPolicyFromRegistry());
+        internal static ITelemetrySink DefaultTelemetrySink { get; } = new TelemetrySink(Container.GetDefaultInstance()?.Telemetry, DoesRegistryGroupPolicyAllowTelemetry());
 
         private readonly ITelemetry _telemetry;
 
@@ -30,7 +30,7 @@ namespace AccessibilityInsights.SharedUx.Telemetry
             DoesGroupPolicyAllowTelemetry = doesGroupPolicyAllowTelemetry;
         }
 
-        private static bool ReadGroupPolicyFromRegistry()
+        private static bool DoesRegistryGroupPolicyAllowTelemetry()
         {
             // Return true unless the policy exists to disable the telemetry
             int? policyValue = (int?)Registry.GetValue(

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetrySink.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetrySink.cs
@@ -46,14 +46,14 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         public bool DoesGroupPolicyAllowTelemetry { get; }
 
         /// <summary>
-        /// Implements <see cref="ITelemetrySink.IsTelemetryAllowed"/>
+        /// Implements <see cref="ITelemetrySink.HasUserOptedIntoTelemetry"/>
         /// </summary>
-        public bool IsTelemetryAllowed { get; set; }
+        public bool HasUserOptedIntoTelemetry { get; set; }
 
         /// <summary>
         /// Implements <see cref="ITelemetrySink.IsEnabled"/>
         /// </summary>
-        public bool IsEnabled => DoesGroupPolicyAllowTelemetry && IsTelemetryAllowed && _telemetry != null;
+        public bool IsEnabled => DoesGroupPolicyAllowTelemetry && HasUserOptedIntoTelemetry && _telemetry != null;
 
         /// <summary>
         /// Implements <see cref="ITelemetrySink.PublishTelemetryEvent(string, string, string)"/>

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetrySink.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetrySink.cs
@@ -34,7 +34,7 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         {
             // Return true unless the policy exists to disable the telemetry
             int? policyValue = (int?)Registry.GetValue(
-                @"HKEY_LOCAL_MACHINE\Software\Policies\Accessibility Insights",
+                @"HKEY_LOCAL_MACHINE\Software\Policies\Accessibility Insights for Windows",
                 "DisableTelemetry", 0);
 
             return !(policyValue.HasValue && policyValue.Value == 1);

--- a/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
@@ -92,7 +92,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
             ConfirmEnumerablesMatchExpectations(new int[] { }, config.CoreTPAttributes.ToArray());
             Assert.IsFalse(config.DisableTestsInSnapMode);
             Assert.IsFalse(config.DisableDarkMode);
-            Assert.IsTrue(config.EnableTelemetry);
+            Assert.IsFalse(config.EnableTelemetry);
             Assert.IsTrue(config.EventRecordPath.Equals(testProvider.UserDataFolderPath));
             Assert.AreEqual(FontSize.Standard, config.FontSize);
             Assert.AreEqual(HighlighterMode.HighlighterBeakerTooltip, config.HighlighterMode);

--- a/src/AccessibilityInsights.SharedUxTests/Telemetry/TelemetrySinkUnitTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Telemetry/TelemetrySinkUnitTests.cs
@@ -51,7 +51,7 @@ namespace AccessibilityInsights.SharedUxTests.Telemetry
         [Timeout(1000)]
         public void IsTelemetryAllowed_DefaultToFalse()
         {
-            Assert.IsFalse(_telemetrySink.IsTelemetryAllowed);
+            Assert.IsFalse(_telemetrySink.HasUserOptedIntoTelemetry);
         }
 
         [TestMethod]
@@ -65,7 +65,7 @@ namespace AccessibilityInsights.SharedUxTests.Telemetry
         [Timeout(1000)]
         public void IsEnabled_IsTelemetryAllowedIsTrue_ReturnsTrue()
         {
-            _telemetrySink.IsTelemetryAllowed = true;
+            _telemetrySink.HasUserOptedIntoTelemetry = true;
             Assert.IsTrue(_telemetrySink.IsEnabled);
         }
 
@@ -82,7 +82,7 @@ namespace AccessibilityInsights.SharedUxTests.Telemetry
         {
             PropertyBag actualPropertyBag = null;
 
-            _telemetrySink.IsTelemetryAllowed = true;
+            _telemetrySink.HasUserOptedIntoTelemetry = true;
             _telemetryMock.Setup(x => x.PublishEvent(EventName1, It.IsAny<PropertyBag>()))
                 .Callback<string, PropertyBag>((_, p) => actualPropertyBag = p);
 
@@ -98,7 +98,7 @@ namespace AccessibilityInsights.SharedUxTests.Telemetry
         public void PublishTelemetryEvent_SingleProperty_TelemetryAllowed_ThrowsOnPublish_ReportsException()
         {
             Exception expectedExpection = new OutOfMemoryException();
-            _telemetrySink.IsTelemetryAllowed = true;
+            _telemetrySink.HasUserOptedIntoTelemetry = true;
             _telemetryMock.Setup(x => x.PublishEvent(EventName1, It.IsAny<PropertyBag>()))
                 .Throws(expectedExpection);
             _telemetryMock.Setup(x => x.ReportException(expectedExpection));
@@ -131,7 +131,7 @@ namespace AccessibilityInsights.SharedUxTests.Telemetry
                 { PropertyName2, Value2 },
             };
 
-            _telemetrySink.IsTelemetryAllowed = true;
+            _telemetrySink.HasUserOptedIntoTelemetry = true;
             _telemetryMock.Setup(x => x.PublishEvent(EventName2, expectedPropertyBag));
             _telemetrySink.PublishTelemetryEvent(EventName2, expectedPropertyBag);
 
@@ -149,7 +149,7 @@ namespace AccessibilityInsights.SharedUxTests.Telemetry
                 { PropertyName2, Value1 },
             };
 
-            _telemetrySink.IsTelemetryAllowed = true;
+            _telemetrySink.HasUserOptedIntoTelemetry = true;
             _telemetryMock.Setup(x => x.PublishEvent(EventName2, expectedPropertyBag))
                 .Throws(expectedExpection);
             _telemetryMock.Setup(x => x.ReportException(expectedExpection));
@@ -170,7 +170,7 @@ namespace AccessibilityInsights.SharedUxTests.Telemetry
         [Timeout(1000)]
         public void AddOrUpdateContextProperty_TelemetryIsAllowed_ChainsSameData()
         {
-            _telemetrySink.IsTelemetryAllowed = true;
+            _telemetrySink.HasUserOptedIntoTelemetry = true;
             _telemetryMock.Setup(x => x.AddOrUpdateContextProperty(PropertyName2, Value2));
 
             _telemetrySink.AddOrUpdateContextProperty(PropertyName2, Value2);
@@ -183,7 +183,7 @@ namespace AccessibilityInsights.SharedUxTests.Telemetry
         public void AddOrUpdateContextProperty_TelemetryIsAllowed_TelemetryThrowsException_ReportsException()
         {
             Exception expectedExpection = new OutOfMemoryException();
-            _telemetrySink.IsTelemetryAllowed = true;
+            _telemetrySink.HasUserOptedIntoTelemetry = true;
             _telemetryMock.Setup(x => x.AddOrUpdateContextProperty(PropertyName2, Value2))
                 .Throws(expectedExpection);
             _telemetryMock.Setup(x => x.ReportException(expectedExpection));
@@ -204,7 +204,7 @@ namespace AccessibilityInsights.SharedUxTests.Telemetry
         [Timeout(1000)]
         public void ReportException_TelemetryIsAllowed_ExceptionIsNull_DoesNotChain()
         {
-            _telemetrySink.IsTelemetryAllowed = true;
+            _telemetrySink.HasUserOptedIntoTelemetry = true;
             _telemetrySink.ReportException(null);
         }
 
@@ -214,7 +214,7 @@ namespace AccessibilityInsights.SharedUxTests.Telemetry
         {
             Exception expectedException = new OutOfMemoryException();
 
-            _telemetrySink.IsTelemetryAllowed = true;
+            _telemetrySink.HasUserOptedIntoTelemetry = true;
             _telemetryMock.Setup(x => x.ReportException(expectedException));
 
             _telemetrySink.ReportException(expectedException);
@@ -229,7 +229,7 @@ namespace AccessibilityInsights.SharedUxTests.Telemetry
             Exception expectedException = new OutOfMemoryException();
             Exception unexpectedException = new InvalidOperationException();
 
-            _telemetrySink.IsTelemetryAllowed = true;
+            _telemetrySink.HasUserOptedIntoTelemetry = true;
             _telemetryMock.Setup(x => x.ReportException(expectedException))
                 .Throws(unexpectedException);
 

--- a/src/AccessibilityInsights.SharedUxTests/Telemetry/TelemetrySinkUnitTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Telemetry/TelemetrySinkUnitTests.cs
@@ -28,14 +28,22 @@ namespace AccessibilityInsights.SharedUxTests.Telemetry
         public void BeforeEachTest()
         {
             _telemetryMock = new Mock<ITelemetry>(MockBehavior.Strict);
-            _telemetrySink = new TelemetrySink(_telemetryMock.Object);
+            _telemetrySink = new TelemetrySink(_telemetryMock.Object, true);
         }
 
         [TestMethod]
         [Timeout(1000)]
         public void IsEnabled_TelemetryIsNull_ReturnsFalse()
         {
-            TelemetrySink sink = new TelemetrySink(null);
+            TelemetrySink sink = new TelemetrySink(null, true);
+            Assert.IsFalse(sink.IsEnabled);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void IsEnabled_TelemetryIsDisabledByGroupPolicy_ReturnsFalse()
+        {
+            TelemetrySink sink = new TelemetrySink(_telemetryMock.Object, false);
             Assert.IsFalse(sink.IsEnabled);
         }
 

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -143,7 +143,7 @@ namespace AccessibilityInsights
 
             // enable/disable telemetry
             if (ConfigurationManager.GetDefaultInstance().AppConfig.EnableTelemetry)
-                TelemetryController.EnableTelemetry();
+                TelemetryController.OptIntoTelemetry();
 
             // Update theming since it depends on config options
             SetColorTheme();

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -141,9 +141,12 @@ namespace AccessibilityInsights
             // Configure the correct ReleaseChannel for autoupdate
             Container.SetAutoUpdateReleaseChannel(ConfigurationManager.GetDefaultInstance().AppConfig.ReleaseChannel.ToString());
 
-            // enable/disable telemetry
-            if (ConfigurationManager.GetDefaultInstance().AppConfig.EnableTelemetry)
+            // Opt into telemetry if allowed and user has chosen to do so
+            if (TelemetryController.DoesGroupPolicyAllowTelemetry &&
+                ConfigurationManager.GetDefaultInstance().AppConfig.EnableTelemetry)
+            {
                 TelemetryController.OptIntoTelemetry();
+            }
 
             // Update theming since it depends on config options
             SetColorTheme();

--- a/src/AccessibilityInsights/MainWindowHelpers/TelemetryStartup.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/TelemetryStartup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Settings;
+using AccessibilityInsights.SharedUx.Telemetry;
 using System.Windows;
 
 namespace AccessibilityInsights
@@ -18,9 +19,12 @@ namespace AccessibilityInsights
         {
             if (ConfigurationManager.GetDefaultInstance().AppConfig.ShowTelemetryDialog)
             {
+                if (TelemetryController.DoesGroupPolicyAllowTelemetry)
+                {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                ctrlDialogContainer.ShowDialog(new TelemetryApproveContainedDialog());
+                    ctrlDialogContainer.ShowDialog(new TelemetryApproveContainedDialog());
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                }
             }
         }
     }

--- a/src/AccessibilityInsights/MainWindowHelpers/TelemetryStartup.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/TelemetryStartup.cs
@@ -3,7 +3,6 @@
 using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Settings;
 using AccessibilityInsights.SharedUx.Telemetry;
-using System.Windows;
 
 namespace AccessibilityInsights
 {
@@ -17,14 +16,12 @@ namespace AccessibilityInsights
         /// </summary>
         private void ShowTelemetryDialog()
         {
-            if (ConfigurationManager.GetDefaultInstance().AppConfig.ShowTelemetryDialog)
+            if (TelemetryController.DoesGroupPolicyAllowTelemetry &&
+                ConfigurationManager.GetDefaultInstance().AppConfig.ShowTelemetryDialog)
             {
-                if (TelemetryController.DoesGroupPolicyAllowTelemetry)
-                {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                    ctrlDialogContainer.ShowDialog(new TelemetryApproveContainedDialog());
+                ctrlDialogContainer.ShowDialog(new TelemetryApproveContainedDialog());
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                }
             }
         }
     }


### PR DESCRIPTION
#### Details

Create a registry-based policy to disable telemetry from a computer. The suppression is system-wide and persists across uninstall/reinstall. The suppression is added by creating the following registry value:

Key: HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Accessibility Insights for Windows
Value (DWORD): DisableTelemetry = 1

In terms of a reg file, it looks like this:
```
Windows Registry Editor Version 5.00

[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Accessibility Insights for Windows]
"DisableTelemetry"=dword:00000001
```

If this value exists and is set to 1, then the initial telemetry prompt is skipped. Inside the settings dialog, the standard telemetry block is also changed, as shown here:

Key not set (default) | Key set (with this change)
--- | ---
![image](https://user-images.githubusercontent.com/45672944/135184401-6453e698-04d4-4132-9bf1-0ffd018e4167.png) | ![image](https://user-images.githubusercontent.com/45672944/135184309-9aecc3e5-f68d-47fa-948a-eb73999e1a65.png)

The key is read when the app starts up, and changes to the key will be ignored until after the app is restarted.

##### Motivation

Addresses #1182 

##### Context

I also walked through this extended scenario:
1. Disable telemetry via registry
2. Start without configuration files
3. Telemetry dialog is skipped (user can't enable it)
4. Close app
5. Enable telemetry via registry
6. Start app (with or without configuration files)
7. Telemetry dialog displays

This works because the ShowTelemetryDialog flag defaults to true, then never gets set to false. When the registry override is removed, we display the telemetry dialog, as expected.

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue - #1182 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



