### PR TITLE
fix: Remove dependency on legacy assembly

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.43" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.20.0" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="6.20.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.20.0" />
@@ -36,7 +37,6 @@
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="Unofficial.Microsoft.mshtml" Version="7.0.3300" />
     <ProjectReference Include="..\AccessibilityInsights.CommonUxComponents\CommonUxComponents.csproj" />
     <ProjectReference Include="..\AccessibilityInsights.Extensions\Extensions.csproj" />
   </ItemGroup>

--- a/src/AccessibilityInsights.Extensions.AzureDevOpsTests/FileIssue/FileIssueHelpersTests.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOpsTests/FileIssue/FileIssueHelpersTests.cs
@@ -47,7 +47,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOpsTests.FileIssue
             var guid = Guid.NewGuid().ToString();
             // Internal id doesn't exist if the text is modified by user in edit pane. this scenario simulate the case.
             string original = $"<br><br><div><hr>{guid}<hr></div>";
-            string expected = "\r\n<BODY><BR><BR>\r\n<DIV></DIV></BODY>";
+            string expected = "<br><br><div></div>";
 
             Assert.AreEqual(expected, FileIssueHelpers.RemoveInternalHTML(original, guid));
         }
@@ -59,9 +59,19 @@ namespace AccessibilityInsights.Extensions.AzureDevOpsTests.FileIssue
             var guid = Guid.NewGuid().ToString();
 
             string original = "<br><br><div><hr>should not be removed<hr></div>";
-            string expected = "\r\n<BODY><BR><BR>\r\n<DIV>\r\n<HR>\r\nshould not be removed\r\n<HR>\r\n</DIV></BODY>";
+            string expected = original;
 
             Assert.AreEqual(expected, FileIssueHelpers.RemoveInternalHTML(original, guid));
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void WrapInHtmlBody_AddsExtraData()
+        {
+            string original = "<br><br><div><hr>This is the original text<hr></div>";
+            string expected = "<body>" + original + "</body>";
+
+            Assert.AreEqual(expected, FileIssueHelpers.WrapInHtmlBody(original));
         }
 
         [TestMethod]

--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Drop3PartySignedFile Include="$(TargetDir)\Ben.Demystifier.dll" />
     <Drop3PartySignedFile Include="$(TargetDir)\CommandLine.dll" />
+    <Drop3PartySignedFile Include="$(TargetDir)\HtmlAgilityPack.dll" />
     <Drop3PartySignedFile Include="$(TargetDir)\Microsoft.Deployment.WindowsInstaller.dll" />
     <Drop3PartySignedFile Include="$(TargetDir)\Newtonsoft.Json.dll" />
   </ItemGroup>

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -74,13 +74,13 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
               <File Source="..\AccessibilityInsights\bin\Release\net472\Axe.Windows.Win32.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Ben.Demystifier.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\CommandLine.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net472\HtmlAgilityPack.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.ApplicationInsights.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Deployment.WindowsInstaller.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.IdentityModel.JsonWebTokens.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.IdentityModel.Logging.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.IdentityModel.Tokens.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.mshtml.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.Build2.WebApi.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.Common.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.Core.WebApi.dll" />


### PR DESCRIPTION
#### Details

As called out in #1377, the ADO issue filing code has a dependency on an assembly that Microsoft no longer supports but that someone has published to NuGet with a license that is probably incorrect. This code gets used to modify the HTML that is used to attach a screenshot to the issue in ADO.

This PR replaces the code that uses the old assembly with code that uses the HtmlAgilityPack [package](https://www.nuget.org/packages/HtmlAgilityPack), which is _genuinely_ MIT licensed, is actively maintained, and is fully open source at [this GitHub repo](https://github.com/zzzprojects/html-agility-pack/).

In addition to minor API differences, the HTML produced is different in 3 ways:
1. The old library forced all HTML tags to upper case; the new library doesn't do this. HTML is case-insensitive so we don't try to reproduce this
2. The old library inserted `\r\n` in various places in the output stream; the new library doesn't do this. These characters might make the output a little easier for humans to parse, but isn't needed for our usage. We won't try to reproduce this.
3. The old library wrapped its output in a `<BODY>` tag; the new library doesn't do this. For API compatibility, we add this explicitly

Tested by creating new ADO issues with the modified code and confirming that the end result matches expectations.

The PR also updates the file set in the WXS file and makes sure that the 3rd party file gets properly signed

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
In checking the WXS file, I noticed some files that should probably be in the WXS file but are not. Looking at the [csproj file](https://github.com/zzzprojects/html-agility-pack/blob/master/src/HtmlAgilityPack.Net45/HtmlAgilityPack.Net45.csproj), none of these assemblies are used by `HtmlAgilityPack.dll`, so I'll add those file references in a separate PR.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue: #1377
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



