### PR TITLE
fix: Ensure ADO file issue dialog can reach authenticated page

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
@@ -5,6 +5,7 @@ using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.WinForms;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -22,6 +23,9 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
         enum State
         {
             Initializing,
+            NeedsAuthentication,
+            Authenticating,
+            Authenticated,
             TemplateIsOpen,
             Saving,
             Saved,
@@ -110,8 +114,21 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
                     case State.Initializing:
                         if (currentUri.Host == Url.Host && currentUri.AbsolutePath == Url.AbsolutePath)
                             _currentState = State.TemplateIsOpen;
+                        else
+                        {
+                            _currentState = State.NeedsAuthentication;
+                        }
                         break;
-
+                    case State.NeedsAuthentication:
+                        _currentState = State.Authenticating;
+                        break;
+                    case State.Authenticating:
+                        if (currentUri.Host == Url.Host && currentUri.AbsolutePath == Url.AbsolutePath)
+                            _currentState = State.Authenticated;
+                        break;
+                    case State.Authenticated:
+                        _currentState = State.Initializing;
+                        break;
                     case State.TemplateIsOpen:
                         if (currentUri.Host == Url.Host && currentUri.AbsolutePath != Url.AbsolutePath)
                             _currentState = State.Saving;
@@ -122,43 +139,53 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
                         break;
                 }
             }
+            Trace.WriteLine(Invariant($"State is {_currentState.ToString()}"));
 
             return _currentState;
         }
 
         private void CoreWebView2_HistoryChanged(object sender, object e)
         {
-            if (updateState() == State.Saving)
+            switch (updateState())
             {
-                var url = fileIssueBrowser.Source.PathAndQuery;
-                var savedUrlSubstrings = new List<String>() { "_queries/edit/", "_workitems/edit/", "_workitems?id=" };
-                int urlIndex = savedUrlSubstrings.FindIndex(str => url.Contains(str));
-                if (urlIndex >= 0)
-                {
-                    var matched = savedUrlSubstrings[urlIndex];
-                    var endIndex = url.IndexOf(matched, StringComparison.Ordinal) + matched.Length;
+                case State.Saving:
 
-                    // URL looks like "_queries/edit/2222222/..." where 2222222 is issue id
-                    // or is "_workitems/edit/2222222"
-                    // or is "_workitems?id=2222222"
-                    url = url.Substring(endIndex);
-                    int result;
-                    bool worked = int.TryParse(new String(url.TakeWhile(Char.IsDigit).ToArray()), out result);
-                    if (worked)
+                    var url = fileIssueBrowser.Source.PathAndQuery;
+                    var savedUrlSubstrings = new List<String>() { "_queries/edit/", "_workitems/edit/", "_workitems?id=" };
+                    int urlIndex = savedUrlSubstrings.FindIndex(str => url.Contains(str));
+                    if (urlIndex >= 0)
                     {
-                        this.IssueId = result;
+                        var matched = savedUrlSubstrings[urlIndex];
+                        var endIndex = url.IndexOf(matched, StringComparison.Ordinal) + matched.Length;
+
+                        // URL looks like "_queries/edit/2222222/..." where 2222222 is issue id
+                        // or is "_workitems/edit/2222222"
+                        // or is "_workitems?id=2222222"
+                        url = url.Substring(endIndex);
+                        int result;
+                        bool worked = int.TryParse(new String(url.TakeWhile(Char.IsDigit).ToArray()), out result);
+                        if (worked)
+                        {
+                            this.IssueId = result;
+                        }
+                        else
+                        {
+                            this.IssueId = null;
+                        }
+                        updateState();
+                        this.Close();
                     }
                     else
                     {
-                        this.IssueId = null;
+                        updateState(revert: true);
                     }
-                    updateState();
-                    this.Close();
-                }
-                else
-                {
-                    updateState(revert: true);
-                }
+                    break;
+                case State.NeedsAuthentication:
+                    fileIssueBrowser.Source = new Uri(Url.GetLeftPart(UriPartial.Path));
+                    break;
+                case State.Authenticated:
+                    Navigate(Url);
+                    break;
             }
         }
 
@@ -178,7 +205,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
 
             await this.fileIssueBrowser.EnsureCoreWebView2Async(environment).ConfigureAwait(true);
             this.fileIssueBrowser.NavigationCompleted += NavigationComplete;
-
             this.TopMost = makeTopMost;
             Navigate(this.Url);
 

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
@@ -5,7 +5,6 @@ using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.WinForms;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -139,7 +138,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
                         break;
                 }
             }
-            Trace.WriteLine(Invariant($"State is {_currentState.ToString()}"));
 
             return _currentState;
         }

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/FileIssue/IssueFileForm.cs
@@ -114,9 +114,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
                         if (currentUri.Host == Url.Host && currentUri.AbsolutePath == Url.AbsolutePath)
                             _currentState = State.TemplateIsOpen;
                         else
-                        {
                             _currentState = State.NeedsAuthentication;
-                        }
                         break;
                     case State.NeedsAuthentication:
                         _currentState = State.Authenticating;
@@ -132,7 +130,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
                         if (currentUri.Host == Url.Host && currentUri.AbsolutePath != Url.AbsolutePath)
                             _currentState = State.Saving;
                         break;
-
                     case State.Saving:
                         _currentState = revert ? State.TemplateIsOpen : State.Saved;
                         break;
@@ -147,7 +144,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.FileIssue
             switch (updateState())
             {
                 case State.Saving:
-
                     var url = fileIssueBrowser.Source.PathAndQuery;
                     var savedUrlSubstrings = new List<String>() { "_queries/edit/", "_workitems/edit/", "_workitems?id=" };
                     int urlIndex = savedUrlSubstrings.FindIndex(str => url.Contains(str));


### PR DESCRIPTION
#### Details

This PR updates the File Issue dialog's state machine to detect when an authentication redirect is taking place and confirm the dialog can reach the page without the query parameters before visiting the full pre-populated issue template.

##### Motivation

Addresses issue #1398 

##### Context

The error state in #1398 appears to happen because the `WebView2` dialog that opens during the File Issue flow does not load with the cached credentials from the ADO connection, causing the dialog to redirect to AAD endpoints as it logs in. These redirects extend the url and include the original query parameters in addition to new query parameters that allow for post-authentication redirection to the original page. These new urls are both past the 2000-character limit and prevent the dialog from ever reaching the original url. We found that once the dialog reaches an authenticated state it successfully opens the original url on subsequent attempts and that a shorter initial url will allow the dialog to successfully navigate the authentication redirects.

Because of this, we implemented a flow where we send dialog to a blank issue template if we detect auth redirects and then send it to the original url after we detect it has successfully reached the template.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



