### PR TITLE
feat(framework-issues-ui): Revisit scrollbars in AutomatedChecks view

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml
@@ -20,6 +20,7 @@
                         AutomationProperties.Name="{Binding Path=DataGridAccessibleName, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:AutomatedChecksCustomListControl}}"
                         AutomationProperties.AutomationId="{Binding Path=DataGridAutomationId, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:AutomatedChecksCustomListControl}}"
                         HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderThickness="0"
+                        ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                         Name="lvResults" Background="Transparent">
                 <ListView.View>
                     <GridView x:Name="gv">

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml
@@ -59,7 +59,7 @@
                 </Grid>
             </Grid>
             <Border Grid.Row="1" BorderBrush="{DynamicResource ResourceKey=TabBorderBrush}" BorderThickness="0,1,0,0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
-                <ScrollViewer HorizontalScrollBarVisibility ="Disabled" VerticalScrollBarVisibility="Auto">
+                <ScrollViewer HorizontalScrollBarVisibility ="Auto" VerticalScrollBarVisibility="Auto">
                     <StackPanel>
                     <local:AutomatedChecksCustomListControl KeyboardNavigation.TabNavigation="Once" DataGridAccessibleName="{x:Static Properties:Resources.lblTitleContent}"
                               x:Name="nonFrameworkListControl" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderThickness="0"


### PR DESCRIPTION
#### Details

In #1354, we made a change that shifted the horizontal scrollbar from the pane to each child ListView, which triggered a design discussion and the decision was made that we didn't want it that way. This PR makes both ListView controls scroll horizontally together.

##### Motivation

Feature work

##### Screenshots
Description | Screenshot
--- | ---
Current Production (1 scrollbar) | ![image](https://user-images.githubusercontent.com/45672944/173632740-35a8ec18-07ea-49fb-8527-0b5fc60b14a5.png)
Current Canary (2 scrollbars) | ![image](https://user-images.githubusercontent.com/45672944/173632923-db765b33-fce6-42aa-8dfe-62a885872574.png)
This PR (1 scrollbar) | ![image](https://user-images.githubusercontent.com/45672944/173633129-f970c4b1-05b7-456e-b7b4-3ecf1e5da19a.png)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue: [1959215](https://mseng.visualstudio.com/1ES/_workitems/edit/1959215)
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



