### PR TITLE
chore: Fix various spelling and typographical errors in source code comments and strings (AccessibilityInsights.SharedUx.Controls namespace)

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ColorChooser.xaml.cs
@@ -140,7 +140,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         }
 
         /// <summary>
-        /// Close popup with esc
+        /// Close popup with Esc
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>

--- a/src/AccessibilityInsights.SharedUx/Controls/ColorPicker/ColorPickerControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ColorPicker/ColorPickerControl.xaml.cs
@@ -108,7 +108,7 @@ namespace AccessibilityInsights.SharedUx.Controls.ColorPicker
         }
         #endregion RGB Properties
 
-        // Gets or sets the the selected color in hexadecimal notation.
+        // Gets or sets the selected color in hexadecimal notation.
         public string HexadecimalString
         {
             get

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
@@ -159,7 +159,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         }
 
         /// <summary>
-        /// Notify Element selection to swith mode to snapshot
+        /// Notify Element selection to switch mode to snapshot
         /// </summary>
         private void NotifySelected(A11yElement element)
         {

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml.cs
@@ -456,7 +456,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         }
 
         /// <summary>
-        /// Switch listviewitem side on doubleclick
+        /// Switch listviewitem side on double-click
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml.cs
@@ -147,7 +147,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         }
 
         /// <summary>
-        /// App configation
+        /// App configuration
         /// </summary>
         public static ConfigurationModel Configuration
         {

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -64,7 +64,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         const int TreeButtonVerticalSpacing = 36;
 
         /// <summary>
-        /// App configation
+        /// App configuration
         /// </summary>
         public static ConfigurationModel Configuration
         {
@@ -147,7 +147,7 @@ namespace AccessibilityInsights.SharedUx.Controls
                 UpdateButtonVisibility();
 
                 // We remove and re-add the "show uncertain" item from the visual tree
-                // in order to ensure n-of-m information is read correctly
+                // to ensure n-of-m information is read correctly
                 // by screen readers via the SizeOfSet and PositionInSet properties.
                 if (cmHierarchySettings.Items.Contains(mniShowUncertain))
                 {
@@ -787,7 +787,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         }
 
         /// <summary>
-        /// Keep event butotn inside of scrollview
+        /// Keep event button inside of scrollview
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>

--- a/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml.cs
@@ -327,7 +327,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         /// <param name="e"></param>
         private void TabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            // This handler can be called by selectionchanged events occuring in child controls of the tabcontrol
+            // This handler can be called by selectionchanged events occurring in child controls of the tabcontrol
             // We check to make sure the event source is actually the intended tab control before handling the event.
             if (e.Source == tabControlInspect && e.AddedItems.Count > 0)
             {

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -53,7 +53,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         new readonly ResourceDictionary Resources = new ResourceDictionary();
 
         /// <summary>
-        /// App configation
+        /// App configuration
         /// </summary>
         public static ConfigurationModel Configuration
         {

--- a/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/SettingsTabs/ConnectionControl.xaml.cs
@@ -134,7 +134,7 @@ namespace AccessibilityInsights.SharedUx.Controls.SettingsTabs
         #endregion
 
         /// <summary>
-        /// Inititates the view. Fetches a list of all the available issue reporters and creates a list.
+        /// Initializes the view. Fetches a list of all the available issue reporters and creates a list.
         /// </summary>
         public void InitializeView()
         {

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -61,7 +61,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         }
 
         /// <summary>
-        /// App configation
+        /// App configuration
         /// </summary>
         public static ConfigurationModel Configuration
         {
@@ -189,7 +189,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         public void Show()
         {
             var ha = ImageOverlayDriver.GetDefaultInstance();
-            // set handler here. it will make sure that highliter button is shown and working.
+            // set handler here. It will make sure that highlighter button is shown and working.
             ha.SetHighlighterButtonClickHandler(TBElem_Click);
 
             if (this.HighlightVisibility)
@@ -234,7 +234,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         }
 
         /// <summary>
-        /// Notify Element selection to swith mode to snapshot
+        /// Notify Element selection to switch mode to snapshot
         /// </summary>
         /// <param name="e"></param>
         private void NotifySelected(A11yElement e)
@@ -253,7 +253,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
             try
             {
-                // set handler here. it will make sure that highliter button is shown and working.
+                // set handler here. it will make sure that highlighter button is shown and working.
                 ImageOverlayDriver.GetDefaultInstance().SetHighlighterButtonClickHandler(TBElem_Click);
 
                 if (this.ElementContext == null || ec.Element != this.ElementContext.Element || this.DataContext != ec.DataContext)

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
@@ -65,7 +65,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         private readonly object _lockObject = new object();
 
         /// <summary>
-        /// App configation
+        /// App configuration
         /// </summary>
         public static ConfigurationModel Configuration
         {


### PR DESCRIPTION
#### Details
This PR fixes various spelling and typographical errors found in strings and comments in the `AccessibilityInsights.SharedUx.Controls` namespace.


##### Motivation
Motivated by errors discovered while working on microsoft/accessibility-insights-windows#1323.


##### Context
One of a series of PRs.


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



