### PR TITLE
feat(framework-issues-ui): Consolidate issue filing

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
@@ -661,7 +661,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
                 vm.GetIssueInformation,
                 FileBugRequestSource.AutomatedChecks,
                 Properties.Resources.AutomatedChecksControl_btnFileBug_Click_File_Issue_Configure);
-            FileIssueWrapper.FileBugFromRuleResultViewModel(input);
+            FileIssueWrapper.FileIssueFromControl(input);
         }
 
         private void btnFileBug_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
@@ -659,8 +659,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
                 _controlContext.ElementContext.Id,
                 _controlContext.SwitchToServerLogin,
                 vm.GetIssueInformation,
-                FileBugRequestSource.AutomatedChecks,
-                Properties.Resources.AutomatedChecksControl_btnFileBug_Click_File_Issue_Configure);
+                FileBugRequestSource.AutomatedChecks);
             FileIssueWrapper.FileIssueFromControl(input);
         }
 

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListControl.xaml.cs
@@ -163,8 +163,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
                 _controlContext.EcId,
                 _controlContext.SwitchToServerLogin,
                 vm.GetIssueInformation,
-                FileBugRequestSource.HowtoFix,
-                Properties.Resources.ScannerResultControl_btnFileBug_Click_File_Issue_Configure);
+                FileBugRequestSource.HowtoFix);
             FileIssueWrapper.FileIssueFromControl(input);
         }
 

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListControl.xaml.cs
@@ -1,16 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using AccessibilityInsights.CommonUxComponents.Dialogs;
-using AccessibilityInsights.Extensions.Helpers;
-using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
 using AccessibilityInsights.SharedUx.Enums;
-using AccessibilityInsights.SharedUx.FileIssue;
-using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.SharedUx.Utilities;
 using AccessibilityInsights.SharedUx.ViewModels;
 using System;
 using System.Collections;
-using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;

