### PR TITLE
Add telemetry for auto colour contrast detection

### DIFF
--- a/docs/TelemetryDetails.md
+++ b/docs/TelemetryDetails.md
@@ -10,6 +10,21 @@ Application events are queried from the `customEvents` table. All application ev
 - A `name` property that matches one of the events defined below.
 - An optional set of event-specific properties, as defined with each event.
 
+#### ColorContrast_AutoDetect
+Trigger: Automatic contrast detection is run.
+Additional properties:
+Name | Value
+--- | ---
+`Confidence` | The confidence of the analysis. One of `High`, `Mid`, `Low`, or `None`.
+`BitmapSize` | The size in pixels (width times height) of the bitmap being processed.
+
+#### ColorContrast_Click_Autodetect_Toggle
+Trigger: The user clicks the "Auto detect contrast ratio" button in the color contrast view.
+Additional properties:
+Name | Value
+--- | ---
+`IsAutoDetectColorContrastEnabled` | one of `true` or `false` indicating whether automatic detection is enabled.
+
 #### ColorContrast_Click_Dropdown
 Trigger: The user opens a color picker popup in the Color Contrast view.  
 Additional properties: None.
@@ -27,7 +42,7 @@ Trigger: The application was configured with a `CustomUIA.json` file as describe
 Additional properties:
 Name | Value 
 --- | ---
-CustomUIAPropertyCount | The count of custom UIA properties that were defined in the `CustomUIA.json` file.
+`CustomUIAPropertyCount` | The count of custom UIA properties that were defined in the `CustomUIA.json` file.
 
 #### Event_Load
 Trigger: The user successfully opens a previously-saved A11yEvents file.  

--- a/docs/TelemetryDetails.md
+++ b/docs/TelemetryDetails.md
@@ -23,7 +23,7 @@ Trigger: The user clicks the "Auto detect contrast ratio" button in the color co
 Additional properties:
 Name | Value
 --- | ---
-`IsAutoDetectColorContrastEnabled` | one of `true` or `false` indicating whether automatic detection is enabled.
+`IsNowEnabled` | one of `true` or `false` indicating whether automatic detection is enabled.
 
 #### ColorContrast_Click_Dropdown
 Trigger: The user opens a color picker popup in the Color Contrast view.  

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
@@ -125,7 +125,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                     new Dictionary<TelemetryProperty, string>
                     {
                         {TelemetryProperty.BitmapSize, (bitmap.Width * bitmap.Height).ToString(CultureInfo.InvariantCulture)},
-                        [TelemetryProperty.Confidence] = "None"
+                        { TelemetryProperty.Confidence, "None" }
                     }
                 );
                 throw new InvalidOperationException("Unable to determine colors!");
@@ -139,8 +139,8 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 TelemetryAction.ColorContrast_AutoDetect,
                 new Dictionary<TelemetryProperty, string>
                 {
-                    [TelemetryProperty.BitmapSize] = (bitmap.Width * bitmap.Height).ToString(CultureInfo.InvariantCulture),
-                    [TelemetryProperty.Confidence] = result.Confidence.ToString()
+                    { TelemetryProperty.BitmapSize, (bitmap.Width * bitmap.Height).ToString(CultureInfo.InvariantCulture) },
+                    { TelemetryProperty.Confidence, result.Confidence.ToString() }
                 }
             );
         }
@@ -298,7 +298,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                     TelemetryAction.ColorContrast_Click_Autodetect_Toggle,
                     new Dictionary<TelemetryProperty, string>
                     {
-                        [TelemetryProperty.IsAutoDetectColorContrastEnabled] = isEnabled.ToString(CultureInfo.InvariantCulture)
+                        { TelemetryProperty.IsNowEnabled, isEnabled.ToString(CultureInfo.InvariantCulture) }
                     }
                 );
             }

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
@@ -124,7 +124,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                     TelemetryAction.ColorContrast_AutoDetect,
                     new Dictionary<TelemetryProperty, string>
                     {
-                        [TelemetryProperty.BitmapSize] = (bitmap.Width * bitmap.Height).ToString(CultureInfo.InvariantCulture),
+                        {TelemetryProperty.BitmapSize, (bitmap.Width * bitmap.Height).ToString(CultureInfo.InvariantCulture)},
                         [TelemetryProperty.Confidence] = "None"
                     }
                 );

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
@@ -12,6 +12,7 @@ using Axe.Windows.Actions.Contexts;
 using Axe.Windows.Desktop.ColorContrastAnalyzer;
 using Axe.Windows.Desktop.Utility;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
@@ -119,6 +120,14 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
 
             if (pair == null)
             {
+                Logger.PublishTelemetryEvent(
+                    TelemetryAction.ColorContrast_AutoDetect,
+                    new Dictionary<TelemetryProperty, string>
+                    {
+                        [TelemetryProperty.BitmapSize] = (bitmap.Width * bitmap.Height).ToString(CultureInfo.InvariantCulture),
+                        [TelemetryProperty.Confidence] = "None"
+                    }
+                );
                 throw new InvalidOperationException("Unable to determine colors!");
             }
 
@@ -126,6 +135,14 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             this.ContrastVM.FirstColor = pair.DarkerColor.DrawingColor.ToMediaColor();
             this.ContrastVM.SecondColor = pair.LighterColor.DrawingColor.ToMediaColor();
             tbConfidence.Text = result.Confidence.ToString();
