### PR TITLE
chore: Run automatic cleanup tool

### DIFF
--- a/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/CustomControlOverridingAutomationPeer.cs
@@ -12,7 +12,7 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
     /// CustomControlOverridingAutomationPeer class
     /// class to override LocalizedControlType and control/content element values for custom control(UserControl)
     /// </summary>
-    public class CustomControlOverridingAutomationPeer: UserControlAutomationPeer
+    public class CustomControlOverridingAutomationPeer : UserControlAutomationPeer
     {
         private bool IsControlElem;
 

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/ProgressRingControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/ProgressRingControl.xaml.cs
@@ -45,7 +45,7 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
             var control = d as ProgressRingControl;
             if (control != null)
             {
-                control.IsActive = (bool) e.NewValue;
+                control.IsActive = (bool)e.NewValue;
             }
         }
 
@@ -226,7 +226,7 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
             }
             get
             {
-                return (int) (ell1.RenderTransformOrigin.Y * ell1.Height * -2);
+                return (int)(ell1.RenderTransformOrigin.Y * ell1.Height * -2);
             }
         }
 

--- a/src/AccessibilityInsights.CommonUxComponents/Dialogs/MessageDialog.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Dialogs/MessageDialog.xaml.cs
@@ -66,7 +66,7 @@ namespace AccessibilityInsights.CommonUxComponents.Dialogs
         /// <param name="e"></param>
         private void Window_KeyUp(object sender, KeyEventArgs e)
         {
-            if(e.Key == Key.Escape)
+            if (e.Key == Key.Escape)
             {
                 this.DialogResult = false;
                 this.Close();

--- a/src/AccessibilityInsights.CustomActions/ConfigFileCleaner.cs
+++ b/src/AccessibilityInsights.CustomActions/ConfigFileCleaner.cs
@@ -61,7 +61,7 @@ namespace AccessibilityInsights.CustomActions
         private void DeleteConfigFiles()
         {
             var configDirectory = FixedConfigSettingsProvider.CreateDefaultSettingsProvider().ConfigurationFolderPath;
-            if (_systemShim.DirectoryExists(configDirectory)) 
+            if (_systemShim.DirectoryExists(configDirectory))
             {
                 _systemShim.LogToSession("RemoveUserConfigFiles: Deleting config directory: " + configDirectory);
                 _systemShim.DeleteDirectory(configDirectory);

--- a/src/AccessibilityInsights.CustomActions/SystemShim.cs
+++ b/src/AccessibilityInsights.CustomActions/SystemShim.cs
@@ -1,18 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using AccessibilityInsights.SetupLibrary;
 using Microsoft.Deployment.WindowsInstaller;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 
 namespace AccessibilityInsights.CustomActions
 {
     /// <summary>
     /// Production implementation of ISystemShim
     /// </summary>
-    internal class SystemShim: ISystemShim
+    internal class SystemShim : ISystemShim
     {
         private readonly Session _session;
 

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs
@@ -63,7 +63,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
 
         public Guid StableIdentifier { get; } = new Guid("73D8F6EB-E98A-4285-9BA3-B532A7601CC4");
 
-        public bool IsConfigured => _devOpsIntegration.ConnectedToAzureDevOps 
+        public bool IsConfigured => _devOpsIntegration.ConnectedToAzureDevOps
             && Configuration?.SavedConnection?.IsPopulated == true
             && _devOpsIntegration.CheckIfAbleToGetProjects().Result;
 
@@ -110,7 +110,8 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                         {
                             DisplayText = null,
                             IssueLink = null,
-                            PostAction = () => {
+                            PostAction = () =>
+                            {
                                 MessageDialog.Show(Properties.Resources.There_was_an_error_identifying_the_created_issue_This_may_occur_if_the_ID_used_to_create_the_issue_is_removed_from_its_Azure_DevOps_description_Attachments_have_not_been_uploaded);
                             },
                         };

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
@@ -414,7 +414,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         /// <summary>
         /// Implements <see cref="IDevOpsIntegration.HandleLoginAsync(CredentialPromptType, Uri)"/>
         /// </summary>
-        public async Task HandleLoginAsync(CredentialPromptType showDialog=CredentialPromptType.DoNotPrompt, Uri serverUri = null)
+        public async Task HandleLoginAsync(CredentialPromptType showDialog = CredentialPromptType.DoNotPrompt, Uri serverUri = null)
         {
             serverUri = serverUri ?? Configuration.SavedConnection.ServerUri;
 

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Enums/AzureDevOpsField.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Enums/AzureDevOpsField.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 
 namespace AccessibilityInsights.Extensions.AzureDevOps.Enums
 {
@@ -31,11 +30,11 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Enums
             switch (value)
             {
                 // These fields are all documented at https://docs.microsoft.com/en-us/rest/api/azure/devops/wit/Revisions/List?view=azure-devops-rest-5.0
-                case AzureDevOpsField.Title:           return "System.Title";
-                case AzureDevOpsField.ReproSteps:      return "Microsoft.VSTS.TCM.ReproSteps";
-                case AzureDevOpsField.Tags:            return "System.Tags";
-                case AzureDevOpsField.AreaPath:        return "System.AreaPath";
-                case AzureDevOpsField.IterationPath:   return "System.IterationPath";
+                case AzureDevOpsField.Title: return "System.Title";
+                case AzureDevOpsField.ReproSteps: return "Microsoft.VSTS.TCM.ReproSteps";
+                case AzureDevOpsField.Tags: return "System.Tags";
+                case AzureDevOpsField.AreaPath: return "System.AreaPath";
+                case AzureDevOpsField.IterationPath: return "System.IterationPath";
             }
             return string.Empty;
         }

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
@@ -17,7 +17,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
     /// Winform based issue filing dialog code.
     /// because of parenting issue, wpf can't be used for IE Control
     /// </summary>
-    public partial class IssueFileForm: Form
+    public partial class IssueFileForm : Form
     {
         enum State
         {

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Models/TeamProjectViewModel.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Models/TeamProjectViewModel.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Windows;
 
 namespace AccessibilityInsights.Extensions.AzureDevOps.Models

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Models/ViewModelBase.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Models/ViewModelBase.cs
@@ -7,7 +7,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Models
     /// <summary>
     /// ViewModel base class
     /// </summary>
-    public class ViewModelBase: INotifyPropertyChanged
+    public class ViewModelBase : INotifyPropertyChanged
     {
         /// <summary>
         /// to notify property changes

--- a/src/AccessibilityInsights.Extensions.AzureDevOpsTests/ConnectionInfoTests.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOpsTests/ConnectionInfoTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Extensions.AzureDevOps;
 using AccessibilityInsights.Extensions.AzureDevOps.Models;
-using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 

--- a/src/AccessibilityInsights.Extensions.DiskLoggingTelemetry/LocalTelemetry.cs
+++ b/src/AccessibilityInsights.Extensions.DiskLoggingTelemetry/LocalTelemetry.cs
@@ -59,7 +59,7 @@ namespace AccessibilityInsights.Extensions.DiskLoggingTelemetry
         {
             Dictionary<string, string> copy = new Dictionary<string, string>();
 
-            foreach(KeyValuePair<string, string> pair in original)
+            foreach (KeyValuePair<string, string> pair in original)
             {
                 copy.Add(pair.Key, pair.Value);
             }

--- a/src/AccessibilityInsights.Extensions.DiskLoggingTelemetryTests/LocalTelemetryUnitTests.cs
+++ b/src/AccessibilityInsights.Extensions.DiskLoggingTelemetryTests/LocalTelemetryUnitTests.cs
@@ -39,7 +39,7 @@ namespace AccessibilityInsights.Extensions.DiskLoggingTelemetryTests
 
         private void SetContextProperties()
         {
-            foreach(KeyValuePair<string, string> pair in ContextProperties)
+            foreach (KeyValuePair<string, string> pair in ContextProperties)
             {
                 _testSubject.AddOrUpdateContextProperty(pair.Key, pair.Value);
             }

--- a/src/AccessibilityInsights.Extensions.GitHub/Configuration.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/Configuration.cs
@@ -11,7 +11,7 @@ namespace AccessibilityInsights.Extensions.GitHub
     {
         public string RepoLink { get; set; }
 
-        public ConnectionConfiguration(): this(String.Empty)
+        public ConnectionConfiguration() : this(String.Empty)
         {
         }
 

--- a/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/ConfigurationModelControl.xaml.cs
@@ -93,7 +93,7 @@ namespace AccessibilityInsights.Extensions.GitHub
 
         private void IssueConfigurationControl_IsVisibleChanged(object sender, System.Windows.DependencyPropertyChangedEventArgs e)
         {
-            if (sender!=null && (bool)e.NewValue)
+            if (sender != null && (bool)e.NewValue)
             {
                 if (Config != null && !string.IsNullOrEmpty(Config.RepoLink) && LinkValidator.IsValidGitHubRepoLink(Config.RepoLink) && !Config.RepoLink.Equals(this.tbURL.Text, StringComparison.Ordinal))
                 {

--- a/src/AccessibilityInsights.Extensions.GitHub/IssueReporter.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/IssueReporter.cs
@@ -46,7 +46,7 @@ namespace AccessibilityInsights.Extensions.GitHub
 
         public string ServiceName => Properties.Resources.extensionName;
 
-        public Guid StableIdentifier => new Guid ("bbdf3582-d4a6-4b76-93ea-ef508d1fd4b8");
+        public Guid StableIdentifier => new Guid("bbdf3582-d4a6-4b76-93ea-ef508d1fd4b8");
         public bool IsConfigured { get; private set; }
 
         public string ConfigurationPath { get; private set; }
@@ -93,7 +93,7 @@ namespace AccessibilityInsights.Extensions.GitHub
         private void RestoreConfigurationAsyncAction(string serializedConfig)
         {
             ConnectionConfiguration config = JsonConvert.DeserializeObject<ConnectionConfiguration>(serializedConfig);
-            if (config!=null && !string.IsNullOrEmpty(config.RepoLink) && LinkValidator.IsValidGitHubRepoLink(config.RepoLink))
+            if (config != null && !string.IsNullOrEmpty(config.RepoLink) && LinkValidator.IsValidGitHubRepoLink(config.RepoLink))
             {
                 this.configurationControl.Config = config;
                 this.IsConfigured = true;

--- a/src/AccessibilityInsights.Extensions.GitHub/SingleFailureIssueFormatter.cs
+++ b/src/AccessibilityInsights.Extensions.GitHub/SingleFailureIssueFormatter.cs
@@ -8,7 +8,7 @@ namespace AccessibilityInsights.Extensions.GitHub
     /// <summary>
     /// GitHub Issue Single Issue Formatting
     /// </summary>
-    public class SingleFailureIssueFormatter:IIssueFormatter
+    public class SingleFailureIssueFormatter : IIssueFormatter
     {
         public IssueInformation IssueInfo { get; }
         public SingleFailureIssueFormatter(IssueInformation issueInfo)

--- a/src/AccessibilityInsights.Extensions.Telemetry/AITelemetry.cs
+++ b/src/AccessibilityInsights.Extensions.Telemetry/AITelemetry.cs
@@ -30,7 +30,7 @@ namespace AccessibilityInsights.Extensions.Telemetry
         /// Production ctor--must be public for MEF
         /// </summary>
         public AITelemetry()
-            :this(new TelemetryClientWrapper(TelemetryClientFactory.GetClient(InstrumentationKey)))
+            : this(new TelemetryClientWrapper(TelemetryClientFactory.GetClient(InstrumentationKey)))
         {
         }
 

--- a/src/AccessibilityInsights.Extensions/Container.cs
+++ b/src/AccessibilityInsights.Extensions/Container.cs
@@ -91,9 +91,9 @@ namespace AccessibilityInsights.Extensions
 
         public static Container GetDefaultInstance()
         {
-            if(_defaultInstance == null)
+            if (_defaultInstance == null)
             {
-                lock(_lockObject)
+                lock (_lockObject)
                 {
 #pragma warning disable CA1508 // Analyzer doesn't understand threading
                     if (_defaultInstance == null)

--- a/src/AccessibilityInsights.Extensions/Interfaces/IssueReporting/IssueType.cs
+++ b/src/AccessibilityInsights.Extensions/Interfaces/IssueReporting/IssueType.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 namespace AccessibilityInsights.Extensions.Interfaces.IssueReporting
 {
-    public enum  IssueType
+    public enum IssueType
     {
         SingleFailure,
         NoFailure,

--- a/src/AccessibilityInsights.SetupLibrary/IGitHubWrapper.cs
+++ b/src/AccessibilityInsights.SetupLibrary/IGitHubWrapper.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 using System.IO;
 
 namespace AccessibilityInsights.SetupLibrary

--- a/src/AccessibilityInsights.SetupLibrary/REST/GitHubClient.cs
+++ b/src/AccessibilityInsights.SetupLibrary/REST/GitHubClient.cs
@@ -31,7 +31,7 @@ namespace AccessibilityInsights.SetupLibrary.REST
                 throw new ArgumentNullException(nameof(uri));
 
             Stopwatch stopwatch = Stopwatch.StartNew();
-            DownloadState state = new DownloadState 
+            DownloadState state = new DownloadState
             {
                 Stream = stream,
                 ProgressCallback = progressCallback,

--- a/src/AccessibilityInsights.SharedUx/ActionViews/GeneralActionView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/GeneralActionView.xaml.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Dialogs;
-using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.ViewModels;
 using System;
 using System.Globalization;
@@ -39,7 +38,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
             this.Counter = 0;
             InitializeComponent();
 
-            if(this.ActionViewModel.Parameters == null || this.ActionViewModel.Parameters.Count == 0)
+            if (this.ActionViewModel.Parameters == null || this.ActionViewModel.Parameters.Count == 0)
             {
                 this.dgParams.Visibility = Visibility.Collapsed;
             }
@@ -159,7 +158,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
         {
             lock (_lockObject)
             {
-                if(Counter != 0 && this.IsVisible == false)
+                if (Counter != 0 && this.IsVisible == false)
                 {
                     this.timerInvoke.Enabled = false;
                     this.btnAction.IsEnabled = true;

--- a/src/AccessibilityInsights.SharedUx/ActionViews/NotSupportActionView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/NotSupportActionView.xaml.cs
@@ -20,7 +20,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
         {
             InitializeComponent();
             this.ActionViewModel = a ?? throw new ArgumentNullException(nameof(a));
-            this.tbName.Text = string.Format(CultureInfo.InvariantCulture,"{0}.{1}", ActionViewModel.PatternName, ActionViewModel.Name);
+            this.tbName.Text = string.Format(CultureInfo.InvariantCulture, "{0}.{1}", ActionViewModel.PatternName, ActionViewModel.Name);
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)

--- a/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml.cs
@@ -64,7 +64,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
 
                 if (value)
                 {
-                    if(hollowDriver.IsEnabled)
+                    if (hollowDriver.IsEnabled)
                     {
                         overlayDriver.Show();
                         ClearOverlayDriver.BringMainWindowOfPOIElementToFront();
@@ -151,7 +151,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
             TurnOffHighlighter();
         }
 
-        public ReturnA11yElementsView(ReturnA11yElementsViewModel a )
+        public ReturnA11yElementsView(ReturnA11yElementsViewModel a)
         {
             this.ActionViewModel = a ?? throw new ArgumentNullException(nameof(a));
             this.Counter = 0;
@@ -202,7 +202,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
             });
         }
 
-         private void btnRun_Click(object sender, RoutedEventArgs e)
+        private void btnRun_Click(object sender, RoutedEventArgs e)
         {
             SetElement();
             int delay;

--- a/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Dialogs;
-using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Utilities;
 using AccessibilityInsights.SharedUx.ViewModels;
 using System;
@@ -32,7 +31,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
             this.Counter = 0;
             InitializeComponent();
 
-            if(this.ActionViewModel.Parameters == null || this.ActionViewModel.Parameters.Count == 0)
+            if (this.ActionViewModel.Parameters == null || this.ActionViewModel.Parameters.Count == 0)
             {
                 this.dgParams.Visibility = Visibility.Collapsed;
             }
@@ -155,7 +154,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
         {
             lock (_lockObject)
             {
-                if(Counter != 0 && this.IsVisible == false)
+                if (Counter != 0 && this.IsVisible == false)
                 {
                     this.timerInvoke.Enabled = false;
                     this.btnAction.IsEnabled = true;

--- a/src/AccessibilityInsights.SharedUx/Behaviors/ExpanderBehavior.cs
+++ b/src/AccessibilityInsights.SharedUx/Behaviors/ExpanderBehavior.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using AccessibilityInsights.SharedUx.Settings;
 using Microsoft.Xaml.Behaviors;
 using System;
 using System.Windows;
@@ -33,7 +32,7 @@ namespace AccessibilityInsights.SharedUx.Behaviors
         /// <param name="e"></param>
         private void Expander_Collapsed(object sender, RoutedEventArgs e)
         {
-            double height = (double) Application.Current.Resources["ExpanderCollapsedHeight"];
+            double height = (double)Application.Current.Resources["ExpanderCollapsedHeight"];
 
             var exp = sender as Expander;
             int row = Grid.GetRow(exp);

--- a/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml.cs
@@ -56,10 +56,11 @@ namespace AccessibilityInsights.SharedUx.Controls
         public static readonly DependencyProperty StoredColorProperty =
             DependencyProperty.Register("StoredColor", typeof(Color), typeof(ColorChooser));
 
-        public Color StoredColor {
+        public Color StoredColor
+        {
             get
             {
-                return (Color) GetValue(StoredColorProperty);
+                return (Color)GetValue(StoredColorProperty);
             }
             set
             {

--- a/src/AccessibilityInsights.SharedUx/Controls/ColorPicker/ColorPickerControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ColorPicker/ColorPickerControl.xaml.cs
@@ -414,7 +414,7 @@ namespace AccessibilityInsights.SharedUx.Controls.ColorPicker
             int dx = 0;
             int dy = 0;
 
-            switch(e.Key)
+            switch (e.Key)
             {
                 case Key.Left:
                     dx = -1;

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
@@ -83,7 +83,8 @@ namespace AccessibilityInsights.SharedUx.Controls
             }
 
             var properties = new EventConfigNodeViewModel(
-                Properties.Resources.EventConfigTabControl_Properties, isThreeState: true) { Depth = 1 };
+                Properties.Resources.EventConfigTabControl_Properties, isThreeState: true)
+            { Depth = 1 };
             properties.AddChildren(el.Properties.Values);
 
             if (properties.Children.Any())
@@ -101,7 +102,8 @@ namespace AccessibilityInsights.SharedUx.Controls
                 Properties.Resources.EventConfigTabControl_MyEvents, isThreeState: true);
 
             CustomPropertiesNode = new EventConfigNodeViewModel(
-                Properties.Resources.EventConfigTabControl_Properties, isThreeState: true) { Depth = 1 };
+                Properties.Resources.EventConfigTabControl_Properties, isThreeState: true)
+            { Depth = 1 };
             EditBtnNode = new EventConfigNodeViewModel("", Visibility.Visible, Properties.Resources.EventConfigTabControl_SetElement_Edit_My_Events) { Depth = 1, TextVisibility = Visibility.Collapsed };
 
             UpdateCustomNode();
@@ -139,8 +141,8 @@ namespace AccessibilityInsights.SharedUx.Controls
             CustomNode.InsertChildAtIndex(0, EditBtnNode);
 
             custom = (from e in ConfigurationManager.GetDefaultInstance().EventConfig.Properties
-                          where e.IsRecorded
-                          select e.Id).ToList();
+                      where e.IsRecorded
+                      select e.Id).ToList();
 
             CustomPropertiesNode.Children.Where(c => c.Type != EventConfigNodeType.Group && !custom.Contains(c.Id)).ToList().ForEach(c => CustomPropertiesNode.RemoveChild(c));
 

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml.cs
@@ -66,7 +66,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         {
             get
             {
-                return (bool) this.GetValue(CanDragReorderProperty);
+                return (bool)this.GetValue(CanDragReorderProperty);
             }
             set
             {
@@ -107,7 +107,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         {
             get
             {
-                return (bool) this.GetValue(ShowColumnLabelsProperty);
+                return (bool)this.GetValue(ShowColumnLabelsProperty);
             }
             set
             {
@@ -206,7 +206,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             new CommandBinding(MoveFocusToSearchCommand, OnMoveFocusToSearchField) };
         }
 
-    protected override AutomationPeer OnCreateAutomationPeer()
+        protected override AutomationPeer OnCreateAutomationPeer()
         {
             return new CustomControlOverridingAutomationPeer(this, "pane");
         }
@@ -464,7 +464,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         {
             var lvi = sender as ListViewItem;
             var listView = ItemsControl.ItemsControlFromItemContainer(lvi) as ListView;
-            var records =  from l in this.List where l.Id == (lvi.Content as RecordEntitySetting).Id select l;
+            var records = from l in this.List where l.Id == (lvi.Content as RecordEntitySetting).Id select l;
             var record = records.FirstOrDefault();
 
             if (listView == lvLeft)

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml.cs
@@ -39,7 +39,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// <summary>
         /// Event handler to main window for recording start
         /// </summary>
-        public Action<bool> NotifyRecordingChange{ get; set; }
+        public Action<bool> NotifyRecordingChange { get; set; }
 
         /// Updates the focus changed checkbox based on current config setting
         public Action UpdateGlobalFocusEventCheckbox { get; set; }
@@ -71,7 +71,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             set
             {
                 // if we already have it, release it from ListenAction first.
-                if(_eventRecorderId != null)
+                if (_eventRecorderId != null)
                 {
                     ListenAction.ReleaseInstance(_eventRecorderId.Value);
                 }
@@ -279,8 +279,8 @@ namespace AccessibilityInsights.SharedUx.Controls
         private static IEnumerable<int> GeneratePropertyIds(RecorderSetting config)
         {
             return from c in config.Properties
-                where config.IsListeningAllEvents || c.CheckedCount > 0
-                select c.Id;
+                   where config.IsListeningAllEvents || c.CheckedCount > 0
+                   select c.Id;
         }
 
         /// <summary>
@@ -288,7 +288,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// </summary>
         public async void StopRecordEvents(bool onclose = false)
         {
-            if(onclose)
+            if (onclose)
             {
                 this.isClosed = true;
                 if (this.EventRecorderId != null)
@@ -302,7 +302,8 @@ namespace AccessibilityInsights.SharedUx.Controls
             {
                 this.ctrlProgressRing.Activate();
 
-                await Task.Run(() => {
+                await Task.Run(() =>
+                {
                     var la = ListenAction.GetInstance(this.EventRecorderId.Value);
                     la.Stop();
                 }).ConfigureAwait(false);

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -142,7 +142,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 }
                 else
                 {
-                    UpdateTreeView(ec.DataContext.GetRootNodeHierarchyViewModel(Configuration.ShowAncestry,Configuration.ShowUncertain, this.IsLiveMode), expandall);
+                    UpdateTreeView(ec.DataContext.GetRootNodeHierarchyViewModel(Configuration.ShowAncestry, Configuration.ShowUncertain, this.IsLiveMode), expandall);
                     this._selectedElement = ec.Element;
                 }
 
@@ -259,7 +259,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// </summary>
         /// <param name="ec"></param>
         /// <param name="expandall"></param>
-        private void PopulateHierarchyTree(ElementContext ec , bool expandall)
+        private void PopulateHierarchyTree(ElementContext ec, bool expandall)
         {
             var begin = DateTime.Now;
             HierarchyNodeViewModel rnvm = null;
@@ -272,7 +272,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             rnvm = ec.DataContext.GetRootNodeHierarchyViewModel(Configuration.ShowAncestry, Configuration.ShowUncertain, this.IsLiveMode);
 
             // send exception to mode control.
-            if(rnvm == null)
+            if (rnvm == null)
             {
                 throw new ApplicationException(Properties.Resources.HierarchyControl_PopulateHierarchyTree_No_data_to_populate_hierarchy);
             }
@@ -302,7 +302,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             this.HierarchyActions.SelectedElementChanged();
 
             // expand all if it is required.
-            if(expandall)
+            if (expandall)
             {
                 rnvm.Expand(true);
             }
@@ -363,7 +363,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// </summary>
         public void CleanUpTreeView()
         {
-            if(this.treeviewHierarchy.ItemsSource != null)
+            if (this.treeviewHierarchy.ItemsSource != null)
             {
                 try
                 {
@@ -414,9 +414,9 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// <param name="e"></param>
         private void treeviewHierarchy_GotFocus(object sender, RoutedEventArgs e)
         {
-            if(this.treeviewHierarchy.SelectedItem == null)
+            if (this.treeviewHierarchy.SelectedItem == null)
             {
-                if(this._rootNode != null)
+                if (this._rootNode != null)
                 {
                     this._rootNode.IsSelected = true;
                 }
@@ -719,7 +719,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 {
                     btnMenu.Visibility = Visibility.Visible;
                     btnTestElement.Visibility = Visibility.Visible;
-                    var hlptxt = string.Format(CultureInfo.InvariantCulture, 
+                    var hlptxt = string.Format(CultureInfo.InvariantCulture,
                         Properties.Resources.HierarchyControl_LiveMode_InvokeToTestFormat,
                         vm.Element.Glimpse);
                     AutomationProperties.SetHelpText(btnTestElement, hlptxt);
@@ -809,7 +809,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             else
             {
                 right = 4;
-                treeviewHierarchy.Margin = new Thickness(0,0,2,0);
+                treeviewHierarchy.Margin = new Thickness(0, 0, 2, 0);
             }
 
             /// set button locations too.

--- a/src/AccessibilityInsights.SharedUx/Controls/NPISlider.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/NPISlider.cs
@@ -10,7 +10,7 @@ using System.Windows.Controls;
 
 namespace AccessibilityInsights.SharedUx.Controls
 {
-    public class NPISlider:Slider
+    public class NPISlider : Slider
     {
         protected override AutomationPeer OnCreateAutomationPeer()
         {
@@ -66,7 +66,7 @@ namespace AccessibilityInsights.SharedUx.Controls
 
             set
             {
-                ((NPISlider)base.Owner).Value = Convert.ToDouble(value,CultureInfo.InvariantCulture);
+                ((NPISlider)base.Owner).Value = Convert.ToDouble(value, CultureInfo.InvariantCulture);
             }
         }
 
@@ -80,7 +80,7 @@ namespace AccessibilityInsights.SharedUx.Controls
 
         public void SetValue(string value)
         {
-            ((NPISlider)base.Owner).Value = Convert.ToDouble(value,CultureInfo.InvariantCulture);
+            ((NPISlider)base.Owner).Value = Convert.ToDouble(value, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Controls/NamedPane.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/NamedPane.cs
@@ -79,7 +79,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             if (control == null)
                 return;
 
-            control.Orientation = (Orientation) e.NewValue;
+            control.Orientation = (Orientation)e.NewValue;
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml.cs
@@ -118,7 +118,7 @@ namespace AccessibilityInsights.SharedUx.Controls
 
         private void treePatterns_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
         {
-            if(this.treePatterns.SelectedItem != null)
+            if (this.treePatterns.SelectedItem != null)
             {
                 dynamic si = this.treePatterns.SelectedItem;
                 if (si is ScanListViewItemViewModel)
@@ -211,7 +211,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         {
             if (sender is TreeViewItem tvi && tvi.DataContext is PatternViewModel vm && vm.Pattern != null)
             {
-                    ExpStates[vm.Pattern.Id] = true;
+                ExpStates[vm.Pattern.Id] = true;
             }
         }
 

--- a/src/AccessibilityInsights.SharedUx/Controls/PrivacyLearnMore.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/PrivacyLearnMore.xaml.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Dialogs;
-using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Telemetry;
 using System;
 using System.Diagnostics;

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -123,9 +123,9 @@ namespace AccessibilityInsights.SharedUx.Controls
         private void UpdateTree()
         {
             IEnumerable<ScanListViewItemViewModel> itemViewModel = from l in this.List
-                                         where l.Status == ScanStatus.Fail || l.Status == ScanStatus.ScanNotSupported || (Configuration.ShowUncertain && l.Status == ScanStatus.Uncertain) || ShowAllResults
-                                         orderby l.Status descending, l.Source, l.Header
-                                         select l;
+                                                                   where l.Status == ScanStatus.Fail || l.Status == ScanStatus.ScanNotSupported || (Configuration.ShowUncertain && l.Status == ScanStatus.Uncertain) || ShowAllResults
+                                                                   orderby l.Status descending, l.Source, l.Header
+                                                                   select l;
 
             var viewModelCount = itemViewModel.Count();
 
@@ -301,7 +301,7 @@ namespace AccessibilityInsights.SharedUx.Controls
 
                 if (IssueReporter.IsConnected)
                 {
-                    IssueInformation issueInformation = null ;
+                    IssueInformation issueInformation = null;
                     try
                     {
                         issueInformation = vm.GetIssueInformation();
@@ -321,7 +321,7 @@ namespace AccessibilityInsights.SharedUx.Controls
 #pragma warning restore CA1031 // Do not catch general exception types
                     finally
                     {
-                        if(issueInformation != null && File.Exists(issueInformation.TestFileName))
+                        if (issueInformation != null && File.Exists(issueInformation.TestFileName))
                         {
                             File.Delete(issueInformation.TestFileName);
                         }

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -122,10 +122,10 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// </summary>
         private void UpdateTree()
         {
-            IEnumerable<ScanListViewItemViewModel> itemViewModel = from l in this.List
-                                                                   where l.Status == ScanStatus.Fail || l.Status == ScanStatus.ScanNotSupported || (Configuration.ShowUncertain && l.Status == ScanStatus.Uncertain) || ShowAllResults
-                                                                   orderby l.Status descending, l.Source, l.Header
-                                                                   select l;
+            var itemViewModel = from l in this.List
+                                where l.Status == ScanStatus.Fail || l.Status == ScanStatus.ScanNotSupported || (Configuration.ShowUncertain && l.Status == ScanStatus.Uncertain) || ShowAllResults
+                                orderby l.Status descending, l.Source, l.Header
+                                select l;
 
             var viewModelCount = itemViewModel.Count();
 

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ApplicationSettingsControl.xaml.cs
@@ -263,7 +263,7 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
             config.HotKeyForMoveToNextSibling = (string)this.btnHotekyToNext.Content;
             config.HotKeyForMoveToFirstChild = (string)this.btnHotkeyToFirstChild.Content;
             config.HotKeyForMoveToLastChild = (string)this.btnTHotkeyoLastChild.Content;
-            config.MouseSelectionDelayMilliSeconds = Math.Max(int.Parse(this.tbMouseDelay.Text,CultureInfo.InvariantCulture), ConfigurationModel.MinimumSelectionDelayMilliseconds); // make sure that we allow only bigger than minimum value.
+            config.MouseSelectionDelayMilliSeconds = Math.Max(int.Parse(this.tbMouseDelay.Text, CultureInfo.InvariantCulture), ConfigurationModel.MinimumSelectionDelayMilliseconds); // make sure that we allow only bigger than minimum value.
             DataContextVM.SaveToConfig(config);
         }
 

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 using System.Windows.Navigation;
 
 namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -149,7 +149,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 this.gdFailures.Focus();
                 var count = results.Where(r => r.RuleResult.Status == Axe.Windows.Core.Results.ScanStatus.Fail).Count();
 
-                switch(count)
+                switch (count)
                 {
                     case 0:
                         this.runFailures.Text = Properties.Resources.AutomatedChecksControl_SetRuleResults_No_failure_was;
@@ -158,7 +158,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                         this.runFailures.Text = Properties.Resources.AutomatedChecksControl_SetRuleResults_1_failure_was;
                         break;
                     default:
-                        this.runFailures.Text = String.Format(CultureInfo.InvariantCulture,Properties.Resources.AutomatedChecksControl_SetRuleResults_0_failures_were, results.Count);
+                        this.runFailures.Text = String.Format(CultureInfo.InvariantCulture, Properties.Resources.AutomatedChecksControl_SetRuleResults_0_failures_were, results.Count);
                         break;
                 }
 
@@ -459,7 +459,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                     DependencyObject child = VisualTreeHelper.GetChild(element, i);
                     if (child != null && child is T)
                     {
-                        yield return (T) child;
+                        yield return (T)child;
                     }
                     foreach (T descendant in FindChildren<T>(child))
                     {
@@ -563,7 +563,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 {
                     if (selectedElementIndex + 1 < elements.Count)
                     {
-                        ((UIElement) elements.ElementAt(selectedElementIndex + 1)).Focus();
+                        ((UIElement)elements.ElementAt(selectedElementIndex + 1)).Focus();
                     }
                 }
                 else if (selectedElementIndex - 1 >= 0)
@@ -648,7 +648,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             for (int x = 0; x < VisualTreeHelper.GetChildrenCount(root); x++)
             {
                 DependencyObject child = VisualTreeHelper.GetChild(root, x);
-                CheckAllBoxes(child,check);
+                CheckAllBoxes(child, check);
             }
         }
 
@@ -661,7 +661,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         private bool SetItemsChecked(IReadOnlyCollection<Object> lst, bool check)
         {
             var ret = true;
-            foreach(RuleResultViewModel itm in lst.AsParallel())
+            foreach (RuleResultViewModel itm in lst.AsParallel())
             {
                 if (check && !SelectedItems.Contains(itm))
                 {
@@ -723,7 +723,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
             SelectedItems.Remove(srvm);
             var groupitem = GetParentElem<GroupItem>(exp) as GroupItem;
-            var dc =  cb.DataContext as CollectionViewGroup;
+            var dc = cb.DataContext as CollectionViewGroup;
             var itms = dc.Items;
             var any = itms.Intersect(SelectedItems).Any();
             if (any)

--- a/src/AccessibilityInsights.SharedUx/Converters/ActionViewModelConverter.cs
+++ b/src/AccessibilityInsights.SharedUx/Converters/ActionViewModelConverter.cs
@@ -22,9 +22,9 @@ namespace AccessibilityInsights.SharedUx.Converters
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
 
-            var attrs = value.GetType().GetCustomAttributes(typeof(TargetActionViewAttribute),false);
+            var attrs = value.GetType().GetCustomAttributes(typeof(TargetActionViewAttribute), false);
 
-            if(attrs != null && attrs.Length == 1)
+            if (attrs != null && attrs.Length == 1)
             {
                 var attr = (TargetActionViewAttribute)attrs[0];
 

--- a/src/AccessibilityInsights.SharedUx/Converters/ColorStringConverter.cs
+++ b/src/AccessibilityInsights.SharedUx/Converters/ColorStringConverter.cs
@@ -36,7 +36,7 @@ namespace AccessibilityInsights.SharedUx.Converters
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            System.Windows.Media.Color colorValue = (System.Windows.Media.Color) value;
+            System.Windows.Media.Color colorValue = (System.Windows.Media.Color)value;
             return String.Format(CultureInfo.InvariantCulture, Resources.ColorStringConverter_Convert_0_X2_1_X2_2_X2, colorValue.R, colorValue.G, colorValue.B);
         }
 

--- a/src/AccessibilityInsights.SharedUx/Converters/ColumnMaxWidthSpacingConverter.cs
+++ b/src/AccessibilityInsights.SharedUx/Converters/ColumnMaxWidthSpacingConverter.cs
@@ -19,9 +19,9 @@ namespace AccessibilityInsights.SharedUx.Converters
 
         public ColumnMaxWidthSpacingConverter() { }
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => (double) value - SpacingConstant;
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => (double)value - SpacingConstant;
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => (double) value + SpacingConstant;
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => (double)value + SpacingConstant;
 
         public override object ProvideValue(IServiceProvider serviceProvider)
         {

--- a/src/AccessibilityInsights.SharedUx/Converters/ElementToSenderTextConverter.cs
+++ b/src/AccessibilityInsights.SharedUx/Converters/ElementToSenderTextConverter.cs
@@ -21,7 +21,7 @@ namespace AccessibilityInsights.SharedUx.Converters
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         { // do not let the culture default to local to prevent variable outcome re decimal syntax
-            var e = (A11yElement) value;
+            var e = (A11yElement)value;
             return e != null ? e.Glimpse : Resources.ElementToSenderTextConverter_Convert_Event_Recorder;
         }
 

--- a/src/AccessibilityInsights.SharedUx/Converters/EventIdToEventNameConverter.cs
+++ b/src/AccessibilityInsights.SharedUx/Converters/EventIdToEventNameConverter.cs
@@ -20,7 +20,7 @@ namespace AccessibilityInsights.SharedUx.Converters
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         { // do not let the culture default to local to prevent variable outcome re decimal syntax
-            var eId = (int) value;
+            var eId = (int)value;
             return EventType.GetInstance().GetNameById(eId);
         }
 

--- a/src/AccessibilityInsights.SharedUx/Converters/TreeNodeToMarginConverter.cs
+++ b/src/AccessibilityInsights.SharedUx/Converters/TreeNodeToMarginConverter.cs
@@ -42,7 +42,7 @@ namespace AccessibilityInsights.SharedUx.Converters
                 // intent event recording config
                 nodeDepth = evnvm.Depth;
             }
-            return new Thickness(nodeDepth * -16, 0,0,0);
+            return new Thickness(nodeDepth * -16, 0, 0, 0);
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/AccessibilityInsights.SharedUx/Dialogs/ControlPatternDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/ControlPatternDialog.xaml.cs
@@ -30,7 +30,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         /// <param name="e"></param>
         private void Window_KeyUp(object sender, KeyEventArgs e)
         {
-            if(e.Key == Key.Escape)
+            if (e.Key == Key.Escape)
             {
                 this.Close();
             }

--- a/src/AccessibilityInsights.SharedUx/Dialogs/ElementInfoDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/ElementInfoDialog.xaml.cs
@@ -26,7 +26,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
 
         private void lbElements_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if(this.lbElements.SelectedItem != null)
+            if (this.lbElements.SelectedItem != null)
             {
                 var el = lbElements.SelectedItem as DesktopElement;
 

--- a/src/AccessibilityInsights.SharedUx/Dialogs/EventConfigDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/EventConfigDialog.xaml.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.Settings;
-using Axe.Windows.Desktop.Settings;
 using System.Linq;
 using System.Windows;
 

--- a/src/AccessibilityInsights.SharedUx/Dialogs/GlobalEyedropperWindow.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/GlobalEyedropperWindow.xaml.cs
@@ -77,7 +77,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         private void InitializeRenderTransform()
         {
             renderTransformGroup = new TransformGroup();
-            renderTransformGroup.Children.Add(new ScaleTransform(zoomLevel,  zoomLevel));
+            renderTransformGroup.Children.Add(new ScaleTransform(zoomLevel, zoomLevel));
             eyedropperPreview.RenderTransform = renderTransformGroup;
         }
 

--- a/src/AccessibilityInsights.SharedUx/Dialogs/MoveTextRangeDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/MoveTextRangeDialog.xaml.cs
@@ -62,7 +62,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
                     break;
                 case OpMode.Move:
                 case OpMode.MoveEndpointByUnit:
-                    this.lbxTargetRanges.Visibility =  Visibility.Collapsed;
+                    this.lbxTargetRanges.Visibility = Visibility.Collapsed;
                     this.lbTargetTR.Visibility = Visibility.Collapsed;
                     break;
                 case OpMode.Compare:
@@ -100,7 +100,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             try
             {
                 var ps = GetParametersArray();
-                var ret = this.MethodInfo.Invoke(this.ViewModel.TextRange, ps );
+                var ret = this.MethodInfo.Invoke(this.ViewModel.TextRange, ps);
 
                 if (this.ReturnType != typeof(void))
                 {
@@ -108,7 +108,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
                 }
 
                 /// Refresh Highlighter via TextPatternExplorer dialog
-                if(UpdateHighlighter != null)
+                if (UpdateHighlighter != null)
                 {
                     UpdateHighlighter();
                 }
@@ -139,7 +139,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
 
         private object GetConvertedValue(Parameter p)
         {
-            if(p.ParamType == typeof(Axe.Windows.Desktop.UIAutomation.Patterns.TextRange))
+            if (p.ParamType == typeof(Axe.Windows.Desktop.UIAutomation.Patterns.TextRange))
             {
                 return ((TextRangeViewModel)this.lbxTargetRanges.SelectedItem).TextRange;
             }

--- a/src/AccessibilityInsights.SharedUx/Dialogs/PropertyConfigDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/PropertyConfigDialog.xaml.cs
@@ -42,13 +42,14 @@ namespace AccessibilityInsights.SharedUx.Dialogs
                 Properties.Resources.PropertyConfigDialog_SelectedItemsFormat, title);
 
             var list = (from kv in source.GetKeyValuePairList()
-                       where !DesktopElement.IsExcludedProperty(kv.Key,kv.Value)
-                       select new RecordEntitySetting {
-                           Id = kv.Key,
-                           Name = kv.Value,
-                           IsRecorded = coreProps.Contains(kv.Key),
-                           Type = RecordEntityType.Property
-                       }).ToList();
+                        where !DesktopElement.IsExcludedProperty(kv.Key, kv.Value)
+                        select new RecordEntitySetting
+                        {
+                            Id = kv.Key,
+                            Name = kv.Value,
+                            IsRecorded = coreProps.Contains(kv.Key),
+                            Type = RecordEntityType.Property
+                        }).ToList();
 
             var selList = coreProps.Select(l => list.Where(r => r.Id == l).FirstOrDefault()).ToList();
             CoreProperties = selList.ToList();// generate base list here.

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml.cs
@@ -126,7 +126,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
                     trvms.Add(new TextRangeViewModel(list[i], string.Format(CultureInfo.InvariantCulture, Properties.Resources.TextPatternExplorerDialog_UpdateTextRanges__0___1, prefix, i)));
                 }
             }
-            else if(list.Count == 1)
+            else if (list.Count == 1)
             {
                 trvms.Add(new TextRangeViewModel(list[0], string.Format(CultureInfo.InvariantCulture, Properties.Resources.TextPatternExplorerDialog_UpdateTextRanges__0, prefix)));
             }
@@ -566,7 +566,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         /// <param name="e"></param>
         private void Window_KeyUp(object sender, KeyEventArgs e)
         {
-            if(e.Key == Key.Escape)
+            if (e.Key == Key.Escape)
             {
                 this.Close();
             }
@@ -579,9 +579,9 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         /// <param name="e"></param>
         private void cbRanges_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if(e.AddedItems.Count > 0)
+            if (e.AddedItems.Count > 0)
             {
-                Dispatcher.BeginInvoke(new Action( () => GetRanges((SourceTypes)(e.AddedItems[0] as ComboBoxItem).Tag)), DispatcherPriority.Background);
+                Dispatcher.BeginInvoke(new Action(() => GetRanges((SourceTypes)(e.AddedItems[0] as ComboBoxItem).Tag)), DispatcherPriority.Background);
             }
         }
 

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml.cs
@@ -57,7 +57,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             {
                 this.Hilighter.HilightBoundingRectangles(false);
 
-                if(item.Item3 is List<KeyValuePair<int, string>> || item.Item3 is List<KeyValuePair<bool, string>>)
+                if (item.Item3 is List<KeyValuePair<int, string>> || item.Item3 is List<KeyValuePair<bool, string>>)
                 {
                     cbValues.ItemsSource = item.Item3;
                     cbValues.SelectedIndex = 0;
@@ -92,7 +92,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         private object GetAttributeValue()
         {
             var item = cbAttributes.SelectedItem as Tuple<int, string, dynamic, Type>;
-            if(item.Item3 == null)
+            if (item.Item3 == null)
             {
                 return ConvertToType(tbValue.Text, item.Item4);
             }
@@ -101,7 +101,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
                 return ((KeyValuePair<bool, string>)cbValues.SelectedItem).Key;
             }
 
-            var value = (KeyValuePair<int, string >)cbValues.SelectedItem;
+            var value = (KeyValuePair<int, string>)cbValues.SelectedItem;
             return value.Key;
         }
 
@@ -113,20 +113,20 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         /// <returns></returns>
         private static object ConvertToType(string text, Type type)
         {
-            if(type == typeof(int))
+            if (type == typeof(int))
             {
-                return Convert.ToInt32(text,CultureInfo.InvariantCulture);
+                return Convert.ToInt32(text, CultureInfo.InvariantCulture);
             }
-            else if(type == typeof(double))
+            else if (type == typeof(double))
             {
                 return Convert.ToDouble(text, CultureInfo.InvariantCulture);
             }
-            else if(type== typeof(string))
+            else if (type == typeof(string))
             {
                 return text;
             }
 
-            throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, Properties.Resources.TextRangeFindDialog_ConvertToType__0__type_is_not_supported,type.Name));
+            throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, Properties.Resources.TextRangeFindDialog_ConvertToType__0__type_is_not_supported, type.Name));
         }
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
             {
                 var attributeId = GetAttributeId();
 
-                range =  attributeId == SearchForText
+                range = attributeId == SearchForText
                     ? this.Finder.FindText(GetAttributeValue() as string, backward, chbIgnoreCase.IsChecked ?? false)
                     : this.Finder.Find(attributeId, GetAttributeValue(), backward);
 

--- a/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporter.cs
+++ b/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
-using AccessibilityInsights.SharedUx.Settings;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,7 +36,7 @@ namespace AccessibilityInsights.SharedUx.FileIssue
 
         public static bool IsConnected => IsEnabled && (IssueReporting == null ? false : IssueReporting.IsConfigured);
 
-        public static ReporterFabricIcon Logo => (IsEnabled && IssueReporting != null )? IssueReporting.Logo : ReporterFabricIcon.PlugDisconnected ;
+        public static ReporterFabricIcon Logo => (IsEnabled && IssueReporting != null) ? IssueReporting.Logo : ReporterFabricIcon.PlugDisconnected;
 
         public static string DisplayName
         {

--- a/src/AccessibilityInsights.SharedUx/Highlighting/ClearOverlayDriver.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/ClearOverlayDriver.cs
@@ -18,7 +18,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
     /// Since OverlayHighlighter is used for Tabstop which doesn't record data into Any context.
     /// it is using element to set highlighting information.
     /// </summary>
-    public class ClearOverlayDriver:IDisposable
+    public class ClearOverlayDriver : IDisposable
     {
         /// <summary>
         /// OverlayHighlighter to use
@@ -112,7 +112,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// <param name="num">Id Number of highlighter</param>
         public void AddElement(A11yElement e, string num)
         {
-            Highlighter.AddElementRoundBorder(e,num);
+            Highlighter.AddElementRoundBorder(e, num);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Highlighting/Highlighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/Highlighter.cs
@@ -231,7 +231,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
             {
                 if (disposing)
                 {
-                    if(this.Border.Count != 0)
+                    if (this.Border.Count != 0)
                     {
                         this.Border.ForEach(b => b.Dispose());
                         this.Border.Clear();

--- a/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/HollowHighlightDriver.cs
@@ -15,7 +15,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
     /// hovering over the resulting rectangle still allows clicking through to the
     /// underlying element
     /// </summary>
-    public class HollowHighlightDriver:IDisposable
+    public class HollowHighlightDriver : IDisposable
     {
         readonly Highlighter Highlighter;
 
@@ -194,7 +194,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         {
             HollowHighlightDriver ha = null;
 
-            if(sHighlightActions.ContainsKey(name))
+            if (sHighlightActions.ContainsKey(name))
             {
                 ha = sHighlightActions[name];
             }
@@ -215,9 +215,9 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// </summary>
         public static void ClearAllHighlighters()
         {
-            if(sHighlightActions != null && sHighlightActions.Count != 0)
+            if (sHighlightActions != null && sHighlightActions.Count != 0)
             {
-                foreach(var ha in sHighlightActions.Values)
+                foreach (var ha in sHighlightActions.Values)
                 {
                     ha.Dispose();
                 }

--- a/src/AccessibilityInsights.SharedUx/Highlighting/ImageHighlighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/ImageHighlighter.cs
@@ -61,7 +61,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         /// <param name="el"></param>
         /// <param name="gap"></param>
         /// <param name="brush"></param>
-        public void SetElement(A11yElement el, int gap = 2, SolidColorBrush brush=null)
+        public void SetElement(A11yElement el, int gap = 2, SolidColorBrush brush = null)
         {
             this.BaseElement = el ?? throw new ArgumentNullException(nameof(el));
             if (brush == null)
@@ -98,7 +98,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
 
             // check whether el is from saved file.
             // if so make sure that dimension is correct to be visible.
-            if(el.PlatformObject == null)
+            if (el.PlatformObject == null)
             {
                 var dpi = HelperMethods.GetDPI((int)Application.Current.MainWindow.Top, (int)Application.Current.MainWindow.Left);
                 this.WinRect = new Rect()

--- a/src/AccessibilityInsights.SharedUx/Highlighting/ImageOverlayDriver.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/ImageOverlayDriver.cs
@@ -10,7 +10,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
     /// Wraps and provides access to highlight capabilities for
     /// elements over an image
     /// </summary>
-    public class ImageOverlayDriver:IDisposable
+    public class ImageOverlayDriver : IDisposable
     {
         /// <summary>
         /// imageHighlighter to use

--- a/src/AccessibilityInsights.SharedUx/Highlighting/OverlayHighlighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/OverlayHighlighter.cs
@@ -216,8 +216,8 @@ namespace AccessibilityInsights.SharedUx.Highlighting
 
             try
             {
-                var xyDpi = HelperMethods.GetDPI((int)this.HighlightWindow.Left+ (3 * GapWidth), (int)this.HighlightWindow.Top + (3 * GapWidth));
-                var l = (Dimensions.Width / xyDpi- toast.Width) - (GapWidth * 2) ;
+                var xyDpi = HelperMethods.GetDPI((int)this.HighlightWindow.Left + (3 * GapWidth), (int)this.HighlightWindow.Top + (3 * GapWidth));
+                var l = (Dimensions.Width / xyDpi - toast.Width) - (GapWidth * 2);
                 var t = (Dimensions.Height / xyDpi - toast.Height) - (GapWidth * 2);
                 canvas.Children.Add(toast);
                 toast.SetValue(Canvas.LeftProperty, l);

--- a/src/AccessibilityInsights.SharedUx/Highlighting/TextRangeHilighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/TextRangeHilighter.cs
@@ -13,7 +13,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
     /// class TextRangeHilighter
     /// Hiligt all bounding rectangles from a Text Range
     /// </summary>
-    public class TextRangeHilighter: IDisposable
+    public class TextRangeHilighter : IDisposable
     {
         /// <summary>
         /// Hilighter color

--- a/src/AccessibilityInsights.SharedUx/Highlighting/WindowHighlighterBase.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/WindowHighlighterBase.cs
@@ -101,7 +101,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
                     hdo.TbError.SetValue(Canvas.TopProperty, GetMidPoint(t, el.BoundingRectangle.Height, hdo.TbError.Height));
 
                     hdo.BrdrError.Width = 28;
-                    hdo.BrdrError.Height = 28 ;
+                    hdo.BrdrError.Height = 28;
                     hdo.BrdrError.SetValue(Canvas.LeftProperty, GetMidPoint(l, el.BoundingRectangle.Width, hdo.BrdrError.Width));
                     hdo.BrdrError.SetValue(Canvas.TopProperty, GetMidPoint(t, el.BoundingRectangle.Height, hdo.BrdrError.Height));
 

--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
@@ -447,7 +447,7 @@ namespace AccessibilityInsights.SharedUx.Settings
         {
             if (ShowWelcomeScreenOnLaunch == false)
             {
-                if (this.AppVersion !=VersionTools.GetAppVersion())
+                if (this.AppVersion != VersionTools.GetAppVersion())
                 {
                     this.AppVersion = VersionTools.GetAppVersion();
                     this.ShowWelcomeScreenOnLaunch = true;

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryBuffer.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryBuffer.cs
@@ -27,7 +27,7 @@ namespace AccessibilityInsights.SharedUx.Telemetry
             if (processor == null)
                 throw new ArgumentNullException(nameof(processor));
 
-            foreach(Func<TelemetryEvent> eventFactory in _eventFactoryList)
+            foreach (Func<TelemetryEvent> eventFactory in _eventFactoryList)
             {
                 processor(eventFactory());
             }

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryController.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryController.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 
 namespace AccessibilityInsights.SharedUx.Telemetry
 {

--- a/src/AccessibilityInsights.SharedUx/Utilities/ContainedControlFinder.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/ContainedControlFinder.cs
@@ -7,7 +7,7 @@ using System.Windows;
 
 namespace AccessibilityInsights.SharedUx.Utilities
 {
-    internal static class ContainedControlFinder<T> where T: DependencyObject
+    internal static class ContainedControlFinder<T> where T : DependencyObject
     {
         internal static IEnumerable<T> Find(DependencyObject currentControl)
         {

--- a/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
@@ -57,7 +57,7 @@ namespace AccessibilityInsights.SharedUx.Utilities
             {
                 fn = GetTestResultFileNameWithId(namebase, idx, filetype);
 
-                if(File.Exists(Path.Combine(path,fn)) == false)
+                if (File.Exists(Path.Combine(path, fn)) == false)
                 {
                     break;
                 }
@@ -226,7 +226,7 @@ namespace AccessibilityInsights.SharedUx.Utilities
         /// <param name="column">Column whose header is to be found</param>
         /// <param name="root">Element in which to search</param>
         /// <returns></returns>
-        public static DataGridColumnHeader GetDGColumnHeader(this DataGrid dg, DataGridColumn column, DependencyObject root=null)
+        public static DataGridColumnHeader GetDGColumnHeader(this DataGrid dg, DataGridColumn column, DependencyObject root = null)
         {
             if (root == null)
                 root = dg;

--- a/src/AccessibilityInsights.SharedUx/ViewModels/BaseActionViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/BaseActionViewModel.cs
@@ -19,7 +19,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// Base class for ActionViewModels
     /// ActionViewModel is to drive Action(method)s in a control
     /// </summary>
-    abstract public class BaseActionViewModel: ViewModelBase
+    abstract public class BaseActionViewModel : ViewModelBase
     {
         internal A11yPattern pattern;
         internal MethodInfo methodinfo;
@@ -41,7 +41,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// <summary>
         /// Execution status: succeeded or not
         /// </summary>
-        public bool IsSucceeded { get; private set;  }
+        public bool IsSucceeded { get; private set; }
 
         /// <summary>
         /// Parameters
@@ -78,7 +78,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         protected object[] GetParametersArray()
         {
             return (from p in this.Parameters
-                    select Convert.ChangeType(p.ParamValue, p.ParamType,CultureInfo.InvariantCulture)).ToArray();
+                    select Convert.ChangeType(p.ParamValue, p.ParamType, CultureInfo.InvariantCulture)).ToArray();
         }
 
         #region Command invoke
@@ -122,7 +122,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// </summary>
         protected virtual void InvokeMethod()
         {
-            var ret = ControlPatternAction.RunAction(this.pattern.Element.UniqueId,this.pattern.Id, this.methodinfo.Name ,GetParametersArray());
+            var ret = ControlPatternAction.RunAction(this.pattern.Element.UniqueId, this.pattern.Id, this.methodinfo.Name, GetParametersArray());
 
             if (this.ReturnType != typeof(void))
             {
@@ -144,19 +144,19 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             {
                 return new ReturnA11yElementsViewModel(p, m);
             }
-            else if(m.ReturnType.Name != "IAccessible")
+            else if (m.ReturnType.Name != "IAccessible")
             {
                 if (m.ReturnType != typeof(TextRange) && m.ReturnType != typeof(IList<TextRange>))
                 {
                     return new GeneralActionViewModel(p, m);
                 }
-                else if(m.ReturnType == typeof(TextRange))
+                else if (m.ReturnType == typeof(TextRange))
                 {
                     return new TextRangeActionViewModel(p, m);
                 }
             }
 
-            return new NotSupportedActionViewModel(p,m);
+            return new NotSupportedActionViewModel(p, m);
         }
     }
 

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -216,7 +216,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// Add a single child to node
         /// </summary>
         /// <param name="child"></param>
-        public void AddChild(EventConfigNodeViewModel child, bool isChecked=false)
+        public void AddChild(EventConfigNodeViewModel child, bool isChecked = false)
         {
             if (child == null)
                 throw new ArgumentNullException(nameof(child));
@@ -293,7 +293,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         {
             var l = _children.OrderBy(e => e.Header).ToList();
             this._children.Clear();
-            foreach(var c in l)
+            foreach (var c in l)
             {
                 this._children.Add(c);
             }
@@ -401,9 +401,9 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         {
             this.IsExpanded = true;
 
-            if(expandchildren && this._children.Count != 0)
+            if (expandchildren && this._children.Count != 0)
             {
-                foreach(var c in this._children)
+                foreach (var c in this._children)
                 {
                     c.Expand(true);
                 }

--- a/src/AccessibilityInsights.SharedUx/ViewModels/GeneralActionViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/GeneralActionViewModel.cs
@@ -17,6 +17,6 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// </summary>
         /// <param name="pattern"></param>
         /// <param name="m"></param>
-        public GeneralActionViewModel(A11yPattern pattern, MethodInfo m):base(pattern, m) { }
+        public GeneralActionViewModel(A11yPattern pattern, MethodInfo m) : base(pattern, m) { }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/ViewModels/HierarchyNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/HierarchyNodeViewModel.cs
@@ -19,7 +19,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// HierarchyTreeItem class
     /// ViewModel for A11yElement in Hierarchy tree
     /// </summary>
-    public class HierarchyNodeViewModel: ViewModelBase
+    public class HierarchyNodeViewModel : ViewModelBase
     {
         const int NormalIconSizeBack = 14; // size for non composite icon
         const int TreeIconSizeBack = 16;   // size for tree in composite icon
@@ -313,7 +313,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                     this.IconVisibility = Visibility.Visible;
                     automationNameFormat = Resources.HierarchyNodeViewModel_AutomationNameFailedResultsFormat;
                 }
-                else if(this.Element.TestStatus == ScanStatus.ScanNotSupported)
+                else if (this.Element.TestStatus == ScanStatus.ScanNotSupported)
                 {
                     this.IconBack = FabricIcon.MapDirections;
                     this.IconSizeBack = NormalIconSizeBack;
@@ -381,7 +381,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                 this.IsHilighted = true;
             }
 
-            if(isfiltered)
+            if (isfiltered)
             {
                 this.Visibility = Visibility.Collapsed;
             }
@@ -436,9 +436,9 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         {
             this.IsExpanded = true;
 
-            if(expandchildren && this.Children.Count != 0)
+            if (expandchildren && this.Children.Count != 0)
             {
-                foreach(var c in this.Children)
+                foreach (var c in this.Children)
                 {
                     c.Expand(true);
                 }

--- a/src/AccessibilityInsights.SharedUx/ViewModels/NotSupportedActionViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/NotSupportedActionViewModel.cs
@@ -11,7 +11,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// ViewModel for Not yet supported Action.
     /// </summary>
     [TargetActionView(ViewType = typeof(NotSupportActionView))]
-    public class NotSupportedActionViewModel:BaseActionViewModel
+    public class NotSupportedActionViewModel : BaseActionViewModel
     {
         public NotSupportedActionViewModel(A11yPattern p, MethodInfo m) : base(p, m) { }
 

--- a/src/AccessibilityInsights.SharedUx/ViewModels/PatternViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/PatternViewModel.cs
@@ -20,9 +20,9 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// <summary>
     /// UI wrapper for Pattern
     /// </summary>
-    public class PatternViewModel:ViewModelBase
+    public class PatternViewModel : ViewModelBase
     {
-        public PatternViewModel(A11yElement e,A11yPattern pattern, bool isActionAllowed, bool isExpanded)
+        public PatternViewModel(A11yElement e, A11yPattern pattern, bool isActionAllowed, bool isExpanded)
         {
             this.IsExpanded = isExpanded;
             this.Pattern = pattern ?? throw new ArgumentNullException(nameof(pattern));
@@ -142,7 +142,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             {
                 ShowActionDialog();
             }
-            else if(this.ActionType == ActionType.TextExplorer)
+            else if (this.ActionType == ActionType.TextExplorer)
             {
                 ShowTextExplorerDialog();
             }
@@ -172,7 +172,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         {
             var tp2 = this.Element.Patterns.ById(PatternType.UIA_TextPattern2Id);
 
-            var dlg = new TextPatternExplorerDialog((TextPattern)this.Pattern,tp2 == null ? null : (TextPattern2)tp2);
+            var dlg = new TextPatternExplorerDialog((TextPattern)this.Pattern, tp2 == null ? null : (TextPattern2)tp2);
 
             dlg.Owner = Application.Current.MainWindow;
 

--- a/src/AccessibilityInsights.SharedUx/ViewModels/RuleResultViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/RuleResultViewModel.cs
@@ -18,7 +18,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// Class RuleResultViewModel
     /// this is for FastPass scan result display
     /// </summary>
-    public class RuleResultViewModel: ViewModelBase
+    public class RuleResultViewModel : ViewModelBase
     {
         /// <summary>
         /// Element
@@ -103,7 +103,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// <summary>
         /// reference to rule result object
         /// </summary>
-        public RuleResult RuleResult { get;}
+        public RuleResult RuleResult { get; }
 
         private System.Windows.Visibility loadingVisibility;
         /// <summary>
@@ -137,7 +137,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             var p = e.Properties.ById(rr.MetaInfo.PropertyId);
             if (p != null)
             {
-                this.Properties= String.Format(CultureInfo.InvariantCulture, "{0}={1}", p.Name, p.TextValue);
+                this.Properties = String.Format(CultureInfo.InvariantCulture, "{0}={1}", p.Name, p.TextValue);
             }
 
             if (StandardLinksHelper.GetDefaultInstance().HasStoredLink(rr.MetaInfo))

--- a/src/AccessibilityInsights.SharedUx/ViewModels/ScanListViewItemViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/ScanListViewItemViewModel.cs
@@ -23,7 +23,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// <summary>
     /// ViewModel class for scanlistview Item
     /// </summary>
-    public class ScanListViewItemViewModel:ViewModelBase
+    public class ScanListViewItemViewModel : ViewModelBase
     {
         public static IList<ScanListViewItemViewModel> GetScanListViewItemViewModels(A11yElement e)
         {
@@ -34,9 +34,9 @@ namespace AccessibilityInsights.SharedUx.ViewModels
 
             var list = new List<ScanListViewItemViewModel>();
 
-            foreach(var sr in tr.Items)
+            foreach (var sr in tr.Items)
             {
-                foreach(var rr in sr.Items )
+                foreach (var rr in sr.Items)
                 {
                     list.Add(new ScanListViewItemViewModel(e, rr));
                 }
@@ -79,7 +79,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                 {
                     return FabricIcon.CompletedSolid;
                 }
-                else if(this.Status == ScanStatus.ScanNotSupported)
+                else if (this.Status == ScanStatus.ScanNotSupported)
                 {
                     return FabricIcon.MapDirections;
                 }
@@ -199,7 +199,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         /// <returns></returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.InvariantCulture, 
+            return string.Format(CultureInfo.InvariantCulture,
                 Resources.ScanListViewItemViewModel_StatusFormat,
                 this.Status, this.Header);
         }

--- a/src/AccessibilityInsights.SharedUx/ViewModels/TabStopItemViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/TabStopItemViewModel.cs
@@ -10,7 +10,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// Class TabStopItemViewModel
     /// this is for tab stop listview
     /// </summary>
-    public class TabStopItemViewModel: ViewModelBase
+    public class TabStopItemViewModel : ViewModelBase
     {
         /// <summary>
         /// Element

--- a/src/AccessibilityInsights.SharedUx/ViewModels/TargetActionViewAttribute.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/TargetActionViewAttribute.cs
@@ -9,7 +9,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// indicate the target action view for the ActionViewModel
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
-    public class TargetActionViewAttribute: Attribute
+    public class TargetActionViewAttribute : Attribute
     {
         public Type ViewType { get; set; }
     }

--- a/src/AccessibilityInsights.SharedUx/ViewModels/TextAttributeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/TextAttributeViewModel.cs
@@ -12,7 +12,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// <summary>
     /// Class for Text
     /// </summary>
-    public class TextAttributeViewModel: ViewModelBase
+    public class TextAttributeViewModel : ViewModelBase
     {
         private TextRangeViewModel TextRange;
         private DesktopElement Element;

--- a/src/AccessibilityInsights.SharedUx/ViewModels/TextRangeActionViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/TextRangeActionViewModel.cs
@@ -13,6 +13,6 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     public class TextRangeActionViewModel : BaseActionViewModel
     {
 
-        public TextRangeActionViewModel(A11yPattern pattern, MethodInfo m):base(pattern, m) { }
+        public TextRangeActionViewModel(A11yPattern pattern, MethodInfo m) : base(pattern, m) { }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/ViewModels/TextRangeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/TextRangeViewModel.cs
@@ -20,7 +20,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// <summary>
     /// TextRange ViewModel class
     /// </summary>
-    public class TextRangeViewModel:ViewModelBase
+    public class TextRangeViewModel : ViewModelBase
     {
         const int MaxTextSize = 5000; // based on Inspect code.
 
@@ -153,7 +153,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
             switch (kv.Key)
             {
                 case TextAttributeType.UIA_AnimationStyleAttributeId:
-                    if(value is int)
+                    if (value is int)
                     {
                         list.Add(new TextAttributeViewModel(kv.Key, kv.Value, AnimationStyle.GetInstance().GetNameById(value)));
                     }
@@ -264,7 +264,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                 case TextAttributeType.UIA_TabsAttributeId:
                     var txt = ConvertArrayToString(value);
 
-                    if(txt != null)
+                    if (txt != null)
                     {
                         list.Add(new TextAttributeViewModel(kv.Key, kv.Value, txt));
                     }
@@ -304,8 +304,8 @@ namespace AccessibilityInsights.SharedUx.ViewModels
                             {
                                 strBuild.Append(Invariant($"{item.Key}: {item.Value}, "));
                             }
-                            strBuild.Length-=2; //remove final , and <space>
-                            list.Add(new TextAttributeViewModel(kv.Key, kv.Value,strBuild.ToString()));
+                            strBuild.Length -= 2; //remove final , and <space>
+                            list.Add(new TextAttributeViewModel(kv.Key, kv.Value, strBuild.ToString()));
                         }
                         else // create a row for each array value
                         {

--- a/src/AccessibilityInsights.SharedUx/ViewModels/TwoStateButtonViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/TwoStateButtonViewModel.cs
@@ -5,10 +5,11 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// <summary>
     /// Keep the status of ToolBarButton
     /// </summary>
-    public class TwoStateButtonViewModel:ViewModelBase
+    public class TwoStateButtonViewModel : ViewModelBase
     {
         private ButtonState state = ButtonState.On;
-        public ButtonState State {
+        public ButtonState State
+        {
             get
             {
                 return state;
@@ -28,7 +29,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
 
         public void FlipButtonState()
         {
-            if(this.State == ButtonState.On)
+            if (this.State == ButtonState.On)
             {
                 this.State = ButtonState.Off;
             }

--- a/src/AccessibilityInsights.SharedUx/ViewModels/ViewModelBase.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/ViewModelBase.cs
@@ -7,7 +7,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// <summary>
     /// ViewModel base class
     /// </summary>
-    public class ViewModelBase: INotifyPropertyChanged
+    public class ViewModelBase : INotifyPropertyChanged
     {
         /// <summary>
         /// to notify property changes

--- a/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
@@ -164,7 +164,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
             ConfirmEnumerablesMatchExpectations(
                 new int[] { 30005, 30003, 30004, 30009, 30001, 30007, 30006, 30013, 30102, 30101 },
                 config.CoreProperties.ToArray());
-            ConfirmEnumerablesMatchExpectations( new int[] { }, config.CoreTPAttributes.ToArray());
+            ConfirmEnumerablesMatchExpectations(new int[] { }, config.CoreTPAttributes.ToArray());
             Assert.IsFalse(config.DisableTestsInSnapMode);
             Assert.AreEqual(config.DisableDarkMode, disableDarkMode);
             Assert.IsFalse(config.EnableTelemetry);

--- a/src/AccessibilityInsights.SharedUxTests/Telemetry/LoggerUnitTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Telemetry/LoggerUnitTests.cs
@@ -5,9 +5,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 using System.Collections.Generic;
-
-using TelemetryPropertyBag = System.Collections.Generic.IReadOnlyDictionary<AccessibilityInsights.SharedUx.Telemetry.TelemetryProperty, string>;
 using StringPropertyBag = System.Collections.Generic.IReadOnlyDictionary<string, string>;
+using TelemetryPropertyBag = System.Collections.Generic.IReadOnlyDictionary<AccessibilityInsights.SharedUx.Telemetry.TelemetryProperty, string>;
 
 namespace AccessibilityInsights.SharedUXTests.Telemetry
 {

--- a/src/AccessibilityInsights.SharedUxTests/ViewModels/ColorContrastViewModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/ViewModels/ColorContrastViewModelTests.cs
@@ -143,7 +143,7 @@ namespace AccessibilityInsights.SharedUxTest.ViewModels
         {
             ColorContrastViewModel vm = new ColorContrastViewModel();
             vm.FirstColor = Colors.White;
-            vm.SecondColor = Color.FromRgb(255, 0 ,0);
+            vm.SecondColor = Color.FromRgb(255, 0, 0);
             Assert.IsFalse(vm.PassSmallText);
         }
 

--- a/src/AccessibilityInsights.VersionSwitcher/EventLogger.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/EventLogger.cs
@@ -81,7 +81,7 @@ namespace AccessibilityInsights.VersionSwitcher
 
         #region IDisposable Support
 
-        private bool IsDisposed { get ; set ; }
+        private bool IsDisposed { get; set; }
 
         private void Dispose(bool disposing)
         {

--- a/src/AccessibilityInsights.Win32/NativeMethods.cs
+++ b/src/AccessibilityInsights.Win32/NativeMethods.cs
@@ -17,11 +17,11 @@ namespace AccessibilityInsights.Win32
 
         //https://msdn.microsoft.com/en-us/library/windows/desktop/dd145062(v=vs.85).aspx
         [DllImport("User32.dll")]
-        internal static extern IntPtr MonitorFromPoint([In]Point pt, [In]uint dwFlags);
+        internal static extern IntPtr MonitorFromPoint([In] Point pt, [In] uint dwFlags);
 
         //https://msdn.microsoft.com/en-us/library/windows/desktop/dn280510(v=vs.85).aspx
         [DllImport("Shcore.dll")]
-        internal static extern uint GetDpiForMonitor([In]IntPtr hmonitor, [In]DpiType dpiType, [Out]out uint dpiX, [Out]out uint dpiY);
+        internal static extern uint GetDpiForMonitor([In] IntPtr hmonitor, [In] DpiType dpiType, [Out] out uint dpiX, [Out] out uint dpiY);
 
         [DllImport("Gdi32.dll", CharSet = CharSet.Auto, SetLastError = true, ExactSpelling = true)]
         internal static extern IntPtr CreateCompatibleDC(IntPtr hDC);
@@ -195,7 +195,7 @@ namespace AccessibilityInsights.Win32
         [DllImport("wintrust.dll", ExactSpelling = true, SetLastError = false, CharSet = CharSet.Unicode)]
         public static extern WinVerifyTrustResult WinVerifyTrust(
         [In] IntPtr hwnd,
-        [In] [MarshalAs(UnmanagedType.LPStruct)] Guid pgActionID,
+        [In][MarshalAs(UnmanagedType.LPStruct)] Guid pgActionID,
         [In] WinTrustData pWVTData);
 
         public static readonly Guid WINTRUST_ACTION_GENERIC_VERIFY_V2 = new Guid("{00AAC56B-CD44-11d0-8CC2-00C04FC295EE}");

--- a/src/AccessibilityInsights.Win32/Win32Enums.cs
+++ b/src/AccessibilityInsights.Win32/Win32Enums.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
-using System.Runtime.InteropServices;
 
 namespace AccessibilityInsights.Win32
 {

--- a/src/AccessibilityInsights.Win32/Win32Helper.cs
+++ b/src/AccessibilityInsights.Win32/Win32Helper.cs
@@ -3,7 +3,6 @@
 using Microsoft.Win32;
 using System;
 using System.Drawing;
-using System.Threading;
 
 namespace AccessibilityInsights.Win32
 {

--- a/src/AccessibilityInsights/MainWindowHelpers/CCAMode.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/CCAMode.cs
@@ -20,7 +20,7 @@ namespace AccessibilityInsights
         /// <returns></returns>
         void StartCCAMode(CCAView view)
         {
-            if(this.CurrentPage==AppPage.CCA && (CCAView) this.CurrentView == CCAView.CapturingData)
+            if (this.CurrentPage == AppPage.CCA && (CCAView)this.CurrentView == CCAView.CapturingData)
             {
                 return;
             }
@@ -95,7 +95,7 @@ namespace AccessibilityInsights
         {
             var mode = GetDataAction.GetDataContextMode();
 
-            switch(mode)
+            switch (mode)
             {
                 case DataContextMode.Live:
                     return DataContextMode.Test;

--- a/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
@@ -20,7 +20,7 @@ namespace AccessibilityInsights
     /// <summary>
     /// MainWindow partial class for Helping flow control
     /// </summary>
-    public partial class MainWindow: ICCAMode
+    public partial class MainWindow : ICCAMode
     {
         /// <summary>
         /// flag to allow any further action
@@ -38,7 +38,7 @@ namespace AccessibilityInsights
             if (!sa.IsPaused &&
                 ((CurrentPage == AppPage.Inspect && (InspectView)CurrentView == InspectView.Live)
                 ||
-                (CurrentPage == AppPage.CCA&& (CCAView)CurrentView == CCAView.Automatic)
+                (CurrentPage == AppPage.CCA && (CCAView)CurrentView == CCAView.Automatic)
                 ))
             {
                 this.AllowFurtherAction = true;

--- a/src/AccessibilityInsights/MainWindowHelpers/EventsMode.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/EventsMode.cs
@@ -31,7 +31,7 @@ namespace AccessibilityInsights
                 MessageDialog.Show(Properties.Resources.StartElementDetailViewNoElementIsSelectedMessage);
                 this.AllowFurtherAction = true;
             }
-            else if(e.IsSafeToRefresh() == false)
+            else if (e.IsSafeToRefresh() == false)
             {
                 this.AllowFurtherAction = false;
                 MessageDialog.Show(Properties.Resources.StartEventsModeElementNotAvailableMessage);
@@ -61,7 +61,7 @@ namespace AccessibilityInsights
 #pragma warning restore CS4014
                 this.CurrentPage = AppPage.Events;
                 this.CurrentView = EventsView.Config;
-                PageTracker.TrackPage(this.CurrentPage,this.CurrentView.ToString());
+                PageTracker.TrackPage(this.CurrentPage, this.CurrentView.ToString());
             }
         }
 

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -430,7 +430,7 @@ namespace AccessibilityInsights
         /// </summary>
         private static double GetFirstDefinedNumber(double[] potentialNumbers)
         {
-            foreach(double potentialNumber in potentialNumbers)
+            foreach (double potentialNumber in potentialNumbers)
             {
                 if (!double.IsNaN(potentialNumber))
                 {

--- a/src/AccessibilityInsights/MainWindowHelpers/InspectMode.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/InspectMode.cs
@@ -88,7 +88,7 @@ namespace AccessibilityInsights
         {
             var mode = GetDataAction.GetDataContextMode();
 
-            switch(mode)
+            switch (mode)
             {
                 case DataContextMode.Live:
                     return DataContextMode.Test;

--- a/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
@@ -372,7 +372,7 @@ namespace AccessibilityInsights
             // array of file handlers to be attempted in order. If one throws an exception, the next will be tried
             FileLoadHandler[] fileHandlers = { HandleLoadingSnapshotData, HandleLoadingEventData };
 
-            foreach(var fileHandler in fileHandlers)
+            foreach (var fileHandler in fileHandlers)
             {
                 try
                 {

--- a/src/AccessibilityInsights/MainWindowHelpers/TestMode.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/TestMode.cs
@@ -3,13 +3,11 @@
 using AccessibilityInsights.CommonUxComponents.Dialogs;
 using AccessibilityInsights.Enums;
 using AccessibilityInsights.Misc;
-using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Highlighting;
 using AccessibilityInsights.SharedUx.Telemetry;
 using Axe.Windows.Actions;
 using Axe.Windows.Desktop.Settings;
 using System;
-using System.Globalization;
 
 namespace AccessibilityInsights
 {

--- a/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
+++ b/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
@@ -7,7 +7,6 @@ using AccessibilityInsights.Win32;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Windows.Forms.Design;
 
 namespace AccessibilityInsights.Misc
 {

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
@@ -34,7 +34,7 @@ namespace AccessibilityInsights.Modes
         /// <summary>
         /// Selected element from hierarchy
         /// </summary>
-        public Tuple<Guid,int> SelectedInHierarchyElement { get; private set; }
+        public Tuple<Guid, int> SelectedInHierarchyElement { get; private set; }
 
         /// <summary>
         /// Inidate whether need to EnableElementSelector at the hierarchy node Selection change.
@@ -185,7 +185,8 @@ namespace AccessibilityInsights.Modes
                     {
                         CaptureAction.SetLiveModeDataContext(ecId, Configuration.TreeViewMode);
                     }).ConfigureAwait(false);
-                    Application.Current.Dispatcher.Invoke(() => {
+                    Application.Current.Dispatcher.Invoke(() =>
+                    {
                         this.ctrlHierarchy.DataContext = ec.DataContext;
                         this.ElementContext = ec;
 
@@ -229,7 +230,7 @@ namespace AccessibilityInsights.Modes
 
             if (EnableSelectorWhenPOISelectedInHierarchy == false)
             {
-                Application.Current.Dispatcher.Invoke(() => UpdateStateMachineForLiveMode() );
+                Application.Current.Dispatcher.Invoke(() => UpdateStateMachineForLiveMode());
             }
         }
 

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
@@ -374,7 +374,7 @@ namespace AccessibilityInsights.Modes
         {
             StringBuilder sb = new StringBuilder();
 
-            if(Keyboard.FocusedElement is ListViewItem lvi && lvi.DataContext is ScanListViewItemViewModel stvi)
+            if (Keyboard.FocusedElement is ListViewItem lvi && lvi.DataContext is ScanListViewItemViewModel stvi)
             {
                 ListView listView = ItemsControl.ItemsControlFromItemContainer(lvi) as ListView;
                 foreach (var item in listView.SelectedItems)

--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
@@ -25,7 +25,6 @@ using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
-using static System.FormattableString;
 
 namespace AccessibilityInsights.Modes
 {
@@ -218,7 +217,7 @@ namespace AccessibilityInsights.Modes
                             }
 
                             var count = ec.DataContext?.GetRuleResultsViewModelList()?.Count ?? 0;
-                            AutomationProperties.SetName(this, 
+                            AutomationProperties.SetName(this,
                                 string.Format(CultureInfo.InvariantCulture, Properties.Resources.TestModeControl_DetectedFailureFormat,
                                     this.ElementContext.Element.Glimpse, count));
 
@@ -247,7 +246,8 @@ namespace AccessibilityInsights.Modes
 #pragma warning restore CA1031 // Do not catch general exception types
                 finally
                 {
-                    Application.Current.Dispatcher.Invoke(() => {
+                    Application.Current.Dispatcher.Invoke(() =>
+                    {
                         this.ctrlProgressRing.Deactivate();
                     });
                 }

--- a/src/UITests/AIWinSession.cs
+++ b/src/UITests/AIWinSession.cs
@@ -3,7 +3,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Windows;
-using OpenQA.Selenium.Remote;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -72,7 +71,7 @@ namespace UITests
             _process = Process.Start(exePath, configPathArgument);
 
             const int attempts = 10; // this number should give us enough retries for the build to work
-            bool attached = WaitFor(() => !string.IsNullOrEmpty(_session?.Title), new TimeSpan(0,0,3), attempts, StartNewSession);
+            bool attached = WaitFor(() => !string.IsNullOrEmpty(_session?.Title), new TimeSpan(0, 0, 3), attempts, StartNewSession);
             driver = new AIWinDriver(_session, _process.Id);
 
             return attached;
@@ -140,7 +139,7 @@ namespace UITests
             return logPath;
         }
 
-        protected bool WaitFor(Func<bool> checkSuccess, TimeSpan interval, int attempts, Action doUntilSuccess=null)
+        protected bool WaitFor(Func<bool> checkSuccess, TimeSpan interval, int attempts, Action doUntilSuccess = null)
         {
             while (attempts > 0 && !checkSuccess())
             {


### PR DESCRIPTION
#### Details

In #1302, @karanbirsingh pointed out that the spacing around an interface implementation was slightly off. After fixing it, I wondered how many other places had similar issues. The answer is "a lot". I also noticed that we have many places where we include unnecessary `using` statements. Rather than try to fix them by hand, I found that Microsoft publishes a Visual Studio extension called [Power Commands for Visual Studio](https://marketplace.visualstudio.com/items?itemName=VisualStudioPlatformTeam.PowerCommandsforVisualStudio) that can apply normalizations across an entire project from a single command. I ran the extension using the default set of fixers, which are:

- Format document (includes things like consistent spacing, braces, etc.)
- Remove unnecessary usings
- Sort usings
- Apply file header preferences

The last 2 fixers did nothing to our code, since we've previously sorted using blocks and have no configured file header preferences. The first 2 fixers, though, found and fixed a lot more issues than I'd found manually.

This PR is fairly large (nearly 20% of our files), but the individual changes are trivial--the vast majority of them are tiny whitespace tweaks that just got missed in previous changes. I've reviewed them, but it would be good to get a second reviewer

##### Motivation

Code consistency

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue?
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



