### PR TITLE
fix: Support ADO when running from MSI install

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
@@ -40,6 +40,8 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
 
         private Action<int> UpdateZoomLevel;
 
+        private readonly string _userDataFolder;
+
         /// <summary>
         /// Value to zoom the embedded web browser by
         /// </summary>
@@ -62,10 +64,10 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
         public IssueFileForm(Uri url, bool topmost, int zoomLevel, Action<int> updateZoom, string configurationPath)
         {
             InitializeComponent();
+            _userDataFolder = Path.Combine(configurationPath, "WebView2");
             this.fileIssueBrowser.CreationProperties = new CoreWebView2CreationProperties
             {
-                // TODO: Pass this folder in from the main app!
-                UserDataFolder = Path.Combine(configurationPath, "WebView2")
+                UserDataFolder = _userDataFolder,
             };
             this.UpdateZoomLevel = updateZoom;
             this.makeTopMost = topmost;
@@ -170,10 +172,9 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
         {
             CoreWebView2EnvironmentOptions options = new CoreWebView2EnvironmentOptions()
             {
-                AllowSingleSignOnUsingOSPrimaryAccount = true
+                AllowSingleSignOnUsingOSPrimaryAccount = true,
             };
-
-            CoreWebView2Environment environment = await CoreWebView2Environment.CreateAsync(null, null, options).ConfigureAwait(true);
+            CoreWebView2Environment environment = await CoreWebView2Environment.CreateAsync(null, _userDataFolder, options).ConfigureAwait(true);
 
             await this.fileIssueBrowser.EnsureCoreWebView2Async(environment).ConfigureAwait(true);
             this.fileIssueBrowser.NavigationCompleted += NavigationComplete;

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -58,6 +58,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.CommonUxComponents.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.AzureDevOps.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.DiskLoggingTelemetry.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.GitHub.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.GitHubAutoUpdate.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.Telemetry.dll" />

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -58,7 +58,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.CommonUxComponents.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.AzureDevOps.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.DiskLoggingTelemetry.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.GitHub.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.GitHubAutoUpdate.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.Telemetry.dll" />


### PR DESCRIPTION
#### Details

#1312 set a new environment, but it wasn't setting the `userDataFolder` when creating the environment ([docs](https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createasync?view=webview2-dotnet-1.0.1185.39)). As a result, the WebView2 was trying to put data under the folder where the app exists, which is under C:\Program Files (x86) when using an MSI install. This folder requires administrative permissions, so it failed unless the app was running as administrator. Running as administrator still had a problem because the administrative privileges didn't propagate to the hosted control.

This change sets the `userDataFolder` when creating the environment, so no administrative permissions are required and the data ends up where it's expected. Note that we still need to set the `CreationProperties` of the browser that was created inside of [`InitializeComponents`](https://github.com/microsoft/accessibility-insights-windows/blob/main/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.Designer.cs#L38), since it gets created using the default environment and also needs to know where to find the files.

##### Motivation

Fix ADO bug filing from an MSI install. Tested by building a local MSI, installing it, and filing a bug using ADO.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



