### PR TITLE
feat(framework-issues-ui): Minor tweaks

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListContext.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListContext.cs
@@ -9,15 +9,13 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
     {
         internal Action UpdateTree { get; }
         internal Action SwitchToServerLogin { get; }
-        internal Action ChangeVisibility { get; }
         internal Action<ScannerResultCustomListControl, SelectionChangedEventArgs> ItemSelectedHandler { get; }
         internal Guid EcId { get; }
 
-        public ScannerResultCustomListContext(Action updateTree, Action switchToServerLogin, Action changeVisibility, Action<ScannerResultCustomListControl, SelectionChangedEventArgs> itemSelectedHandler, Guid ecId)
+        public ScannerResultCustomListContext(Action updateTree, Action switchToServerLogin, Action<ScannerResultCustomListControl, SelectionChangedEventArgs> itemSelectedHandler, Guid ecId)
         {
             UpdateTree = updateTree ?? throw new ArgumentNullException(nameof(updateTree));
             SwitchToServerLogin = switchToServerLogin ?? throw new ArgumentNullException(nameof(switchToServerLogin));
-            ChangeVisibility = changeVisibility ?? throw new ArgumentNullException(nameof(changeVisibility));
             ItemSelectedHandler = itemSelectedHandler ?? throw new ArgumentNullException(nameof(itemSelectedHandler));
             EcId = ecId;
         }

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListContext.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListContext.cs
@@ -10,10 +10,10 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         internal Action UpdateTree { get; }
         internal Action SwitchToServerLogin { get; }
         internal Action ChangeVisibility { get; }
-        internal Action<object, SelectionChangedEventArgs> ItemSelectedHandler { get; }
+        internal Action<ScannerResultCustomListControl, SelectionChangedEventArgs> ItemSelectedHandler { get; }
         internal Guid EcId { get; }
 
-        public ScannerResultCustomListContext(Action updateTree, Action switchToServerLogin, Action changeVisibility, Action<object, SelectionChangedEventArgs> itemSelectedHandler, Guid ecId)
+        public ScannerResultCustomListContext(Action updateTree, Action switchToServerLogin, Action changeVisibility, Action<ScannerResultCustomListControl, SelectionChangedEventArgs> itemSelectedHandler, Guid ecId)
         {
             UpdateTree = updateTree ?? throw new ArgumentNullException(nameof(updateTree));
             SwitchToServerLogin = switchToServerLogin ?? throw new ArgumentNullException(nameof(switchToServerLogin));

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListControl.xaml
@@ -26,7 +26,7 @@
                     Grid.IsSharedSizeScope="True" KeyboardNavigation.TabNavigation="Once"
                     SelectionMode="Extended"
                     SelectionChanged="lvDetails_SelectedItemChanged"
-                    IsVisibleChanged="lvDetails_IsVisibleChanged" PreviewMouseWheel="lvDetails_PreviewMouseWheel">
+                    PreviewMouseWheel="lvDetails_PreviewMouseWheel">
                 <ListView.ItemContainerStyle>
                     <Style TargetType="{x:Type ListViewItem}">
                         <Style.Triggers>

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListControl.xaml.cs
@@ -143,7 +143,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
                 return;
             }
 
-            _controlContext.ItemSelectedHandler(sender, e);
+            _controlContext.ItemSelectedHandler(this, e);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListControl.xaml.cs
@@ -163,18 +163,6 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         }
 
         /// <summary>