--- a/src/AccessibilityInsights.SharedUx/Controls/FileIssueWrapper.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/FileIssueWrapper.cs
@@ -11,9 +11,15 @@ using System.IO;
 
 namespace AccessibilityInsights.SharedUx.Controls
 {
+    /// <summary>
+    /// Simple class to consolidate control-related code for issue filing into a single place
+    /// </summary>
     internal static class FileIssueWrapper
     {
-        internal static void FileBugFromRuleResultViewModel(FileIssueWrapperInput input)
+        /// <summary>
+        /// Handles control-related issue filing
+        /// </summary>
+        internal static void FileIssueFromControl(FileIssueWrapperInput input)
         {
             IIssueFilingSource vm = input.VM;
             if (vm.IssueLink != null)

--- a/src/AccessibilityInsights.SharedUx/Controls/FileIssueWrapper.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/FileIssueWrapper.cs
@@ -75,7 +75,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 }
                 else
                 {
-                    bool? accepted = MessageDialog.Show(input.ConfigurePrompt);
+                    bool? accepted = MessageDialog.Show(Properties.Resources.FileIssuesChooseLocation);
                     if (accepted.HasValue && accepted.Value)
                     {
                         input.SwitchToServerLogin();

--- a/src/AccessibilityInsights.SharedUx/Controls/FileIssueWrapper.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/FileIssueWrapper.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.CommonUxComponents.Dialogs;
+using AccessibilityInsights.Extensions.Helpers;
+using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
+using AccessibilityInsights.SharedUx.FileIssue;
+using AccessibilityInsights.SharedUx.Interfaces;
+using AccessibilityInsights.SharedUx.Telemetry;
+using System;
+using System.IO;
+
+namespace AccessibilityInsights.SharedUx.Controls
+{
+    internal static class FileIssueWrapper
+    {
+        internal static void FileBugFromRuleResultViewModel(FileIssueWrapperInput input)
+        {
+            IIssueFilingSource vm = input.VM;
+            if (vm.IssueLink != null)
+            {
+                // Bug already filed, open it in a new window
+                try
+                {
+                    System.Diagnostics.Process.Start(vm.IssueLink.OriginalString);
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception ex)
+                {
+                    ex.ReportException();
+                    // Happens when bug is deleted, message describes that work item doesn't exist / possible permission issue
+                    MessageDialog.Show(ex.InnerException?.Message);
+                    vm.IssueDisplayText = null;
+                }
+#pragma warning restore CA1031 // Do not catch general exception types
+            }
+            else
+            {
+                // File a new bug
+                var telemetryEvent = TelemetryEventFactory.ForIssueFilingRequest(input.RequestSource);
+                Logger.PublishTelemetryEvent(telemetryEvent);
+
+                if (IssueReporter.IsConnected)
+                {
+                    IssueInformation issueInformation = null;
+                    try
+                    {
+                        issueInformation = input.IssueInformationProvider();
+                        FileIssueAction.AttachIssueData(issueInformation, input.EcId, vm.Element.BoundingRectangle, vm.Element.UniqueId);
+                        IIssueResult issueResult = FileIssueAction.FileIssueAsync(issueInformation);
+                        if (issueResult != null)
+                        {
+                            vm.IssueDisplayText = issueResult.DisplayText;
+                            vm.IssueLink = issueResult.IssueLink;
+                        }
+                    }
+#pragma warning disable CA1031 // Do not catch general exception types
+                    catch (Exception ex)
+                    {
+                        ex.ReportException();
+                    }
+#pragma warning restore CA1031 // Do not catch general exception types
+                    finally
+                    {
+                        if (issueInformation != null && File.Exists(issueInformation.TestFileName))
+                        {
+                            File.Delete(issueInformation.TestFileName);
+                        }
+                    }
+                }
+                else
+                {
+                    bool? accepted = MessageDialog.Show(input.ConfigurePrompt);
+                    if (accepted.HasValue && accepted.Value)
+                    {
+                        input.SwitchToServerLogin();
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Controls/FileIssueWrapperInput.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/FileIssueWrapperInput.cs
@@ -7,6 +7,10 @@ using System;
 
 namespace AccessibilityInsights.SharedUx.Controls
 {
+    /// <summary>
+    /// Holds inputs to the FileIssueWrapper.FileIssueFromControl method. Allows us to
+    /// decouple the control specifics from the shared code
+    /// </summary>
     internal class FileIssueWrapperInput
     {
         internal IIssueFilingSource VM { get; }

--- a/src/AccessibilityInsights.SharedUx/Controls/FileIssueWrapperInput.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/FileIssueWrapperInput.cs
@@ -18,18 +18,15 @@ namespace AccessibilityInsights.SharedUx.Controls
         internal Action SwitchToServerLogin { get; }
         internal Func<IssueInformation> IssueInformationProvider { get; }
         internal FileBugRequestSource RequestSource { get; }
-        internal string ConfigurePrompt { get; }
 
         internal FileIssueWrapperInput(IIssueFilingSource vm, Guid ecId, Action switchToServerLogin,
-            Func<IssueInformation> issueInformationProvider, FileBugRequestSource requestSource,
-            string configurePrompt)
+            Func<IssueInformation> issueInformationProvider, FileBugRequestSource requestSource)
         {
             VM = vm ?? throw new ArgumentNullException(nameof(vm));
             EcId = ecId;
             SwitchToServerLogin = switchToServerLogin ?? throw new ArgumentNullException(nameof(switchToServerLogin));
             IssueInformationProvider = issueInformationProvider ?? throw new ArgumentNullException(nameof(issueInformationProvider));
             RequestSource = requestSource;
-            ConfigurePrompt = configurePrompt ?? throw new ArgumentNullException(nameof(configurePrompt));
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Controls/FileIssueWrapperInput.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/FileIssueWrapperInput.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
+using AccessibilityInsights.SharedUx.Enums;
+using AccessibilityInsights.SharedUx.Interfaces;
+using System;
+
+namespace AccessibilityInsights.SharedUx.Controls
+{
+    internal class FileIssueWrapperInput
+    {
+        internal IIssueFilingSource VM { get; }
+        internal Guid EcId { get; }
+        internal Action SwitchToServerLogin { get; }
+        internal Func<IssueInformation> IssueInformationProvider { get; }
+        internal FileBugRequestSource RequestSource { get; }
+        internal string ConfigurePrompt { get; }
+
+        internal FileIssueWrapperInput(IIssueFilingSource vm, Guid ecId, Action switchToServerLogin,
+            Func<IssueInformation> issueInformationProvider, FileBugRequestSource requestSource,
+            string configurePrompt)
+        {
+            VM = vm ?? throw new ArgumentNullException(nameof(vm));
+            EcId = ecId;
+            SwitchToServerLogin = switchToServerLogin ?? throw new ArgumentNullException(nameof(switchToServerLogin));
+            IssueInformationProvider = issueInformationProvider ?? throw new ArgumentNullException(nameof(issueInformationProvider));
+            RequestSource = requestSource;
+            ConfigurePrompt = configurePrompt ?? throw new ArgumentNullException(nameof(configurePrompt));
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -851,7 +851,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 () => this._selectedElement.GetIssueInformation(IssueType.NoFailure),
                 FileBugRequestSource.Hierarchy,
                 Properties.Resources.HierarchyControl_FileIssue_Configure);
-            FileIssueWrapper.FileBugFromRuleResultViewModel(input);
+            FileIssueWrapper.FileIssueFromControl(input);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -849,8 +849,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 this.ElementContext.Id,
                 this.HierarchyActions.SwitchToServerLogin,
                 () => this._selectedElement.GetIssueInformation(IssueType.NoFailure),
-                FileBugRequestSource.Hierarchy,
-                Properties.Resources.HierarchyControl_FileIssue_Configure);
+                FileBugRequestSource.Hierarchy);
             FileIssueWrapper.FileIssueFromControl(input);
         }
 

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -278,7 +278,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 vm.GetIssueInformation,
                 FileBugRequestSource.HowtoFix,
                 Properties.Resources.ScannerResultControl_btnFileBug_Click_File_Issue_Configure);
-            FileIssueWrapper.FileBugFromRuleResultViewModel(input);
+            FileIssueWrapper.FileIssueFromControl(input);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Enums/FileBugRequestSource.cs
+++ b/src/AccessibilityInsights.SharedUx/Enums/FileBugRequestSource.cs
@@ -10,6 +10,5 @@ namespace AccessibilityInsights.SharedUx.Enums
         AutomatedChecks,
         Hierarchy,
         HowtoFix,
-        ColorContrast
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Interfaces/IIssueFilingSource.cs
+++ b/src/AccessibilityInsights.SharedUx/Interfaces/IIssueFilingSource.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
+using Axe.Windows.Core.Bases;
+using System;
+
+namespace AccessibilityInsights.SharedUx.Interfaces
+{
+    internal interface IIssueFilingSource
+    {
+        /// <summary>
+        /// Element
+        /// </summary>
+        A11yElement Element { get; }
+
+        /// <summary>
+        /// Used to store the issue link.
+        /// </summary>
+        Uri IssueLink { get; set; }
+
+        /// <summary>
+        /// Bug id of this element
+        /// </summary>
+        string IssueDisplayText { get; set; }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -179,15 +179,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To file issues, select where you want to file issues..
-        /// </summary>
-        public static string AutomatedChecksControl_btnFileBug_Click_File_Issue_Configure {
-            get {
-                return ResourceManager.GetString("AutomatedChecksControl_btnFileBug_Click_File_Issue_Configure", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to ).
         /// </summary>
         public static string AutomatedChecksControl_CloseParenthesis {
@@ -1805,6 +1796,15 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to To file issues, select where you want to file issues..
+        /// </summary>
+        public static string FileIssuesChooseLocation {
+            get {
+                return ResourceManager.GetString("FileIssuesChooseLocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to first color.
         /// </summary>
         public static string firstChooserAutomationPropertiesName {
@@ -2073,15 +2073,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
             get {
                 return ResourceManager.GetString("HierarchyControl_FileBug_Could_not_find_the_selected_item__the_bug_filing_is_canc" +
                         "eled", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to To file issues, select where you want to file issues..
-        /// </summary>
-        public static string HierarchyControl_FileIssue_Configure {
-            get {
-                return ResourceManager.GetString("HierarchyControl_FileIssue_Configure", resourceCulture);
             }
         }
         
@@ -3728,15 +3719,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string ScanListViewItemViewModel_StatusFormat {
             get {
                 return ResourceManager.GetString("ScanListViewItemViewModel_StatusFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to To file issues, select where you want to file issues..
-        /// </summary>
-        public static string ScannerResultControl_btnFileBug_Click_File_Issue_Configure {
-            get {
-                return ResourceManager.GetString("ScannerResultControl_btnFileBug_Click_File_Issue_Configure", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -411,9 +411,6 @@
   <data name="AutomatedChecksControl_SetRuleResults_TitleURL" xml:space="preserve">
     <value>TitleURL</value>
   </data>
-  <data name="AutomatedChecksControl_btnFileBug_Click_File_Issue_Configure" xml:space="preserve">
-    <value>To file issues, select where you want to file issues.</value>
-  </data>
   <data name="ColorContrastAutomationPropertiesName" xml:space="preserve">
     <value>Color contrast analyzer</value>
   </data>
@@ -671,9 +668,6 @@
   <data name="HierarchyControl_FileBug_Could_not_find_the_selected_item__the_bug_filing_is_canceled" xml:space="preserve">
     <value>Could not find the selected item, the bug filing is canceled.</value>
   </data>
-  <data name="HierarchyControl_FileIssue_Configure" xml:space="preserve">
-    <value>To file issues, select where you want to file issues.</value>
-  </data>
   <data name="TextBlockTextDetails" xml:space="preserve">
     <value>DETAILS</value>
   </data>
@@ -800,9 +794,6 @@
   </data>
   <data name="ScannerResultControl_UpdateTree_Passed_and_Uncertain_tests" xml:space="preserve">
     <value>Passed and Uncertain tests</value>
-  </data>
-  <data name="ScannerResultControl_btnFileBug_Click_File_Issue_Configure" xml:space="preserve">
-    <value>To file issues, select where you want to file issues.</value>
   </data>
   <data name="ScannerResultControl_Thumb_DragDelta_Rule" xml:space="preserve">
     <value>Rule</value>
@@ -1768,5 +1759,8 @@ This failure can be caused by a known framework issue. Click the link below to l
   </data>
   <data name="ScannerResultControl_ViewCodeSample" xml:space="preserve">
     <value>View Code Sample</value>
+  </data>
+  <data name="FileIssuesChooseLocation" xml:space="preserve">
+    <value>To file issues, select where you want to file issues.</value>
   </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/ViewModels/HierarchyNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/HierarchyNodeViewModel.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
+using AccessibilityInsights.SharedUx.Interfaces;
 using AccessibilityInsights.SharedUx.Properties;
 using AccessibilityInsights.SharedUx.Utilities;
 using Axe.Windows.Core.Bases;
@@ -19,7 +20,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// HierarchyTreeItem class
     /// ViewModel for A11yElement in Hierarchy tree
     /// </summary>
-    public class HierarchyNodeViewModel : ViewModelBase
+    public class HierarchyNodeViewModel : ViewModelBase, IIssueFilingSource
     {
         const int NormalIconSizeBack = 14; // size for non composite icon
         const int TreeIconSizeBack = 16;   // size for tree in composite icon

--- a/src/AccessibilityInsights.SharedUx/ViewModels/RuleResultViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/RuleResultViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
 using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
+using AccessibilityInsights.SharedUx.Interfaces;
 using AccessibilityInsights.SharedUx.Utilities;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Misc;
@@ -18,7 +19,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// Class RuleResultViewModel
     /// this is for FastPass scan result display
     /// </summary>
-    public class RuleResultViewModel : ViewModelBase
+    public class RuleResultViewModel : ViewModelBase, IIssueFilingSource
     {
         /// <summary>
         /// Element

--- a/src/AccessibilityInsights.SharedUx/ViewModels/ScanListViewItemViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/ScanListViewItemViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
 using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
+using AccessibilityInsights.SharedUx.Interfaces;
 using AccessibilityInsights.SharedUx.Properties;
 using AccessibilityInsights.SharedUx.Utilities;
 using Axe.Windows.Core.Bases;
@@ -23,7 +24,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
     /// <summary>
     /// ViewModel class for scanlistview Item
     /// </summary>
-    public class ScanListViewItemViewModel : ViewModelBase
+    public class ScanListViewItemViewModel : ViewModelBase, IIssueFilingSource
     {
         public static IList<ScanListViewItemViewModel> GetScanListViewItemViewModels(A11yElement e)
         {


### PR DESCRIPTION
#### Details

Issues can be filed from 3 locations in the UI:
1. From the AutomatedChecks view
2. From the HowToFix view
3. From the UIA Hierarchy

Each of these locations has a unique version of the code, with the following differences:
- Source for telemetry
- Input type (generally a ViewModel of some sort)
- Plumbing changes (some callers store their data directly, some delegate to other classes)
- In one case, we have better error handling to clean up temporary files if the issue filing fails

This PR does the following:
- Moves the common code into the new `FileIssueWrapper` class--it uses the version with the file cleanup if issue filing fails
- Provides control class abstraction by adding the `FileIssueWrapperInput` class
- Provides ViewModel abstraction by adding the `IIssueFilingSource` interface
- Updates the ViewModels to implement `IIssueFilingSource`
- Updates the click handlers to create a `FileIssueWrapperInput` object, then call the `FileIssueWrapper` class
- Replaces 3 identical resource strings with a single copy
- Cleans up using statements that are no longer needed
- Removes a legacy enum (no longer used) from a much earlier iteration

Testing:
- When not set up for issue filing, file bugs from all 3 controls and confirm that the user goes to the settings page
- When connected to ADO, file bugs from all 3 controls and confirm that they work as expected

##### Motivation

Reduce duplicated code, make things more consistent

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue: [1959216](https://mseng.visualstudio.com/1ES/_workitems/edit/1959216)
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