+            Logger.PublishTelemetryEvent(
+                TelemetryAction.ColorContrast_AutoDetect,
+                new Dictionary<TelemetryProperty, string>
+                {
+                    [TelemetryProperty.BitmapSize] = (bitmap.Width * bitmap.Height).ToString(CultureInfo.InvariantCulture),
+                    [TelemetryProperty.Confidence] = result.Confidence.ToString()
+                }
+            );
         }
 
         private void SetConfidenceVisibility(Visibility visibility)
@@ -276,6 +293,14 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             if (CCAMode != null)
             {
                 CCAMode.HandleToggleStatusChanged(isEnabled);
+
+                Logger.PublishTelemetryEvent(
+                    TelemetryAction.ColorContrast_Click_Autodetect_Toggle,
+                    new Dictionary<TelemetryProperty, string>
+                    {
+                        [TelemetryProperty.IsAutoDetectColorContrastEnabled] = isEnabled.ToString(CultureInfo.InvariantCulture)
+                    }
+                );
             }
 
             SetConfidenceVisibility(Visibility.Hidden);

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
@@ -122,7 +122,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
                 TelemetryAction.ColorContrast_AutoDetect,
                 new Dictionary<TelemetryProperty, string>
                 {
-                    {TelemetryProperty.BitmapSize, (bitmap.Width * bitmap.Height).ToString(CultureInfo.InvariantCulture)},
+                    { TelemetryProperty.BitmapSize, (bitmap.Width * bitmap.Height).ToString(CultureInfo.InvariantCulture) },
                     { TelemetryProperty.Confidence, result.Confidence.ToString() }
                 }
             );

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/ColorContrast.xaml.cs
@@ -118,16 +118,17 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             var result = bmc.RunColorContrastCalculation();
             var pair = result.MostLikelyColorPair;
 
+            Logger.PublishTelemetryEvent(
+                TelemetryAction.ColorContrast_AutoDetect,
+                new Dictionary<TelemetryProperty, string>
+                {
+                    {TelemetryProperty.BitmapSize, (bitmap.Width * bitmap.Height).ToString(CultureInfo.InvariantCulture)},
+                    { TelemetryProperty.Confidence, result.Confidence.ToString() }
+                }
+            );
+
             if (pair == null)
             {
-                Logger.PublishTelemetryEvent(
-                    TelemetryAction.ColorContrast_AutoDetect,
-                    new Dictionary<TelemetryProperty, string>
-                    {
-                        {TelemetryProperty.BitmapSize, (bitmap.Width * bitmap.Height).ToString(CultureInfo.InvariantCulture)},
-                        { TelemetryProperty.Confidence, "None" }
-                    }
-                );
                 throw new InvalidOperationException("Unable to determine colors!");
             }
 
@@ -135,14 +136,6 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
             this.ContrastVM.FirstColor = pair.DarkerColor.DrawingColor.ToMediaColor();
             this.ContrastVM.SecondColor = pair.LighterColor.DrawingColor.ToMediaColor();
             tbConfidence.Text = result.Confidence.ToString();
-            Logger.PublishTelemetryEvent(
-                TelemetryAction.ColorContrast_AutoDetect,
-                new Dictionary<TelemetryProperty, string>
-                {
-                    { TelemetryProperty.BitmapSize, (bitmap.Width * bitmap.Height).ToString(CultureInfo.InvariantCulture) },
-                    { TelemetryProperty.Confidence, result.Confidence.ToString() }
-                }
-            );
         }
 
         private void SetConfidenceVisibility(Visibility visibility)

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryAction.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryAction.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 namespace AccessibilityInsights.SharedUx.Telemetry
 {
@@ -45,6 +45,8 @@ namespace AccessibilityInsights.SharedUx.Telemetry
 
         TestSelection_Set_Scope, // set the scope
 
+        ColorContrast_AutoDetect,
+        ColorContrast_Click_Autodetect_Toggle,
         ColorContrast_Click_Eyedropper,
         ColorContrast_Click_Dropdown,
         ColorContrast_Click_HexChange,

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
@@ -40,7 +40,7 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         InstalledDotNetFrameworkVersion,
         OsArchitecture,
         CustomUIAPropertyCount,
-        IsAutoDetectColorContrastEnabled,
+        IsNowEnabled,
         Confidence, // For automatic colour contrast detection
         BitmapSize, // For automatic colour contrast detection
     }

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 namespace AccessibilityInsights.SharedUx.Telemetry
 {
@@ -40,5 +40,8 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         InstalledDotNetFrameworkVersion,
         OsArchitecture,
         CustomUIAPropertyCount,
+        IsAutoDetectColorContrastEnabled,
+        Confidence, // For automatic colour contrast detection
+        BitmapSize, // For automatic colour contrast detection
     }
 }


### PR DESCRIPTION
#### Details
This PR adds telemetry to report:

* Whether automatic colour contrast detection is enabled/disabled by the user.
* The size (width * height) of bitmaps run under automatic colour contrast detection.
* The confidence reported by automatic colour contrast detection.

The telemetry schema is compatible with that introduced in #1404.

##### Motivation
We are considering disabling or removing automatic colour contrast detection due to a propensity to provide inaccurate results but want to assess impact first.

Related to #144, #537, #996, #1244, #1387.

##### Context
This PR leaves automatic colour contrast detection as-is, only adding telemetry. No changes to functionality have been made.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 