### PR TITLE
chore: Fix various spelling and typographical errors in source code comments and strings (AccessibilityInsights.VersionSwitcher namespace)

### DIFF
--- a/src/AccessibilityInsights.VersionSwitcher/EventLogger.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/EventLogger.cs
@@ -22,7 +22,7 @@ namespace AccessibilityInsights.VersionSwitcher
         private EventLog _log;
 
         /// <summary>
-        /// ctor
+        /// constructor
         /// </summary>
         internal EventLogger()
         {

--- a/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
@@ -24,7 +24,7 @@ namespace AccessibilityInsights.VersionSwitcher
         private readonly string _appToLaunchAfterInstall;
 
         /// <summary>
-        /// ctor
+        /// constructor
         /// </summary>
         /// <param name="productName">The localized product name</param>
         /// <param name="appToLaunchAfterInstall">The path to the app to launch after install completes</param>

--- a/src/AccessibilityInsights.VersionSwitcher/InstallationOptions.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/InstallationOptions.cs
@@ -12,7 +12,7 @@ namespace AccessibilityInsights.VersionSwitcher
     internal class InstallationOptions
     {
         /// <summary>
-        /// The URI to the iweb-hosted installer to use
+        /// The URI to the web-hosted installer to use
         /// </summary>
         internal Uri MsiPath { get; }
 

--- a/src/AccessibilityInsights.VersionSwitcher/InstallationOptions.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/InstallationOptions.cs
@@ -12,7 +12,7 @@ namespace AccessibilityInsights.VersionSwitcher
     internal class InstallationOptions
     {
         /// <summary>
-        /// The Uri to the iweb-hosted nstaller to use
+        /// The URI to the iweb-hosted installer to use
         /// </summary>
         internal Uri MsiPath { get; }
 
@@ -37,7 +37,7 @@ namespace AccessibilityInsights.VersionSwitcher
         internal bool EnableUIAccess { get; }
 
         /// <summary>
-        /// ctor
+        /// constructor
         /// </summary>
         /// <param name="msiPath">String identifying the installer location</param>
         /// <param name="newChannel">String indicating the value for NewChannel</param>

--- a/src/AccessibilityInsights.VersionSwitcher/Properties/AssemblyInfo.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/Properties/AssemblyInfo.cs
@@ -24,7 +24,7 @@ using System.Windows;
 
 //In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
-//inside a <PropertyGroup>.  For example, if you are using US english
+//inside a <PropertyGroup>.  For example, if you are using US English
 //in your source files, set the <UICulture> to en-US.  Then uncomment
 //the NeutralResourceLanguage attribute below.  Update the "en-US" in
 //the line below to match the UICulture setting in the project file.


### PR DESCRIPTION
#### Details
This PR fixes various spelling and typographical errors found in strings and comments in the `AccessibilityInsights.VersionSwitcher` namespace.


##### Motivation
Motivated by errors discovered while working on microsoft/accessibility-insights-windows#1323.


##### Context
One of a series of PRs.


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



