### PR TITLE
chore: Remove dead code

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml.cs
@@ -254,30 +254,6 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
             if (config == null)
                 throw new ArgumentNullException(nameof(config));
 
-            if (config.HotKeyForSnap != (string) this.btnHotkeyToggle.Content)
-            {
-                var dic = new Dictionary<string, string>();
-                dic.Add("HotkeyToggleMode", (string) this.btnHotkeyToggle.Content);
-            }
-
-            if (config.HotKeyForActivatingMainWindow != (string)this.btnHotkeyActivateWindow.Content)
-            {
-                var dic = new Dictionary<string, string>();
-                dic.Add("HotkeyActivateWIndow", (string)this.btnHotkeyActivateWindow.Content);
-            }
-
-            if (config.HotKeyForRecord != (string)this.btnHotkeyRecord.Content)
-            {
-                var dic = new Dictionary<string, string>();
-                dic.Add("HotkeyRecord", (string)this.btnHotkeyRecord.Content);
-            }
-
-            if (config.HotKeyForPause != (string)this.btnHotkeyPause.Content)
-            {
-                var dic = new Dictionary<string, string>();
-                dic.Add("HotkeyPause", (string)this.btnHotkeyPause.Content);
-            }
-
             config.HotKeyForActivatingMainWindow = (string)this.btnHotkeyActivateWindow.Content;
             config.HotKeyForSnap = (string)this.btnHotkeyToggle.Content;
             config.HotKeyForRecord = (string)this.btnHotkeyRecord.Content;


### PR DESCRIPTION
#### Details

Remove some code that serves no purpose. A _**long**_ time ago, each of these blocks included a final line that sent a telemetry event to track that the user had changed a hotkey mapping. The code to _send_ the telemetry was removed, but the code to _set up_ for the telemetry was left intact. The logical options seem to be to bring back the telemetry or to remove the code that sets up for the no-longer called telemetry. I opted for the latter option.

##### Motivation

Code hygiene, reduce clutter

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