-        /// Ensure listview contents are displayed properly
-        /// </summary>
-        private void lvDetails_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
-#pragma warning restore CA1801 // unused parameter
-        {
-            if ((bool)e.NewValue)
-            {
-                _controlContext.ChangeVisibility();
-            }
-        }
-
-        /// <summary>
         /// Navigate to link on enter in listview
         /// </summary>
         private void ListViewItem_KeyDown(object sender, KeyEventArgs e)

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -93,7 +93,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// </summary>
         private void SetScannerResultTreeView(A11yElement e)
         {
-            var context = new ScannerResultCustomListContext(UpdateTree, SwitchToServerLogin, ChangeVisibility, ItemSelectedHandler, this.EcId);
+            var context = new ScannerResultCustomListContext(UpdateTree, SwitchToServerLogin, ItemSelectedHandler, this.EcId);
             this.nonFrameworkListControl.SetControlContext(context);
             this.frameworkListControl.SetControlContext(context);
             _list.AddRange(ScanListViewItemViewModel.GetScanListViewItemViewModels(e));
@@ -202,16 +202,6 @@ namespace AccessibilityInsights.SharedUx.Controls
             this.ShowAllResults = true;
             UpdateTree();
             (sender as Button).Visibility = Visibility.Collapsed;
-        }
-
-        /// <summary>
-        /// Change visibility of scanner results details
-        /// </summary>
-        public void ChangeVisibility()
-        {
-            var visible = this.btnShowAll.Visibility;
-            UpdateTree();
-            this.btnShowAll.Visibility = visible;
         }
 
         private void ItemSelectedHandler(ScannerResultCustomListControl control, SelectionChangedEventArgs e)

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -93,8 +93,9 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// </summary>
         private void SetScannerResultTreeView(A11yElement e)
         {
-            this.nonFrameworkListControl.SetControlContext(new ScannerResultCustomListContext(UpdateTree, SwitchToServerLogin, ChangeVisibility, ItemSelectedHandler, this.EcId));
-            this.frameworkListControl.SetControlContext(new ScannerResultCustomListContext(UpdateTree, SwitchToServerLogin, ChangeVisibility, ItemSelectedHandler, this.EcId));
+            var context = new ScannerResultCustomListContext(UpdateTree, SwitchToServerLogin, ChangeVisibility, ItemSelectedHandler, this.EcId);
+            this.nonFrameworkListControl.SetControlContext(context);
+            this.frameworkListControl.SetControlContext(context);
             _list.AddRange(ScanListViewItemViewModel.GetScanListViewItemViewModels(e));
 
             // enable UI elements since Clear() disables them.

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -144,12 +144,12 @@ namespace AccessibilityInsights.SharedUx.Controls
             {
                 if (nonFrameworkIssues.Count > 0)
                 {
-                    nonFrameworkListControl.lvDetails.SelectedItem = 0;
+                    nonFrameworkListControl.lvDetails.SelectedIndex = 0;
                     this.spHowToFix.DataContext = nonFrameworkIssues.First<ScanListViewItemViewModel>();
                 }
                 else
                 {
-                    frameworkListControl.lvDetails.SelectedItem = 0;
+                    frameworkListControl.lvDetails.SelectedIndex = 0;
                     this.spHowToFix.DataContext = frameworkIssues.First<ScanListViewItemViewModel>();
                 }
             }

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -214,9 +214,9 @@ namespace AccessibilityInsights.SharedUx.Controls
             this.btnShowAll.Visibility = visible;
         }
 
-        private void ItemSelectedHandler(object sender, SelectionChangedEventArgs e)
+        private void ItemSelectedHandler(ScannerResultCustomListControl control, SelectionChangedEventArgs e)
         {
-            if (this.frameworkListControl.lvDetails == sender)
+            if (this.frameworkListControl == control)
             {
                 this.nonFrameworkListControl.UnselectAll();
             }

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -50,7 +50,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// <summary>
         /// Style dictionary
         /// </summary>
-        new ResourceDictionary Resources = new ResourceDictionary();
+        new readonly ResourceDictionary Resources = new ResourceDictionary();
 
         /// <summary>
         /// App configation


### PR DESCRIPTION
#### Details

This PR includes some small tweaks to displaying results in the `ScannerResultControl`. In order of commit, they are:
1. The original code created a separate `ScannerResultCustomListContext` for each `ScannerResultCustomListControl` object. The 2 controls can and should share the same context, since all of the state is shared.
2. The `ItemSelectedHandler` was weakly typed since it passed on a generic object. I passed along the `this` object, which gives us stronger typing and stronger encapsulation.
3. The code was trying to select an item in the list, but was setting the `SelectedItem` property (which tries to match an object). The fix is to set the `SelectedIndex` property instead of `SelectedItem`
4. The `ChangeVisibility` method ends up generating multiple calls to `UpdateTree`, so we do a lot more work than is needed. I experimented with removing the method and everything still works as expected
5. The `ScannerResultControl.Resources` property can be readonly. VS suggested this change.

##### Motivation

Fix a behavioral bug (commit #3), general cleanup

##### Screenshots
Description | Image
--- | ---
Current code (no item selected in list) | ![image](https://user-images.githubusercontent.com/45672944/174651732-993af442-3c8e-4338-a367-34924178652e.png)
Fixed code (item 0 is selected in list) | ![image](https://user-images.githubusercontent.com/45672944/174651869-e04d28b6-a15f-4c99-87c3-ecab107014f8.png)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes? (default selection is correct)
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



