### PR TITLE
fix: Bold MenuItem text when selected

### DIFF
--- a/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml
@@ -125,7 +125,7 @@
                             </i:Interaction.Behaviors>
                             <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                             <Button.ContextMenu>
-                                <ContextMenu AutomationProperties.Name="{x:Static Properties:Resources.btnSettingAutomationPropertiesName}">
+                                <ContextMenu AutomationProperties.Name="{x:Static Properties:Resources.btnSettingAutomationPropertiesName}" Style="{StaticResource menuPlainWhite}">
                                     <MenuItem Header="{x:Static Properties:Resources.ReturnA11yElementsView_Menu_ShowAllPropertiesWithValues}" x:Name="mniShowCoreProps" IsCheckable="true" 
                                     Background="White" Checked="mniShowCoreProps_Checked" Unchecked="mniShowCoreProps_Unchecked" Loaded="mniShowCoreProps_Loaded"/>
                                     <MenuItem Header="{x:Static Properties:Resources.ReturnA11yElementsView_Menu_ConfigurePropertiesToAlwaysShow}" x:Name="mniIncludeAllProps" Click="mniIncludeAllProps_Click"

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -116,7 +116,7 @@
                     </Button.Style>
                     <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                     <Button.ContextMenu>
-                        <ContextMenu FlowDirection="LeftToRight" Loaded="ContextMenu_Loaded" Unloaded="ContextMenu_Unloaded" Style="{StaticResource menuDefault}">
+                        <ContextMenu FlowDirection="LeftToRight" Loaded="ContextMenu_Loaded" Unloaded="ContextMenu_Unloaded" Style="{StaticResource ctxMenuDefault}">
                             <MenuItem Header="{x:Static Properties:Resources.EventRecordControlScopeHeader}">
                                 <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRB_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName}">

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -116,7 +116,7 @@
                     </Button.Style>
                     <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                     <Button.ContextMenu>
-                        <ContextMenu FlowDirection="LeftToRight" Loaded="ContextMenu_Loaded" Unloaded="ContextMenu_Unloaded">
+                        <ContextMenu FlowDirection="LeftToRight" Loaded="ContextMenu_Loaded" Unloaded="ContextMenu_Unloaded" Style="{StaticResource menuDefault}">
                             <MenuItem Header="{x:Static Properties:Resources.EventRecordControlScopeHeader}">
                                 <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRB_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName}">

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -63,8 +63,8 @@
                         </MenuItem>
                     </ContextMenu>
                     <ContextMenu x:Key="cmLive" FlowDirection="LeftToRight" Style="{StaticResource menuPlainWhite}">
-                        <MenuItem Tag="LightningBolt" IsCheckable="False" Header="{x:Static Properties:Resources.MenuItemHeaderListenToEvents}" Click="mniEvents_Click" Style="{StaticResource miFabIcon}"/>
-                        <MenuItem Tag="LadybugSolid" Visibility ="{Binding FileBugVisibility}" IsCheckable="False" Header="{x:Static Properties:Resources.MenuItemHeaderNewIssue}" Click="mniFileBugLive_Click" Style="{StaticResource miFabIcon}"/>
+                        <MenuItem Tag="LightningBolt" IsCheckable="False" Header="{x:Static Properties:Resources.MenuItemHeaderListenToEvents}" Click="mniEvents_Click"/>
+                        <MenuItem Tag="LadybugSolid" Visibility ="{Binding FileBugVisibility}" IsCheckable="False" Header="{x:Static Properties:Resources.MenuItemHeaderNewIssue}" Click="mniFileBugLive_Click"/>
                     </ContextMenu>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
@@ -131,7 +131,7 @@
                 </Button.ToolTip>
                 <controls:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                 <Button.ContextMenu>
