### PR TITLE
fix: Address theming issues in dark mode

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml
@@ -100,7 +100,7 @@
                                 AutomationProperties.Name="{x:Static Properties:Resources.btnMoveRightAutomationPropertiesName}"
                                 AutomationProperties.HelpText="{x:Static Properties:Resources.btnMoveRightAutomationPropertiesHelpText}"
                                 AutomationProperties.AcceleratorKey="Alt+A">
-                            <fabric:FabricIconControl GlyphName="CaretSolidRight" GlyphSize="Default" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
+                            <fabric:FabricIconControl GlyphName="CaretSolidRight" GlyphSize="Default" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnUnthemedButtonParent}"/>
                         </Button>
                     </DockPanel>
                     <DockPanel VerticalAlignment="Center" Grid.Row="2">
@@ -110,7 +110,7 @@
                                 AutomationProperties.Name="{x:Static Properties:Resources.btnMoveLeftAutomationPropertiesName}"
                                 AutomationProperties.HelpText="{x:Static Properties:Resources.btnMoveLeftAutomationPropertiesHelpText}"
                                 AutomationProperties.AcceleratorKey="Alt+R">
-                            <fabric:FabricIconControl GlyphName="CaretSolidLeft" GlyphSize="Default" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
+                            <fabric:FabricIconControl GlyphName="CaretSolidLeft" GlyphSize="Default" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnUnthemedButtonParent}"/>
                         </Button>
                     </DockPanel>
                 </Grid>
@@ -150,7 +150,7 @@
                     <Button.ToolTip>
                         <ToolTip Content="{x:Static Properties:Resources.btnMoveUpAutomationPropertiesName}"/>
                     </Button.ToolTip>
-                    <fabric:FabricIconControl GlyphName="Up" GlyphSize="Small" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
+                    <fabric:FabricIconControl GlyphName="Up" GlyphSize="Small" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnUnthemedButtonParent}"/>
                 </Button>
                 <Button x:Name="btnMoveDown" Width="20" Height="20" Click="btnMoveDown_Click"
                   Style="{StaticResource BtnStandard}"
@@ -164,7 +164,7 @@
                     <Button.ToolTip>
                         <ToolTip Content="{x:Static Properties:Resources.btnMoveDownAutomationPropertiesName}"/>
                     </Button.ToolTip>
-                    <fabric:FabricIconControl GlyphName="Down" GlyphSize="Small" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
+                    <fabric:FabricIconControl GlyphName="Down" GlyphSize="Small" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnUnthemedButtonParent}"/>
                 </Button>
             </Grid>
         </Grid>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/ElementInfoDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/ElementInfoDialog.xaml
@@ -19,7 +19,7 @@
     <Window.Resources>
         <ResourceDictionary Source="..\Resources\Styles.xaml"/>
     </Window.Resources>
-    <Grid>
+    <Grid Background="{DynamicResource ResourceKey=PrimaryBGBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>


### PR DESCRIPTION
#### Details

As called out in #1266, we have controls that become invisible in dark mode due to theming issues. This PR address the items in #1266, but in slightly different ways. In the `EventConfigurationControl`, we just change the styles of the `fabricIconControl` objects and leave the surrounding dialog unthemed. In the `ElementInfoDialog`, it's simpler to just theme the dialog. 

##### Motivation

Address #1266

##### Screenshots
Attributes dialog: In each case, the mouse hover is on the "Add" button.

Theme | Screenshot
--- | ---
Light | <img width="425" alt="attributes-light" src="https://user-images.githubusercontent.com/45672944/144302856-519bc350-1210-418a-8d4a-1b1b25672989.png">
Dark | <img width="425" alt="attributes-dark" src="https://user-images.githubusercontent.com/45672944/144302877-30387a17-055c-47b4-9cff-9278a86a4350.png">
HC 1 | <img width="435" alt="attributes-hc-1" src="https://user-images.githubusercontent.com/45672944/144302904-42fe618f-aa56-45e4-9e63-c17025e2922d.png">
HC 2 | <img width="435" alt="attributes-hc-2" src="https://user-images.githubusercontent.com/45672944/144304495-7522d023-e975-4153-8dab-bcccba57c52a.png">
HC Black | <img width="435" alt="attributes-hc-black" src="https://user-images.githubusercontent.com/45672944/144302988-efec1261-18c6-4462-83bd-bc8a6182b231.png">
HC White | <img width="435" alt="attributes-hc-white" src="https://user-images.githubusercontent.com/45672944/144303007-bfc8670f-6825-479c-a280-c50a1182b91e.png">

Element Information dialog: Mouse hover is not shown in these screenshots, but is appropriate for each theme:
Theme | Screenshot
--- | ---
Light | <img width="298" alt="element-info-light" src="https://user-images.githubusercontent.com/45672944/144303240-0e4cd93e-b80f-46d0-b00e-6d60ba997609.png">
Dark | <img width="298" alt="element-info-dark" src="https://user-images.githubusercontent.com/45672944/144303258-a4f68c02-e153-4764-a918-308750858fa6.png">
HC 1 | <img width="308" alt="element-info-hc-1" src="https://user-images.githubusercontent.com/45672944/144303293-4eb342e1-9a41-43d0-b4fe-48b56e5f81ac.png">
HC 2 | <img width="308" alt="element-info-hc-2" src="https://user-images.githubusercontent.com/45672944/144303314-d8adf9f7-6a40-4101-84ed-5fd39a8428d7.png">
HC Black | <img width="308" alt="element-info-hc-black" src="https://user-images.githubusercontent.com/45672944/144303340-1d88afdc-0a24-4076-ac58-3ff5106d8f0f.png">
HC White | <img width="308" alt="element-info-hc-white" src="https://user-images.githubusercontent.com/45672944/144303392-eea5063e-e1cd-4dde-bcae-2513599e8a73.png">

##### Context

It's a bit jarring to go from a themed Hierarchy view to an unthemed TextPatternExplorer, and then to a themed ElementInfoDialog, but it's a very small use case. If/when it becomes an issue, the more correct answer is probably to theme the TextPatternExplorer (but not today).

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue #1266
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



