### PR TITLE
chore: switch signed build agent pools

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -211,6 +211,7 @@ jobs:
     displayName: 'Install Signing Plugin'
     inputs:
       signType: real
+      feedSource: '$(SigningPluginFeedSource)'
 
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'


### PR DESCRIPTION
#### Details

We need to change agent pools for our signed build. The new pools are hosted publicly and have no corp file share access - it took two changes to get this working:
- the localization plugin had a dependency on a fileshare; since we don't use the localization plugin, I removed the step entirely
- the feed source for the microbuild plugin should be explicitly provided; I added the value in a build variable

##### Motivation

old agent pool is being deprecated

Here's a sample build: https://dev.azure.com/mseng/1ES/_build/results?buildId=16221004&view=results