### PR TITLE
Chore: Disable automatic colour contrast detection by default

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -974,7 +974,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Auto-detection allows you to evaluate color contrast ratios by hovering over an element or setting the keyboard focus on it..
+        ///   Looks up a localized string similar to Auto-detection allows you to evaluate color contrast ratios by hovering over an element or setting the keyboard focus on it. The colors are detected heuristically. If incorrect colors are detected, please use the eyedroppers to improve the accuracy of the results..
         /// </summary>
         public static string ColorContrast_AutoDetectGuidance {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1305,7 +1305,7 @@ We collect anonymized data to identify the top accessibility issues found by use
     <value>Auto detect contrast ratio</value>
   </data>
   <data name="ColorContrast_AutoDetectGuidance" xml:space="preserve">
-    <value>Auto-detection allows you to evaluate color contrast ratios by hovering over an element or setting the keyboard focus on it.</value>
+    <value>Auto-detection allows you to evaluate color contrast ratios by hovering over an element or setting the keyboard focus on it. The colors are detected heuristically. If incorrect colors are detected, please use the eyedroppers to improve the accuracy of the results.</value>
   </data>
   <data name="hlHelpName" xml:space="preserve">
     <value>Help</value>

--- a/src/AccessibilityInsights/Modes/CCAModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/CCAModeControl.xaml.cs
@@ -145,8 +145,6 @@ namespace AccessibilityInsights.Modes
                 this.SetFocusOnDefaultControl();
             }
             , System.Windows.Threading.DispatcherPriority.Input);
-
-            ctrlContrast.SetAutoCCAState(true);
         }
 
         /// <summary>


### PR DESCRIPTION
#### Details
This PR disables automatic colour contrast detection by default and adds additional explanatory text to reduce possible user confusion.

##### Motivation
Related to #996. Follow-up of #1427.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
