### PR TITLE
fix: Improve some accessible names

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -104,7 +104,7 @@
                 <Button x:Name="btnSetting" Grid.Column="1"
                         HorizontalAlignment="Center" VerticalAlignment="Center" VerticalContentAlignment="Center"
                         Height="28" Width="35" 
-                        AutomationProperties.Name="{x:Static Properties:Resources.btnSettingAutomationPropertiesName}">
+                        AutomationProperties.Name="{x:Static Properties:Resources.btnEventSettingsAutomationPropertiesName}">
                     <i:Interaction.Behaviors>
                         <behaviors:DropDownButtonBehavior/>
                         <behaviors:KeyboardToolTipButtonBehavior/>

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -121,7 +121,7 @@
                   BorderThickness="0"  HorizontalAlignment="Center" VerticalAlignment="Center" VerticalContentAlignment="Center"
                   Height="28" Width="35" 
                   Style="{StaticResource BtnStandard}"
-                  AutomationProperties.Name="{x:Static Properties:Resources.btnSettingsAutomationPropertiesName1}">
+                  AutomationProperties.Name="{x:Static Properties:Resources.btnHierarchyTreeSettingsAutomationPropertiesName}">
                 <i:Interaction.Behaviors>
                     <behaviors:KeyboardToolTipButtonBehavior/>
                     <behaviors:DropDownButtonBehavior/>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -458,6 +458,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hierarchy Tree Settings.
