### PR TITLE
feat(compliance-fall-21): Improve localizability in xaml files

### DIFF
--- a/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml
@@ -58,7 +58,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Value" Width="200" 
+                <DataGridTemplateColumn Header="{x:Static Properties:Resources.ReturnA11yElementsView_Header_Value}" Width="200" 
                     CellTemplateSelector="{StaticResource DynamicDataTemplateSelector}"/>
             </DataGrid.Columns>
         </DataGrid>
@@ -126,9 +126,9 @@
                             <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                             <Button.ContextMenu>
                                 <ContextMenu AutomationProperties.Name="{x:Static Properties:Resources.btnSettingAutomationPropertiesName}">
-                                    <MenuItem Header="_Include all properties that have values" x:Name="mniShowCoreProps" IsCheckable="true" 
+                                    <MenuItem Header="{x:Static Properties:Resources.ReturnA11yElementsView_Menu_ShowAllPropertiesWithValues}" x:Name="mniShowCoreProps" IsCheckable="true" 
                                     Background="White" Checked="mniShowCoreProps_Checked" Unchecked="mniShowCoreProps_Unchecked" Loaded="mniShowCoreProps_Loaded"/>
-                                    <MenuItem Header="_Configure properties to always show" x:Name="mniIncludeAllProps" Click="mniIncludeAllProps_Click"
+                                    <MenuItem Header="{x:Static Properties:Resources.ReturnA11yElementsView_Menu_ConfigurePropertiesToAlwaysShow}" x:Name="mniIncludeAllProps" Click="mniIncludeAllProps_Click"
                                     Background="White"/>
                                 </ContextMenu>
                             </Button.ContextMenu>

--- a/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml
@@ -58,7 +58,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="{x:Static Properties:Resources.ReturnA11yElementsView_Header_Value}" Width="200" 
+                <DataGridTemplateColumn Header="{x:Static Properties:Resources.ReturnA11yElementsView_Value_Header}" Width="200" 
                     CellTemplateSelector="{StaticResource DynamicDataTemplateSelector}"/>
             </DataGrid.Columns>
         </DataGrid>

--- a/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml
@@ -48,7 +48,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Value" Width="200" 
+                <DataGridTemplateColumn Header="{x:Static Properties:Resources.TextRangeActionView_Value_Header}" Width="200" 
                     CellTemplateSelector="{StaticResource DynamicDataTemplateSelector}"/>
             </DataGrid.Columns>
         </DataGrid>

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -137,7 +137,7 @@
                                     </MenuItem.Header>
                                 </MenuItem>
                             </MenuItem>
-                            <MenuItem Header="Record _AutomationFocusChanged Event" x:Name="mniFocusChanged" IsCheckable="True"/>
+                            <MenuItem Header="{x:Static Properties:Resources.EventRecordControl_Menu_RecordAutomationFocusChanged}" x:Name="mniFocusChanged" IsCheckable="True"/>
                         </ContextMenu>
                     </Button.ContextMenu>
                 </Button>

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -132,7 +132,7 @@
                 <controls:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                 <Button.ContextMenu>
                     <ContextMenu FlowDirection="LeftToRight" x:Name="cmHierarchySettings">
-                        <MenuItem Header="Tree view">
+                        <MenuItem Header="{x:Static Properties:Resources.HierarchyControl_Menu_TreeView}">
                             <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRaw_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName1}">
                                 <MenuItem.Header>
@@ -152,9 +152,9 @@
                                 </MenuItem.Header>
                             </MenuItem>
                         </MenuItem>
-                        <MenuItem Header="Show _Ancestry" x:Name="mniShowAncestry" IsCheckable="True" 
+                        <MenuItem Header="{x:Static Properties:Resources.HierarchyControl_Menu_ShowAncestry}" x:Name="mniShowAncestry" IsCheckable="True" 
                                   Loaded="mniShowAncestry_Loaded" Click="mniShowAncestry_Click"/>
-                        <MenuItem Header="Show _Uncertain results" x:Name="mniShowUncertain" IsCheckable="True" 
+                        <MenuItem Header="{x:Static Properties:Resources.HierarchyControl_Menu_ShowUncertainResults}" x:Name="mniShowUncertain" IsCheckable="True" 
                                   Click="mniShowUncertain_Click" Loaded="mniShowUncertain_Loaded"/>
                     </ContextMenu>
                 </Button.ContextMenu>

