### PR TITLE
AI-Win color contrast bug

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
@@ -83,7 +83,11 @@
                             <ListView.View>
                                 <GridView x:Name="gvRules">
                                     <GridViewColumn>
-                                        <GridViewColumnHeader Content="{x:Static Properties:Resources.ScannerResultControl_Rule}" IsTabStop="False" Focusable="True" IsEnabled="False" FontSize="{DynamicResource StandardTextSize}" Background="Transparent" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                                        <GridViewColumnHeader 
+                                            Style="{DynamicResource ScannerResultColumnHeader}"
+                                            Content="{x:Static Properties:Resources.ScannerResultControl_Rule}" 
+                                            IsTabStop="False" 
+                                            Focusable="True"/>
                                         <GridViewColumn.CellTemplate>
                                             <DataTemplate>
                                                 <StackPanel Orientation="Horizontal">
@@ -118,7 +122,12 @@
                                         </GridViewColumn.CellTemplate>
                                     </GridViewColumn>
                                     <GridViewColumn Width="{Binding BugColumnWidth}">
-                                        <GridViewColumnHeader Visibility="{Binding BugColumnVisibility}" Content="{x:Static Properties:Resources.ScannerResultControl_Issue}" IsTabStop="False" Focusable="True" IsEnabled="False" FontSize="{DynamicResource StandardTextSize}" Background="Transparent" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                                        <GridViewColumnHeader 
+                                            Style="{DynamicResource ScannerResultColumnHeader}"
+                                            Visibility="{Binding BugColumnVisibility}" 
+                                            Content="{x:Static Properties:Resources.ScannerResultControl_Issue}" 
+                                            IsTabStop="False" 
+                                            Focusable="True"/>
                                         <GridViewColumn.CellTemplate>
                                             <DataTemplate>
                                                 <StackPanel Orientation="Horizontal" MinWidth="200">

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
@@ -83,7 +83,7 @@
                             <ListView.View>
                                 <GridView x:Name="gvRules">
                                     <GridViewColumn>
-                                        <GridViewColumnHeader Content="{x:Static Properties:Resources.ScannerResultControl_Rule}" IsTabStop="False" Focusable="True" FontSize="{DynamicResource StandardTextSize}" Background="Transparent" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                                        <GridViewColumnHeader Content="{x:Static Properties:Resources.ScannerResultControl_Rule}" IsTabStop="False" Focusable="True" IsEnabled="False" FontSize="{DynamicResource StandardTextSize}" Background="Transparent" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                                         <GridViewColumn.CellTemplate>
                                             <DataTemplate>
                                                 <StackPanel Orientation="Horizontal">
@@ -118,7 +118,7 @@
                                         </GridViewColumn.CellTemplate>
                                     </GridViewColumn>
                                     <GridViewColumn Width="{Binding BugColumnWidth}">
-                                        <GridViewColumnHeader Visibility="{Binding BugColumnVisibility}" Content="{x:Static Properties:Resources.ScannerResultControl_Issue}" IsTabStop="False" Focusable="True" FontSize="{DynamicResource StandardTextSize}" Background="Transparent" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+                                        <GridViewColumnHeader Visibility="{Binding BugColumnVisibility}" Content="{x:Static Properties:Resources.ScannerResultControl_Issue}" IsTabStop="False" Focusable="True" IsEnabled="False" FontSize="{DynamicResource StandardTextSize}" Background="Transparent" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                                         <GridViewColumn.CellTemplate>
                                             <DataTemplate>
                                                 <StackPanel Orientation="Horizontal" MinWidth="200">

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -535,7 +535,7 @@
         <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=ColumnHeaderFGBrush}"/>
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -529,6 +529,16 @@
         </Style.Triggers>
     </Style>
     <!-- GridView related styles -->
+    <Style TargetType="GridViewColumnHeader" x:Key="ScannerResultColumnHeader">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="FontSize" Value="{DynamicResource StandardTextSize}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
     <Style TargetType="GridViewColumnHeader" x:Key="GvchNoContent">
         <Setter Property="Margin" Value="0,0,0,2"/>
         <Setter Property="Template">


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
This is a quick fix to the color contrast problem reported in bug #845 

Due to problems with the current implementation of the GridViewColumnHeader, it is not possible to customize the background properties (the color changes are not reflected in the element). This is the reason why I decided to change the foreground color to increase the ratio between the header and the background as shown in the following picture.

![image](https://user-images.githubusercontent.com/32908302/140977667-6677dd89-e11e-4411-8107-baead535152c.png)
(The image above shows the color contrast analyzer test of the background color against the foreground color, which gives a ratio of 8.917:1)

| Mode  | Image |
| ------------- | ------------- |
| Light  | ![image](https://user-images.githubusercontent.com/32908302/141720212-67e2f6f9-7d6f-42d6-aa83-6e2b9a63b55c.png) |
| Dark  | ![image](https://user-images.githubusercontent.com/32908302/141719696-5f8be5ac-9324-4eb9-b58f-314ef3e93bc4.png) |
| HC1  | ![image](https://user-images.githubusercontent.com/32908302/141719881-48b4c314-b63f-46ba-85c3-bae87dfb7b73.png) |
| HC2  | ![image](https://user-images.githubusercontent.com/32908302/141719985-5f62676f-1af3-4d82-a6fc-3378af86810b.png)|
| HC Light  | ![image](https://user-images.githubusercontent.com/32908302/141720171-bc27de16-9bf0-44d5-b4cd-cbb5a1a6e7b4.png) |
| HC Dark  | ![image](https://user-images.githubusercontent.com/32908302/141720072-d90e65da-dce8-4c32-9f57-ae8c4b34c9a4.png)  |

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

This PR intends to address issue #845 through a quick fix that allows the header to be displayed during the onMouseOver event, since during this bug's investigation multiple errors related to the GridViewColumnHeader implementation were discovered, such as:

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->


- The inability to change the background color of the element
- Inconsistency between multiple implementations of the GridViewColumnHeader element throughout the project.
- The unintentional ability to move columns around.

A suitable solution to all these problems will be addressed in a future bug.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue #845  
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