-                    <ContextMenu FlowDirection="LeftToRight" x:Name="cmHierarchySettings">
+                    <ContextMenu FlowDirection="LeftToRight" x:Name="cmHierarchySettings" Style="{StaticResource menuDefault}">
                         <MenuItem Header="{x:Static Properties:Resources.HierarchyControl_Menu_TreeView}">
                             <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRaw_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName1}">

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -131,7 +131,7 @@
                 </Button.ToolTip>
                 <controls:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                 <Button.ContextMenu>
-                    <ContextMenu FlowDirection="LeftToRight" x:Name="cmHierarchySettings" Style="{StaticResource menuDefault}">
+                    <ContextMenu FlowDirection="LeftToRight" x:Name="cmHierarchySettings" Style="{StaticResource ctxMenuDefault}">
                         <MenuItem Header="{x:Static Properties:Resources.HierarchyControl_Menu_TreeView}">
                             <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRaw_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName1}">

--- a/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
@@ -91,7 +91,7 @@
                                     </Button.ToolTip>
                                     <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="9" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource ResourceKey=hoverAwareFabricIconOnButtonParent}"/>
                                     <Button.ContextMenu>
-                                        <ContextMenu AutomationProperties.Name="{x:Static Properties:Resources.btnSettingAutomationPropertiesName2}">
+                                        <ContextMenu AutomationProperties.Name="{x:Static Properties:Resources.btnSettingAutomationPropertiesName2}" Style="{StaticResource menuPlainWhite}">
                                             <MenuItem Header="{x:Static Properties:Resources.InspectTabsControl_Menu_ShowAllPropertiesWithValues}" x:Name="mniShowCoreProps" IsCheckable="true" 
                                                     Checked="mniShowCoreProps_Checked" Unchecked="mniShowCoreProps_Unchecked" Loaded="mniShowCoreProps_Loaded"/>
                                             <MenuItem Header="{x:Static Properties:Resources.InspectTabsControl_Menu_ConfigurePropertiesToAlwaysShow}" x:Name="mniIncludeAllProps" Click="mniIncludeAllProps_Click" />

--- a/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PatternInfoControl.xaml
@@ -22,7 +22,7 @@
             <TreeView.ContextMenu>
                 <ContextMenu FlowDirection="LeftToRight" Style="{StaticResource menuPlainWhite}">
                     <MenuItem x:Name="copyMenuItemPattern" Tag="Copy" IsCheckable="False" 
-                              Header="{x:Static Properties:Resources.copyMenuItemPatternHeader}" Style="{StaticResource miFabIcon}"
+                              Header="{x:Static Properties:Resources.copyMenuItemPatternHeader}"
                               Click="copyMenuItemPattern_Click"/>
                 </ContextMenu>
             </TreeView.ContextMenu>

--- a/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
@@ -60,7 +60,7 @@
                     </i:Interaction.Behaviors>
                     <ListView.ContextMenu>
                         <ContextMenu FlowDirection="LeftToRight" Style="{StaticResource menuPlainWhite}">
-                            <MenuItem x:Name="copyMenuItemProperty" Tag="{x:Static Properties:Resources.copyMenuItemPropertyTag}" IsCheckable="False" Header="{x:Static Properties:Resources.copyMenuItemPropertyHeader}" Command="Copy" Style="{StaticResource miFabIcon}"/>
+                            <MenuItem x:Name="copyMenuItemProperty" Tag="{x:Static Properties:Resources.copyMenuItemPropertyTag}" IsCheckable="False" Header="{x:Static Properties:Resources.copyMenuItemPropertyHeader}" Command="Copy"/>
                         </ContextMenu>
                     </ListView.ContextMenu>
                     <ListView.View>

--- a/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TextRangeControl.xaml
@@ -106,7 +106,7 @@
                         </i:Interaction.Behaviors>
                         <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnUnthemedButtonParent}"/>
                         <Button.ContextMenu>
