### PR TITLE
feat(compliance-fall-21): Improve localizability in SharedUx project

### DIFF
--- a/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml.cs
@@ -350,7 +350,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
             {
                 this.tbResult.Text = Properties.Resources.FailedEmphasizedText;
             }
-            AutomationProperties.SetName(this.tbResult, "Execution result failed");
+            AutomationProperties.SetName(this.tbResult, Properties.Resources.A11yElementView_ExecutionError);
         }
 
         private void cbElements_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
@@ -82,7 +82,8 @@ namespace AccessibilityInsights.SharedUx.Controls
                 SuggestedNode.SortChildren();
             }
 
-            var properties = new EventConfigNodeViewModel("Properties", isThreeState: true) { Depth = 1 };
+            var properties = new EventConfigNodeViewModel(
+                Properties.Resources.EventConfigTabControl_Properties, isThreeState: true) { Depth = 1 };
             properties.AddChildren(el.Properties.Values);
 
             if (properties.Children.Any())
@@ -96,9 +97,11 @@ namespace AccessibilityInsights.SharedUx.Controls
                 RootNodes.Add(SuggestedNode);
             }
 
-            CustomNode = new EventConfigNodeViewModel("My Events", isThreeState: true);
+            CustomNode = new EventConfigNodeViewModel(
+                Properties.Resources.EventConfigTabControl_MyEvents, isThreeState: true);
 
-            CustomPropertiesNode = new EventConfigNodeViewModel("Properties", isThreeState: true) { Depth = 1 };
+            CustomPropertiesNode = new EventConfigNodeViewModel(
+                Properties.Resources.EventConfigTabControl_Properties, isThreeState: true) { Depth = 1 };
             EditBtnNode = new EventConfigNodeViewModel("", Visibility.Visible, Properties.Resources.EventConfigTabControl_SetElement_Edit_My_Events) { Depth = 1, TextVisibility = Visibility.Collapsed };
 
             UpdateCustomNode();

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml.cs
@@ -392,7 +392,8 @@ namespace AccessibilityInsights.SharedUx.Controls
                             catch (Exception ex)
                             {
                                 ex.ReportException();
-                                MessageDialog.Show(string.Format(CultureInfo.InvariantCulture, "Couldn't save the event record file: {0}", ex.Message));
+                                MessageDialog.Show(string.Format(CultureInfo.InvariantCulture,
+                                    Properties.Resources.EventRecordControl_FileSaveError, ex.Message));
                             }
 #pragma warning restore CA1031 // Do not catch general exception types
                         }

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -514,8 +514,11 @@ namespace AccessibilityInsights.SharedUx.Controls
                 this.mniRaw.IsEnabled = false;
                 this.rbRaw.IsChecked = this.ElementContext.Element.TreeWalkerMode == TreeViewMode.Raw;
             }
-            var suffix = this.rbRaw.IsChecked.HasValue && this.rbRaw.IsChecked.Value ? "Checked" : "";
-            this.mniRaw.SetValue(AutomationProperties.NameProperty, $"Raw view {suffix}");
+            bool isChecked = this.rbRaw.IsChecked.HasValue && this.rbRaw.IsChecked.Value;
+            this.mniRaw.SetValue(AutomationProperties.NameProperty,
+                isChecked ?
+                    Properties.Resources.HierarchyControl_RawView_Checked :
+                    Properties.Resources.HierarchyControl_RawView_Unchecked);
         }
 
         /// <summary>
@@ -535,8 +538,11 @@ namespace AccessibilityInsights.SharedUx.Controls
                 this.mniContent.IsEnabled = false;
                 this.rbContent.IsChecked = this.ElementContext.Element.TreeWalkerMode == TreeViewMode.Content;
             }
-            var suffix = this.rbContent.IsChecked.HasValue && this.rbContent.IsChecked.Value ? "Checked" : "";
-            this.mniContent.SetValue(AutomationProperties.NameProperty, $"Content view {suffix}");
+            bool isChecked = this.rbContent.IsChecked.HasValue && this.rbContent.IsChecked.Value;
+            this.mniContent.SetValue(AutomationProperties.NameProperty,
+                isChecked ?
+                    Properties.Resources.HierarchyControl_ContentView_Checked :
+                    Properties.Resources.HierarchyControl_ContentView_Unchecked);
         }
 
         /// <summary>
@@ -556,8 +562,11 @@ namespace AccessibilityInsights.SharedUx.Controls
                 this.mniControl.IsEnabled = false;
                 this.rbControl.IsChecked = this.ElementContext.Element.TreeWalkerMode == TreeViewMode.Control;
             }
-            var suffix = this.rbControl.IsChecked.HasValue && this.rbControl.IsChecked.Value ? "Checked" : "";
-            this.mniControl.SetValue(AutomationProperties.NameProperty, $"Control view {suffix}");
+            bool isChecked = this.rbControl.IsChecked.HasValue && this.rbControl.IsChecked.Value;
+            this.mniControl.SetValue(AutomationProperties.NameProperty,
+                isChecked ?
+                    Properties.Resources.HierarchyControl_ControlView_Checked :
+                    Properties.Resources.HierarchyControl_ControlView_Unchecked);
         }
 
         /// <summary>
@@ -710,7 +719,9 @@ namespace AccessibilityInsights.SharedUx.Controls
                 {
                     btnMenu.Visibility = Visibility.Visible;
                     btnTestElement.Visibility = Visibility.Visible;
-                    var hlptxt = string.Format(CultureInfo.InvariantCulture, "Invoke to test {0} and descendants", vm.Element.Glimpse);
+                    var hlptxt = string.Format(CultureInfo.InvariantCulture, 
+                        Properties.Resources.HierarchyControl_LiveMode_InvokeToTestFormat,
+                        vm.Element.Glimpse);
                     AutomationProperties.SetHelpText(btnTestElement, hlptxt);
                 }
                 else

