### PR TITLE
chore: Update wxs file to match package contents

### DIFF
--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -75,7 +75,9 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
               <File Source="..\AccessibilityInsights\bin\Release\net472\Ben.Demystifier.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\CommandLine.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.ApplicationInsights.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Azure.DevOps.Comments.WebApi.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Deployment.WindowsInstaller.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.IdentityModel.Abstractions.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.IdentityModel.JsonWebTokens.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.IdentityModel.Logging.dll" />
@@ -102,7 +104,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Web.WebView2.Core.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Web.WebView2.WinForms.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Web.WebView2.Wpf.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\WebView2Loader.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Win32.Registry.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Xaml.Behaviors.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\Newtonsoft.Json.dll" />
@@ -120,6 +121,9 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
               <File Source="..\AccessibilityInsights\bin\Release\net472\System.Security.AccessControl.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\System.Security.Principal.Windows.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\System.Threading.Tasks.Extensions.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Web.Http.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Web.Http.WebHost.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net472\WebView2Loader.dll" />
               <File Source="..\AccessibilityInsights\bin\Release\net472\ThirdPartyNotices.html"/>
               <File Source="..\AccessibilityInsights\bin\Release\net472\eula.rtf"/>
               <File Source="..\AccessibilityInsights\bin\Release\net472\links.json"/>


### PR DESCRIPTION
#### Details

Our WXS file has not been kept current when package contents change. This PR just updates the WXS file to match the list of assemblies in `./src/AccessibilityInsights/bin/release/net472`, with the intentional omission of the local disk logging assembly.

##### Motivation

Keep the code up to date

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
Most of these changes probably came from dependabot updates. I wonder if we should consider having a pipeline check that intelligently compares the WXS file with the contents of the folder, then fails if they get out of sync. I'll add this to my list of things to do in slack time...

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



