### PR TITLE
Play sound when scanning independent of the screen reader flag

### DIFF
--- a/src/AccessibilityInsights.CommonUxComponents/Controls/ProgressRingControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/ProgressRingControl.xaml.cs
@@ -94,14 +94,6 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
         }
 
         /// <summary>
-        /// Check if any Screen Reader is running
-        /// </summary>
-        public static bool IsScreenReaderActive()
-        {
-            return (IsInternalScreenReaderActive() || NativeMethods.IsExternalScreenReaderActive()) && AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged);
-        }
-
-        /// <summary>
         /// Check whether to play sound feedback while scanning
         /// </summary>
         public bool ShouldPlayScannerSound() => WithSound;

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/ProgressRingControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/ProgressRingControl.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Win32;
 using Microsoft.Win32;
@@ -102,11 +102,9 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
         }
 
         /// <summary>
-        /// Check if we need to play scanning sound, play sound while meet both conditions below:
-        ///    1. "play sound while scanning" option in settings panel is on
-        ///    2. At least one AT tool is running
+        /// Check whether to play sound feedback while scanning
         /// </summary>
-        public bool ShouldPlayScannerSound() => WithSound && IsScreenReaderActive();
+        public bool ShouldPlayScannerSound() => WithSound;
 
         /// <summary>
         /// Overriding LocalizedControlType


### PR DESCRIPTION
#### Details
##### Summary of the issue
Accessibility Insights for Windows has an option to play a sound when scanning, but it is only honoured when the system screen reader flag is set.

##### Description of how this pull request fixes the issue
Remove the SR flag check. We might bring it back in another location if we need it down the track.

##### Testing strategy
* Run the latest canary build with the sr flag set (run NVDA with no command line options).
    *  With the option to play a sound while scanning active, observe that the Windows NFC connection sound is played while scanning a complex app (such as `devenv`).
* Run the latest canary build without the sr flag set (run nvda with `--no-sr-flag` on the command line).
    *  With the option to play a sound while scanning active, observe that no sound is played while scanning a complex app (such as `devenv`).
* Run a build of this PR with the SR flag set and unset (as above).
    * Observe that the Windows NFC connection sound is played while scanning.

##### Motivation
Inspired by discussions surrounding #1440.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge.