### PR TITLE
fix: Line breaks in resources files are rendered as literals

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3509,7 +3509,8 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error loading the URL.\nURL: {0}.
+        ///   Looks up a localized string similar to There was an error loading the URL.
+        ///URL: {0}.
         /// </summary>
         public static string ReleaseNotes_ClickLoadErrorMessage {
             get {
@@ -3518,7 +3519,8 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The URL was not properly formatted.\nURL: {0}.
+        ///   Looks up a localized string similar to The URL was not properly formatted.
+        ///URL: {0}.
         /// </summary>
         public static string ReleaseNotes_ClickURLErrorMessage {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1534,10 +1534,12 @@ Do you want to change the channel? </value>
     <value>An update is available</value>
   </data>
   <data name="ReleaseNotes_ClickLoadErrorMessage" xml:space="preserve">
-    <value>There was an error loading the URL.\nURL: {0}</value>
+    <value>There was an error loading the URL.
+URL: {0}</value>
   </data>
   <data name="ReleaseNotes_ClickURLErrorMessage" xml:space="preserve">
-    <value>The URL was not properly formatted.\nURL: {0}</value>
+    <value>The URL was not properly formatted.
+URL: {0}</value>
   </data>
   <data name="ReleaseNotesText" xml:space="preserve">
     <value>View the release notes here.</value>

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -439,7 +439,8 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Ratio: {0}\nConfidence: {1}.
+        ///   Looks up a localized string similar to Ratio: {0}
+        ///Confidence: {1}.
         /// </summary>
         public static string ColorContrast_RatioAndConfidenceFormat {
             get {

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -537,7 +537,8 @@ Please ensure that you are opening a valid test file using the most recent relea
     <value>No Element Selected!</value>
   </data>
   <data name="ColorContrast_RatioAndConfidenceFormat" xml:space="preserve">
-    <value>Ratio: {0}\nConfidence: {1}</value>
+    <value>Ratio: {0}
+Confidence: {1}</value>
     <comment>{0} is the ratio; {1} is the confidence</comment>
   </data>
   <data name="ColorContrast_UnableToDetectColors" xml:space="preserve">


### PR DESCRIPTION
#### Details

Together, #1201 and #1250 added 3 resource strings that each contain a newline. In each case, the newline was added as a `\n` in the resx file, but the resource compiler treats this as visible text, meaning that the newline gets misrendered. This change simply replaces the `\n` sequence with a newline in the resx file. Changes were made via the resource editor, so no manual changes to the resx files occurred. I checked for any other instances of escaped characters in resource files and found nothing else that needed changes.

##### Motivation

Represent newlines correctly. Two of the strings are error messages and unlikely to occur very often. The third one is in rendering the auto-detected color contrast and is easy to demonstrate:

Current Version | Fixed version
--- | ---
![image](https://user-images.githubusercontent.com/45672944/151430953-079323b5-62e4-4f9d-aabf-bb67ccff351f.png) | ![image](https://user-images.githubusercontent.com/45672944/151431004-842848dd-cd13-46d1-b8c3-5a009dc86aba.png)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