--- a/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml.cs
@@ -14,7 +14,6 @@ using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
-using static System.FormattableString;
 
 namespace AccessibilityInsights.SharedUx.Controls
 {

--- a/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml.cs
@@ -7,6 +7,7 @@ using AccessibilityInsights.SharedUx.ViewModels;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Windows;
@@ -141,7 +142,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         private void CopyAllPatternsToClipboard()
         {
             StringBuilder sb = new StringBuilder();
-            sb.AppendLine("Available patterns:");
+            sb.AppendLine(Properties.Resources.PatternInfoControl_AvailablePatterns);
             // patterns
             foreach (var pt in this.Element.Patterns)
             {
@@ -163,7 +164,9 @@ namespace AccessibilityInsights.SharedUx.Controls
                 sb.AppendLine(pattern.Name);
                 foreach (var prop in pattern.Properties)
                 {
-                    sb.AppendLine(Invariant($"- {prop.Name}: {prop.Value}"));
+                    sb.AppendLine(string.Format(CultureInfo.InvariantCulture,
+                        Properties.Resources.PatternInfoControl_PatternPropertyFormat,
+                        prop.Name, prop.Value));
                 }
             }
         }

--- a/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml.cs
@@ -186,7 +186,8 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// </summary>
         public void mniIncludeAllPropertiesClicked()
         {
-            var dlg = new PropertyConfigDialog(Configuration.CoreProperties, PropertyType.GetInstance(), "Properties");
+            var dlg = new PropertyConfigDialog(Configuration.CoreProperties, PropertyType.GetInstance(),
+                Properties.Resources.PropertyInfoControl_Properties);
             var wnd = (IMainWindow)Application.Current.MainWindow;
 
             dlg.Owner = Window.GetWindow(this);

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -23,10 +23,8 @@ using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Navigation;
 using System.Windows.Threading;
 
 namespace AccessibilityInsights.SharedUx.Controls.TestTabs

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -317,7 +317,8 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                     this.chbxSelectAll.IsEnabled = ScreenshotAvailable;
                     this.lvResults.ItemsSource = null;
                     this.ElementContext = ec;
-                    this.tbGlimpse.Text = "Target: " + ec.Element.Glimpse;
+                    this.tbGlimpse.Text = string.Format(CultureInfo.InvariantCulture,
+                        Properties.Resources.AutomatedChecksControl_TargetFormat, ec.Element.Glimpse);
                     UpdateUI();
                 }
             }

--- a/src/AccessibilityInsights.SharedUx/Dialogs/PropertyConfigDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/PropertyConfigDialog.xaml.cs
@@ -6,6 +6,7 @@ using Axe.Windows.Desktop.UIAutomation;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Globalization;
 using System.Linq;
 using System.Windows;
 using System.Windows.Input;
@@ -33,9 +34,12 @@ namespace AccessibilityInsights.SharedUx.Dialogs
 
             InitializeComponent();
 
