### PR TITLE
feat(compliance-fall-21): Improve localizability in AzureDevOps project

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
@@ -59,7 +59,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
 
         public bool IsConnected => _devOpsIntegration.ConnectedToAzureDevOps;
 
-        public string ServiceName { get; } = "Azure Boards";
+        public string ServiceName { get; } = Properties.Resources.ServiceName;
 
         public Guid StableIdentifier { get; } = new Guid("73D8F6EB-E98A-4285-9BA3-B532A7601CC4");
 

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
@@ -71,7 +71,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
 
         public string ConfigurationPath { get; private set; }
 
-        public string LogoText => "Azure Boards";
+        public string LogoText => Properties.Resources.LogoText;
 
         public IssueConfigurationControl ConfigurationControl { get; } = new ConfigurationControl();
 

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
@@ -278,7 +278,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
             {
                 Operation = Operation.Add,
                 Path = "/fields/System.History",
-                Value = "Attached an Accessibility Insights for Windows test file and screenshot."
+                Value = Properties.Resources.AttachDataFilesDescription,
             }
             );
             patchDoc.Add(new JsonPatchOperation()
@@ -289,7 +289,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                 {
                     rel = "AttachedFile",
                     url = attachment.Url,
-                    attributes = new { comment = "Accessibility Insights for Windows test file" }
+                    attributes = new { comment = Properties.Resources.AttachTestFileComment },
                 }
             }
             );
@@ -325,7 +325,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                 {
                     rel = "AttachedFile",
                     url = attachment.Url,
-                    attributes = new { comment = "Screenshot of element" }
+                    attributes = new { comment = Properties.Resources.AttachScreenShotComment },
                 }
             }
             );

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
@@ -260,7 +260,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                 catch (Exception e)
                 {
                     e.ReportException();
-                    Dispatcher.Invoke(() => MessageDialog.Show("Error when retrieving team projects"));
+                    Dispatcher.Invoke(() => MessageDialog.Show(Properties.Resources.TeamProjectRetrievalError));
                     ToggleLoading(false);
                     disconnectButton_Click(null, null);
                 }

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/FileIssueHelpers.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/FileIssueHelpers.cs
@@ -447,7 +447,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
             foreach (var pair in issueFieldPairs)
             {
                 var name = Enum.GetName(typeof(IssueField), pair.Key);
-                var value = pair.Value ?? "[unknown]";
+                var value = pair.Value ?? Properties.Resources.UnknownValue;
                 inputTemplate = inputTemplate.Replace($"@[{name}]@", value);
             }
             return inputTemplate;
