### PR TITLE
chore: Control color contrast detection parameters from AIWin

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
@@ -113,7 +113,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
         private void RunAutoCCA(Bitmap bitmap)
         {
-            var bmc = new BitmapCollection(bitmap);
+            var bmc = new BitmapCollection(bitmap, new DefaultColorContrastConfig());
             var result = bmc.RunColorContrastCalculation();
             var pair = result.MostLikelyColorPair;
 


### PR DESCRIPTION
#### Details

Back in https://github.com/microsoft/axe-windows/pull/469, we made it possible for AIWin to control the parameters used for automatic color detection. We then forgot to use this ability. This finishes that change so that we have the ability to experiment with color contrast parameters strictly from the AIWin side (without requiring a re-release of Axe.Windows). Once this merges, we can also remove the legacy ctor from the Axe.Windows `BitmapCollection` class (https://github.com/microsoft/axe-windows/pull/652).

##### Motivation

Complete a task that was only halfway finished

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



