### PR TITLE
chore: Add OS Architecture to telemetry

### DIFF
--- a/docs/TelemetryDetails.md
+++ b/docs/TelemetryDetails.md
@@ -79,7 +79,7 @@ Name | Value
 --- | ---
 `customDimensions.UIAccessEnabled` | `True` if the user has explicitly enabled UIAccess, otherwise `False`. 
 `customDimensions.InstalledDotNetFrameworkVersion` | The numeric version of the installed .NET Framework version. If this value is 528040 or greater, then .NET Framework 4.8 is installed. Otherwise, .NET Framework 4.7.2 is installed.
-`customDimensions.OsArchitecture` | The architecture of the current Windows platform. Supported value: `x86` or `x64`
+`customDimensions.OsArchitecture` | The architecture of the current Windows platform. Supported values: `x86` or `x64`
 
 #### Mainwindow_Timer_Started
 Trigger: The user uses the "Scan with Timer" feature with a non-default value. *Note that this does not send data if the default value is used*.   

--- a/docs/TelemetryDetails.md
+++ b/docs/TelemetryDetails.md
@@ -78,7 +78,8 @@ Additional properties:
 Name | Value
 --- | ---
 `customDimensions.UIAccessEnabled` | `True` if the user has explicitly enabled UIAccess, otherwise `False`. 
-c`ustomDimensions.InstalledDotNetFrameworkVersion` | The numeric version of the installed .NET Framework version. If this value is 528040 or greater, then .NET Framework 4.8 is installed. Otherwise, .NET Framework 4.7.2 is installed.
+`customDimensions.InstalledDotNetFrameworkVersion` | The numeric version of the installed .NET Framework version. If this value is 528040 or greater, then .NET Framework 4.8 is installed. Otherwise, .NET Framework 4.7.2 is installed.
+`customDimensions.OsArchitecture` | The architecture of the current Windows platform. Supported value: `x86` or `x64`
 
 #### Mainwindow_Timer_Started
 Trigger: The user uses the "Scan with Timer" feature with a non-default value. *Note that this does not send data if the default value is used*.   

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
@@ -38,6 +38,7 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         ReleaseChannelConsidered,
         IssueReporter,
         InstalledDotNetFrameworkVersion,
+        OsArchitecture,
         CustomUIAPropertyCount,
     }
 }

--- a/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
+++ b/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
@@ -111,6 +111,7 @@ namespace AccessibilityInsights.Misc
                 new Dictionary<TelemetryProperty, string>
                 {
                     { TelemetryProperty.UIAccessEnabled, NativeMethods.IsRunningWithUIAccess().ToString(CultureInfo.InvariantCulture) },
+                    { TelemetryProperty.OsArchitecture, Environment.Is64BitOperatingSystem ? "x64" : "x86" },
                     { TelemetryProperty.InstalledDotNetFrameworkVersion, formattedDotNetFrameworkVersion }
                 });
         }


### PR DESCRIPTION
#### Details

In a recent conversation, @RobGallo and I considered the possibility of moving from being an x86 app to being an x64 app. This would be a breaking change for users on x86 platforms and we have no way to approximate how many people it would impact. This PR adds a new `OsArchitecture` property to the `Mainwindow_Startup` telemetry event so that we have data to inform that decision. The supported values are either `x86` or `x64`. Here's the local telemetry that it produced on my x64 machine:

```
{
  "EventName": "Mainwindow_Startup",
  "EventProperties": {
    "UIAccessEnabled": "False",
    "OsArchitecture": "x64",
    "InstalledDotNetFrameworkVersion": "528372"
  }
}
```

##### Motivation

Help us to understand the impact of moving to x64.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



