### PR TITLE
chore: Update Windows version

### DIFF
--- a/build/prbuild-Control.yml
+++ b/build/prbuild-Control.yml
@@ -5,7 +5,7 @@ pr: none
 jobs:
 - job: ValidateReleaseInfo
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   steps:
   - task: NuGetCommand@2
     displayName: 'NuGet - Octokit install'


### PR DESCRIPTION
#### Details

During our recent release, the following warning was displayed during the [validation pipeline](https://dev.azure.com/accessibility-insights/Accessibility%20Insights%20(private)/_build/results?buildId=36711&view=logs&j=638eecd0-5cac-57a6-ab90-2825363d4ba8):

```
##[warning]The windows-2016 environment is deprecated and will be removed on June 30, 2022. For more details, see https://github.com/actions/virtual-environments/issues/5403
```

This pipeline simply executes a PowerShell script and has no output that links to the build, so we can reasonably allow it to "float" to the latest version of Windows.

##### Motivation

Prevent the pipeline from breaking in a few days.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
We could pin to a specific Windows version, but why?

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