-                            <ContextMenu FlowDirection="LeftToRight">
+                            <ContextMenu FlowDirection="LeftToRight" Style="{StaticResource menuPlainWhite}">
                                 <MenuItem Header="{x:Static Properties:Resources.TextRangeControl_Menu_CollapseAnnotationTypes}" IsChecked="True" IsCheckable="True" Click="MenuItem_Click"/>
                                 <Separator/>
                                 <MenuItem Header="{x:Static Properties:Resources.TextRangeControl_Menu_ShowAllAttributesWithValues}" IsChecked="True" IsCheckable="True" Name="mniShowAll" Click="mniShowAll_Click"/>
@@ -183,7 +183,7 @@
                 </i:Interaction.Behaviors>
                 <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnUnthemedButtonParent}"/>
                 <Button.ContextMenu>
-                    <ContextMenu FlowDirection="LeftToRight">
+                    <ContextMenu FlowDirection="LeftToRight" Style="{StaticResource menuPlainWhite}">
                         <MenuItem Header="{x:Static Properties:Resources.TextRangeControl_Menu_ReplaceWhitespaceWithSymbols}" IsChecked="True" IsCheckable="True" Name="mniWhitespace" Click="mniWhitespace_Click"/>
                     </ContextMenu>
                 </Button.ContextMenu>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/ElementInfoDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/ElementInfoDialog.xaml
@@ -72,7 +72,7 @@
                             </i:Interaction.Behaviors>
                             <fabric:FabricIconControl GlyphName="Settings" GlyphSize="Custom" FontSize="9" VerticalAlignment="Center" HorizontalAlignment="Center" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                             <Button.ContextMenu>
-                                <ContextMenu AutomationProperties.Name="{x:Static Properties:Resources.btnSettingContextMenuAutomationPropertiesName}">
+                                <ContextMenu AutomationProperties.Name="{x:Static Properties:Resources.btnSettingContextMenuAutomationPropertiesName}" Style="{StaticResource menuPlainWhite}">
                                     <MenuItem Header="{x:Static Properties:Resources.mniShowCorePropsHeader}" x:Name="mniShowCoreProps" IsCheckable="true" 
                                     Background="White" Checked="mniShowCoreProps_Checked" Unchecked="mniShowCoreProps_Unchecked" Loaded="mniShowCoreProps_Loaded"/>
                                     <MenuItem Header="{x:Static Properties:Resources.mniIncludeAllPropsHeader}" x:Name="mniIncludeAllProps" Click="mniIncludeAllProps_Click"

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml
@@ -68,7 +68,7 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="{Binding Header}" />
-                            <Menu x:Name="mnTRControl" Grid.Column="1" Visibility="{Binding Path=MenuVisibility, Mode=OneWay}" Margin="10,0,0,0" >
+                            <Menu x:Name="mnTRControl" Grid.Column="1" Visibility="{Binding Path=MenuVisibility, Mode=OneWay}" Margin="10,0,0,0" Style="{StaticResource menuDefault}">
                                 <MenuItem IsCheckable="False" Padding="0" AutomationProperties.Name="{x:Static Properties:Resources.MenuItemAutomationPropertiesNameControlSelectedTextRange}">
                                     <MenuItem.Icon>
                                         <fabric:FabricIconControl GlyphName="More" Foreground="{DynamicResource ResourceKey=TextPatternExplorerFGBrush}" GlyphSize="Default"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -8,7 +8,7 @@
                     xmlns:colorpickers="clr-namespace:AccessibilityInsights.SharedUx.Controls.ColorPicker"
                     xmlns:controls="clr-namespace:AccessibilityInsights.SharedUx.Controls.CustomControls"
                     xmlns:converters="clr-namespace:AccessibilityInsights.SharedUx.Converters"
-                      xmlns:properties="clr-namespace:AccessibilityInsights.SharedUx.Properties"
+                    xmlns:properties="clr-namespace:AccessibilityInsights.SharedUx.Properties"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <converters:TreeNodeToMarginConverter x:Key="nodeMargin"/>
     <Style x:Key="{x:Static SystemParameters.FocusVisualStyleKey}">
@@ -1233,10 +1233,9 @@
         <Setter Property="FontWeight" Value="Regular"/>
         <Style.Triggers>
             <Trigger Property="IsHighlighted" Value="True">
