### PR TITLE
chore: Correct GUID in solution file

### DIFF
--- a/src/AccessibilityInsights.sln
+++ b/src/AccessibilityInsights.sln
@@ -89,7 +89,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AccessibilityInsightsUnitTe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extensions.DiskLoggingTelemetry", "AccessibilityInsights.Extensions.DiskLoggingTelemetry\Extensions.DiskLoggingTelemetry.csproj", "{772E1812-AE54-4E3C-B44C-118BBA6305D2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extensions.DiskLoggingTelemetryTests", "AccessibilityInsights.Extensions.DiskLoggingTelemetryTests\Extensions.DiskLoggingTelemetryTests.csproj", "{9A5CD914-222A-46A3-B8BA-9AD836929F01}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extensions.DiskLoggingTelemetryTests", "AccessibilityInsights.Extensions.DiskLoggingTelemetryTests\Extensions.DiskLoggingTelemetryTests.csproj", "{9A5CD914-222A-46A3-B8BA-9AD836929F01}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
#### Details

This PR updates a GUID in the solution file. I noticed that VS make this change when an unrelated change I made locally updated the solution file. The GUID in question identifies the project type and probably goes back to a mistake when the project was added in #1302.

This change has no impact on what tests are run, and exists primarily to keep the same change from randomly appearing in a future change that touches the solution file.

##### Motivation

Code hygiene

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



