### PR TITLE
chore: Embed symbols and SourceLink in released binaries

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -39,7 +39,21 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
 
   <Choose>
     <When Condition=" '$(DropSignedFile)' == '' ">


### PR DESCRIPTION
#### Details

Embed symbol (PDB) files into the shipping assemblies and enable SourceLink. This is similar to what we did for Axe.Windows in [#719](https://github.com/microsoft/axe-windows/pull/719) and [#727](https://github.com/microsoft/axe-windows/pull/727). In this case, though, we're moving directly to centrally managed settings, instead of first adding them in the projects, then centralizing them.

##### Motivation

A recent issue included a dump file in which the symbols did not resolve (because they aren't indexed). Looking at crash reports, the embedded symbols in Axe.Windows are getting recognized, so embedding symbols in AIWin should be helpful. It increases the file size by about 20%, but that's a small price to pay if we have better debugging support.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
I tested this by building a signed build from this branch, then installing it locally. I was able to attach VS to the running process and set function breakpoints, When the breakpoint triggered, VS used the SourceLink data to download the sources to a local cache and provide source-level debugging. While this shows that the information is available, we won't have proof that it works in the broader debugging ecosystem until we deploy it and watch for results in the crash reporting system.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue?
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