--- a/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
@@ -92,9 +92,9 @@
                                     <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="9" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource ResourceKey=hoverAwareFabricIconOnButtonParent}"/>
                                     <Button.ContextMenu>
                                         <ContextMenu AutomationProperties.Name="{x:Static Properties:Resources.btnSettingAutomationPropertiesName2}">
-                                            <MenuItem Header="_Include all properties that have values" x:Name="mniShowCoreProps" IsCheckable="true" 
+                                            <MenuItem Header="{x:Static Properties:Resources.InspectTabsControl_Menu_ShowAllPropertiesWithValues}" x:Name="mniShowCoreProps" IsCheckable="true" 
                                                     Checked="mniShowCoreProps_Checked" Unchecked="mniShowCoreProps_Unchecked" Loaded="mniShowCoreProps_Loaded"/>
-                                            <MenuItem Header="_Configure properties to always show" x:Name="mniIncludeAllProps" Click="mniIncludeAllProps_Click" />
+                                            <MenuItem Header="{x:Static Properties:Resources.InspectTabsControl_Menu_ConfigurePropertiesToAlwaysShow}" x:Name="mniIncludeAllProps" Click="mniIncludeAllProps_Click" />
                                         </ContextMenu>
                                     </Button.ContextMenu>
                                 </Button>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -78,7 +78,7 @@
                                                 AutomationProperties.Name="{x:Static Properties:Resources.btnExpandAllAutomationPropertiesName}"
                                                 AutomationProperties.AutomationId="{x:Static Properties:AutomationIDs.AutomatedChecksExpandAllButton}">
                                             <Grid>
-                                                <AccessText Text="_c" Opacity="0"/>
+                                                <AccessText Text="{x:Static Properties:Resources.AutomatedChecksControl_ExpandCollapseAll_AccessText}" Opacity="0"/>
                                                 <fabric:FabricIconControl x:Name="fabicnExpandAll" GlyphName="CaretSolidRight" GlyphSize="Custom" FontSize="8" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}" Margin="0,2,0,-2"/>
                                             </Grid>
                                         </Button>

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml
@@ -77,8 +77,8 @@
                 </ListView.Resources>
                 <ListView.View>
                     <GridView ColumnHeaderContainerStyle="{StaticResource gvchTabStops}">
-                        <GridViewColumn Header="Order" DisplayMemberBinding="{Binding Path=Number}" Width="40" />
-                        <GridViewColumn DisplayMemberBinding="{Binding Path=Element, Converter={StaticResource cvtElementToSender}}" Header="Element" Width="300"/>
+                        <GridViewColumn Header="{x:Static Properties:Resources.TabStopControl_Order_Header}" DisplayMemberBinding="{Binding Path=Number}" Width="40" />
+                        <GridViewColumn DisplayMemberBinding="{Binding Path=Element, Converter={StaticResource cvtElementToSender}}" Header="{x:Static Properties:Resources.TabStopControl_Element_Header}" Width="300"/>
                     </GridView>
                 </ListView.View>
             </ListView>

--- a/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
@@ -53,7 +53,7 @@
                         </Style>
                     </Button.Style>
                     <Grid>
-                        <AccessText Text="_h"  Opacity="0"/>
+                        <AccessText Text="{x:Static Properties:Resources.TextRangeControl_HighlightButton_AccessText}"  Opacity="0"/>
                         <fabric:FabricIconControl Height="18" Width="18" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}" GlyphSize="Custom" FontSize="18">
                             <fabric:FabricIconControl.Style>
                                 <Style TargetType="fabric:FabricIconControl">
@@ -101,10 +101,10 @@
                         <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                         <Button.ContextMenu>
                             <ContextMenu FlowDirection="LeftToRight">
-                                <MenuItem Header="_Collapse AnnotationTypes" IsChecked="True" IsCheckable="True" Click="MenuItem_Click"/>
+                                <MenuItem Header="{x:Static Properties:Resources.TextRangeControl_Menu_CollapseAnnotationTypes}" IsChecked="True" IsCheckable="True" Click="MenuItem_Click"/>
                                 <Separator/>