@@ -465,7 +465,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
         {
             issueFieldPairs[IssueField.ProcessName] = TruncateString(issueInfo.ProcessName, 50, ".exe");
             issueFieldPairs[IssueField.Glimpse] = TruncateString(issueInfo.Glimpse, 50);
-            issueFieldPairs[IssueField.TestMessages] = TruncateString(issueInfo.TestMessages, 150, "...open attached A11y test file for full details.");
+            issueFieldPairs[IssueField.TestMessages] = TruncateString(issueInfo.TestMessages, 150, Properties.Resources.ConcatenationMessage);
             issueFieldPairs[IssueField.RuleSource] = RemoveSurroundingBrackets(issueInfo.RuleSource);
         }
 

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
@@ -196,6 +196,15 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Azure Boards.
+        /// </summary>
+        public static string LogoText {
+            get {
+                return ResourceManager.GetString("LogoText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Azure Boards link.
         /// </summary>
         public static string ServerComboBoxAutomationPropertiesName {

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
@@ -232,6 +232,15 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error when retrieving team projects.
+        /// </summary>
+        public static string TeamProjectRetrievalError {
+            get {
+                return ResourceManager.GetString("TeamProjectRetrievalError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Change.
         /// </summary>
         public static string TextBlockTextChange {

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
@@ -151,6 +151,15 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ...open attached A11y test file for full details..
+        /// </summary>
+        public static string ConcatenationMessage {
+            get {
+                return ResourceManager.GetString("ConcatenationMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select your Azure Boards team.
         /// </summary>
         public static string ConnectionControl_selectTeam {
@@ -257,6 +266,15 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         public static string UnableToConnectFormattedMessage {
             get {
                 return ResourceManager.GetString("UnableToConnectFormattedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [unknown].
+        /// </summary>
+        public static string UnknownValue {
+            get {
+                return ResourceManager.GetString("UnknownValue", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
@@ -178,6 +178,15 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Azure Boards.
+        /// </summary>
+        public static string ServiceName {
+            get {
+                return ResourceManager.GetString("ServiceName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select your Azure Boards team.
         /// </summary>
         public static string tbTeamProjectSearchAutomationPropertiesName {

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.Designer.cs
@@ -70,6 +70,33 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Attached an Accessibility Insights for Windows test file and screenshot..
+        /// </summary>
+        public static string AttachDataFilesDescription {
+            get {
+                return ResourceManager.GetString("AttachDataFilesDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Screenshot of element.
+        /// </summary>
+        public static string AttachScreenShotComment {
+            get {
+                return ResourceManager.GetString("AttachScreenShotComment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Accessibility Insights for Windows test file.
+        /// </summary>
+        public static string AttachTestFileComment {
+            get {
+                return ResourceManager.GetString("AttachTestFileComment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Connect Azure Boards account.
         /// </summary>
         public static string btnNextAutomationPropertiesName {

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -193,6 +193,9 @@
   <data name="UnknownValue" xml:space="preserve">
     <value>[unknown]</value>
   </data>
+  <data name="LogoText" xml:space="preserve">
+    <value>Azure Boards</value>
+  </data>
   <data name="TeamProjectRetrievalError" xml:space="preserve">
     <value>Error when retrieving team projects</value>
   </data>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -175,6 +175,15 @@
   <data name="WaitingToConnect" xml:space="preserve">
     <value>Waiting to connect to Azure Boards</value>
   </data>
+  <data name="AttachDataFilesDescription" xml:space="preserve">
+    <value>Attached an Accessibility Insights for Windows test file and screenshot.</value>
+  </data>
+  <data name="AttachScreenShotComment" xml:space="preserve">
+    <value>Screenshot of element</value>
+  </data>
+  <data name="AttachTestFileComment" xml:space="preserve">
+    <value>Accessibility Insights for Windows test file</value>
+  </data>
   <data name="ServiceName" xml:space="preserve">
     <value>Azure Boards</value>
   </data>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -193,4 +193,7 @@
   <data name="UnknownValue" xml:space="preserve">
     <value>[unknown]</value>
   </data>
+  <data name="TeamProjectRetrievalError" xml:space="preserve">
+    <value>Error when retrieving team projects</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -184,7 +184,13 @@
   <data name="AttachTestFileComment" xml:space="preserve">
     <value>Accessibility Insights for Windows test file</value>
   </data>
+  <data name="ConcatenationMessage" xml:space="preserve">
+    <value>...open attached A11y test file for full details.</value>
+  </data>
   <data name="ServiceName" xml:space="preserve">
     <value>Azure Boards</value>
+  </data>
+  <data name="UnknownValue" xml:space="preserve">
+    <value>[unknown]</value>
   </data>
 </root>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Properties/Resources.resx
@@ -175,4 +175,7 @@
   <data name="WaitingToConnect" xml:space="preserve">
     <value>Waiting to connect to Azure Boards</value>
   </data>
+  <data name="ServiceName" xml:space="preserve">
+    <value>Azure Boards</value>
+  </data>
 </root>


### PR DESCRIPTION
#### Details

This PR improves localization in the `AccessibilityInsights.Extensions.AzureDevOps` project. All of the changes replace a hardcoded string with a new resource string.

##### Motivation

Global Readiness component of compliance feature.

##### Context

To make the work more manageable, I'll create a separate PR for each project.

Each commit includes strings from a single .cs file. It might be easier to review each commit separately. They do not overlap.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



