### PR TITLE
fix: Announce tree view item checked/unchecked

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
@@ -227,6 +227,16 @@ namespace AccessibilityInsights.SharedUx.Controls
                 {
                     evm.IsChecked = !evm.IsChecked;
                 }
+
+                if (AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+                {
+                    TreeViewItemAutomationPeer peer = UIElementAutomationPeer.FromElement(sender as TreeViewItem) as TreeViewItemAutomationPeer;
+                    if (peer != null)
+                    {
+                        peer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+                    }
+                }
+
                 e.Handled = true;
             }
             else if (e.Key == Key.Enter)


### PR DESCRIPTION
#### Details

Address bug in which checkboxes in the event configuration do not report being checked/ unchecked with a screenreader.

##### Motivation

Addresses https://github.com/microsoft/accessibility-insights-windows/issues/1323

#### Pull request checklist
- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, [#1323](https://github.com/microsoft/accessibility-insights-windows/issues/1323)
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.