### PR TITLE
fix: Give items in events data grid readable UIA name

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -158,10 +158,16 @@
                       SelectionChanged="listEvents_SelectionChanged" SelectionMode="Single"
                       HorizontalContentAlignment="Stretch"
                       FontSize="11" Margin="2,0"
-                      Style="{StaticResource dgStyle}" CellStyle="{StaticResource dgcStyle}" RowStyle="{StaticResource dgrStyle}" ColumnHeaderStyle="{StaticResource dgchStyle}">
+                      Style="{StaticResource dgStyle}" CellStyle="{StaticResource dgcStyle}" ColumnHeaderStyle="{StaticResource dgchStyle}">
                 <i:Interaction.Behaviors>
                     <behaviors:ColumnResizeHotkeyBehavior/>
                 </i:Interaction.Behaviors>
+                <DataGrid.RowStyle>
+                    <Style BasedOn="{StaticResource dgrStyle}" TargetType="DataGridRow">
+                        <!-- Empty row name to override WPF default of using long data type -->
+                        <Setter Property="AutomationProperties.Name" Value=" "/>
+                    </Style>
+                </DataGrid.RowStyle>
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding Path=TimeStamp}" ElementStyle="{StaticResource DataGridTextCellStyle}" Header="{x:Static Properties:Resources.DataGridTextColumnHeaderTimeStamp}" Width="Auto" IsReadOnly="True" />
                     <DataGridTextColumn Binding="{Binding Path=EventId, Converter={StaticResource cvtIdToName}}" ElementStyle="{StaticResource DataGridTextCellStyle}" Header="{x:Static Properties:Resources.DataGridTextColumnHeaderEventName}" Width="Auto" IsReadOnly="True" />

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -164,8 +164,7 @@
                 </i:Interaction.Behaviors>
                 <DataGrid.RowStyle>
                     <Style BasedOn="{StaticResource dgrStyle}" TargetType="DataGridRow">
-                        <!-- Empty row name to override WPF default of using long data type -->
-                        <Setter Property="AutomationProperties.Name" Value=" "/>
+                        <Setter Property="AutomationProperties.Name" Value="{Binding Path=EventId, Converter={StaticResource cvtIdToName}}"/>
                     </Style>
                 </DataGrid.RowStyle>
                 <DataGrid.Columns>


### PR DESCRIPTION
#### Details

Address https://github.com/microsoft/accessibility-insights-windows/issues/1438 by implementing the suggestion to set name on element to "{Event Type} from {Event Source} at {Event Time}".

##### Motivation

Addresses issue https://github.com/microsoft/accessibility-insights-windows/issues/1438

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? https://github.com/microsoft/accessibility-insights-windows/issues/1438
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.