### PR TITLE
fix: Specify font size in welcome screen text

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml
@@ -132,7 +132,7 @@
                             </AutomationProperties.Name>
                         </Label>
                     </Border>
-                    <TextBlock Name="txtEventHk" Style="{StaticResource TbBaseWrap}" Grid.Row="3" Grid.Column="3" Text="{x:Static properties:Resources.toggleEventText}" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
+                    <TextBlock Name="txtEventHk" Style="{StaticResource TbStandardSize}" Grid.Row="3" Grid.Column="3" Text="{x:Static properties:Resources.toggleEventText}" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
                     <Border Grid.Row="5" Grid.Column="1" Style="{StaticResource BrdrKey}" VerticalAlignment="Center">
                         <Label Name="lblTestHk" Style="{StaticResource LblKey}" Content="{x:Static properties:Resources.StartUpModeControl_ShiftF8}" Padding="3,6">
                             <AutomationProperties.Name>
@@ -143,7 +143,7 @@
                             </AutomationProperties.Name>
                         </Label>
                     </Border>
-                    <TextBlock Name="txtTesttHk" Style="{StaticResource TbBaseWrap}" Grid.Row="5" Grid.Column="3" Text="{x:Static properties:Resources.runSelectedTestText}" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
+                    <TextBlock Name="txtTesttHk" Style="{StaticResource TbStandardSize}" Grid.Row="5" Grid.Column="3" Text="{x:Static properties:Resources.runSelectedTestText}" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
                     <Border Grid.Row="7" Grid.Column="1" Style="{StaticResource BrdrKey}" Height="32" VerticalAlignment="Center">
                         <Label Name="lblActivateHk" Style="{StaticResource LblKey}" Content="{x:Static properties:Resources.StartUpModeControl_ShiftF9}" Padding="3,6">
                             <AutomationProperties.Name>
@@ -154,7 +154,7 @@
                             </AutomationProperties.Name>
                         </Label>
                     </Border>
-                    <TextBlock Name="txtActivateHk" Grid.Row="7" Grid.Column="3" Style="{StaticResource TbBaseWrap}" Text="{x:Static properties:Resources.minmizeOrActivateWindowText}" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
+                    <TextBlock Name="txtActivateHk" Grid.Row="7" Grid.Column="3" Style="{StaticResource TbStandardSize}" Text="{x:Static properties:Resources.minmizeOrActivateWindowText}" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=StartupFGBrush}"/>
                     <TextBlock Grid.Row="8" Grid.ColumnSpan="8" Padding="16,4,0,10" TextWrapping="Wrap">
                         <Hyperlink FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" RequestNavigate="hlLink_RequestNavigate" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2073853"
                                    AutomationProperties.Name="{Binding ElementName=shortcutsDescTxt, Path=Text}" Style="{StaticResource hLink}">

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1191,6 +1191,9 @@
         <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
         <Setter Property="TextWrapping" Value="Wrap"/>
     </Style>
+    <Style TargetType="{x:Type TextBlock}" x:Key="TbStandardSize" BasedOn="{StaticResource TbBaseWrap}">
+        <Setter Property="FontSize" Value="{DynamicResource StandardTextSize}"/>
+    </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="TbFocusable" BasedOn="{StaticResource TbBaseWrap}">
         <Setter Property="Focusable" Value="True"/>
         <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}"/>


### PR DESCRIPTION
#### Details

In #1249, the welcome screen has some text that responds to text scaling, some that doesn't. As a result, the dialog becomes unusable. This PR just specifies a font size for the 3 screen items that are being clipped.

##### Motivation

Address #1249 

##### Screenshots
Before at 200% text size (from #1249):
![old-200%](https://user-images.githubusercontent.com/45672944/142951713-304499d7-1d65-40b0-ba76-5aba37875bea.png)

After at 200% text size:
![image](https://user-images.githubusercontent.com/45672944/142951781-fa70dc59-2625-4bc3-a9af-32f8020c9771.png)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue - #1249 
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



