### PR TITLE
chore: Fix various spelling and typographical errors in source code comments and strings (AccessibilityInsights.SharedUx.ActionViews and AccessibilityInsights.SharedUx.Dialogs namespaces)

### DIFF
--- a/src/AccessibilityInsights.SharedUx/ActionViews/GeneralActionView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/GeneralActionView.xaml.cs
@@ -15,7 +15,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
 {
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable
     /// <summary>
-    /// Interaction logic for General ations
+    /// Interaction logic for General actions
     /// handle cases with any number of parameters and any type of returns except A11yElement
     /// </summary>
     public partial class GeneralActionView : UserControl
@@ -26,7 +26,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
         readonly Timer timerInvoke;
         private readonly object _lockObject = new object();
 
-        // Keep track of comboxbox dropdown state
+        // Keep track of combobox dropdown state
         bool isDropDownOpen;
 
         public GeneralActionView(GeneralActionViewModel a)
@@ -199,7 +199,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
 
             if (e.Key == Key.Escape)
             {
-                e.Handled = this.isDropDownOpen; // if the combobox dropdown was open, don't let esc close the dialog
+                e.Handled = this.isDropDownOpen; // if the combobox dropdown was open, don't let Esc close the dialog
                 this.isDropDownOpen = cmbx.IsDropDownOpen = false;
             }
         }

--- a/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml.cs
@@ -14,7 +14,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
 {
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable
     /// <summary>
-    /// Interaction logic for TextRange ations
+    /// Interaction logic for TextRange actions
     /// handle cases with any number of parameters and any type of returns except A11yElement
     /// </summary>
     public partial class TextRangeActionView : UserControl

--- a/src/AccessibilityInsights.SharedUx/Dialogs/MoveTextRangeDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/MoveTextRangeDialog.xaml.cs
@@ -23,7 +23,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         private readonly List<Parameter> Parameters;
         private readonly Type ReturnType;
         /// <summary>
-        /// Notify TextPattern Explorer to update Hilighter
+        /// Notify TextPattern Explorer to update Highlighter
         /// </summary>
         private readonly Action UpdateHighlighter;
 

--- a/src/AccessibilityInsights.SharedUx/Dialogs/PropertyConfigDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/PropertyConfigDialog.xaml.cs
@@ -69,7 +69,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         }
 
         /// <summary>
-        /// Ok button click
+        /// OK button click
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>

--- a/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml.cs
@@ -24,7 +24,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         const string VideoUrl = "https://go.microsoft.com/fwlink/?linkid=2077681";
 
         /// <summary>
-        /// App configation
+        /// App configuration
         /// </summary>
         public static ConfigurationModel Configuration
         {

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextPatternExplorerDialog.xaml.cs
@@ -34,7 +34,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         private readonly List<TextRangeViewModel> CustomList;
 
         /// <summary>
-        /// indidate the type of source methods
+        /// indicate the type of source methods
         /// </summary>
         private SourceTypes CurrentSourceType;
 
@@ -397,7 +397,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         }
 
         /// <summary>
-        /// Refresh highliter with new Bounding Rectangle information.
+        /// Refresh highlighter with new Bounding Rectangle information.
         /// </summary>
         private void UpdateHilighter()
         {

--- a/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/TextRangeFindDialog.xaml.cs
@@ -154,7 +154,7 @@ namespace AccessibilityInsights.SharedUx.Dialogs
         /// <param name="backward"></param>
         private void FindTextRange(bool backward)
         {
-            //turn off hilighter
+            //turn off highlighter
             this.Hilighter.HilightBoundingRectangles(false);
 
             try


### PR DESCRIPTION
#### Details
This PR fixes various spelling and typographical errors found in strings and comments in the `AccessibilityInsights.SharedUx.ActionViews` and `AccessibilityInsights.SharedUx.Dialogs` namespaces.


##### Motivation
Motivated by errors discovered while working on microsoft/accessibility-insights-windows#1323.


##### Context
One of a series of PRs.


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



