### PR TITLE
fix: Provide effective way for user to request Pattern Action

### DIFF
--- a/src/AccessibilityInsights.SharedUx/ActionViews/NotSupportActionView.xaml
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/NotSupportActionView.xaml
@@ -10,14 +10,7 @@
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>
         <StackPanel VerticalAlignment="Center" Margin="10">
-            <TextBlock TextWrapping="Wrap">
-                <Run Text="{x:Static Properties:Resources.UnsupportedActionPart1BeforeActionName}"/>
-                <Run Name="actionName" FontWeight="Bold"/>
-                <Run Text="{x:Static Properties:Resources.UnsupportedActionPart2BetweenActionNameAndLink}"/>
-                <Hyperlink NavigateUri="https://github.com/microsoft/accessibility-insights-windows/issues" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" >
-                    <Run Text="https://github.com/microsoft/accessibility-insights-windows/issues" />
-                </Hyperlink><Run Text="{x:Static Properties:Resources.UnsupportedActionPart3AfterLink}"/>
-            </TextBlock>
+            <TextBlock Name="requestActionMessage" TextWrapping="Wrap" Text="{x:Static Properties:Resources.UnsupportedActionMessageFormat}" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/src/AccessibilityInsights.SharedUx/ActionViews/NotSupportActionView.xaml
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/NotSupportActionView.xaml
@@ -5,15 +5,19 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:AccessibilityInsights.SharedUx.ActionViews"
              xmlns:Properties="clr-namespace:AccessibilityInsights.SharedUx.Properties"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>
         <StackPanel VerticalAlignment="Center" Margin="10">