-                <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
-                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
                 <Setter Property="TextBlock.LayoutTransform">
                     <Setter.Value>
+                        <!-- This reduces the visual shift that occurs due to the extra width of bold text-->
                         <ScaleTransform ScaleX=".97"/>
                     </Setter.Value>
                 </Setter>
@@ -1262,6 +1261,10 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="false">
                             <Setter TargetName="fbIcn" Property="Foreground" Value="{DynamicResource ResourceKey=IconBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsHighlighted" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.5"/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1255,6 +1255,7 @@
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
                             <fabric:FabricIconControl Foreground="{TemplateBinding Foreground}" x:Name="fbIcn" VerticalAlignment="Center" Grid.Column="0" GlyphSize="Small" GlyphName="{Binding Tag, RelativeSource={RelativeSource Mode=TemplatedParent}}" ShowInControlView="False"/>
+                            <fabric:FabricIconControl Foreground="{TemplateBinding Foreground}" x:Name="fbCheckMark" VerticalAlignment="Center" Grid.Column="0" GlyphSize="Small" Visibility="Collapsed" GlyphName="CheckMark" ShowInControlView="False"/>
                             <ContentPresenter VerticalAlignment="Center" Grid.Column="1" ContentSource="Header" RecognizesAccessKey="True" LayoutTransform="{TemplateBinding LayoutTransform}"/>
                         </Grid>
                     </Border>
@@ -1266,14 +1267,19 @@
                             <Setter Property="Opacity" Value="0.5"/>
                         </Trigger>
                         <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="fbIcn" Property="GlyphName" Value="CheckMark"/>
+                            <Setter TargetName="fbCheckMark" Property="Visibility" Value="Visible"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    <Style TargetType="{x:Type ContextMenu}" x:Key="menuDefault">
+    <Style TargetType="{x:Type ContextMenu}" x:Key="ctxMenuDefault">
+        <Style.Resources>
+            <Style x:Key="{x:Type MenuItem}" TargetType="{x:Type MenuItem}" BasedOn="{StaticResource miBoldOnSelection}"/>
+        </Style.Resources>
+    </Style>
+    <Style TargetType="{x:Type Menu}" x:Key="menuDefault">
         <Style.Resources>
             <Style x:Key="{x:Type MenuItem}" TargetType="{x:Type MenuItem}" BasedOn="{StaticResource miBoldOnSelection}"/>
         </Style.Resources>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -8,7 +8,7 @@
                     xmlns:colorpickers="clr-namespace:AccessibilityInsights.SharedUx.Controls.ColorPicker"
                     xmlns:controls="clr-namespace:AccessibilityInsights.SharedUx.Controls.CustomControls"
                     xmlns:converters="clr-namespace:AccessibilityInsights.SharedUx.Converters"
-                    xmlns:properties="clr-namespace:AccessibilityInsights.SharedUx.Properties"
+                      xmlns:properties="clr-namespace:AccessibilityInsights.SharedUx.Properties"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <converters:TreeNodeToMarginConverter x:Key="nodeMargin"/>
     <Style x:Key="{x:Static SystemParameters.FocusVisualStyleKey}">
@@ -1229,39 +1229,59 @@
     <Style TargetType="{x:Type CheckBox}" x:Key="CkbxRightSide" BasedOn="{StaticResource CheckBoxContastingBorder}">
         <Setter Property="FontSize" Value="14"/>
     </Style>
-    <Style TargetType="{x:Type MenuItem}" x:Key="miFabIcon">
+    <Style TargetType="{x:Type MenuItem}" x:Key="miBoldOnSelection">
+        <Setter Property="FontWeight" Value="Regular"/>
+        <Style.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
+                <Setter Property="TextBlock.LayoutTransform">
+                    <Setter.Value>
+                        <ScaleTransform ScaleX=".97"/>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="FontWeight" Value="Bold"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type MenuItem}" x:Key="miFabIcon" BasedOn="{StaticResource miBoldOnSelection}">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type MenuItem}">
-                    <Border Padding="8,4" x:Name="Border" Background="{DynamicResource ResourceKey=SecondaryBGBrush}">
+                    <Border Padding="8,4" x:Name="Border" Background="{TemplateBinding Background}">
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="24"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <fabric:FabricIconControl x:Name="fbIcn" VerticalAlignment="Center" Grid.Column="0" GlyphSize="Small" GlyphName="{Binding Tag, RelativeSource={RelativeSource Mode=TemplatedParent}}" ShowInControlView="False"/>
-                            <ContentPresenter VerticalAlignment="Center" Grid.Column="1" ContentSource="Header" RecognizesAccessKey="True" />
+                            <fabric:FabricIconControl Foreground="{TemplateBinding Foreground}" x:Name="fbIcn" VerticalAlignment="Center" Grid.Column="0" GlyphSize="Small" GlyphName="{Binding Tag, RelativeSource={RelativeSource Mode=TemplatedParent}}" ShowInControlView="False"/>
+                            <ContentPresenter VerticalAlignment="Center" Grid.Column="1" ContentSource="Header" RecognizesAccessKey="True" LayoutTransform="{TemplateBinding LayoutTransform}"/>
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsHighlighted" Value="true">
-                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
-                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
-                            <Setter TargetName="fbIcn" Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
-                            <Setter Property="FontWeight" Value="Bold"/>
-                        </Trigger>
                         <Trigger Property="IsHighlighted" Value="false">
                             <Setter TargetName="fbIcn" Property="Foreground" Value="{DynamicResource ResourceKey=IconBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.5"/>
                         </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="fbIcn" Property="GlyphName" Value="CheckMark"/>
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
+    <Style TargetType="{x:Type ContextMenu}" x:Key="menuDefault">
+        <Style.Resources>
+            <Style x:Key="{x:Type MenuItem}" TargetType="{x:Type MenuItem}" BasedOn="{StaticResource miBoldOnSelection}"/>
+        </Style.Resources>
+    </Style>
     <Style TargetType="{x:Type ContextMenu}" x:Key="menuPlainWhite">
+        <Style.Resources>
+            <Style x:Key="{x:Type MenuItem}" TargetType="{x:Type MenuItem}" BasedOn="{StaticResource miFabIcon}"/>
+        </Style.Resources>
         <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
         <Setter Property="Template">
             <Setter.Value>

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -453,7 +453,7 @@
                                     </i:Interaction.Behaviors>
                                     <fabric:FabricIconControl GlyphName="Timer" FontSize="16" Style="{StaticResource hoverAwareFabricIconOnButtonParent}"/>
                                     <Button.ContextMenu>
-                                        <ContextMenu>
+                                        <ContextMenu Style="{StaticResource menuPlainWhite}">
                                             <MenuItem Name="miTimer" AutomationProperties.Name="{x:Static properties:Resources.miTimerAutomationPropertiesName}" Click="btnTimer_Click">
                                                 <MenuItem.Header>
                                                     <TextBlock Name="tbTimer">


### PR DESCRIPTION
#### Details
Currently, some of our MenuItems are bolded and highlighted when selected, while others are just highlighted. Because the default highlight behavior has insufficient color contrast, this PR ensures all MenuItems are bolded when selected. To do this, 
`menuPlainWhite` is applied to as many menus as possible. In cases where it has issues, a new `menuDefault` style has been created to provide the bolding behavior. 

Screen capture:
![screen capture showing a variety of menus with the new bolding on selection behavior](https://user-images.githubusercontent.com/4615491/164778387-d94879fa-807d-4095-a134-2144258738d7.gif)

##### Motivation
Addresses an accessibility issue

##### Context
Ideally, we would fully standardize to use `menuPlainWhite`. Unfortunately, it has issues with multi-leveled menus which were too complicated to address as a part of this PR.

To reduce the amount of size changing on selection, a minor `LayoutTransform` is applied alongside the bolding.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - ADO 1928590
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



