### PR TITLE
feat(ai-win-ado-sep21): improvements to ADO issue filing - check access before filing a bug, show error dialog

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
@@ -63,7 +63,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
 
         public Guid StableIdentifier { get; } = new Guid("73D8F6EB-E98A-4285-9BA3-B532A7601CC4");
 
-        public bool IsConfigured => _devOpsIntegration.ConnectedToAzureDevOps;
+        public bool IsConfigured => _devOpsIntegration.ConnectedToAzureDevOps && _devOpsIntegration.CheckIfAbleToGetProjects().Result;
 
         public ReporterFabricIcon Logo => ReporterFabricIcon.VSTSLogo;
 

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
@@ -63,7 +63,9 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
 
         public Guid StableIdentifier { get; } = new Guid("73D8F6EB-E98A-4285-9BA3-B532A7601CC4");
 
-        public bool IsConfigured => _devOpsIntegration.ConnectedToAzureDevOps && _devOpsIntegration.CheckIfAbleToGetProjects().Result;
+        public bool IsConfigured => _devOpsIntegration.ConnectedToAzureDevOps 
+            && Configuration.SavedConnection.IsPopulated
+            && _devOpsIntegration.CheckIfAbleToGetProjects().Result;
 
         public ReporterFabricIcon Logo => ReporterFabricIcon.VSTSLogo;
 

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
@@ -85,7 +85,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
             return _devOpsIntegration.HandleLoginAsync();
         }
 
