### PR TITLE
chore: Remove DisableDarkMode config setting

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationConstants.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationConstants.cs
@@ -37,7 +37,6 @@ namespace AccessibilityInsights.SharedUx.Settings
         private const string KeyAppVersion = "AppVersion";
         private const string KeyCoreProperties = "CoreProperties";
         private const string KeyCoreTPAttributes = "CoreTPAttributes";
-        private const string KeyDisableDarkMode = "DisableDarkMode";
         private const string KeyDisableTestsInSnapMode = "DisableTestsInSnapMode";
         private const string KeyEnableTelemetry = "EnableTelemetry";
         private const string KeyEventRecordPath = "EventRecordPath";

--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
@@ -422,15 +422,6 @@ namespace AccessibilityInsights.SharedUx.Settings
         }
 
         /// <summary>
-        /// If true, dark mode will be disabled
-        /// </summary>
-        public bool DisableDarkMode
-        {
-            get => GetDataValue<bool>(KeyDisableDarkMode);
-            set => SetDataValue<bool>(KeyDisableDarkMode, value);
-        }
-
-        /// <summary>
         /// If true, telemetry startup dialog will be displayed
         /// </summary>
         public bool ShowTelemetryDialog

--- a/src/AccessibilityInsights.SharedUxTests/Resources/ConfigSettings.json
+++ b/src/AccessibilityInsights.SharedUxTests/Resources/ConfigSettings.json
@@ -14,7 +14,6 @@
         30101
     ],
     "CoreTPAttributes": [],
-    "DisableDarkMode": true,
     "DisableTestsInSnapMode": false,
     "EnableTelemetry": false,
     "EventRecordPath": "C:\\blah\\AccessibilityInsightsEventFiles",

--- a/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SetupLibrary;
 using AccessibilityInsights.SharedUx.Enums;
@@ -91,7 +91,6 @@ namespace AccessibilityInsights.SharedUxTests.Settings
                 config.CoreProperties.ToArray());
             ConfirmEnumerablesMatchExpectations(new int[] { }, config.CoreTPAttributes.ToArray());
             Assert.IsFalse(config.DisableTestsInSnapMode);
-            Assert.IsFalse(config.DisableDarkMode);
             Assert.IsFalse(config.EnableTelemetry);
             Assert.IsTrue(config.EventRecordPath.Equals(testProvider.UserDataFolderPath));
             Assert.AreEqual(FontSize.Standard, config.FontSize);
@@ -124,7 +123,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
             Assert.AreEqual(TreeViewMode.Control, config.TreeViewMode);
             Assert.AreEqual(ReleaseChannel.Production, config.ReleaseChannel);
             Assert.AreEqual("1.1.10", config.Version);
-            Assert.AreEqual(37, typeof(ConfigurationModel).GetProperties().Length, "Count of ConfigurationModel properties has changed! Please ensure that you are testing the default value for all properties, then update the expected value");
+            Assert.AreEqual(36, typeof(ConfigurationModel).GetProperties().Length, "Count of ConfigurationModel properties has changed! Please ensure that you are testing the default value for all properties, then update the expected value");
         }
 
         [TestMethod]
@@ -141,7 +140,6 @@ namespace AccessibilityInsights.SharedUxTests.Settings
             ConfigurationModel config = ConfigurationModel.LoadFromJSON(@".\Resources\ConfigSettings.json", testProvider);
 
             ConfirmOverrideConfigMatchesExpectation(config,
-                disableDarkMode: true,
                 issueReporterSerializedConfigs: @"{""27f21dff-2fb3-4833-be55-25787fce3e17"":""hello world""}",
                 selectedIssueReporter: new Guid("{27f21dff-2fb3-4833-be55-25787fce3e17}"),
                 releaseChannel: ReleaseChannel.Canary
@@ -155,7 +153,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
 
         private static void ConfirmOverrideConfigMatchesExpectation(ConfigurationModel config,
             Guid? selectedIssueReporter = null, string issueReporterSerializedConfigs = null,
-            ReleaseChannel? releaseChannel = null, bool disableDarkMode = false)
+            ReleaseChannel? releaseChannel = null)
         {
             Assert.IsFalse(config.AlwaysOnTop);
             Assert.AreEqual("1.1.", config.AppVersion.Substring(0, 4));
@@ -166,7 +164,6 @@ namespace AccessibilityInsights.SharedUxTests.Settings
                 config.CoreProperties.ToArray());
             ConfirmEnumerablesMatchExpectations(new int[] { }, config.CoreTPAttributes.ToArray());
             Assert.IsFalse(config.DisableTestsInSnapMode);
-            Assert.AreEqual(config.DisableDarkMode, disableDarkMode);
             Assert.IsFalse(config.EnableTelemetry);
             Assert.AreEqual(@"C:\blah\AccessibilityInsightsEventFiles", config.EventRecordPath);
             Assert.AreEqual(FontSize.Small, config.FontSize);

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
 using AccessibilityInsights.CommonUxComponents.Dialogs;
@@ -229,10 +229,7 @@ namespace AccessibilityInsights
             }
             else
             {
-                // Due to initialization order, config will be null the first time this is called
-                ConfigurationModel config = ConfigurationManager.GetDefaultInstance()?.AppConfig;
-
-                theme = (config != null && !config.DisableDarkMode && NativeMethods.IsDarkModeEnabled())
+                theme = (NativeMethods.IsDarkModeEnabled())
                     ? App.Theme.Dark
                     : App.Theme.Light;
             }


### PR DESCRIPTION
#### Details

Remove support for the `DisableDarkMode` config setting. This setting has no UI and required manual editing of the config file.

##### Motivation

When dark mode was introduced in #719, it was gated behind a non-UI config setting named `EnableDarkMode` so that people had to explicitly _opt in_ to use dark mode. When dark mode was enabled by default in #764, we provided a non-UI config setting named `DisableDarkMode` so that people had a way to _opt out_ from dark mode in AIWin. Both of these settings were included because we were concerned about dark mode bugs that could potentially block usability. That was 2 years ago and dark mode has matured a lot since then, so this config setting can now be removed.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



