### PR TITLE
chore: Use newer signing plugin

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -205,7 +205,7 @@ jobs:
     GDN_CODESIGN_TARGETDIRECTORY: '$(Build.ArtifactStagingDirectory)\SigningValidation'
 
   steps:
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@2
+  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
     displayName: 'Install Signing Plugin'
     inputs:
       signType: real


### PR DESCRIPTION
#### Details

The version of the ADO signing task that we've been using has been deprecated, causing our signed build to break. This simply bumps the task to the latest version. None of the parameters needed to be updated. Validation build is at https://dev.azure.com/mseng/1ES/_build/results?buildId=18305232&view=results.

##### Motivation

We need to be able to sign to ship.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