-        public Task<IIssueResult> FileIssueAsync(IssueInformation issueInfo)
+        public Task<IIssueResultWithPostAction> FileIssueAsync(IssueInformation issueInfo)
         {
             bool topMost = false;
             Application.Current.Dispatcher.Invoke(() => topMost = Application.Current.MainWindow.Topmost);
@@ -94,7 +94,8 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
             (int? issueId, string newIssueId) = _fileIssueHelpers.FileNewIssue(issueInfo, Configuration.SavedConnection,
                 topMost, Configuration.ZoomLevel, updateZoom);
 
-            return Task.Run<IIssueResult>(() => {
+            return Task.Run<IIssueResultWithPostAction>(() =>
+            {
                 // Check whether issue was filed once dialog closed & process accordingly
                 if (!issueId.HasValue)
                     return null;
@@ -103,13 +104,21 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                 {
                     if (!_fileIssueHelpers.AttachIssueData(issueInfo, newIssueId, issueId.Value).Result)
                     {
-                        MessageDialog.Show(Properties.Resources.There_was_an_error_identifying_the_created_issue_This_may_occur_if_the_ID_used_to_create_the_issue_is_removed_from_its_Azure_DevOps_description_Attachments_have_not_been_uploaded);
+                        return new IssueResultWithPostAction()
+                        {
+                            DisplayText = null,
+                            IssueLink = null,
+                            PostAction = () => {
+                                MessageDialog.Show(Properties.Resources.There_was_an_error_identifying_the_created_issue_This_may_occur_if_the_ID_used_to_create_the_issue_is_removed_from_its_Azure_DevOps_description_Attachments_have_not_been_uploaded);
+                            },
+                        };
                     }
 
-                    return new IssueResult()
+                    return new IssueResultWithPostAction()
                     {
                         DisplayText = issueId.ToString(),
-                        IssueLink = _devOpsIntegration.GetExistingIssueUrl(issueId.Value)
+                        IssueLink = _devOpsIntegration.GetExistingIssueUrl(issueId.Value),
+                        PostAction = null,
                     };
                 }
 #pragma warning disable CA1031 // Do not catch general exception types

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
@@ -64,7 +64,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         public Guid StableIdentifier { get; } = new Guid("73D8F6EB-E98A-4285-9BA3-B532A7601CC4");
 
         public bool IsConfigured => _devOpsIntegration.ConnectedToAzureDevOps 
-            && Configuration.SavedConnection.IsPopulated
+            && Configuration?.SavedConnection?.IsPopulated == true
             && _devOpsIntegration.CheckIfAbleToGetProjects().Result;
 
         public ReporterFabricIcon Logo => ReporterFabricIcon.VSTSLogo;

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
@@ -80,11 +80,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         /// </summary>
         public string Email => UserProfile?.EmailAddress;
 
-        #region base AzureDevOps (non-server) connection code
-
-        private const string BASE_VSO_URL = "https://app.vssps.visualstudio.com";
-        #endregion
-
         #region IssueFiling
         /// <summary>
         /// Implements <see cref="IDevOpsIntegration.ConnectToAzureDevOpsAccount(Uri, CredentialPromptType)"/>
@@ -115,6 +110,20 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
             }
         }
 
+        public async Task<bool> CheckIfAbleToGetProjects()
+        {
+            try
+            {
+                ProjectHttpClient proClient = _baseServerConnection.GetClient<ProjectHttpClient>();
+                var project = await proClient.GetProjects(null, 1).ConfigureAwait(false);
+                return project.Any();
+            }
+            catch (VssException)
+            {
+                return false;
+            }
+        }
+
         /// Implements <see cref="IDevOpsIntegration.PopulateUserProfile"/>
         public Task PopulateUserProfile()
         {
@@ -124,9 +133,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                 {
                     if (ConnectedToAzureDevOps)
                     {
-                        // We need to use deployment level connection to get profile info
-                        var deploymentConn = new VssConnection(new Uri(BASE_VSO_URL), _baseServerConnection.Credentials);
-                        ProfileHttpClient client = deploymentConn.GetClient<ProfileHttpClient>();
+                        ProfileHttpClient client = _baseServerConnection.GetClient<ProfileHttpClient>();
                         ProfileQueryContext context = new ProfileQueryContext(AttributesScope.Core, CoreProfileAttributes.All, null);
                         this.UserProfile = await client.GetProfileAsync(context).ConfigureAwait(false);
                     }
@@ -428,12 +435,18 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
             {
                 await ConnectToAzureDevOpsAccount(serverUri, showDialog).ConfigureAwait(true);
                 await PopulateUserProfile().ConfigureAwait(true);
+                var canGetProjects = await CheckIfAbleToGetProjects().ConfigureAwait(true);
+                if (!canGetProjects)
+                {
+                    throw new Exception("unable to get projects");
+                }
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
             {
                 ex.ReportException();
                 FlushToken(serverUri);
+                Disconnect();
             }
 #pragma warning restore CA1031 // Do not catch general exception types
 

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
@@ -116,7 +116,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
             {
                 ProjectHttpClient proClient = _baseServerConnection.GetClient<ProjectHttpClient>();
                 var project = await proClient.GetProjects(null, 1).ConfigureAwait(false);
-                return project.Any();
+                return project.Count >= 0;
             }
             catch (VssException)
             {

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
@@ -108,12 +108,12 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
                 switch (_currentState)
                 {
                     case State.Initializing:
-                        if (currentUri.AbsoluteUri == Url.AbsoluteUri)
+                        if (currentUri.Host == Url.Host && currentUri.AbsolutePath == Url.AbsolutePath)
                             _currentState = State.TemplateIsOpen;
                         break;
 
                     case State.TemplateIsOpen:
-                        if (currentUri.AbsoluteUri != Url.AbsoluteUri)
+                        if (currentUri.Host == Url.Host && currentUri.AbsolutePath != Url.AbsolutePath)
                             _currentState = State.Saving;
                         break;
 

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/IDevOpsIntegration.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/IDevOpsIntegration.cs
@@ -61,6 +61,8 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         /// </summary>
         Task PopulateUserProfile();
 
+        Task<bool> CheckIfAbleToGetProjects();
+
         /// <summary>
         /// Disconnects from AzureDevOps, resets AzureDevOps instance
         /// </summary>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Models/IssueResult.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Models/IssueResult.cs
@@ -20,4 +20,12 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Models
         /// </summary>
         public Uri IssueLink { get; set; }
     }
+
+    public class IssueResultWithPostAction : IssueResult, IIssueResultWithPostAction
+    {
+        /// <summary>
+        /// Action to run on UI thread after issue filing is completed
+        /// </summary>
+        public Action PostAction { get; set; }
+    }
 }

--- a/src/AccessibilityInsights.Extensions.GitHub/IssueReporter.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/IssueReporter.cs
@@ -57,12 +57,12 @@ namespace AccessibilityInsights.Extensions.GitHub
 
         public bool CanAttachFiles => false;
 
-        public Task<IIssueResult> FileIssueAsync(IssueInformation issueInfo)
+        public Task<IIssueResultWithPostAction> FileIssueAsync(IssueInformation issueInfo)
         {
-            return Task.Run<IIssueResult>(() => FileIssueAsyncAction(issueInfo));
+            return Task.Run<IIssueResultWithPostAction>(() => FileIssueAsyncAction(issueInfo));
         }
 
-        private IIssueResult FileIssueAsyncAction(IssueInformation issueInfo)
+        private IIssueResultWithPostAction FileIssueAsyncAction(IssueInformation issueInfo)
         {
             if (this.IsConfigured)
             {

--- a/src/AccessibilityInsights.Extensions/Interfaces/IssueReporting/IIssueReporting.cs
+++ b/src/AccessibilityInsights.Extensions/Interfaces/IssueReporting/IIssueReporting.cs
@@ -61,6 +61,6 @@ namespace AccessibilityInsights.Extensions.Interfaces.IssueReporting
         /// </summary>
         /// <param name="issueInfo">Information that describes the issue to create</param>
         /// <returns>Optionally, an issue result with details about this filed issue</returns>
-        Task<IIssueResult> FileIssueAsync(IssueInformation issueInfo);
+        Task<IIssueResultWithPostAction> FileIssueAsync(IssueInformation issueInfo);
     }
 }

--- a/src/AccessibilityInsights.Extensions/Interfaces/IssueReporting/IIssueResult.cs
+++ b/src/AccessibilityInsights.Extensions/Interfaces/IssueReporting/IIssueResult.cs
@@ -19,4 +19,12 @@ namespace AccessibilityInsights.Extensions.Interfaces.IssueReporting
         /// </summary>
         Uri IssueLink { get; }
     }
+
+    public interface IIssueResultWithPostAction : IIssueResult
+    {
+        /// <summary>
+        /// Action to run on UI thread after issue filing is completed
+        /// </summary>
+        Action PostAction { get; }
+    }
 }

--- a/src/AccessibilityInsights.ExtensionsTests/DummyClasses/DummyIssueReporting.cs
+++ b/src/AccessibilityInsights.ExtensionsTests/DummyClasses/DummyIssueReporting.cs
@@ -26,7 +26,7 @@ namespace AccessibilityInsights.ExtensionsTests.DummyClasses
 
         public string LogoText => throw new NotImplementedException();
 
-        public Task<IIssueResult> FileIssueAsync(IssueInformation issueInfo)
+        public Task<IIssueResultWithPostAction> FileIssueAsync(IssueInformation issueInfo)
         {
             throw new NotImplementedException();
         }

--- a/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporter.cs
+++ b/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporter.cs
@@ -80,7 +80,8 @@ namespace AccessibilityInsights.SharedUx.FileIssue
                 // It does seem like we currently block the main thread when we show the win form for azure devops
                 // so keeping it as is till we have a discussion. Check for blocking behavior at that link.
                 // https://github.com/Microsoft/accessibility-insights-windows/blob/main/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs#L858
-                IIssueResult result = IssueReporting.FileIssueAsync(issueInformation).Result;
+                IIssueResultWithPostAction result = IssueReporting.FileIssueAsync(issueInformation).Result;
+                result.PostAction?.Invoke();
                 IssueReporterManager.GetInstance().UpdateIssueReporterSettings(IssueReporting);
                 return result;
             }

--- a/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
@@ -73,6 +73,7 @@ namespace AccessibilityInsights
             UpdateMainCommandButtons();
             UpdateTabSelection();
             UpdateTitleString();
+            UpdateMainWindowConnectionFields();
         }
 
         /// <summary>


### PR DESCRIPTION
#### Details

This PR contains a number of small changes to improve the ADO issue filing experience after the switch to WebView2 in  #1170. This part of the codebase is less robust than the rest of the product & we therefore try to keep changes scoped to small areas until a more holistic rewrite or replacement.

Changes:
- Add a `CheckIfAbleToGetProjects` method that verifies the ADO client is able to access the project API
- Update UX to reflect connection status given by `CheckIfAbleToGetProjects` more often; in the past the icon could say "Signed in to Azure Boards" even if disconnected
- When attachments fail to post, the current `MessageDialog` was not being shown; fix this by moving the dialog after the asynchronous issue filing task so we're back on the main thread
- Change `ProfileHttpClient` to use the same connection we use for the other APIs. Previously this used a deployment-level connection; all my tests with the project-level connection have worked so far; the upside is this reduces extra login prompts (down to 1 on my machine)
- Update the state machine in `IssueFileForm` to compare URLs ignoring query parameters; this fixes an issue where filing an issue after a login redirect didn't work - slightly different URLs meant we never hit the `Saving` state, so the window would not close

Signed build in progress here: https://dev.azure.com/mseng/1ES/_build/results?buildId=16139035&view=results

##### Testing

I have used the following scenarios to test:

**No saved credentials**

- Delete the registry key in `Computer\HKEY_CURRENT_USER\SOFTWARE\Microsoft\VSCommon\14.0\ClientServices\TokenStorage`
- Delete the `WebView2` folder and other configuration files in `%LocalAppData%/AccessibilityInsights/V1/Configurations`
- Run AI-Windows and connect to a project
- File an issue (connect to a project in the browser)
- Close AI-Windows

**Saved credentials**
- Open AI-Windows
- The credentials should be cached from the previous run
- Filing an issue should work without additional logging in

**Disconnect**
- Disconnect from Azure Boards in the UI
- Try to file a bug
- A message dialog displays "select where to file issues"
- Connect to Azure Boards
- Filing an issue should work

**Attachment fails to post** 
- Begin to file an issue
- Change the GUID in the preview window
- Try to save the issue
- A message dialog informs you that attachments could not be uploaded

**Using non-Connected-to-Windows account**
- Connect with an account that's not "Connected to Windows" (for example, I made a new outlook.com email)
- Connecting in the app works, but connecting in the browser fails because of a long redirect URL
- Checked with PM and will leave this for now; most users are using their corporate Connected-to-Windows account
- Fixing this in the product requires adding a "Test WebView2 connection" button that opens a new WebView2 window to a shorter URL. One workaround is to:

> click 'Inspect' in the 404 WebView page
> go to DevTools console
> run window.open("https://dev.azure.com/YOUR_ORG") with your base URL
> log into the new window
> close the new window
> close the original 404 WebView page
> try filing a new bug

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



