### PR TITLE
chore: Pick up Axe.Windows 1.1.3

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
@@ -113,7 +113,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
         private void RunAutoCCA(Bitmap bitmap)
         {
-            var bmc = new BitmapCollection(bitmap, new DefaultColorContrastConfig());
+            var bmc = new BitmapCollection(bitmap, new ColorContrastConfigBuilder().Build());
             var result = bmc.RunColorContrastCalculation();
             var pair = result.MostLikelyColorPair;
 
@@ -125,7 +125,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             SetConfidenceVisibility(Visibility.Visible);
             this.ContrastVM.FirstColor = pair.DarkerColor.DrawingColor.ToMediaColor();
             this.ContrastVM.SecondColor = pair.LighterColor.DrawingColor.ToMediaColor();
-            tbConfidence.Text = result.ConfidenceValue().ToString();
+            tbConfidence.Text = result.Confidence.ToString();
         }
 
         private void SetConfidenceVisibility(Visibility visibility)

--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -10,7 +10,7 @@
   <Import Project="..\..\build\NetFrameworkRelease.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Axe.Windows" Version="1.1.2" />
+    <PackageReference Include="Axe.Windows" Version="1.1.3" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <Reference Include="Interop.UIAutomationClient, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
@@ -17,6 +17,7 @@ using Axe.Windows.Actions.Misc;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Desktop.Settings;
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Threading.Tasks;
@@ -135,6 +136,7 @@ namespace AccessibilityInsights.Modes
                 ElementContext ec = null;
                 await Task.Run(() =>
                 {
+                    Stopwatch stopwatch = Stopwatch.StartNew();
                     bool contextChanged = CaptureAction.SetTestModeDataContext(ecId,
                         this.DataContextMode, Configuration.TreeViewMode);
                     ec = GetDataAction.GetElementContext(ecId);
@@ -143,7 +145,7 @@ namespace AccessibilityInsights.Modes
                     {
                         // send telemetry of scan results.
                         var dc = GetDataAction.GetElementDataContext(ecId);
-                        dc.PublishScanResults();
+                        dc.PublishScanResults(stopwatch.ElapsedMilliseconds);
                     }
                 }).ConfigureAwait(false);
 

--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
@@ -148,6 +148,7 @@ namespace AccessibilityInsights.Modes
 
                     await Task.Run(() =>
                     {
+                        Stopwatch stopwatch = Stopwatch.StartNew();
                         bool contextChanged = CaptureAction.SetTestModeDataContext(ecId,
                             this.DataContextMode, Configuration.TreeViewMode);
                         ec = GetDataAction.GetElementContext(ecId);
@@ -163,7 +164,7 @@ namespace AccessibilityInsights.Modes
                         }
                         if (contextChanged && this.DataContextMode != DataContextMode.Load)
                         {
-                            dc.PublishScanResults();
+                            dc.PublishScanResults(stopwatch.ElapsedMilliseconds);
                         }
                     }).ConfigureAwait(false);
 

--- a/src/UITests/UITests.csproj
+++ b/src/UITests/UITests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
-    <PackageReference Include="Axe.Windows" Version="1.1.2" />
+    <PackageReference Include="Axe.Windows" Version="1.1.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />


### PR DESCRIPTION
#### Details

Move to Axe.Windows 1.1.3. This PR includes a couple of tiny changes in the private API that we use with Axe.Windows.

##### Motivation

We want to include the Axe.Windows scanDurationInMilliseconds telemetry changes in our next Prod release.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



