### PR TITLE
chore: Fix various spelling and typographical errors in source code comments and strings (AccessibilityInsights.SharedUx namespaces)

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -575,7 +575,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Ok.
+        ///   Looks up a localized string similar to OK.
         /// </summary>
         public static string btnOkContent {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1273,7 +1273,7 @@
     <value>Select the Events you want to listen to:</value>
   </data>
   <data name="btnOkContent" xml:space="preserve">
-    <value>Ok</value>
+    <value>OK</value>
   </data>
   <data name="lblEnableTelemetryContent" xml:space="preserve">
     <value>Enable Telemetry</value>
@@ -1587,7 +1587,7 @@ URL: {0}</value>
   </data>
   <data name="PatternInfoControl_PatternPropertyFormat" xml:space="preserve">
     <value>- {0}: {1}</value>
-    <comment>{0} is the propety name; {1} is the property value</comment>
+    <comment>{0} is the property name; {1} is the property value</comment>
   </data>
   <data name="PropertyInfoControl_Properties" xml:space="preserve">
     <value>Properties</value>
@@ -1618,7 +1618,7 @@ URL: {0}</value>
   </data>
   <data name="BaseActionViewModel_ExceptionMessage" xml:space="preserve">
     <value>Exception while invoking {0} : {1}</value>
-    <comment>{0} is the method; {1} is the Exception mesage</comment>
+    <comment>{0} is the method; {1} is the Exception message</comment>
   </data>
   <data name="ColorContrastViewModel_ContrastRatioFormat" xml:space="preserve">
     <value>{0}:1</value>

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -23,7 +23,7 @@
         <GradientStop Color="#004880" Offset="0"/>
         <GradientStop Color="#000000" Offset="0.5"/>
     </LinearGradientBrush>
-    <SolidColorBrush po:Freeze="True" x:Key="PrimaryFGBrush" Color="#FFFFFF"/>          <!-- (UPDATED) Primary Foreground color (used most eveywhere) -->
+    <SolidColorBrush po:Freeze="True" x:Key="PrimaryFGBrush" Color="#FFFFFF"/>          <!-- (UPDATED) Primary Foreground color (used most everywhere) -->
     <SolidColorBrush po:Freeze="True" x:Key="SecondaryFGBrush" Color="#B2B3B5"/>        <!-- (UPDATED) Secondary Foreground color (de-emphasized text) -->
     <SolidColorBrush po:Freeze="True" x:Key="BubbleBGBrush" Color="#696C6F"/>           <!-- (UPDATED) Used ONLY for "New for WCAG 2.1" bubble BG -->
     <SolidColorBrush po:Freeze="True" x:Key="BubbleFGBrush" Color="#FFFFFF"/>           <!-- (UPDATED) Used ONLY for "New for WCAG 2.1" bubble FG -->

--- a/src/AccessibilityInsights.SharedUx/Settings/AppLayout.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/AppLayout.cs
@@ -91,8 +91,7 @@ namespace AccessibilityInsights.SharedUx.Settings
             if (this.Version == null || string.CompareOrdinal(this.Version, AppLayout.CurrentVersion) != 0)
             {
                 // for now we enforce the layout to be always be default if the version mismatch.
-                // it will reduce the unnecessary crashes or
-                // noise. but it may lose the previous layout info.
+                // it will reduce the unnecessary crashes or noise, but it may lose the previous layout info.
                 // we may bear the lose of previous layout for now.
                 this.Top = top;
                 this.Left = left;

--- a/src/AccessibilityInsights.SharedUx/Settings/AppLayout.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/AppLayout.cs
@@ -91,7 +91,8 @@ namespace AccessibilityInsights.SharedUx.Settings
             if (this.Version == null || string.CompareOrdinal(this.Version, AppLayout.CurrentVersion) != 0)
             {
                 // for now we enforce the layout to be always be default if the version mismatch.
-                // it will reduce the unnecessary crashes or noize. but it may lose the previous layout info.
+                // it will reduce the unnecessary crashes or
+                // noise. but it may lose the previous layout info.
                 // we may bear the lose of previous layout for now.
                 this.Top = top;
                 this.Left = left;

--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationBase.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationBase.cs
@@ -25,7 +25,7 @@ namespace AccessibilityInsights.SharedUx.Settings
         public string AppVersion { get; set; }
 
         /// <summary>
-        /// Protected initial ctor--sets version to null
+        /// Protected initial constructor--sets version to null
         /// </summary>
         /// <param name="version">The value for version (can be null)</param>
         protected ConfigurationBase() : this(null)
@@ -33,7 +33,7 @@ namespace AccessibilityInsights.SharedUx.Settings
         }
 
         /// <summary>
-        /// Protected initial ctor--caller provides the version for the config object
+        /// Protected initial constructor--caller provides the version for the config object
         /// </summary>
         /// <param name="version">The value for version (can be null)</param>
         protected ConfigurationBase(string version)

--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
@@ -316,7 +316,7 @@ namespace AccessibilityInsights.SharedUx.Settings
         }
 
         /// <summary>
-        /// Indicate which hightlighter mode to use
+        /// Indicate which highlighter mode to use
         /// </summary>
         public HighlighterMode HighlighterMode
         {
@@ -343,7 +343,7 @@ namespace AccessibilityInsights.SharedUx.Settings
         }
 
         /// <summary>
-        /// if it is true, show the full list of ancesters up to desktop in snap mode.
+        /// if it is true, show the full list of ancestors up to desktop in snap mode.
         /// </summary>
         public bool ShowAncestry
         {
@@ -472,7 +472,7 @@ namespace AccessibilityInsights.SharedUx.Settings
         }
 
         /// <summary>
-        /// ctor from DiskConfigurationModel
+        /// constructor from DiskConfigurationModel
         /// </summary>
         private ConfigurationModel(SettingsDictionary source)
         {
@@ -482,7 +482,7 @@ namespace AccessibilityInsights.SharedUx.Settings
         }
 
         /// <summary>
-        /// Copy ctor
+        /// Copy constructor
         /// </summary>
         /// <param name="source"></param>
         private ConfigurationModel(ConfigurationModel source)

--- a/src/AccessibilityInsights.SharedUx/Telemetry/ReportExceptionBuffer.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/ReportExceptionBuffer.cs
@@ -20,7 +20,7 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         private readonly Action<Exception> _target;
 
         /// <summary>
-        /// Ctor
+        /// Constructor
         /// </summary>
         /// <param name="target">The target to receive exceptions</param>
         internal ReportExceptionBuffer(Action<Exception> target)

--- a/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
@@ -128,14 +128,14 @@ namespace AccessibilityInsights.SharedUx.Utilities
         /// Get Root Node Hierarchy ViewModel based on currently populated data.
         /// </summary>
         /// <param name="dc">Datacontext to create nodes from</param>
-        /// <param name="showAncestry">Should ancestory be shown</param>
+        /// <param name="showAncestry">Should ancestry be shown</param>
         /// <param name="showUncertain">Should uncertain scans be shown</param>
         /// <param name="isLiveMode">Is node for live mode</param>
         public static HierarchyNodeViewModel GetRootNodeHierarchyViewModel(this ElementDataContext dc, bool showAncestry, bool showUncertain, bool isLiveMode)
         {
             if (dc?.RootElment?.Properties != null && dc.RootElment.Properties.Count != 0 && dc.Element != null)
             {
-                // if need to show ancestry, start from rootnode
+                // if need to show ancestry, start from root node
                 // if not show ancestry, but element has no parent, return element itself.
                 return new HierarchyNodeViewModel(showAncestry ? dc.RootElment : dc.Element.Parent ?? dc.Element, showUncertain, isLiveMode);
             }

--- a/src/AccessibilityInsights.SharedUx/Utilities/HelperMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/HelperMethods.cs
@@ -40,7 +40,7 @@ namespace AccessibilityInsights.SharedUx.Utilities
         }
 
         /// <summary>
-        /// General visibilty status of bug-filing features. This is visible when a bug filing
+        /// General visibility status of bug-filing features. This is visible when a bug filing
         /// extension exists, otherwise it's collapsed. Used when the decision is independent
         /// of the selected ElementContext
         /// </summary>

--- a/src/AccessibilityInsights.SharedUx/Utilities/InstallationInfo.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/InstallationInfo.cs
@@ -29,7 +29,7 @@ namespace AccessibilityInsights.SharedUx.Utilities
         public DateTime LastReset { get; private set; }
 
         /// <summary>
-        /// Production ctor - Uses a new installId and current time
+        /// Production constructor - Uses a new installId and current time
         /// </summary>
         public InstallationInfo()
             : this(Guid.NewGuid(), DateTime.UtcNow)
@@ -37,7 +37,7 @@ namespace AccessibilityInsights.SharedUx.Utilities
         }
 
         /// <summary>
-        /// Unit test ctor - lets caller specify installID and lastReset time
+        /// Unit test constructor - lets caller specify installID and lastReset time
         /// </summary>
         /// <param name="installId">The initial value of InstallationGuid</param>
         /// <param name="lastReset">The initial value of LastReset</param>

--- a/src/AccessibilityInsights.SharedUx/Utilities/ReferenceHolder.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/ReferenceHolder.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 namespace AccessibilityInsights.SharedUx.Utilities
 {
     /// <summary>
-    /// Wrapper to store the hwind as key and (BorderLine, TextTip or Win32SnapShotButton) as Value
+    /// Wrapper to store the hwnd as key and (BorderLine, TextTip or Win32SnapShotButton) as Value
     /// Since it all runs in the UI thread, we don't need to use a thread safe data structure like ConcurrentDictionary
     /// </summary>
     public class ReferenceHolder<TKey, TValue>


### PR DESCRIPTION
#### Details
This PR fixes spelling and typographical errors found in strings and comments in various namespaces under `AccessibilityInsights.SharedUx`.


##### Motivation
Motivated by errors discovered while working on microsoft/accessibility-insights-windows#1323.


##### Context
One of a series of PRs.


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