-                                <MenuItem Header="_Include all attributes that have values" IsChecked="True" IsCheckable="True" Name="mniShowAll" Click="mniShowAll_Click"/>
-                                <MenuItem Header="_Configure attributes to always show" IsCheckable="False" Name="mniConfig" Click="mniConfig_Click"/>
+                                <MenuItem Header="{x:Static Properties:Resources.TextRangeControl_Menu_ShowAllAttributesWithValues}" IsChecked="True" IsCheckable="True" Name="mniShowAll" Click="mniShowAll_Click"/>
+                                <MenuItem Header="{x:Static Properties:Resources.TextRangeControl_Menu_ConfigureAttributesToAlwaysShow}" IsCheckable="False" Name="mniConfig" Click="mniConfig_Click"/>
                             </ContextMenu>
                         </Button.ContextMenu>
                     </Button>
@@ -119,7 +119,7 @@
                 <ListView.View>
                     <GridView>
                         <GridViewColumn DisplayMemberBinding="{Binding Path=Name}"  Header="Name" Width="140"/>
-                        <GridViewColumn Header="Value" Width="200">
+                        <GridViewColumn Header="{x:Static Properties:Resources.TextRangeControl_Value_Header}" Width="200">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
                                     <Grid>
@@ -178,7 +178,7 @@
                 <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                 <Button.ContextMenu>
                     <ContextMenu FlowDirection="LeftToRight">
-                        <MenuItem Header="_Replace whitespace with formatting symbols" IsChecked="True" IsCheckable="True" Name="mniWhitespace" Click="mniWhitespace_Click"/>
+                        <MenuItem Header="{x:Static Properties:Resources.TextRangeControl_Menu_ReplaceWhitespaceWithSymbols}" IsChecked="True" IsCheckable="True" Name="mniWhitespace" Click="mniWhitespace_Click"/>
                     </ContextMenu>
                 </Button.ContextMenu>
             </Button>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/EventConfigDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/EventConfigDialog.xaml
@@ -20,7 +20,7 @@
         </Grid.RowDefinitions>
         <DockPanel Grid.Row="0">
             <TabControl SelectedIndex="0">
-                <TabItem x:Name="tabEvents" Header="_Events" AutomationProperties.Name="{x:Static Properties:Resources.tabEventsAutomationPropertiesName}"
+                <TabItem x:Name="tabEvents" Header="{x:Static Properties:Resources.EventConfigDialog_Events_Header}" AutomationProperties.Name="{x:Static Properties:Resources.tabEventsAutomationPropertiesName}"
                          AutomationProperties.HelpText="{x:Static Properties:Resources.tabEventsAutomationPropertiesHelpText}">
                     <Grid Grid.IsSharedSizeScope="True" Margin="10">
                         <Grid.RowDefinitions>
@@ -34,7 +34,7 @@
                         </DockPanel>
                     </Grid>
                 </TabItem>
-                <TabItem x:Name="tabProperties" Header="_Properties" AutomationProperties.Name="{x:Static Properties:Resources.tabPropertiesAutomationPropertiesName}"
+                <TabItem x:Name="tabProperties" Header="{x:Static Properties:Resources.EventConfigDialog_Properties_Header}" AutomationProperties.Name="{x:Static Properties:Resources.tabPropertiesAutomationPropertiesName}"
                          AutomationProperties.HelpText="{x:Static Properties:Resources.tabPropertiesAutomationPropertiesHelpText}">
                     <Grid Grid.IsSharedSizeScope="True" Margin="10">
                         <Grid.RowDefinitions>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -4630,6 +4630,60 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _h.
