### PR TITLE
feat(framework-issues-ui): Add link to framework issue

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
@@ -170,7 +170,7 @@
                     <behaviors:ExpanderBehavior/>
                 </i:Interaction.Behaviors>
                 <Expander.Header>
-                    <Label  Margin="4" Style="{StaticResource ResourceKey=lblAccordionHeader}" x:Name="labelFixFollowing">Fix the following</Label>
+                    <Label  Margin="4" Style="{StaticResource ResourceKey=lblAccordionHeader}" x:Name="labelFixFollowing" Content="{x:Static Properties:Resources.ScannerResultControl_FixTheFollowing}" />
                 </Expander.Header>
                 <Grid Margin="8,4,8,8">
                     <StackPanel Name="spHowToFix" Grid.Row="1" >
@@ -209,7 +209,8 @@
                                 </Style>
                             </TextBlock.Style>
                             <Hyperlink Click="HyperlinkSnippetClick"
-                                FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">View Code Sample
+                                FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">
+                                <Run Text="{Binding Path=HyperlinkText, Mode=OneWay}"/>
                                 <Hyperlink.Style>
                                     <Style TargetType="Hyperlink" BasedOn="{StaticResource hLink}">
                                         <Setter Property="FontSize" Value="{DynamicResource StandardTextSize}"/>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -3741,6 +3741,35 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fix the following.
+        /// </summary>
+        public static string ScannerResultControl_FixTheFollowing {
+            get {
+                return ResourceManager.GetString("ScannerResultControl_FixTheFollowing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Potential framework issue.
+        ///This failure can be caused by a known framework issue. Click the link below to learn more about investigating this issue.
+        ///.
+        /// </summary>
+        public static string ScannerResultControl_FrameworkIssueBoilerplate {
+            get {
+                return ResourceManager.GetString("ScannerResultControl_FrameworkIssueBoilerplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to How to investigate.
+        /// </summary>
+        public static string ScannerResultControl_HowToInvestigate {
+            get {
+                return ResourceManager.GetString("ScannerResultControl_HowToInvestigate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Issue.
         /// </summary>
         public static string ScannerResultControl_Issue {
@@ -3800,6 +3829,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string ScannerResultControl_UpdateTree_Passed_tests {
             get {
                 return ResourceManager.GetString("ScannerResultControl_UpdateTree_Passed_tests", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View Code Sample.
+        /// </summary>
+        public static string ScannerResultControl_ViewCodeSample {
+            get {
+                return ResourceManager.GetString("ScannerResultControl_ViewCodeSample", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1755,4 +1755,18 @@ URL: {0}</value>
   <data name="AutomatedChecksControlFrameworkIssuesLabel" xml:space="preserve">
     <value>Potential framework issues</value>
   </data>
+  <data name="ScannerResultControl_FixTheFollowing" xml:space="preserve">
+    <value>Fix the following</value>
+  </data>
+  <data name="ScannerResultControl_FrameworkIssueBoilerplate" xml:space="preserve">
+    <value>Potential framework issue.
+This failure can be caused by a known framework issue. Click the link below to learn more about investigating this issue.
+</value>
+  </data>
+  <data name="ScannerResultControl_HowToInvestigate" xml:space="preserve">
+    <value>How to investigate</value>
+  </data>
+  <data name="ScannerResultControl_ViewCodeSample" xml:space="preserve">
+    <value>View Code Sample</value>
+  </data>
 </root>


### PR DESCRIPTION
#### Details

This PR extends the existing "View Code Sample" behavior to allow it to be used for framework issues, as well. Specifically:
1. `ScannerResultControl.xaml` uses hardcoded strings for "Fix the following" and "View Code Sample". Move these strings into resource strings
2. Add resource strings that we display when we have a FrameworkIssueLink
3. Add `ScanListViewItemViewModel.HyperlinkText` to provide the string that is the visible portion of the Hyperlink. It's "View Code Sample" for issues without a FrameworkIssueLink, and "How to investigate" for issues with a FrameworkIssueLink
4. Use `ScanListVIewItemViewModel.HyperlinkText` to set the text for the Hyperlink
5. Overload `ScanViewItemViewModel.HowToFixText` so that it uses the framework issue boilerplate text if the issue has a FrameworkIssueLink

##### Motivation

Feature work

##### Screenshots

Note: The scan results aren't yet separated into 2 lists, so please disregard that part

Scenario | Image
--- | ---
Failure (non-framework) | ![image](https://user-images.githubusercontent.com/45672944/173469959-6efdcc68-c1ad-4a80-abe6-f6661db3c7c0.png)
Failure (framework) | ![image](https://user-images.githubusercontent.com/45672944/173469918-5c6f8e24-b99f-4396-b1ce-4a3dc38b95e0.png)
Success | ![image](https://user-images.githubusercontent.com/45672944/173469991-e60f6ca8-1c97-4a31-b126-7f48cf30140f.png)


##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
This PR overloads fields in the ViewModel. I considered having completely separate controls with different ViewModel fields, but since we dynamically control the visibility of the controls, it seemed simpler to just leave the dynamic visibility unchanged and modify the content of what gets displayed.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue: [1918329](https://mseng.visualstudio.com/1ES/_workitems/edit/1918329)
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



