### PR TITLE
fix: Ensure proper sequencing during initialization

### DIFF
--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -162,6 +162,8 @@ namespace AccessibilityInsights
             // create necessary config folders & their internal config files
             PopulateConfigurations(telemetryBuffer);
 
+            InitializeTelemetry();
+
             SetFontSize();
 
             InitCommandBindings();

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -19,7 +19,6 @@ using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interop;
-using System.Windows.Media;
 using System.Windows.Shell;
 
 namespace AccessibilityInsights
@@ -116,7 +115,7 @@ namespace AccessibilityInsights
         }
 
         /// <summary>
-        /// Populate all configurations
+        /// Populate all configurations. Call this method before calling any extension-dependent methods!
         /// </summary>
         private static void PopulateConfigurations(TelemetryBuffer telemetryBuffer)
         {
@@ -141,15 +140,18 @@ namespace AccessibilityInsights
             // Configure the correct ReleaseChannel for autoupdate
             Container.SetAutoUpdateReleaseChannel(ConfigurationManager.GetDefaultInstance().AppConfig.ReleaseChannel.ToString());
 
+            // Update theming since it depends on config options
+            SetColorTheme();
+        }
+
+        private static void InitializeTelemetry()
+        {
             // Opt into telemetry if allowed and user has chosen to do so
             if (TelemetryController.DoesGroupPolicyAllowTelemetry &&
                 ConfigurationManager.GetDefaultInstance().AppConfig.EnableTelemetry)
             {
                 TelemetryController.OptIntoTelemetry();
             }
-
-            // Update theming since it depends on config options
-            SetColorTheme();
         }
 
         /// <summary>


### PR DESCRIPTION
#### Details

Fix canary upgrade problem by ensuring that ordering assumptions are respected during initialization. For the autoupdate to work as expected, it's important that `Container.SetAutoUpdateReleaseChannel` gets called before `Container.GetDefaultInstance`. When #1204 was added, the code is in the proper sequence, and the upgrade works as expected when built for the debug config. When built for the release config, though, I was able to prove that the calls were occurring in the wrong order. It seems that the optimizer decided to change the sequence of calls between the API's, meaning that the autoUpdate code always loaded the production data.

The change here is to move the telemetry initialization code into a separate method so the optimizer can no longer change the call order. As an aside, enabling telemetry in a method called `PopulateConfigurations` was a bit off, so having it in a separate method is also better coding style. I included a comment in `PopulateConfigurations` as a reminder about the calling order dependency.

##### Motivation

Address #1226 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue - #1226 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



