### PR TITLE
feat(ai-win-ado-sep21): delete WebView2 folder when uninstalled

### DIFF
--- a/src/AccessibilityInsights.CustomActions/ConfigFileCleaner.cs
+++ b/src/AccessibilityInsights.CustomActions/ConfigFileCleaner.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SetupLibrary;
 using Microsoft.Deployment.WindowsInstaller;
 using System;
 
@@ -59,19 +60,11 @@ namespace AccessibilityInsights.CustomActions
 
         private void DeleteConfigFiles()
         {
-            _systemShim.LogToSession("RemoveUserConfigFiles: Finding config files");
-            foreach (string fileName in _systemShim.GetConfigFiles())
+            var configDirectory = FixedConfigSettingsProvider.CreateDefaultSettingsProvider().ConfigurationFolderPath;
+            if (_systemShim.DirectoryExists(configDirectory)) 
             {
-                if (_systemShim.DirectoryExists(fileName)) 
-                {
-                    _systemShim.LogToSession("RemoveUserConfigFiles: Deleting directory: " + fileName);
-                    _systemShim.DeleteDirectory(fileName);
-                }
-                else
-                {
-                    _systemShim.LogToSession("RemoveUserConfigFiles: Deleting file: " + fileName);
-                    _systemShim.DeleteFile(fileName);
-                }
+                _systemShim.LogToSession("RemoveUserConfigFiles: Deleting config directory: " + configDirectory);
+                _systemShim.DeleteDirectory(configDirectory);
             }
         }
     }

--- a/src/AccessibilityInsights.CustomActions/ISystemShim.cs
+++ b/src/AccessibilityInsights.CustomActions/ISystemShim.cs
@@ -10,8 +10,6 @@ namespace AccessibilityInsights.CustomActions
     internal interface ISystemShim
     {
         IEnumerable<string> GetRunningProcessNames();
-        IEnumerable<string> GetConfigFiles();
-        void DeleteFile(string fileName);
         void DeleteDirectory(string dirName);
         bool DirectoryExists(string dirName);
         void LogToSession(string message);

--- a/src/AccessibilityInsights.CustomActions/SystemShim.cs
+++ b/src/AccessibilityInsights.CustomActions/SystemShim.cs
@@ -29,18 +29,6 @@ namespace AccessibilityInsights.CustomActions
             }
         }
 
-        public IEnumerable<string> GetConfigFiles()
-        {
-            string configPath = FixedConfigSettingsProvider.CreateDefaultSettingsProvider().ConfigurationFolderPath;
-
-            return Directory.EnumerateDirectories(configPath).Concat(Directory.EnumerateFiles(configPath));
-        }
-
-        public void DeleteFile(string fileName)
-        {
-            File.Delete(fileName);
-        }
-
         public void DeleteDirectory(string dirName)
         {
             Directory.Delete(dirName, true);

--- a/src/AccessibilityInsights.CustomActionsUnitTests/ConfigFileCleanerUnitTests.cs
+++ b/src/AccessibilityInsights.CustomActionsUnitTests/ConfigFileCleanerUnitTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CustomActions;
+using AccessibilityInsights.SetupLibrary;
 using Microsoft.Deployment.WindowsInstaller;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -39,36 +40,18 @@ namespace AccessibilityInsights.CustomActionsUnitTests
         }
 
         [TestMethod]
-        public void RunAction_VersionSwitcherIsNotRunning_NoConfigFilesExist_NothingIsDeleted()
-        {
-            _systemShimMock.Setup(x => x.GetConfigFiles())
-                .Returns(Enumerable.Empty<string>);
-
-            Assert.AreEqual(ActionResult.Success, _cleaner.RunAction());
-
-            _systemShimMock.VerifyAll();
-        }
-
-        [TestMethod]
         public void RunAction_VersionSwitcherIsNotRunning_ConfigFilesExist_FilesAreDeleted()
         {
-            List<string> configFiles = new List<string> { "a.json", "b.json", "c.json" };
-            List<string> configDirs = new List<string> { "dir" };
-            List<string> deletedFiles = new List<string>();
             List<string> deletedDirs = new List<string>();
 
-            _systemShimMock.Setup(x => x.GetConfigFiles())
-                .Returns(configFiles.Concat(configDirs));
+            var configDirectory = FixedConfigSettingsProvider.CreateDefaultSettingsProvider().ConfigurationFolderPath;
             _systemShimMock.Setup(x => x.DirectoryExists(It.IsAny<string>()))
-                .Returns<string>(fileName => fileName.EndsWith("dir"));
+                .Returns<string>(fileName => fileName.Equals(configDirectory));
             _systemShimMock.Setup(x => x.DeleteDirectory(It.IsAny<string>()))
                 .Callback<string>(fileName => deletedDirs.Add(fileName));
-            _systemShimMock.Setup(x => x.DeleteFile(It.IsAny<string>()))
-                .Callback<string>(fileName => deletedFiles.Add(fileName));
 
             Assert.AreEqual(ActionResult.Success, _cleaner.RunAction());
-            Assert.IsTrue(configFiles.SequenceEqual(deletedFiles));
-            Assert.IsTrue(configDirs.SequenceEqual(deletedDirs));
+            Assert.IsTrue(deletedDirs.Count == 1 && deletedDirs.First().Equals(configDirectory));
 
             _systemShimMock.VerifyAll();
         }


### PR DESCRIPTION
#### Details

This PR deletes the WebView2 folder (and any other files/folders in the configuration path) when the app is uninstalled. Tested locally by building an MSI - after uninstall, the `Configurations` folder is deleted.

The current approach in main is to delete any files (but no directories). This PR includes other subdirectories.

We discussed other strategies with @DaveTryon including:
- deleting only the WebView2 folder, *.json, *.bat files to be closer to files we know we create
- creating an explicit list of configuration files to delete (would need to handle *.bat files)

We decided to go with this approach for now to handle the WebView2 folder - we can change it later if needed.

##### Motivation

delete WebView2 settings/cache on uninstall

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