+        /// </summary>
+        public static string TextRangeControl_HighlightButton_AccessText {
+            get {
+                return ResourceManager.GetString("TextRangeControl_HighlightButton_AccessText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Collapse AnnotationTypes.
+        /// </summary>
+        public static string TextRangeControl_Menu_CollapseAnnotationTypes {
+            get {
+                return ResourceManager.GetString("TextRangeControl_Menu_CollapseAnnotationTypes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Configure attributes to always show.
+        /// </summary>
+        public static string TextRangeControl_Menu_ConfigureAttributesToAlwaysShow {
+            get {
+                return ResourceManager.GetString("TextRangeControl_Menu_ConfigureAttributesToAlwaysShow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Replace whitespace with formatting symbols.
+        /// </summary>
+        public static string TextRangeControl_Menu_ReplaceWhitespaceWithSymbols {
+            get {
+                return ResourceManager.GetString("TextRangeControl_Menu_ReplaceWhitespaceWithSymbols", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Include all attributes that have values.
+        /// </summary>
+        public static string TextRangeControl_Menu_ShowAllAttributesWithValues {
+            get {
+                return ResourceManager.GetString("TextRangeControl_Menu_ShowAllAttributesWithValues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value.
+        /// </summary>
+        public static string TextRangeControl_Value_Header {
+            get {
+                return ResourceManager.GetString("TextRangeControl_Value_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to  ({0}):.
         /// </summary>
         public static string TextRangeFindDialog_cbAttributes_SelectionChanged {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3573,15 +3573,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Value.
-        /// </summary>
-        public static string ReturnA11yElementsView_Header_Value {
-            get {
-                return ResourceManager.GetString("ReturnA11yElementsView_Header_Value", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to _Configure properties to always show.
         /// </summary>
         public static string ReturnA11yElementsView_Menu_ConfigurePropertiesToAlwaysShow {
@@ -3605,6 +3596,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string ReturnA11yElementsView_ShowErrorHResult_Failed_HResult_0x_0_X8 {
             get {
                 return ResourceManager.GetString("ReturnA11yElementsView_ShowErrorHResult_Failed_HResult_0x_0_X8", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value.
+        /// </summary>
+        public static string ReturnA11yElementsView_Value_Header {
+            get {
+                return ResourceManager.GetString("ReturnA11yElementsView_Value_Header", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1669,6 +1669,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Record _AutomationFocusChanged Event.
+        /// </summary>
+        public static string EventRecordControl_Menu_RecordAutomationFocusChanged {
+            get {
+                return ResourceManager.GetString("EventRecordControl_Menu_RecordAutomationFocusChanged", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No element is selected yet. please select first!!.
         /// </summary>
         public static string EventRecordControl_StartRecordingEvent_No_element_is_selected_yet__please_select_first {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -4117,6 +4117,24 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Element.
+        /// </summary>
+        public static string TabStopControl_Element_Header {
+            get {
+                return ResourceManager.GetString("TabStopControl_Element_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Order.
+        /// </summary>
+        public static string TabStopControl_Order_Header {
+            get {
+                return ResourceManager.GetString("TabStopControl_Order_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Recorded order results.
         /// </summary>
         public static string TabStopControl_RecordedOrderResults {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1506,6 +1506,24 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _Events.
+        /// </summary>
+        public static string EventConfigDialog_Events_Header {
+            get {
+                return ResourceManager.GetString("EventConfigDialog_Events_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Properties.
+        /// </summary>
+        public static string EventConfigDialog_Properties_Header {
+            get {
+                return ResourceManager.GetString("EventConfigDialog_Properties_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} node.
         /// </summary>
         public static string EventConfigNodeViewModel_NodeFormat {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -4612,6 +4612,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Value.
+        /// </summary>
+        public static string TextRangeActionView_Value_Header {
+            get {
+                return ResourceManager.GetString("TextRangeActionView_Value_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Details.
         /// </summary>
         public static string TextRangeControl_Details {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2068,6 +2068,33 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show _Ancestry.
+        /// </summary>
+        public static string HierarchyControl_Menu_ShowAncestry {
+            get {
+                return ResourceManager.GetString("HierarchyControl_Menu_ShowAncestry", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show _Uncertain results.
+        /// </summary>
+        public static string HierarchyControl_Menu_ShowUncertainResults {
+            get {
+                return ResourceManager.GetString("HierarchyControl_Menu_ShowUncertainResults", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tree view.
+        /// </summary>
+        public static string HierarchyControl_Menu_TreeView {
+            get {
+                return ResourceManager.GetString("HierarchyControl_Menu_TreeView", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No data to populate hierarchy..
         /// </summary>
         public static string HierarchyControl_PopulateHierarchyTree_No_data_to_populate_hierarchy {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3528,6 +3528,33 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Value.
+        /// </summary>
+        public static string ReturnA11yElementsView_Header_Value {
+            get {
+                return ResourceManager.GetString("ReturnA11yElementsView_Header_Value", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Configure properties to always show.
+        /// </summary>
+        public static string ReturnA11yElementsView_Menu_ConfigurePropertiesToAlwaysShow {
+            get {
+                return ResourceManager.GetString("ReturnA11yElementsView_Menu_ConfigurePropertiesToAlwaysShow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Include all properties that have values.
+        /// </summary>
+        public static string ReturnA11yElementsView_Menu_ShowAllPropertiesWithValues {
+            get {
+                return ResourceManager.GetString("ReturnA11yElementsView_Menu_ShowAllPropertiesWithValues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed:HResult (0x{0:X8}).
         /// </summary>
         public static string ReturnA11yElementsView_ShowErrorHResult_Failed_HResult_0x_0_X8 {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -206,6 +206,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _e.
+        /// </summary>
+        public static string AutomatedChecksControl_ExpandCollapseAll_AccessText {
+            get {
+                return ResourceManager.GetString("AutomatedChecksControl_ExpandCollapseAll_AccessText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Issue.
         /// </summary>
         public static string AutomatedChecksControl_Issue {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2249,6 +2249,24 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _Configure properties to always show.
+        /// </summary>
+        public static string InspectTabsControl_Menu_ConfigurePropertiesToAlwaysShow {
+            get {
+                return ResourceManager.GetString("InspectTabsControl_Menu_ConfigurePropertiesToAlwaysShow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Include all properties that have values.
+        /// </summary>
+        public static string InspectTabsControl_Menu_ShowAllPropertiesWithValues {
+            get {
+                return ResourceManager.GetString("InspectTabsControl_Menu_ShowAllPropertiesWithValues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid link {0}.
         /// </summary>
         public static string InvalidLink {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1690,6 +1690,9 @@ Do you want to change the channel? </value>
   <data name="EventConfigDialog_Properties_Header" xml:space="preserve">
     <value>_Properties</value>
   </data>
+  <data name="EventRecordControl_Menu_RecordAutomationFocusChanged" xml:space="preserve">
+    <value>Record _AutomationFocusChanged Event</value>
+  </data>
   <data name="InspectTabsControl_Menu_ConfigurePropertiesToAlwaysShow" xml:space="preserve">
     <value>_Configure properties to always show</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1684,4 +1684,10 @@ Do you want to change the channel? </value>
   <data name="String" xml:space="preserve">
     <value>AutomationName</value>
   </data>
+  <data name="InspectTabsControl_Menu_ConfigurePropertiesToAlwaysShow" xml:space="preserve">
+    <value>_Configure properties to always show</value>
+  </data>
+  <data name="InspectTabsControl_Menu_ShowAllPropertiesWithValues" xml:space="preserve">
+    <value>_Include all properties that have values</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1693,6 +1693,15 @@ Do you want to change the channel? </value>
   <data name="EventRecordControl_Menu_RecordAutomationFocusChanged" xml:space="preserve">
     <value>Record _AutomationFocusChanged Event</value>
   </data>
+  <data name="HierarchyControl_Menu_ShowAncestry" xml:space="preserve">
+    <value>Show _Ancestry</value>
+  </data>
+  <data name="HierarchyControl_Menu_ShowUncertainResults" xml:space="preserve">
+    <value>Show _Uncertain results</value>
+  </data>
+  <data name="HierarchyControl_Menu_TreeView" xml:space="preserve">
+    <value>Tree view</value>
+  </data>
   <data name="InspectTabsControl_Menu_ConfigurePropertiesToAlwaysShow" xml:space="preserve">
     <value>_Configure properties to always show</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1711,14 +1711,14 @@ Do you want to change the channel? </value>
   <data name="InspectTabsControl_Menu_ShowAllPropertiesWithValues" xml:space="preserve">
     <value>_Include all properties that have values</value>
   </data>
-  <data name="ReturnA11yElementsView_Header_Value" xml:space="preserve">
-    <value>Value</value>
-  </data>
   <data name="ReturnA11yElementsView_Menu_ConfigurePropertiesToAlwaysShow" xml:space="preserve">
     <value>_Configure properties to always show</value>
   </data>
   <data name="ReturnA11yElementsView_Menu_ShowAllPropertiesWithValues" xml:space="preserve">
     <value>_Include all properties that have values</value>
+  </data>
+  <data name="ReturnA11yElementsView_Value_Header" xml:space="preserve">
+    <value>Value</value>
   </data>
   <data name="TabStopControl_Element_Header" xml:space="preserve">
     <value>Element</value>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1729,4 +1729,22 @@ Do you want to change the channel? </value>
   <data name="TextRangeActionView_Value_Header" xml:space="preserve">
     <value>Value</value>
   </data>
+  <data name="TextRangeControl_HighlightButton_AccessText" xml:space="preserve">
+    <value>_h</value>
+  </data>
+  <data name="TextRangeControl_Menu_CollapseAnnotationTypes" xml:space="preserve">
+    <value>_Collapse AnnotationTypes</value>
+  </data>
+  <data name="TextRangeControl_Menu_ConfigureAttributesToAlwaysShow" xml:space="preserve">
+    <value>_Configure attributes to always show</value>
+  </data>
+  <data name="TextRangeControl_Menu_ReplaceWhitespaceWithSymbols" xml:space="preserve">
+    <value>_Replace whitespace with formatting symbols</value>
+  </data>
+  <data name="TextRangeControl_Menu_ShowAllAttributesWithValues" xml:space="preserve">
+    <value>_Include all attributes that have values</value>
+  </data>
+  <data name="TextRangeControl_Value_Header" xml:space="preserve">
+    <value>Value</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1696,4 +1696,13 @@ Do you want to change the channel? </value>
   <data name="InspectTabsControl_Menu_ShowAllPropertiesWithValues" xml:space="preserve">
     <value>_Include all properties that have values</value>
   </data>
+  <data name="ReturnA11yElementsView_Header_Value" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="ReturnA11yElementsView_Menu_ConfigurePropertiesToAlwaysShow" xml:space="preserve">
+    <value>_Configure properties to always show</value>
+  </data>
+  <data name="ReturnA11yElementsView_Menu_ShowAllPropertiesWithValues" xml:space="preserve">
+    <value>_Include all properties that have values</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1684,6 +1684,12 @@ Do you want to change the channel? </value>
   <data name="String" xml:space="preserve">
     <value>AutomationName</value>
   </data>
+  <data name="EventConfigDialog_Events_Header" xml:space="preserve">
+    <value>_Events</value>
+  </data>
+  <data name="EventConfigDialog_Properties_Header" xml:space="preserve">
+    <value>_Properties</value>
+  </data>
   <data name="InspectTabsControl_Menu_ConfigurePropertiesToAlwaysShow" xml:space="preserve">
     <value>_Configure properties to always show</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1726,4 +1726,7 @@ Do you want to change the channel? </value>
   <data name="TabStopControl_Order_Header" xml:space="preserve">
     <value>Order</value>
   </data>
+  <data name="TextRangeActionView_Value_Header" xml:space="preserve">
+    <value>Value</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1684,6 +1684,9 @@ Do you want to change the channel? </value>
   <data name="String" xml:space="preserve">
     <value>AutomationName</value>
   </data>
+  <data name="AutomatedChecksControl_ExpandCollapseAll_AccessText" xml:space="preserve">
+    <value>_e</value>
+  </data>
   <data name="EventConfigDialog_Events_Header" xml:space="preserve">
     <value>_Events</value>
   </data>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1720,4 +1720,10 @@ Do you want to change the channel? </value>
   <data name="ReturnA11yElementsView_Menu_ShowAllPropertiesWithValues" xml:space="preserve">
     <value>_Include all properties that have values</value>
   </data>
+  <data name="TabStopControl_Element_Header" xml:space="preserve">
+    <value>Element</value>
+  </data>
+  <data name="TabStopControl_Order_Header" xml:space="preserve">
+    <value>Order</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -165,7 +165,7 @@
                             </i:Interaction.Behaviors>
                             <Grid Width="40" Height="40" x:Name="addAccountGrid">
                                 <Grid x:Name="newAccountGrid" Visibility="Visible">
-                                    <AccessText Text="_i" Opacity="0"/>
+                                    <AccessText Text="{x:Static properties:Resources.NavBar_IssueFilingConfig_AccessText}" Opacity="0"/>
                                     <fabric:FabricIconControl GlyphName="{Binding Path=vmReporterLogo.FabricIconLogoName, TargetNullValue=PlugDisconnected}" FontSize="24" VerticalAlignment="Center" Style="{StaticResource hoverAwareNavBarFabricIcon}" HorizontalAlignment="Center"/>
                                 </Grid>
                             </Grid>
@@ -185,7 +185,7 @@
                                 <behaviors:KeyboardToolTipButtonBehavior/>
                             </i:Interaction.Behaviors>
                             <Grid>
-                                <AccessText Text="_c" Opacity="0"/>
+                                <AccessText Text="{x:Static properties:Resources.NavBar_Config_AccessText}" Opacity="0"/>
                                 <fabric:FabricIconControl GlyphName="Settings" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareNavBarFabricIcon}"/>
                             </Grid>
                         </Button>

--- a/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/ConfigurationModeControl.xaml
@@ -27,7 +27,7 @@
                 <Grid Grid.Row="0" >
                     <Button x:Name="btnClose" Margin="12,24,20,14" Width="15" Height="15" Click="Button_Click" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" VerticalAlignment="Top" HorizontalAlignment="Left" IsCancel="True" IsTabStop="True" AutomationProperties.Name="{x:Static properties:Resources.gdConfigBtnCloseAutomationPropertiesName}" KeyboardNavigation.TabIndex="-2" Style="{StaticResource BtnNoAutoHelpText}">
                         <Grid>
-                            <AccessText Text="_x" Opacity="0"/>
+                            <AccessText Text="{x:Static properties:Resources.ConfigPane_Exit_AccessText}" Opacity="0"/>
                             <fabric:FabricIconControl GlyphName="ChromeBack" GlyphSize="Custom" FontSize="11" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                         </Grid>
                         <Button.ToolTip>

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -466,6 +466,15 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _x.
+        /// </summary>
+        public static string ConfigPane_Exit_AccessText {
+            get {
+                return ResourceManager.GetString("ConfigPane_Exit_AccessText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Accessibility Insights for Windows was unable to change channels. Please check your internet connection and try again later..
         /// </summary>
         public static string ConfigurationModeControl_VersionSwitcherException {

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -844,6 +844,24 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _c.
+        /// </summary>
+        public static string NavBar_Config_AccessText {
+            get {
+                return ResourceManager.GetString("NavBar_Config_AccessText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _i.
+        /// </summary>
+        public static string NavBar_IssueFilingConfig_AccessText {
+            get {
+                return ResourceManager.GetString("NavBar_IssueFilingConfig_AccessText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The element&apos;s bounding rectangle is empty (app minimized?)- no screenshot is available..
         /// </summary>
         public static string noScreenShotAvailableMessage {

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -572,4 +572,10 @@ Please ensure that you are opening a valid test file using the most recent relea
     <value>Start test in {0} seconds</value>
     <comment>{0} is the timer delay in seconds</comment>
   </data>
+  <data name="NavBar_Config_AccessText" xml:space="preserve">
+    <value>_c</value>
+  </data>
+  <data name="NavBar_IssueFilingConfig_AccessText" xml:space="preserve">
+    <value>_i</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -572,6 +572,9 @@ Please ensure that you are opening a valid test file using the most recent relea
     <value>Start test in {0} seconds</value>
     <comment>{0} is the timer delay in seconds</comment>
   </data>
+  <data name="ConfigPane_Exit_AccessText" xml:space="preserve">
+    <value>_x</value>
+  </data>
   <data name="NavBar_Config_AccessText" xml:space="preserve">
     <value>_c</value>
   </data>


### PR DESCRIPTION
#### Details

I found some localizable resources embedded into XAML files. This PR simply pulls them out into resx files. It also corrects a shortcut conflict where the "expand/collapse all" accessibility shortcut in the automated checks view and the "show configuration" accessibility shortcut in the main window were both mapped to alt+c. The "expand/collapse all" accessibility shortcut in the automated checks view is now mapped to alt+e so there's no longer a conflict.

##### Motivation

Baby steps towards being able to localize.

##### Context

This is another case where it's probably easiest to review on a per-commit basis. There's 1 overlapping commit because I realized that `RetunA11yElementsView_Header_Value` should have been `RetunA11yElementsView_Value_Header` for consistency

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue
- [x] Includes UI changes? (Accessibility key changed)
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



