### PR TITLE
fix: Use ReportException from correct namespace

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using AccessibilityInsights.Extensions.Helpers;
 using AccessibilityInsights.Extensions.Interfaces.IssueReporting;
 using AccessibilityInsights.SharedUx.FileIssue;
 using AccessibilityInsights.SharedUx.Settings;
+using AccessibilityInsights.SharedUx.Telemetry;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/src/AccessibilityInsights.SharedUx/Highlighting/Win32SnapshotButton.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/Win32SnapshotButton.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Utilities;
-using AccessibilityInsights.Extensions.Helpers;
+using AccessibilityInsights.SharedUx.Telemetry;
 using AccessibilityInsights.SharedUx.Utilities;
 using AccessibilityInsights.Win32;
 using System;

--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationBase.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationBase.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.SharedUx.Telemetry;
 using Axe.Windows.Core.Misc;
-using Axe.Windows.Telemetry;
 using Newtonsoft.Json;
 using System;
 


### PR DESCRIPTION
#### Details

We have a `ReportException` method in 3 namespaces, each with a slightly different intended scope:
Namespace | Intended scope
--- | ---
`Axe.Windows.Telemetry` | Exceptions caught inside Axe.Windows
`AccessibilityInsights.Extensions` | Exceptions caught inside extension assemblies
`AccessibilityInsights.SharedUx.Telemetry` | Exceptions caught inside the rest of AIWin

I found 3 places where the wrong namespace was being used. It was probably a case where the method was added, VS suggested a namespace, and the wrong one was chosen. This PR ensures that AIWin's non-extension calls to `ReportException` use the method from the `AccessibilityInsights.SharedUx.Telemetry` namespace.

I've confirmed that the only remaining reference to the `Axe.Windows.Telemetry` namespace is correct (it's where we connect Axe.Windows telemetry into AIWin's telemetry). I also temporarily renamed the `AccessibilityInsights.Extensions` method and confirmed that all associated changes were inside extension assemblies. I reversed the rename before making the commit.

##### Motivation

Code hygiene & consistency

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue?
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



