### PR TITLE
chore: Enable .NET accessibility features from August 2020 .NET update

### DIFF
--- a/src/AccessibilityInsights/App.config
+++ b/src/AccessibilityInsights/App.config
@@ -9,6 +9,6 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
   <runtime>
-    <AppContextSwitchOverrides value="Switch.UseLegacyAccessibilityFeatures=false;Switch.UseLegacyAccessibilityFeatures.2=false;Switch.UseLegacyAccessibilityFeatures.3=false;Switch.UseLegacyToolTipDisplay=false" />
+    <AppContextSwitchOverrides value="Switch.UseLegacyAccessibilityFeatures=false;Switch.UseLegacyAccessibilityFeatures.2=false;Switch.UseLegacyAccessibilityFeatures.3=false;Switch.UseLegacyAccessibilityFeatures.4=false;Switch.UseLegacyToolTipDisplay=false" />
   </runtime>
 </configuration>


### PR DESCRIPTION
#### Details

.NET released some [accessibility fixes](https://docs.microsoft.com/en-us/dotnet/framework/whats-new/whats-new-in-accessibility#whats-new-in-accessibility-in-the-august-11-2020-cumulative-update-for-net-framework-48) in August 2020. These changes are focused around the `PropertyGrid`, `PropertyGridView`, and `DataGridView`, which we use in multiple places. In order to enable these fixes, we need to specify `Switch.UseLegacyAccessibilityFeatures.4=false` in our app manifest.

##### Motivation

Get the latest .NET accessibility fixes. Before merging, we should review old bugs that involve `PropertyGrid`, `PropertyGridView`, or `DataGridView` objects, and see what benefits we receive from the .NET fixes.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