-            this.Title = $"{title} Configuration";
-            this.ctrlPropertySelect.LeftColumnTitle = $"All {title}";
-            this.ctrlPropertySelect.RightColumnTitle = $"Selected {title}";
+            this.Title = string.Format(CultureInfo.InvariantCulture,
+                Properties.Resources.PropertyConfigDialog_TitleFormat, title);
+            this.ctrlPropertySelect.LeftColumnTitle = string.Format(CultureInfo.InvariantCulture,
+                Properties.Resources.PropertyConfigDialog_AllItemsFormat, title);
+            this.ctrlPropertySelect.RightColumnTitle = string.Format(CultureInfo.InvariantCulture,
+                Properties.Resources.PropertyConfigDialog_SelectedItemsFormat, title);
 
             var list = (from kv in source.GetKeyValuePairList()
                        where !DesktopElement.IsExcludedProperty(kv.Key,kv.Value)

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml.cs
@@ -505,7 +505,9 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             try
             {
                 var svm = GetSelectedTextRangeViewModel();
-                var trvm = new TextRangeViewModel(svm.TextRange.Clone(), string.Format(CultureInfo.InvariantCulture, "{0} - cloned", svm.Header));
+                var trvm = new TextRangeViewModel(svm.TextRange.Clone(),
+                    string.Format(CultureInfo.InvariantCulture,
+                        Properties.Resources.TextPatternExplorerDialog_CloneFormat, svm.Header));
                 AddTextRangeViewModelToCustomList(trvm);
             }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -550,7 +552,9 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         {
             StringBuilder sb = new StringBuilder();
             sb.AppendLine(e.Message);
-            sb.AppendFormat(CultureInfo.InvariantCulture, "HResult: 0x{0:X8}", e.HResult);
+            sb.AppendFormat(CultureInfo.InvariantCulture,
+                Properties.Resources.TextPatternExplorerDialog_HresultFormat,
+                e.HResult);
             return sb.ToString();
         }
         #endregion

--- a/src/AccessibilityInsights.SharedUx/Enums/FileFilters.cs
+++ b/src/AccessibilityInsights.SharedUx/Enums/FileFilters.cs
@@ -7,11 +7,11 @@ namespace AccessibilityInsights.SharedUx.Enums
     /// </summary>
     public static class FileFilters
     {
-        public const string A11yFileFilter = "AccessibilityInsights files (*.a11ytest,*.a11yevent)|*.a11ytest;*.a11yevent|A11y Test files (*.a11ytest)|*.a11ytest|A11y Events files (*.a11yevent)|*.a11yevent|All files (*.*)|*.*";
-        public const string TestFileFilter = "AccessibilityInsights Test files (*.a11ytest)|*.a11ytest|All files (*.*)|*.*";
-        public const string EventsFileFilter = "AccessibilityInsights Events files (*.a11yevent)|*.a11yevent|All files (*.*)|*.*";
-        public const string TestExtension = ".a11ytest";
-        public const string EventsExtension = ".a11yevent";
+        public static readonly string A11yFileFilter = Properties.Resources.FileFilter_AllFilesFilter;
+        public static readonly string TestFileFilter = Properties.Resources.FileFilter_TestFilesFilter;
+        public static readonly string EventsFileFilter = Properties.Resources.FileFilter_EventFilesFilter;
+        public static readonly string TestExtension = Properties.Resources.FileFilter_TestFilesExtension;
+        public static readonly string EventsExtension = Properties.Resources.FileFilter_EventFilesExtension;
     }
 
     /// <summary>

--- a/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporterManager.cs
+++ b/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporterManager.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 namespace AccessibilityInsights.SharedUx.FileIssue
 {
     /// <summary>

--- a/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporterManager.cs
+++ b/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporterManager.cs
@@ -81,7 +81,6 @@ namespace AccessibilityInsights.SharedUx.FileIssue
                 catch (Exception ex)
                 {
                     // Fail silently in case of dups.
-                    Console.WriteLine("Found duplicate extensions / Extension failed to restore " + ex.StackTrace);
                     Logger.ReportException(ex);
                 }
 #pragma warning restore CA1031 // Do not catch general exception types

--- a/src/AccessibilityInsights.SharedUx/Highlighting/Highlighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/Highlighter.cs
@@ -111,10 +111,10 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// <summary>
         /// Configure the Highlighter mode
         /// </summary>
-        public void LoadHighlighterMode(HighlighterMode HilighterMode)
+        public void LoadHighlighterMode(HighlighterMode hilighterMode)
         {
             UpdateAllChildren(false, true);
-            switch (HilighterMode)
+            switch (hilighterMode)
             {
                 case HighlighterMode.HighlighterBeakerTooltip:
                     this.IsBorderVisible = true;
@@ -142,7 +142,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
                     this.Text.IsVisible = true;
                     break;
                 default:
-                    throw new ArgumentException($"Argument {this.HighlighterMode.ToString()} is invalid");
+                    throw new ArgumentException($"{hilighterMode} is unsupported", nameof(hilighterMode));
             }
         }
 

--- a/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
@@ -155,7 +155,8 @@ namespace AccessibilityInsights.SharedUx.Highlighting
             StringBuilder sb = new StringBuilder();
 
             sb.AppendLine(element.Glimpse);
-            sb.AppendLine(element.IsKeyboardFocusable ? "Focusable" : "Not Focusable");
+            sb.AppendLine(element.IsKeyboardFocusable ?
+                Properties.Resources.Highlight_Focusable : Properties.Resources.Highlight_NotFocusable);
 
             return sb.ToString();
         }

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2104,7 +2104,34 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to  has failed test results in descendants..
+        ///   Looks up a localized string similar to {0} has failed test results..
+        /// </summary>
+        public static string HierarchyNodeViewModel_FailedResultsFormat {
+            get {
+                return ResourceManager.GetString("HierarchyNodeViewModel_FailedResultsFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is not scanned since it is Web element..
+        /// </summary>
+        public static string HierarchyNodeViewModel_NotSupportResultsFormat {
+            get {
+                return ResourceManager.GetString("HierarchyNodeViewModel_NotSupportResultsFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} has uncertain test results..
+        /// </summary>
+        public static string HierarchyNodeViewModel_UncertainResultsFormat {
+            get {
+                return ResourceManager.GetString("HierarchyNodeViewModel_UncertainResultsFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} has failed test results in descendants..
         /// </summary>
         public static string HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_failed_test_results_in_descendants {
             get {
@@ -2114,7 +2141,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to  has no failed or uncertain test result..
+        ///   Looks up a localized string similar to {0} has no failed or uncertain test result..
         /// </summary>
         public static string HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_no_failed_or_uncertain_test_result {
             get {
@@ -2124,7 +2151,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to  has uncertain test results in descendants..
+        ///   Looks up a localized string similar to {0} has uncertain test results in descendants..
         /// </summary>
         public static string HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_uncertain_test_results_in_descendants {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1679,6 +1679,51 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to AccessibilityInsights files (*.a11ytest,*.a11yevent)|*.a11ytest;*.a11yevent|A11y Test files (*.a11ytest)|*.a11ytest|A11y Events files (*.a11yevent)|*.a11yevent|All files (*.*)|*.*.
+        /// </summary>
+        public static string FileFilter_AllFilesFilter {
+            get {
+                return ResourceManager.GetString("FileFilter_AllFilesFilter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .a11yevent.
+        /// </summary>
+        public static string FileFilter_EventFilesExtension {
+            get {
+                return ResourceManager.GetString("FileFilter_EventFilesExtension", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AccessibilityInsights Events files (*.a11yevent)|*.a11yevent|All files (*.*)|*.*.
+        /// </summary>
+        public static string FileFilter_EventFilesFilter {
+            get {
+                return ResourceManager.GetString("FileFilter_EventFilesFilter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .a11ytest.
+        /// </summary>
+        public static string FileFilter_TestFilesExtension {
+            get {
+                return ResourceManager.GetString("FileFilter_TestFilesExtension", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AccessibilityInsights Test files (*.a11ytest)|*.a11ytest|All files (*.*)|*.*.
+        /// </summary>
+        public static string FileFilter_TestFilesFilter {
+            get {
+                return ResourceManager.GetString("FileFilter_TestFilesFilter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to first color.
         /// </summary>
         public static string firstChooserAutomationPropertiesName {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1887,11 +1887,47 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Content view Checked.
+        /// </summary>
+        public static string HierarchyControl_ContentView_Checked {
+            get {
+                return ResourceManager.GetString("HierarchyControl_ContentView_Checked", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Content view.
+        /// </summary>
+        public static string HierarchyControl_ContentView_Unchecked {
+            get {
+                return ResourceManager.GetString("HierarchyControl_ContentView_Unchecked", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Control.
         /// </summary>
         public static string HierarchyControl_Control {
             get {
                 return ResourceManager.GetString("HierarchyControl_Control", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Control view Checked.
+        /// </summary>
+        public static string HierarchyControl_ControlView_Checked {
+            get {
+                return ResourceManager.GetString("HierarchyControl_ControlView_Checked", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Control view.
+        /// </summary>
+        public static string HierarchyControl_ControlView_Unchecked {
+            get {
+                return ResourceManager.GetString("HierarchyControl_ControlView_Unchecked", resourceCulture);
             }
         }
         
@@ -1915,6 +1951,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invoke to test {0} and descendants.
+        /// </summary>
+        public static string HierarchyControl_LiveMode_InvokeToTestFormat {
+            get {
+                return ResourceManager.GetString("HierarchyControl_LiveMode_InvokeToTestFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No data to populate hierarchy..
         /// </summary>
         public static string HierarchyControl_PopulateHierarchyTree_No_data_to_populate_hierarchy {
@@ -1929,6 +1974,24 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string HierarchyControl_Raw {
             get {
                 return ResourceManager.GetString("HierarchyControl_Raw", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Raw view Checked.
+        /// </summary>
+        public static string HierarchyControl_RawView_Checked {
+            get {
+                return ResourceManager.GetString("HierarchyControl_RawView_Checked", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Raw view.
+        /// </summary>
+        public static string HierarchyControl_RawView_Unchecked {
+            get {
+                return ResourceManager.GetString("HierarchyControl_RawView_Unchecked", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3115,6 +3115,24 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Available Patterns:.
+        /// </summary>
+        public static string PatternInfoControl_AvailablePatterns {
+            get {
+                return ResourceManager.GetString("PatternInfoControl_AvailablePatterns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to - {0}: {1}.
+        /// </summary>
+        public static string PatternInfoControl_PatternPropertyFormat {
+            get {
+                return ResourceManager.GetString("PatternInfoControl_PatternPropertyFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Selected Element Patterns.
         /// </summary>
         public static string PatternInfoControlAutomationPropertiesName {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1606,6 +1606,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Couldn&apos;t save the event record file: {0}.
+        /// </summary>
+        public static string EventRecordControl_FileSaveError {
+            get {
+                return ResourceManager.GetString("EventRecordControl_FileSaveError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No element is selected yet. please select first!!.
         /// </summary>
         public static string EventRecordControl_StartRecordingEvent_No_element_is_selected_yet__please_select_first {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3205,6 +3205,33 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to All {0}.
+        /// </summary>
+        public static string PropertyConfigDialog_AllItemsFormat {
+            get {
+                return ResourceManager.GetString("PropertyConfigDialog_AllItemsFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Selected {0}.
+        /// </summary>
+        public static string PropertyConfigDialog_SelectedItemsFormat {
+            get {
+                return ResourceManager.GetString("PropertyConfigDialog_SelectedItemsFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} Configuration.
+        /// </summary>
+        public static string PropertyConfigDialog_TitleFormat {
+            get {
+                return ResourceManager.GetString("PropertyConfigDialog_TitleFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select properties to always show.
         /// </summary>
         public static string PropertyConfigDialogAutomationName {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3223,6 +3223,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Properties.
+        /// </summary>
+        public static string PropertyInfoControl_Properties {
+            get {
+                return ResourceManager.GetString("PropertyInfoControl_Properties", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Search nodes in hierarchy..
         /// </summary>
         public static string PropertyInfoControl_textboxSearch {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1191,6 +1191,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}:1.
+        /// </summary>
+        public static string ColorContrastViewModel_ContrastRatioFormat {
+            get {
+                return ResourceManager.GetString("ColorContrastViewModel_ContrastRatioFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} eyedropper.
         /// </summary>
         public static string colorPickerAutomationPropertiesName {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2104,59 +2104,66 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}.
+        /// </summary>
+        public static string HierarchyNodeViewModel_AutomationNameDefaultFormat {
+            get {
+                return ResourceManager.GetString("HierarchyNodeViewModel_AutomationNameDefaultFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} has failed test results..
         /// </summary>
-        public static string HierarchyNodeViewModel_FailedResultsFormat {
+        public static string HierarchyNodeViewModel_AutomationNameFailedResultsFormat {
             get {
-                return ResourceManager.GetString("HierarchyNodeViewModel_FailedResultsFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} is not scanned since it is Web element..
-        /// </summary>
-        public static string HierarchyNodeViewModel_NotSupportResultsFormat {
-            get {
-                return ResourceManager.GetString("HierarchyNodeViewModel_NotSupportResultsFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} has uncertain test results..
-        /// </summary>
-        public static string HierarchyNodeViewModel_UncertainResultsFormat {
-            get {
-                return ResourceManager.GetString("HierarchyNodeViewModel_UncertainResultsFormat", resourceCulture);
+                return ResourceManager.GetString("HierarchyNodeViewModel_AutomationNameFailedResultsFormat", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to {0} has failed test results in descendants..
         /// </summary>
-        public static string HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_failed_test_results_in_descendants {
+        public static string HierarchyNodeViewModel_AutomationNameFailedResultsInDescendentsFormat {
             get {
-                return ResourceManager.GetString("HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_failed_test_results_in" +
-                        "_descendants", resourceCulture);
+                return ResourceManager.GetString("HierarchyNodeViewModel_AutomationNameFailedResultsInDescendentsFormat", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to {0} has no failed or uncertain test result..
         /// </summary>
-        public static string HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_no_failed_or_uncertain_test_result {
+        public static string HierarchyNodeViewModel_AutomationNameNoFailedOrUncertainResultsInDescendentsFormat {
             get {
-                return ResourceManager.GetString("HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_no_failed_or_uncertain" +
-                        "_test_result", resourceCulture);
+                return ResourceManager.GetString("HierarchyNodeViewModel_AutomationNameNoFailedOrUncertainResultsInDescendentsForma" +
+                        "t", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is not scanned since it is Web element..
+        /// </summary>
+        public static string HierarchyNodeViewModel_AutomationNameNotSupportResultsFormat {
+            get {
+                return ResourceManager.GetString("HierarchyNodeViewModel_AutomationNameNotSupportResultsFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} has uncertain test results..
+        /// </summary>
+        public static string HierarchyNodeViewModel_AutomationNameUncertainResultsFormat {
+            get {
+                return ResourceManager.GetString("HierarchyNodeViewModel_AutomationNameUncertainResultsFormat", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to {0} has uncertain test results in descendants..
         /// </summary>
-        public static string HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_uncertain_test_results_in_descendants {
+        public static string HierarchyNodeViewModel_AutomationNameUncertainResultsInDescendentsFormat {
             get {
-                return ResourceManager.GetString("HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_uncertain_test_results" +
-                        "_in_descendants", resourceCulture);
+                return ResourceManager.GetString("HierarchyNodeViewModel_AutomationNameUncertainResultsInDescendentsFormat", resourceCulture);
             }
         }
         
@@ -3944,6 +3951,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string StartUpModeControlAutomationPropertiesName {
             get {
                 return ResourceManager.GetString("StartUpModeControlAutomationPropertiesName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AutomationName.
+        /// </summary>
+        public static string String {
+            get {
+                return ResourceManager.GetString("String", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Execution result failed!.
+        ///   Looks up a localized string similar to Execution result failed.
         /// </summary>
         public static string A11yElementView_ExecutionError {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2107,6 +2107,24 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Focusable.
+        /// </summary>
+        public static string Highlight_Focusable {
+            get {
+                return ResourceManager.GetString("Highlight_Focusable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not Focusable.
+        /// </summary>
+        public static string Highlight_NotFocusable {
+            get {
+                return ResourceManager.GetString("Highlight_NotFocusable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Help.
         /// </summary>
         public static string hlHelpName {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1516,6 +1516,24 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to My Events.
+        /// </summary>
+        public static string EventConfigTabControl_MyEvents {
+            get {
+                return ResourceManager.GetString("EventConfigTabControl_MyEvents", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Properties.
+        /// </summary>
+        public static string EventConfigTabControl_Properties {
+            get {
+                return ResourceManager.GetString("EventConfigTabControl_Properties", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select the Events you want to listen to:.
         /// </summary>
         public static string EventConfigTabControl_SelectEvents {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Execution result failed!.
+        /// </summary>
+        public static string A11yElementView_ExecutionError {
+            get {
+                return ResourceManager.GetString("A11yElementView_ExecutionError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Built with Axe.Windows {0}.
         /// </summary>
         public static string AboutTabControl_AxeVersionFormat {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -314,6 +314,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exception while invoking {0} : {1}.
+        /// </summary>
+        public static string BaseActionViewModel_ExceptionMessage {
+            get {
+                return ResourceManager.GetString("BaseActionViewModel_ExceptionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Run action with the value.
         /// </summary>
         public static string btnActionAutomationPropertiesName {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -4217,6 +4217,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} - cloned.
+        /// </summary>
+        public static string TextPatternExplorerDialog_CloneFormat {
+            get {
+                return ResourceManager.GetString("TextPatternExplorerDialog_CloneFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to retrieve range(s): {0}.
         /// </summary>
         public static string TextPatternExplorerDialog_GetRanges_Failed_to_retrieve_range_s____0 {
@@ -4231,6 +4240,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string TextPatternExplorerDialog_GetRanges_This_option_is_not_supported_yet {
             get {
                 return ResourceManager.GetString("TextPatternExplorerDialog_GetRanges_This_option_is_not_supported_yet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to HResult: 0x{0:X8}.
+        /// </summary>
+        public static string TextPatternExplorerDialog_HresultFormat {
+            get {
+                return ResourceManager.GetString("TextPatternExplorerDialog_HresultFormat", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -278,6 +278,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Target: {0}.
+        /// </summary>
+        public static string AutomatedChecksControl_TargetFormat {
+            get {
+                return ResourceManager.GetString("AutomatedChecksControl_TargetFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to detected..
         /// </summary>
         public static string AutomatedChecksControl_tbSubtitleRun {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1497,6 +1497,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} node.
+        /// </summary>
+        public static string EventConfigNodeViewModel_NodeFormat {
+            get {
+                return ResourceManager.GetString("EventConfigNodeViewModel_NodeFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to  checked.
         /// </summary>
         public static string EventConfigNodeViewModel_ToString_checked {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3588,6 +3588,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Scan {0}: {1}.
+        /// </summary>
+        public static string ScanListViewItemViewModel_StatusFormat {
+            get {
+                return ResourceManager.GetString("ScanListViewItemViewModel_StatusFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To file issues, select where you want to file issues..
         /// </summary>
         public static string ScannerResultControl_btnFileBug_Click_File_Issue_Configure {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1564,4 +1564,26 @@ Do you want to change the channel? </value>
     <value>Couldn't save the event record file: {0}</value>
     <comment>{0} is the error message of the Exception</comment>
   </data>
+  <data name="HierarchyControl_ContentView_Checked" xml:space="preserve">
+    <value>Content view Checked</value>
+  </data>
+  <data name="HierarchyControl_ContentView_Unchecked" xml:space="preserve">
+    <value>Content view</value>
+  </data>
+  <data name="HierarchyControl_ControlView_Checked" xml:space="preserve">
+    <value>Control view Checked</value>
+  </data>
+  <data name="HierarchyControl_ControlView_Unchecked" xml:space="preserve">
+    <value>Control view</value>
+  </data>
+  <data name="HierarchyControl_LiveMode_InvokeToTestFormat" xml:space="preserve">
+    <value>Invoke to test {0} and descendants</value>
+    <comment>{0} is the glimpse of the current element</comment>
+  </data>
+  <data name="HierarchyControl_RawView_Checked" xml:space="preserve">
+    <value>Raw view Checked</value>
+  </data>
+  <data name="HierarchyControl_RawView_Unchecked" xml:space="preserve">
+    <value>Raw view</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1596,4 +1596,8 @@ Do you want to change the channel? </value>
   <data name="PropertyInfoControl_Properties" xml:space="preserve">
     <value>Properties</value>
   </data>
+  <data name="AutomatedChecksControl_TargetFormat" xml:space="preserve">
+    <value>Target: {0}</value>
+    <comment>{0} is the glimpse</comment>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1620,4 +1620,24 @@ Do you want to change the channel? </value>
     <value>HResult: 0x{0:X8}</value>
     <comment>{0} is the HRESULT of the exception</comment>
   </data>
+  <data name="FileFilter_AllFilesFilter" xml:space="preserve">
+    <value>AccessibilityInsights files (*.a11ytest,*.a11yevent)|*.a11ytest;*.a11yevent|A11y Test files (*.a11ytest)|*.a11ytest|A11y Events files (*.a11yevent)|*.a11yevent|All files (*.*)|*.*</value>
+    <comment>Do not localize "a11ytest" or "a11yevent" unless absolutely necessary. Changing it here means changing it everywhere, including the file association inside the wxs file</comment>
+  </data>
+  <data name="FileFilter_EventFilesExtension" xml:space="preserve">
+    <value>.a11yevent</value>
+    <comment>Do not localize "a11yevent" unless absolutely necessary. Changing it here means changing it everywhere, including the file association inside the wxs file</comment>
+  </data>
+  <data name="FileFilter_EventFilesFilter" xml:space="preserve">
+    <value>AccessibilityInsights Events files (*.a11yevent)|*.a11yevent|All files (*.*)|*.*</value>
+    <comment>Do not localize "a11yevent" unless absolutely necessary. Changing it here means changing it everywhere, including the file association inside the wxs file</comment>
+  </data>
+  <data name="FileFilter_TestFilesExtension" xml:space="preserve">
+    <value>.a11ytest</value>
+    <comment>Do not localize "a11ytest" unless absolutely necessary. Changing it here means changing it everywhere, including the file association inside the wxs file</comment>
+  </data>
+  <data name="FileFilter_TestFilesFilter" xml:space="preserve">
+    <value>AccessibilityInsights Test files (*.a11ytest)|*.a11ytest|All files (*.*)|*.*</value>
+    <comment>Do not localize "a11ytest" unless absolutely necessary. Changing it here means changing it everywhere, including the file association inside the wxs file</comment>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1554,4 +1554,10 @@ Do you want to change the channel? </value>
   <data name="A11yElementView_ExecutionError" xml:space="preserve">
     <value>Execution result failed!</value>
   </data>
+  <data name="EventConfigTabControl_MyEvents" xml:space="preserve">
+    <value>My Events</value>
+  </data>
+  <data name="EventConfigTabControl_Properties" xml:space="preserve">
+    <value>Properties</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1624,6 +1624,10 @@ Do you want to change the channel? </value>
     <value>Exception while invoking {0} : {1}</value>
     <comment>{0} is the method; {1} is the Exception mesage</comment>
   </data>
+  <data name="EventConfigNodeViewModel_NodeFormat" xml:space="preserve">
+    <value>{0} node</value>
+    <comment>{0} is the button text</comment>
+  </data>
   <data name="FileFilter_AllFilesFilter" xml:space="preserve">
     <value>AccessibilityInsights files (*.a11ytest,*.a11yevent)|*.a11ytest;*.a11yevent|A11y Test files (*.a11ytest)|*.a11ytest|A11y Events files (*.a11yevent)|*.a11yevent|All files (*.*)|*.*</value>
     <comment>Do not localize "a11ytest" or "a11yevent" unless absolutely necessary. Changing it here means changing it everywhere, including the file association inside the wxs file</comment>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1551,4 +1551,7 @@ Do you want to change the channel? </value>
   <data name="ApplicationSettingsControl_TelemetryDisabledByAdministrator" xml:space="preserve">
     <value>Telemetry has been disabled by an administrator of this computer.</value>
   </data>
+  <data name="A11yElementView_ExecutionError" xml:space="preserve">
+    <value>Execution result failed!</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1640,4 +1640,10 @@ Do you want to change the channel? </value>
     <value>AccessibilityInsights Test files (*.a11ytest)|*.a11ytest|All files (*.*)|*.*</value>
     <comment>Do not localize "a11ytest" unless absolutely necessary. Changing it here means changing it everywhere, including the file association inside the wxs file</comment>
   </data>
+  <data name="Highlight_Focusable" xml:space="preserve">
+    <value>Focusable</value>
+  </data>
+  <data name="Highlight_NotFocusable" xml:space="preserve">
+    <value>Not Focusable</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1624,6 +1624,10 @@ Do you want to change the channel? </value>
     <value>Exception while invoking {0} : {1}</value>
     <comment>{0} is the method; {1} is the Exception mesage</comment>
   </data>
+  <data name="ColorContrastViewModel_ContrastRatioFormat" xml:space="preserve">
+    <value>{0}:1</value>
+    <comment>{0} is the numeric contrast value</comment>
+  </data>
   <data name="EventConfigNodeViewModel_NodeFormat" xml:space="preserve">
     <value>{0} node</value>
     <comment>{0} is the button text</comment>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1620,6 +1620,10 @@ Do you want to change the channel? </value>
     <value>HResult: 0x{0:X8}</value>
     <comment>{0} is the HRESULT of the exception</comment>
   </data>
+  <data name="BaseActionViewModel_ExceptionMessage" xml:space="preserve">
+    <value>Exception while invoking {0} : {1}</value>
+    <comment>{0} is the method; {1} is the Exception mesage</comment>
+  </data>
   <data name="FileFilter_AllFilesFilter" xml:space="preserve">
     <value>AccessibilityInsights files (*.a11ytest,*.a11yevent)|*.a11ytest;*.a11yevent|A11y Test files (*.a11ytest)|*.a11ytest|A11y Events files (*.a11yevent)|*.a11yevent|All files (*.*)|*.*</value>
     <comment>Do not localize "a11ytest" or "a11yevent" unless absolutely necessary. Changing it here means changing it everywhere, including the file association inside the wxs file</comment>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1673,4 +1673,8 @@ Do you want to change the channel? </value>
   <data name="Highlight_NotFocusable" xml:space="preserve">
     <value>Not Focusable</value>
   </data>
+  <data name="ScanListViewItemViewModel_StatusFormat" xml:space="preserve">
+    <value>Scan {0}: {1}</value>
+    <comment>{0} is the status; {1} is the header</comment>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1555,7 +1555,7 @@ Do you want to change the channel? </value>
     <value>Telemetry has been disabled by an administrator of this computer.</value>
   </data>
   <data name="A11yElementView_ExecutionError" xml:space="preserve">
-    <value>Execution result failed!</value>
+    <value>Execution result failed</value>
   </data>
   <data name="EventConfigTabControl_MyEvents" xml:space="preserve">
     <value>My Events</value>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1593,4 +1593,7 @@ Do you want to change the channel? </value>
     <value>- {0}: {1}</value>
     <comment>{0} is the propety name; {1} is the property value</comment>
   </data>
+  <data name="PropertyInfoControl_Properties" xml:space="preserve">
+    <value>Properties</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1560,4 +1560,8 @@ Do you want to change the channel? </value>
   <data name="EventConfigTabControl_Properties" xml:space="preserve">
     <value>Properties</value>
   </data>
+  <data name="EventRecordControl_FileSaveError" xml:space="preserve">
+    <value>Couldn't save the event record file: {0}</value>
+    <comment>{0} is the error message of the Exception</comment>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1150,13 +1150,16 @@
     <value> unchecked</value>
   </data>
   <data name="HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_failed_test_results_in_descendants" xml:space="preserve">
-    <value> has failed test results in descendants.</value>
+    <value>{0} has failed test results in descendants.</value>
+    <comment>{0} is the glimpse</comment>
   </data>
   <data name="HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_uncertain_test_results_in_descendants" xml:space="preserve">
-    <value> has uncertain test results in descendants.</value>
+    <value>{0} has uncertain test results in descendants.</value>
+    <comment>{0} is the glimpse</comment>
   </data>
   <data name="HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_no_failed_or_uncertain_test_result" xml:space="preserve">
-    <value> has no failed or uncertain test result.</value>
+    <value>{0} has no failed or uncertain test result.</value>
+    <comment>{0} is the glimpse</comment>
   </data>
   <data name="PatternViewModel_GetActionButtonText_Actions" xml:space="preserve">
     <value>Actions...</value>
@@ -1651,6 +1654,18 @@ Do you want to change the channel? </value>
   <data name="FileFilter_TestFilesFilter" xml:space="preserve">
     <value>AccessibilityInsights Test files (*.a11ytest)|*.a11ytest|All files (*.*)|*.*</value>
     <comment>Do not localize "a11ytest" unless absolutely necessary. Changing it here means changing it everywhere, including the file association inside the wxs file</comment>
+  </data>
+  <data name="HierarchyNodeViewModel_FailedResultsFormat" xml:space="preserve">
+    <value>{0} has failed test results.</value>
+    <comment>{0} is the glimpse</comment>
+  </data>
+  <data name="HierarchyNodeViewModel_NotSupportResultsFormat" xml:space="preserve">
+    <value>{0} is not scanned since it is Web element.</value>
+    <comment>{0} is the glimpse</comment>
+  </data>
+  <data name="HierarchyNodeViewModel_UncertainResultsFormat" xml:space="preserve">
+    <value>{0} has uncertain test results.</value>
+    <comment>{0} is the glimpse</comment>
   </data>
   <data name="Highlight_Focusable" xml:space="preserve">
     <value>Focusable</value>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1149,15 +1149,15 @@
   <data name="EventConfigNodeViewModel_ToString_unchecked" xml:space="preserve">
     <value> unchecked</value>
   </data>
-  <data name="HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_failed_test_results_in_descendants" xml:space="preserve">
+  <data name="HierarchyNodeViewModel_AutomationNameFailedResultsInDescendentsFormat" xml:space="preserve">
     <value>{0} has failed test results in descendants.</value>
     <comment>{0} is the glimpse</comment>
   </data>
-  <data name="HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_uncertain_test_results_in_descendants" xml:space="preserve">
+  <data name="HierarchyNodeViewModel_AutomationNameUncertainResultsInDescendentsFormat" xml:space="preserve">
     <value>{0} has uncertain test results in descendants.</value>
     <comment>{0} is the glimpse</comment>
   </data>
-  <data name="HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_no_failed_or_uncertain_test_result" xml:space="preserve">
+  <data name="HierarchyNodeViewModel_AutomationNameNoFailedOrUncertainResultsInDescendentsFormat" xml:space="preserve">
     <value>{0} has no failed or uncertain test result.</value>
     <comment>{0} is the glimpse</comment>
   </data>
@@ -1655,15 +1655,19 @@ Do you want to change the channel? </value>
     <value>AccessibilityInsights Test files (*.a11ytest)|*.a11ytest|All files (*.*)|*.*</value>
     <comment>Do not localize "a11ytest" unless absolutely necessary. Changing it here means changing it everywhere, including the file association inside the wxs file</comment>
   </data>
-  <data name="HierarchyNodeViewModel_FailedResultsFormat" xml:space="preserve">
+  <data name="HierarchyNodeViewModel_AutomationNameDefaultFormat" xml:space="preserve">
+    <value>{0}</value>
+    <comment>{0} is the glimpse</comment>
+  </data>
+  <data name="HierarchyNodeViewModel_AutomationNameFailedResultsFormat" xml:space="preserve">
     <value>{0} has failed test results.</value>
     <comment>{0} is the glimpse</comment>
   </data>
-  <data name="HierarchyNodeViewModel_NotSupportResultsFormat" xml:space="preserve">
+  <data name="HierarchyNodeViewModel_AutomationNameNotSupportResultsFormat" xml:space="preserve">
     <value>{0} is not scanned since it is Web element.</value>
     <comment>{0} is the glimpse</comment>
   </data>
-  <data name="HierarchyNodeViewModel_UncertainResultsFormat" xml:space="preserve">
+  <data name="HierarchyNodeViewModel_AutomationNameUncertainResultsFormat" xml:space="preserve">
     <value>{0} has uncertain test results.</value>
     <comment>{0} is the glimpse</comment>
   </data>
@@ -1676,5 +1680,8 @@ Do you want to change the channel? </value>
   <data name="ScanListViewItemViewModel_StatusFormat" xml:space="preserve">
     <value>Scan {0}: {1}</value>
     <comment>{0} is the status; {1} is the header</comment>
+  </data>
+  <data name="String" xml:space="preserve">
+    <value>AutomationName</value>
   </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1600,4 +1600,16 @@ Do you want to change the channel? </value>
     <value>Target: {0}</value>
     <comment>{0} is the glimpse</comment>
   </data>
+  <data name="PropertyConfigDialog_AllItemsFormat" xml:space="preserve">
+    <value>All {0}</value>
+    <comment>{0} is the type of item (Patterns, Properties, etc.) being configured</comment>
+  </data>
+  <data name="PropertyConfigDialog_SelectedItemsFormat" xml:space="preserve">
+    <value>Selected {0}</value>
+    <comment>{0} is the type of item (Patterns, Properties, etc.) being configured</comment>
+  </data>
+  <data name="PropertyConfigDialog_TitleFormat" xml:space="preserve">
+    <value>{0} Configuration</value>
+    <comment>{0} is the type of item (Patterns, Properties, etc.) being configured</comment>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1586,4 +1586,11 @@ Do you want to change the channel? </value>
   <data name="HierarchyControl_RawView_Unchecked" xml:space="preserve">
     <value>Raw view</value>
   </data>
+  <data name="PatternInfoControl_AvailablePatterns" xml:space="preserve">
+    <value>Available Patterns:</value>
+  </data>
+  <data name="PatternInfoControl_PatternPropertyFormat" xml:space="preserve">
+    <value>- {0}: {1}</value>
+    <comment>{0} is the propety name; {1} is the property value</comment>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1612,4 +1612,12 @@ Do you want to change the channel? </value>
     <value>{0} Configuration</value>
     <comment>{0} is the type of item (Patterns, Properties, etc.) being configured</comment>
   </data>
+  <data name="TextPatternExplorerDialog_CloneFormat" xml:space="preserve">
+    <value>{0} - cloned</value>
+    <comment>{0} is the Header title</comment>
+  </data>
+  <data name="TextPatternExplorerDialog_HresultFormat" xml:space="preserve">
+    <value>HResult: 0x{0:X8}</value>
+    <comment>{0} is the HRESULT of the exception</comment>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/ViewModels/BaseActionViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/BaseActionViewModel.cs
@@ -110,7 +110,8 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             catch (Exception e)
             {
                 e.ReportException();
-                MessageDialog.Show(string.Format(CultureInfo.InvariantCulture, "Exception during invoking {0} : {1}", val, e.InnerException == null ? e.Message : e.InnerException.Message));
+                MessageDialog.Show(string.Format(CultureInfo.InvariantCulture, Properties.Resources.BaseActionViewModel_ExceptionMessage,
+                    val, e.InnerException == null ? e.Message : e.InnerException.Message));
                 this.IsSucceeded = false;
                 this.ReturnValue = e.InnerException?.HResult;
                 this.ReturnType = typeof(void);

--- a/src/AccessibilityInsights.SharedUx/ViewModels/BaseActionViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/BaseActionViewModel.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Dialogs;
-using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Telemetry;
 using Axe.Windows.Actions;
 using Axe.Windows.Core.Bases;
-using Axe.Windows.Core.Enums;
 using Axe.Windows.Desktop.UIAutomation;
 using Axe.Windows.Desktop.UIAutomation.Patterns;
 using System;

--- a/src/AccessibilityInsights.SharedUx/ViewModels/ColorContrastViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/ColorContrastViewModel.cs
@@ -94,13 +94,15 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         }
 
         /// <summary>
-        /// Formatted to 3 decimal places and then :1, ex: 5.444:1
+        /// Formatted to 3 decimal places and expressed as a ratio
         /// </summary>
         public String FormattedRatio
         {
             get
             {
-                return (Math.Truncate(1000 * Ratio) / 1000).ToString(CultureInfo.InvariantCulture) + ":1";
+                double ratio = Math.Truncate(1000 * Ratio) / 1000;
+                return string.Format(CultureInfo.InvariantCulture,
+                    Properties.Resources.ColorContrastViewModel_ContrastRatioFormat, ratio);
             }
         }
 

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -13,7 +13,6 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Windows;
-using System.Windows.Input.StylusPlugIns;
 
 namespace AccessibilityInsights.SharedUx.ViewModels
 {

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Windows;
 using System.Windows.Input.StylusPlugIns;
@@ -441,7 +442,8 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             }
             else
             {
-                return this.ButtonText + " node";
+                return string.Format(CultureInfo.InvariantCulture,
+                    Resources.EventConfigNodeViewModel_NodeFormat, this.ButtonText);
             }
         }
 

--- a/src/AccessibilityInsights.SharedUx/ViewModels/HierarchyNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/HierarchyNodeViewModel.cs
@@ -11,7 +11,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Windows;
 
 namespace AccessibilityInsights.SharedUx.ViewModels

--- a/src/AccessibilityInsights.SharedUx/ViewModels/HierarchyNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/HierarchyNodeViewModel.cs
@@ -303,7 +303,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         private void UpdateIconInfoAndAutomationName(bool isLiveMode)
         {
             this.IconVisibility = Visibility.Collapsed;
-            string automationNameFormat = null;
+            string automationNameFormat = Resources.HierarchyNodeViewModel_AutomationNameDefaultFormat;
 
             if (!isLiveMode)
             {
@@ -312,21 +312,21 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                     this.IconBack = FabricIcon.AlertSolid;
                     this.IconSizeBack = NormalIconSizeBack;
                     this.IconVisibility = Visibility.Visible;
-                    automationNameFormat = Resources.HierarchyNodeViewModel_FailedResultsFormat;
+                    automationNameFormat = Resources.HierarchyNodeViewModel_AutomationNameFailedResultsFormat;
                 }
                 else if(this.Element.TestStatus == ScanStatus.ScanNotSupported)
                 {
                     this.IconBack = FabricIcon.MapDirections;
                     this.IconSizeBack = NormalIconSizeBack;
                     this.IconVisibility = Visibility.Visible;
-                    automationNameFormat = Resources.HierarchyNodeViewModel_NotSupportResultsFormat;
+                    automationNameFormat = Resources.HierarchyNodeViewModel_AutomationNameNotSupportResultsFormat;
                 }
                 else if (this.Element.TestStatus == ScanStatus.Uncertain && this.ShowUncertain)
                 {
                     this.IconBack = FabricIcon.IncidentTriangle;
                     this.IconSizeBack = NormalIconSizeBack;
                     this.IconVisibility = Visibility.Visible;
-                    automationNameFormat = Resources.HierarchyNodeViewModel_UncertainResultsFormat;
+                    automationNameFormat = Resources.HierarchyNodeViewModel_AutomationNameUncertainResultsFormat;
                 }
                 else
                 {
@@ -337,17 +337,17 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                     if (this.AggregateStatusCounts[(int)ScanStatus.Fail] > 0)
                     {
                         this.IconFront = FabricIcon.AlertSolid;
-                        automationNameFormat = Resources.HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_failed_test_results_in_descendants;
+                        automationNameFormat = Resources.HierarchyNodeViewModel_AutomationNameFailedResultsInDescendentsFormat;
                     }
                     else if (this.AggregateStatusCounts[(int)ScanStatus.Uncertain] > 0 && this.ShowUncertain)
                     {
                         this.IconFront = FabricIcon.IncidentTriangle;
-                        automationNameFormat = Resources.HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_uncertain_test_results_in_descendants;
+                        automationNameFormat = Resources.HierarchyNodeViewModel_AutomationNameUncertainResultsInDescendentsFormat;
                     }
                     else
                     {
                         this.IconBack = default(FabricIcon);
-                        automationNameFormat = Resources.HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_no_failed_or_uncertain_test_result;
+                        automationNameFormat = Resources.HierarchyNodeViewModel_AutomationNameNoFailedOrUncertainResultsInDescendentsFormat;
                     }
 
                     this.IconVisibility = this.IsExpanded == false && this.IconBack != default(FabricIcon) ? Visibility.Visible : Visibility.Collapsed;

--- a/src/AccessibilityInsights.SharedUx/ViewModels/HierarchyNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/HierarchyNodeViewModel.cs
@@ -9,6 +9,7 @@ using Axe.Windows.Core.Results;
 using Axe.Windows.Core.Types;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Windows;
@@ -301,10 +302,8 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// <param name="isLiveMode">Is node in live mode</param>
         private void UpdateIconInfoAndAutomationName(bool isLiveMode)
         {
-            StringBuilder sb = new StringBuilder();
-            sb.Append(this.Element.Glimpse);
-
             this.IconVisibility = Visibility.Collapsed;
+            string automationNameFormat = null;
 
             if (!isLiveMode)
             {
@@ -313,21 +312,21 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                     this.IconBack = FabricIcon.AlertSolid;
                     this.IconSizeBack = NormalIconSizeBack;
                     this.IconVisibility = Visibility.Visible;
-                    sb.Append(" has failed test results.");
+                    automationNameFormat = Resources.HierarchyNodeViewModel_FailedResultsFormat;
                 }
                 else if(this.Element.TestStatus == ScanStatus.ScanNotSupported)
                 {
                     this.IconBack = FabricIcon.MapDirections;
                     this.IconSizeBack = NormalIconSizeBack;
                     this.IconVisibility = Visibility.Visible;
-                    sb.Append(" is not scanned since it is Web element.");
+                    automationNameFormat = Resources.HierarchyNodeViewModel_NotSupportResultsFormat;
                 }
                 else if (this.Element.TestStatus == ScanStatus.Uncertain && this.ShowUncertain)
                 {
                     this.IconBack = FabricIcon.IncidentTriangle;
                     this.IconSizeBack = NormalIconSizeBack;
                     this.IconVisibility = Visibility.Visible;
-                    sb.Append(" has uncertain test results.");
+                    automationNameFormat = Resources.HierarchyNodeViewModel_UncertainResultsFormat;
                 }
                 else
                 {
@@ -338,24 +337,25 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                     if (this.AggregateStatusCounts[(int)ScanStatus.Fail] > 0)
                     {
                         this.IconFront = FabricIcon.AlertSolid;
-                        sb.Append(Resources.HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_failed_test_results_in_descendants);
+                        automationNameFormat = Resources.HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_failed_test_results_in_descendants;
                     }
                     else if (this.AggregateStatusCounts[(int)ScanStatus.Uncertain] > 0 && this.ShowUncertain)
                     {
                         this.IconFront = FabricIcon.IncidentTriangle;
-                        sb.Append(Resources.HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_uncertain_test_results_in_descendants);
+                        automationNameFormat = Resources.HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_uncertain_test_results_in_descendants;
                     }
                     else
                     {
                         this.IconBack = default(FabricIcon);
-                        sb.Append(Resources.HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_no_failed_or_uncertain_test_result);
+                        automationNameFormat = Resources.HierarchyNodeViewModel_UpdateIconInfoAndAutomationName_has_no_failed_or_uncertain_test_result;
                     }
 
                     this.IconVisibility = this.IsExpanded == false && this.IconBack != default(FabricIcon) ? Visibility.Visible : Visibility.Collapsed;
                 }
             }
 
-            this.AutomationName = sb.ToString();
+            this.AutomationName = string.Format(CultureInfo.InvariantCulture, automationNameFormat,
+                this.Element.Glimpse);
         }
 
         public bool ApplyFilter(string filter)

--- a/src/AccessibilityInsights.SharedUx/ViewModels/ScanListViewItemViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/ScanListViewItemViewModel.cs
@@ -12,11 +12,11 @@ using Axe.Windows.Desktop.Utility;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Windows;
 using System.Windows.Input;
-using static System.FormattableString;
 
 namespace AccessibilityInsights.SharedUx.ViewModels
 {
@@ -199,7 +199,9 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// <returns></returns>
         public override string ToString()
         {
-            return Invariant($"Scan {this.Status}: {this.Header}");
+            return string.Format(CultureInfo.InvariantCulture, 
+                Resources.ScanListViewItemViewModel_StatusFormat,
+                this.Status, this.Header);
         }
 
         /// <summary>


### PR DESCRIPTION
#### Details

This PR improves localization in the `AccessibilityInsights.SharedUx` project. Some of the changes replace a hardcoded string with a new resource string, while others replace hardcoded concatenation of resource strings with a parameterized resource string (which would allow the parameters to be used in any order).

##### Motivation

Global Readiness component of compliance feature.

##### Context

Each commit includes strings from a single .cs file. It might be easier to review each commit separately. There is at least 1 overlapping commit, because the first commit to `HierarchyViewNodeModel` created a bug that got fixed in the second commit to `HierarchyViewNodeModel`. The second commit also renamed some of the string resources to be more consistent with the new ones (and to simplify the names).

This PR does not fully address the various places where we hardcode the formatting strings like for how data is presented (strings like `"{0}: {1}` or `"{0} {1}"`, but that feels beyond the scope of this effort. Perhaps we can improve that in the next compliance pass or future slack time, perhaps not.

The other thing that I haven't changed is that I'm still using `CultureInfo.InvariantCulture` for user-visible strings. I may make a separate pass to do that if I have time later during this feature.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue: 
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



