### PR TITLE
fix: Avoid NullReferenceException

### DIFF
--- a/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporter.cs
+++ b/src/AccessibilityInsights.SharedUx/FileIssue/IssueReporter.cs
@@ -88,7 +88,7 @@ namespace AccessibilityInsights.SharedUx.FileIssue
                 // so keeping it as is till we have a discussion. Check for blocking behavior at that link.
                 // https://github.com/Microsoft/accessibility-insights-windows/blob/main/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs#L858
                 IIssueResultWithPostAction result = IssueReporting.FileIssueAsync(issueInformation).Result;
-                result.PostAction?.Invoke();
+                result?.PostAction?.Invoke();
                 IssueReporterManager.GetInstance().UpdateIssueReporterSettings(IssueReporting);
                 return result;
             }


### PR DESCRIPTION
#### Details

There are a couple of valid cases in issue filing where we trigger a `NullReferenceException`:
1. User files an issue in GitHub, where the code [always returns null](https://github.com/microsoft/accessibility-insights-windows/blob/main/src/AccessibilityInsights.Extensions.GitHub/IssueReporter.cs#L85).
2. Users opens the ADO bug filing dialog, but the browser is closed [without saving the bug](https://github.com/microsoft/accessibility-insights-windows/blob/main/src/AccessibilityInsights.Extensions.AzureDevOps/AzureBoardsIssueReporting.cs#L103))

 This PR just adds a level of null propagation to prevent us from making that mistake.

##### Motivation

Make it easier to diagnose what the "real" problem is

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue:
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



