### PR TITLE
chore: Allow SSO with ADO bug filing

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
@@ -168,8 +168,14 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
 
         private async void IssueFileForm_Load(object sender, EventArgs e)
         {
-            await this.fileIssueBrowser.EnsureCoreWebView2Async(null).ConfigureAwait(true);
-            this.fileIssueBrowser.NavigationCompleted += NavigationComplete;
+            CoreWebView2EnvironmentOptions options = new CoreWebView2EnvironmentOptions()
+            {
+                AllowSingleSignOnUsingOSPrimaryAccount = true
+            };
+
+            CoreWebView2Environment environment = await CoreWebView2Environment.CreateAsync(null, null, options).ConfigureAwait(true);
+
+            await this.fileIssueBrowser.EnsureCoreWebView2Async(environment).ConfigureAwait(true); this.fileIssueBrowser.NavigationCompleted += NavigationComplete;
 
             this.TopMost = makeTopMost;
             Navigate(this.Url);


### PR DESCRIPTION
#### Details

We discovered that our ADO bug filing is not compatible with the ADO policy that requires InTune management. The missing piece was to set the [AllowSingleSignOnUsingOSPrimaryAccount ](https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.allowsinglesignonusingosprimaryaccount?view=webview2-dotnet-1.0.1185.39) property, which allows our hosted WebView2 browser to present the credentials that tell ADO that we're InTune managed.

##### Motivation

Enable ADO bug filing to work with more stringent security policy

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue:
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



