### PR TITLE
feat(compliance-fall-21): Improve localizability in VersionSwitcher project

### DIFF
--- a/src/AccessibilityInsights.VersionSwitcher/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/MainWindow.xaml.cs
@@ -4,6 +4,7 @@
 using AccessibilityInsights.SetupLibrary;
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Threading;
 using System.Windows;
 using System.Windows.Automation.Peers;
@@ -56,7 +57,8 @@ namespace AccessibilityInsights.VersionSwitcher
 
         private void UpdateProgress(int percentage)
         {
-            string newText = $"Update {percentage}% complete";
+            string newText = string.Format(CultureInfo.InvariantCulture,
+                Properties.Resources.ProgressIndicatorFormat, percentage);
 
             if (newText != statusText.Text)
             {

--- a/src/AccessibilityInsights.VersionSwitcher/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/Properties/Resources.Designer.cs
@@ -70,6 +70,15 @@ namespace AccessibilityInsights.VersionSwitcher.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Update {0}% complete.
+        /// </summary>
+        public static string ProgressIndicatorFormat {
+            get {
+                return ResourceManager.GetString("ProgressIndicatorFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Untrusted File!.
         /// </summary>
         public static string UntrustedFile {

--- a/src/AccessibilityInsights.VersionSwitcher/Properties/Resources.resx
+++ b/src/AccessibilityInsights.VersionSwitcher/Properties/Resources.resx
@@ -120,6 +120,10 @@
   <data name="InstallError" xml:space="preserve">
     <value>An error occurred during install</value>
   </data>
+  <data name="ProgressIndicatorFormat" xml:space="preserve">
+    <value>Update {0}% complete</value>
+    <comment>{0} is an int from 0 to 100</comment>
+  </data>
   <data name="UntrustedFile" xml:space="preserve">
     <value>Untrusted File!</value>
   </data>


### PR DESCRIPTION
#### Details

This PR improves localization in the `AccessibilityInsights.VersionSwitcher` project. All of the changes replace a hardcoded string with a new resource string.

##### Motivation

Global Readiness component of compliance feature.

##### Context

To make the work more manageable, I'll create a separate PR for each project.

Each commit includes strings from a single .cs file. It might be easier to review each commit separately. They do not overlap.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