-            <TextBlock TextWrapping="Wrap" Focusable="True" Text="{x:Static Properties:Resources.TextBlockText}"/>
-            <TextBlock x:Name="tbName" VerticalAlignment="Center" Margin="0,10,0,0" Focusable="True"/>
-            <Button Content="{x:Static Properties:Resources.ButtonContent}" Click="Button_Click"/>
+            <TextBlock TextWrapping="Wrap">
+                <Run Text="{x:Static Properties:Resources.UnsupportedActionPart1BeforeActionName}"/>
+                <Run Name="actionName" FontWeight="Bold"/>
+                <Run Text="{x:Static Properties:Resources.UnsupportedActionPart2BetweenActionNameAndLink}"/>
+                <Hyperlink NavigateUri="https://github.com/microsoft/accessibility-insights-windows/issues" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" >
+                    <Run Text="https://github.com/microsoft/accessibility-insights-windows/issues" />
+                </Hyperlink><Run Text="{x:Static Properties:Resources.UnsupportedActionPart3AfterLink}"/>
+            </TextBlock>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/src/AccessibilityInsights.SharedUx/ActionViews/NotSupportActionView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/NotSupportActionView.xaml.cs
@@ -21,6 +21,8 @@ namespace AccessibilityInsights.SharedUx.ActionViews
     {
         private readonly BaseActionViewModel ActionViewModel;
 
+        private const int BoldFontWeight = 700;
+
         public NotSupportActionView(BaseActionViewModel a)
         {
             InitializeComponent();
@@ -42,7 +44,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
             {
                 switch (part)
                 {
-                    case "{0}": return new Run { Text = actionID, FontWeight = FontWeight.FromOpenTypeWeight(700) };
+                    case "{0}": return new Run { Text = actionID, FontWeight = FontWeight.FromOpenTypeWeight(BoldFontWeight) };
                     case "{1}": 
                         var hyperLink = new Hyperlink(new Run { Text = url, }) { NavigateUri = new Uri(url) };
                         hyperLink.RequestNavigate += Hyperlink_RequestNavigate;

--- a/src/AccessibilityInsights.SharedUx/ActionViews/NotSupportActionView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/NotSupportActionView.xaml.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using AccessibilityInsights.CommonUxComponents.Dialogs;
+using AccessibilityInsights.Extensions.Helpers;
 using AccessibilityInsights.SharedUx.ViewModels;
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
@@ -19,12 +22,22 @@ namespace AccessibilityInsights.SharedUx.ActionViews
         {
             InitializeComponent();
             this.ActionViewModel = a ?? throw new ArgumentNullException(nameof(a));
-            this.tbName.Text = string.Format(CultureInfo.InvariantCulture, "{0}.{1}", ActionViewModel.PatternName, ActionViewModel.Name);
+            this.actionName.Text = string.Format(CultureInfo.InvariantCulture, "{0}.{1}", ActionViewModel.PatternName, ActionViewModel.Name);
         }
 
-        private void Button_Click(object sender, RoutedEventArgs e)
+        private void Hyperlink_RequestNavigate(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
         {
-            // TODO: This appears to be a remnant of old legacy telemetry code. Consider bringing it back?
+            try
+            {
+                Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri));
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+            {
+                ex.ReportException();
+                MessageDialog.Show(Properties.Resources.hlLink_RequestNavigateException);
+            }
+#pragma warning restore CA1031 // Do not catch general exception types
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -4815,29 +4815,11 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Accessibility Insights for Windows does not yet support the.
+        ///   Looks up a localized string similar to Accessibility Insights for Windows does not yet support the {0} action. To request support for this action, please upvote an existing issue at {1}. If no issue already exists, you can open a new issue (feature request) to request support for this action..
         /// </summary>
-        public static string UnsupportedActionPart1BeforeActionName {
+        public static string UnsupportedActionMessageFormat {
             get {
-                return ResourceManager.GetString("UnsupportedActionPart1BeforeActionName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to action. To request support for this action, please upvote an existing issue at.
-        /// </summary>
-        public static string UnsupportedActionPart2BetweenActionNameAndLink {
-            get {
-                return ResourceManager.GetString("UnsupportedActionPart2BetweenActionNameAndLink", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to . If no issue already exists, you can open a new issue (feature request) to request support for this action..
-        /// </summary>
-        public static string UnsupportedActionPart3AfterLink {
-            get {
-                return ResourceManager.GetString("UnsupportedActionPart3AfterLink", resourceCulture);
+                return ResourceManager.GetString("UnsupportedActionMessageFormat", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -720,15 +720,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to I want this Action!!!.
-        /// </summary>
-        public static string ButtonContent {
-            get {
-                return ResourceManager.GetString("ButtonContent", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to _Ok.
         /// </summary>
         public static string buttonOkContent {
@@ -4381,15 +4372,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The below Action is not supported yet. If you want this action to be provided in this tool. please click below button..
-        /// </summary>
-        public static string TextBlockText {
-            get {
-                return ResourceManager.GetString("TextBlockText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to CONFIGURATION.
         /// </summary>
         public static string TextBlockTextCONFIGURATION {
@@ -4829,6 +4811,33 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string TTAutomationPropertiesName {
             get {
                 return ResourceManager.GetString("TTAutomationPropertiesName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Accessibility Insights for Windows does not yet support the.
+        /// </summary>
+        public static string UnsupportedActionPart1BeforeActionName {
+            get {
+                return ResourceManager.GetString("UnsupportedActionPart1BeforeActionName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to action. To request support for this action, please upvote an existing issue at.
+        /// </summary>
+        public static string UnsupportedActionPart2BetweenActionNameAndLink {
+            get {
+                return ResourceManager.GetString("UnsupportedActionPart2BetweenActionNameAndLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to . If no issue already exists, you can open a new issue (feature request) to request support for this action..
+        /// </summary>
+        public static string UnsupportedActionPart3AfterLink {
+            get {
+                return ResourceManager.GetString("UnsupportedActionPart3AfterLink", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -156,9 +156,6 @@
   <data name="GeneralActionView_ExecuteAction_Failed" xml:space="preserve">
     <value>Failed!!</value>
   </data>
-  <data name="UnsupportedActionPart1BeforeActionName" xml:space="preserve">
-    <value>Accessibility Insights for Windows does not yet support the</value>
-  </data>
   <data name="ReturnA11yElementsView_btnRun_Click_Input_should_be_int_value_greater_than_equal_to_0" xml:space="preserve">
     <value>Input should be int value greater than or equal to 0.</value>
   </data>
@@ -1763,10 +1760,8 @@ This failure can be caused by a known framework issue. Click the link below to l
   <data name="FileIssuesChooseLocation" xml:space="preserve">
     <value>To file issues, select where you want to file issues.</value>
   </data>
-  <data name="UnsupportedActionPart2BetweenActionNameAndLink" xml:space="preserve">
-    <value>action. To request support for this action, please upvote an existing issue at</value>
-  </data>
-  <data name="UnsupportedActionPart3AfterLink" xml:space="preserve">
-    <value>. If no issue already exists, you can open a new issue (feature request) to request support for this action.</value>
+  <data name="UnsupportedActionMessageFormat" xml:space="preserve">
+    <value>Accessibility Insights for Windows does not yet support the {0} action. To request support for this action, please upvote an existing issue at {1}. If no issue already exists, you can open a new issue (feature request) to request support for this action.</value>
+    <comment>{0} is the programmatic ID of the action in question. {1} is a clickable hyperlink whose text is a URL where the user can file issues.</comment>
   </data>
 </root>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -156,11 +156,8 @@
   <data name="GeneralActionView_ExecuteAction_Failed" xml:space="preserve">
     <value>Failed!!</value>
   </data>
-  <data name="ButtonContent" xml:space="preserve">
-    <value>I want this Action!!!</value>
-  </data>
-  <data name="TextBlockText" xml:space="preserve">
-    <value>The below Action is not supported yet. If you want this action to be provided in this tool. please click below button.</value>
+  <data name="UnsupportedActionPart1BeforeActionName" xml:space="preserve">
+    <value>Accessibility Insights for Windows does not yet support the</value>
   </data>
   <data name="ReturnA11yElementsView_btnRun_Click_Input_should_be_int_value_greater_than_equal_to_0" xml:space="preserve">
     <value>Input should be int value greater than or equal to 0.</value>
@@ -1765,5 +1762,11 @@ This failure can be caused by a known framework issue. Click the link below to l
   </data>
   <data name="FileIssuesChooseLocation" xml:space="preserve">
     <value>To file issues, select where you want to file issues.</value>
+  </data>
+  <data name="UnsupportedActionPart2BetweenActionNameAndLink" xml:space="preserve">
+    <value>action. To request support for this action, please upvote an existing issue at</value>
+  </data>
+  <data name="UnsupportedActionPart3AfterLink" xml:space="preserve">
+    <value>. If no issue already exists, you can open a new issue (feature request) to request support for this action.</value>
   </data>
 </root>


### PR DESCRIPTION
#### Details

Revise the unsupported action dialog as outlined in #1420. This replaces a button that does nothing with directions of how to use AIWin's issues to request support for an unsupported pattern action. These dialogs are not themed in dark mode.

##### Screenshots
Mode | Before | After
--- | --- | ---
Light/Dark | ![image](https://user-images.githubusercontent.com/45672944/195468699-4ad04a33-3881-457b-9119-f7e803f2beff.png) | ![image](https://user-images.githubusercontent.com/45672944/195468574-0c5b013f-b712-403b-bf16-f3f78ada611c.png)
Aquatic | ![image](https://user-images.githubusercontent.com/45672944/195468772-f7ea18e0-ecf3-4a71-81da-b72ca43d9215.png) | ![image](https://user-images.githubusercontent.com/45672944/195468374-92a61a27-10ad-46fd-9da1-dbe56101c8d1.png)
Desert | ![image](https://user-images.githubusercontent.com/45672944/195468837-f939e0be-6746-495b-9816-0267d9ed5710.png) |  ![image](https://user-images.githubusercontent.com/45672944/195468278-3a02f6ab-fc4f-4f63-a0c8-18dfe873f87f.png)
Dusk | ![image](https://user-images.githubusercontent.com/45672944/195468880-6d935573-f4f6-46c1-9ce3-3bb619fd34dc.png) | ![image](https://user-images.githubusercontent.com/45672944/195468449-5b90d6b1-6e7a-4bf9-b52e-2a863850ee15.png)
Night Sky | ![image](https://user-images.githubusercontent.com/45672944/195468925-1f05bba5-4b97-4523-b610-c4a6cb7ecb57.png) | ![image](https://user-images.githubusercontent.com/45672944/195468515-5a3b428a-672b-4c0c-8beb-90b645a1675e.png)



##### Motivation

Address #1420, although style the action in bold instead of italic to make it stand out more

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue #1420 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