+        /// </summary>
+        public static string btnHierarchyTreeSettingsAutomationPropertiesName {
+            get {
+                return ResourceManager.GetString("btnHierarchyTreeSettingsAutomationPropertiesName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Highlight bounding rectangles.
         /// </summary>
         public static string btnHilightAutomationPropertiesName {
@@ -607,15 +616,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string btnSettingContextMenuAutomationPropertiesName {
             get {
                 return ResourceManager.GetString("btnSettingContextMenuAutomationPropertiesName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Hierarchy Tree Settings.
-        /// </summary>
-        public static string btnSettingsAutomationPropertiesName1 {
-            get {
-                return ResourceManager.GetString("btnSettingsAutomationPropertiesName1", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -395,6 +395,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Event Settings.
+        /// </summary>
+        public static string btnEventSettingsAutomationPropertiesName {
+            get {
+                return ResourceManager.GetString("btnEventSettingsAutomationPropertiesName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to OK.
         /// </summary>
         public static string btnExitContentTelemetryOK {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -611,7 +611,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Settings.
+        ///   Looks up a localized string similar to Hierarchy Tree Settings.
         /// </summary>
         public static string btnSettingsAutomationPropertiesName1 {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -632,7 +632,7 @@
   <data name="SetterValueSearchByName" xml:space="preserve">
     <value>Search by name and control type</value>
   </data>
-  <data name="btnSettingsAutomationPropertiesName1" xml:space="preserve">
+  <data name="btnHierarchyTreeSettingsAutomationPropertiesName" xml:space="preserve">
     <value>Hierarchy Tree Settings</value>
   </data>
   <data name="btnSettingToolTip1" xml:space="preserve">

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1749,4 +1749,7 @@ URL: {0}</value>
   <data name="TextRangeControl_Value_Header" xml:space="preserve">
     <value>Value</value>
   </data>
+  <data name="btnEventSettingsAutomationPropertiesName" xml:space="preserve">
+    <value>Event Settings</value>
+  </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -633,7 +633,7 @@
     <value>Search by name and control type</value>
   </data>
   <data name="btnSettingsAutomationPropertiesName1" xml:space="preserve">
-    <value>Settings</value>
+    <value>Hierarchy Tree Settings</value>
   </data>
   <data name="btnSettingToolTip1" xml:space="preserve">
     <value>UI Automation Tree Settings</value>

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -320,7 +320,7 @@ namespace AccessibilityInsights
             else
             {
                 btnAccountConfig.Visibility = Visibility.Collapsed;
-                btnAccountConfig.SetValue(AutomationProperties.NameProperty, Properties.Resources.btnConfigAutomationPropertiesNameNoBugFiling);
+                btnConfig.SetValue(AutomationProperties.NameProperty, Properties.Resources.btnConfigAutomationPropertiesNameNoBugFiling);
             }
 
             handleWindowStateChange();

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -761,7 +761,8 @@ namespace AccessibilityInsights
             vmReporterLogo.FabricIconLogoName = isConfigured ? fabricIconName : null;
             string tooltipResource = isConfigured ? Properties.Resources.UpdateMainWindowLoginFieldsSignedInAs : Properties.Resources.HandleLogoutRequestSignIn;
             string tooltipText = string.Format(CultureInfo.InvariantCulture, tooltipResource, IssueReporter.DisplayName);
-            AutomationProperties.SetName(btnAccountConfig, tooltipText);
+            string automationName = string.Format(CultureInfo.InvariantCulture, Properties.Resources.btnAccountConfigAutomationPropertiesNameFormat, tooltipText);
+            AutomationProperties.SetName(btnAccountConfig, automationName);
             btnAccountConfig.ToolTip = new ToolTip() { Content = tooltipText };
         }
 

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -151,7 +151,7 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Settings 1 of 2.
+        ///   Looks up a localized string similar to Application Settings.
         /// </summary>
         public static string btnConfigAutomationPropertiesName {
             get {

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -88,11 +88,20 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sign in 2 of 2.
+        ///   Looks up a localized string similar to Sign in 1 of 2.
         /// </summary>
         public static string btnAccountConfigAutomationPropertiesName {
             get {
                 return ResourceManager.GetString("btnAccountConfigAutomationPropertiesName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} 1 of 2.
+        /// </summary>
+        public static string btnAccountConfigAutomationPropertiesNameFormat {
+            get {
+                return ResourceManager.GetString("btnAccountConfigAutomationPropertiesNameFormat", resourceCulture);
             }
         }
         
@@ -151,7 +160,7 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Application Settings.
+        ///   Looks up a localized string similar to Application Settings 2 of 2.
         /// </summary>
         public static string btnConfigAutomationPropertiesName {
             get {
@@ -160,7 +169,7 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Settings.
+        ///   Looks up a localized string similar to Application Settings.
         /// </summary>
         public static string btnConfigAutomationPropertiesNameNoBugFiling {
             get {
@@ -602,7 +611,7 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SignIn.
+        ///   Looks up a localized string similar to Sign in.
         /// </summary>
         public static string HandleLogoutRequestSignIn {
             get {

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -142,7 +142,7 @@
     <value>Configure settings of Accessibility Insights for Windows</value>
   </data>
   <data name="btnConfigAutomationPropertiesName" xml:space="preserve">
-    <value>Settings 1 of 2</value>
+    <value>Application Settings</value>
   </data>
   <data name="btnConfigToolTip" xml:space="preserve">
     <value>Change settings...</value>

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -121,7 +121,7 @@
     <value>Sign into AzureDevOps and configure sign in settings</value>
   </data>
   <data name="btnAccountConfigAutomationPropertiesName" xml:space="preserve">
-    <value>Sign in 2 of 2</value>
+    <value>Sign in 1 of 2</value>
   </data>
   <data name="btnAccountConfigToolTip" xml:space="preserve">
     <value>Sign in</value>
@@ -142,7 +142,7 @@
     <value>Configure settings of Accessibility Insights for Windows</value>
   </data>
   <data name="btnConfigAutomationPropertiesName" xml:space="preserve">
-    <value>Application Settings</value>
+    <value>Application Settings 2 of 2</value>
   </data>
   <data name="btnConfigToolTip" xml:space="preserve">
     <value>Change settings...</value>
@@ -298,7 +298,7 @@
     <value>Accessibility Insights has lost the connection to the application. Select the application or element and run tests again.</value>
   </data>
   <data name="HandleLogoutRequestSignIn" xml:space="preserve">
-    <value>SignIn</value>
+    <value>Sign in</value>
   </data>
   <data name="HandleRequestRecordingByHotkeySelectElementMessage" xml:space="preserve">
     <value>Please select an element first before starting Event page.</value>
@@ -490,7 +490,7 @@ Please ensure that you are opening a valid test file using the most recent relea
     <value>Command bar</value>
   </data>
   <data name="btnConfigAutomationPropertiesNameNoBugFiling" xml:space="preserve">
-    <value>Settings</value>
+    <value>Application Settings</value>
   </data>
   <data name="LocalizedControlType_Page" xml:space="preserve">
     <value>page</value>
@@ -581,5 +581,9 @@ Confidence: {1}</value>
   </data>
   <data name="NavBar_IssueFilingConfig_AccessText" xml:space="preserve">
     <value>_i</value>
+  </data>
+  <data name="btnAccountConfigAutomationPropertiesNameFormat" xml:space="preserve">
+    <value>{0} 1 of 2</value>
+    <comment>{0} is the text displayed in the tooltip</comment>
   </data>
 </root>


### PR DESCRIPTION
#### Details

Improve some accessible names in the product.

##### Motivation

Address #1322 

##### Comparisons

These table shows the accessible names and tooltips before and after the change. The "1 of 2": and "2 of 2" in the nav bar are because the signin button and the settings button are in a functional group. We follow a similar pattern for the buttons for inspect, test, and color modes (a separate group within the nav bar)

###### Nav Bar, no issue reporters (degenerate but supported case)
Element - property | Before change | After change
--- | --- | ---
Connection button - Name (unchanged) | n/a (button is hidden) | n/a (button is hidden)
Connection button - Tooltip (unchanged) | n/a (button is hidden) | n/a (button is hidden)
Settings button - Name (changed) | Settings 1 of 2 | Application Settings
Settings button - Tooltip (unchanged) | Change settings... | Change settings...

###### Nav Bar, not signed in
Element - property | Before change | After change
--- | --- | ---
Connection button - Name (changed) | SignIn | Sign in 1 of 2
Connection button - Tooltip (changed) | SignIn | Sign in
Settings button - Name (changed) | Settings 1 of 2 | Application Settings 2 of 2
Settings button - Tooltip (unchanged) | Change settings... | Change settings...

###### Nav Bar, signed into ADO
Element - property | Before change | After change
--- | --- | ---
Connection button - Name (changed) | Signed into Azure Boards| Signed into Azure Boards 1 of 2
Connection button - Tooltip (unchanged) | Signed into Azure Boards | Signed into Azure Boards
Settings button - Name (changed) | Settings 1 of 2 | Application Settings 2 of 2
Settings button - Tooltip (unchanged) | Change settings... | Change settings...

###### Nav Bar, signed into GitHub
Element - property | Before change | After change
--- | --- | ---
Connection button - Name (changed) | Signed into GitHub | Signed into GitHub 1 of 2
Connection button - Tooltip (unchanged) | Signed into GitHub | Signed into GitHub
Settings button - Name (changed) | Settings 1 of 2 | Application Settings 2 of 2
Settings button - Tooltip (unchanged) | Change settings... | Change settings...

###### Hierarchy Tree Settings button
Element - property | Before change | After change
--- | --- | ---
Button Name (changed) | Settings | Hierarchy Tree Settings
Button Tooltip (unchanged) | UI Automation Tree Settings | UI Automation Tree Settings

###### Event Recording Settings button
Element - property | Before change | After change
--- | --- | ---
Button Name (changed) | Properties settings | Event Settings
Button Tooltip (unchanged) | Event setting | Event setting


##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
Our existing tooltips seem pretty inconsistent:
- One has a "..." suffix when none of the others that I found do
- Most use "settings" as a plural, while at least one doesn't. 

I can happily pull these into this PR, but they're only incidentally related to the issue.
<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue: #1322 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable (attached as tables to make them more accessible)

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



