### PR TITLE
fix: Stop overtheming controls in dark mode

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
@@ -54,7 +54,7 @@
                     </Button.Style>
                     <Grid>
                         <AccessText Text="{x:Static Properties:Resources.TextRangeControl_HighlightButton_AccessText}"  Opacity="0"/>
-                        <fabric:FabricIconControl Height="18" Width="18" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}" GlyphSize="Custom" FontSize="18">
+                        <fabric:FabricIconControl Height="18" Width="18" VerticalAlignment="Center" HorizontalAlignment="Center" GlyphSize="Custom" FontSize="18">
                             <fabric:FabricIconControl.Style>
                                 <Style TargetType="fabric:FabricIconControl">
                                     <Style.Triggers>
@@ -63,6 +63,12 @@
                                         </DataTrigger>
                                         <DataTrigger Binding="{Binding Path=vmHilighter.State, Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:TextRangeControl}}" Value="Off">
                                             <Setter Property="GlyphName" Value="UnSetColor"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="True">
+                                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=IconHoverFGBrush}"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="False">
+                                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=UnthemedIconFGBrush}"/>
                                         </DataTrigger>
                                     </Style.Triggers>
                                 </Style>
@@ -98,7 +104,7 @@
                         <i:Interaction.Behaviors>
                             <behaviors:DropDownButtonBehavior/>
                         </i:Interaction.Behaviors>
-                        <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
+                        <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnUnthemedButtonParent}"/>
                         <Button.ContextMenu>
                             <ContextMenu FlowDirection="LeftToRight">
                                 <MenuItem Header="{x:Static Properties:Resources.TextRangeControl_Menu_CollapseAnnotationTypes}" IsChecked="True" IsCheckable="True" Click="MenuItem_Click"/>
@@ -175,7 +181,7 @@
                 <i:Interaction.Behaviors>
                     <behaviors:DropDownButtonBehavior/>
                 </i:Interaction.Behaviors>
-                <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
+                <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnUnthemedButtonParent}"/>
                 <Button.ContextMenu>
                     <ContextMenu FlowDirection="LeftToRight">
                         <MenuItem Header="{x:Static Properties:Resources.TextRangeControl_Menu_ReplaceWhitespaceWithSymbols}" IsChecked="True" IsCheckable="True" Name="mniWhitespace" Click="mniWhitespace_Click"/>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml
@@ -52,7 +52,7 @@
                     <Button.ToolTip>
                         <ToolTip Content="{x:Static Properties:Resources.btnRefreshAutomationPropertiesNameUpdateRange}"/>
                     </Button.ToolTip>
-                    <fabric:FabricIconControl GlyphName="Refresh" FontSize="16" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
+                    <fabric:FabricIconControl GlyphName="Refresh" FontSize="16" Style="{StaticResource hoverAwareFabricIconOnUnthemedButtonParent}"/>
                 </Button>
             </StackPanel>
             <ListBox x:Name="ltbRanges" Grid.Row="1"

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -124,4 +124,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverBGBrush" Color="#BEE6FD"/>  <!-- Background of combobox toggle on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverFGBrush" Color="#000000"/>  <!-- Foreground or combobox toggle on mouse hover -->
     <SolidColorBrush po:Freeze="True" x:Key="NoDarkThemeContrastingFGBrush" Color="#000000"/>  <!-- Contrasting foreground for screens with no Dark Mode theme -->
+    <SolidColorBrush po:Freeze="True" x:Key="UnthemedIconFGBrush" Color="#000000"/>      <!-- Used for fabric icons on *unthemed* backgrounds -->
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -109,4 +109,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverBGBrush" Color="{x:Static SystemColors.HighlightColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
     <SolidColorBrush po:Freeze="True" x:Key="NoDarkThemeContrastingFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
+    <SolidColorBrush po:Freeze="True" x:Key="UnthemedIconFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -124,4 +124,5 @@
     <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverBGBrush" Color="#BEE6FD"/>
     <SolidColorBrush po:Freeze="True" x:Key="ComboToggleHoverFGBrush" Color="#000000"/>
     <SolidColorBrush po:Freeze="True" x:Key="NoDarkThemeContrastingFGBrush" Color="#000000"/>
+    <SolidColorBrush po:Freeze="True" x:Key="UnthemedIconFGBrush" Color="#000000"/>
 </ResourceDictionary>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1564,6 +1564,16 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
+    <Style TargetType="fabric:FabricIconControl" x:Key="hoverAwareFabricIconOnUnthemedButtonParent">
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=IconHoverFGBrush}"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button,AncestorLevel=1}, Path=IsMouseOver}" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=UnthemedIconFGBrush}"/>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
     <Style TargetType="fabric:FabricIconControl" x:Key="fabricIconOnPressedButtonParentStyle">
         <!-- This style is set programmatically, so renaming it will require a change in the code-behind -->
         <Setter Property="Foreground" Value="{DynamicResource ResourceKey=IconHoverFGBrush}"/>


### PR DESCRIPTION
#### Details

As called out in #1262, we have some cases where we apply the color theme in unthemed dialogs, leading to controls that are not visible until they experience a mouse hover. This PR creates a new theme, `hoverAwareFabricIconOnUnthemedButtonParent`, and sets an appropriate foreground color when no mouse hover exists.

##### Motivation

Address #1262 

##### Screenshots
These screenshots were all taken with the mouse hover over the settings button of the attributes control. Hover colors for the other 3 buttons all match what is displayed here.

Mode | Screenshot
--- | ---
Light | <img width="478" alt="Explorer-Light" src="https://user-images.githubusercontent.com/45672944/144152405-5d127db1-3259-4f7b-bce1-348409dd8505.png">
Dark | <img width="478" alt="Explorer-Dark" src="https://user-images.githubusercontent.com/45672944/144152417-b32b04d0-9016-4459-b851-11388485f29a.png">
HC 1 | <img width="488" alt="Explorer-HC-1" src="https://user-images.githubusercontent.com/45672944/144152455-c7dd67f0-178e-4d68-ae42-0ae4156199f5.png">
HC 2 | <img width="488" alt="Explorer-HC-2" src="https://user-images.githubusercontent.com/45672944/144152494-d31dc25a-1b68-483d-b3fe-2b82718739c6.png">
HC Black | <img width="488" alt="Explorer-HC-Black" src="https://user-images.githubusercontent.com/45672944/144152509-bb86c665-6c43-4ec4-9b7b-c1bc95354318.png">
HC White | <img width="488" alt="Explorer-HC-White" src="https://user-images.githubusercontent.com/45672944/144152553-4e24ddc8-b0a2-47c9-a514-5d3dbc36e235.png">

##### Context

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue #1262 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



