### PR TITLE
chore: Target .NET Framework 4.8

### DIFF
--- a/build/NetFrameworkAll.targets
+++ b/build/NetFrameworkAll.targets
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningLevel>4</WarningLevel>
     <WarningsAsErrors />

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -264,10 +264,10 @@ jobs:
     inputs:
       InputType: Basic
       # Double-quote syntax with trailing backslash on each line concatenates lines without spaces
-      AnalyzeTarget: "src\\AccessibilityInsights\\bin\\Release\\net472\\*.exe;\
-                      src\\AccessibilityInsights\\bin\\Release\\net472\\AccessibilityInsights.*.dll;\
-                      src\\AccessibilityInsights.VersionSwitcher\\bin\\Release\\net472\\*.exe;\
-                      src\\AccessibilityInsights.VersionSwitcher\\bin\\Release\\net472\\AccessibilityInsights.*.dll;"
+      AnalyzeTarget: "src\\AccessibilityInsights\\bin\\Release\\net48\\*.exe;\
+                      src\\AccessibilityInsights\\bin\\Release\\net48\\AccessibilityInsights.*.dll;\
+                      src\\AccessibilityInsights.VersionSwitcher\\bin\\Release\\net48\\*.exe;\
+                      src\\AccessibilityInsights.VersionSwitcher\\bin\\Release\\net48\\AccessibilityInsights.*.dll;"
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
     displayName: 'Create Security Analysis Report (BinSkim)'
@@ -321,9 +321,9 @@ jobs:
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)\src'
       Contents: |
-       AccessibilityInsights\bin\Release\net472\**\?(*.exe|*.dll)
-       AccessibilityInsights.VersionSwitcher\bin\Release\net472\**\?(*.exe|*.dll)
-       !AccessibilityInsights.VersionSwitcher\bin\Release\net472\**\?(Microsoft.Deployment.WindowsInstaller.dll|Newtonsoft.Json.dll)
+       AccessibilityInsights\bin\Release\net48\**\?(*.exe|*.dll)
+       AccessibilityInsights.VersionSwitcher\bin\Release\net48\**\?(*.exe|*.dll)
+       !AccessibilityInsights.VersionSwitcher\bin\Release\net48\**\?(Microsoft.Deployment.WindowsInstaller.dll|Newtonsoft.Json.dll)
        MSI\bin\Release\msi\**\AccessibilityInsights.msi
       TargetFolder: '$(Build.ArtifactStagingDirectory)\SigningValidation'
 

--- a/docs/NewProject.md
+++ b/docs/NewProject.md
@@ -5,7 +5,7 @@ Do the following when adding a new project:
 1. Add a project to the AccessibilityInsights Solution (`src\AccessibilityInsights.sln`).
 2. Right-click on the project and select Properties.
 2. In the Application tab, configure "Target Framework" to use the same .NET Framework version used by the `AccessibilityInsights` project.
-   - Currently .NET Framework 4.7.2 is used as target. 
+   - Currently .NET Framework 4.8 is used as target. 
 3. In the build tab, set the following for both Debug and Release configurations:
    1. "Warning level" to 4.
    2. "Treat warnings as errors" to "All".

--- a/docs/SetUpDevEnv.md
+++ b/docs/SetUpDevEnv.md
@@ -5,7 +5,7 @@
 ### Install Visual Studio
 1. Install Visual Studio 2022 from [here](https://visualstudio.microsoft.com/vs/)
    - Choose ".NET desktop development" option
-   - Add ".NET Framework 4.7.2 development tools"
+   - Add ".NET Framework 4.8 development tools"
 
 ### Install Wix tools
 To build the MSI project, you need to install the Wix Toolset extension for Visual Studio. The extension is available in the Visual Studio marketplace and can be found [here](http://wixtoolset.org/releases/).

--- a/docs/TelemetryDetails.md
+++ b/docs/TelemetryDetails.md
@@ -93,7 +93,7 @@ Additional properties:
 Name | Value
 --- | ---
 `customDimensions.UIAccessEnabled` | `True` if the user has explicitly enabled UIAccess, otherwise `False`. 
-`customDimensions.InstalledDotNetFrameworkVersion` | The numeric version of the installed .NET Framework version. If this value is 528040 or greater, then .NET Framework 4.8 is installed. Otherwise, .NET Framework 4.7.2 is installed.
+`customDimensions.InstalledDotNetFrameworkVersion` | The numeric version of the installed .NET Framework version. If this value is 528040 or greater, then .NET Framework 4.8 is installed.
 `customDimensions.OsArchitecture` | The architecture of the current Windows platform. Supported values: `x86` or `x64`
 
 #### Mainwindow_Timer_Started

--- a/src/AccessibilityInsights.CustomActions.Package/CustomActions.Package.csproj
+++ b/src/AccessibilityInsights.CustomActions.Package/CustomActions.Package.csproj
@@ -14,8 +14,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>AccessibilityInsights.CustomActions.Package</RootNamespace>
     <AssemblyName>AccessibilityInsights.CustomActions</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -49,9 +50,9 @@
   <Target Name="OverwriteWithSignedAssemblies">
     <!-- Manually overwrite assemblies with signed versions before packing everything up -->
     <ItemGroup>
-      <SignedOverwriteFiles Include="$(SolutionDir)AccessibilityInsights.CustomActions\bin\$(Configuration)\net472\AccessibilityInsights.CustomActions.*" />
-      <SignedOverwriteFiles Include="$(SolutionDir)AccessibilityInsights\bin\$(Configuration)\net472\Microsoft.Deployment.WindowsInstaller.dll" />
-      <SignedOverwriteFiles Include="$(SolutionDir)AccessibilityInsights\bin\$(Configuration)\net472\Newtonsoft.Json.dll" />
+      <SignedOverwriteFiles Include="$(SolutionDir)AccessibilityInsights.CustomActions\bin\$(Configuration)\net48\AccessibilityInsights.CustomActions.*" />
+      <SignedOverwriteFiles Include="$(SolutionDir)AccessibilityInsights\bin\$(Configuration)\net48\Microsoft.Deployment.WindowsInstaller.dll" />
+      <SignedOverwriteFiles Include="$(SolutionDir)AccessibilityInsights\bin\$(Configuration)\net48\Newtonsoft.Json.dll" />
     </ItemGroup>
     <Copy SourceFiles="@(SignedOverwriteFiles)" DestinationFolder="$(IntermediateOutputPath)" />
     <PropertyGroup>

--- a/src/AccessibilityInsights.Extensions.AzureDevOpsTests/app.config
+++ b/src/AccessibilityInsights.Extensions.AzureDevOpsTests/app.config
@@ -9,6 +9,6 @@
     </assemblyBinding>
   </runtime>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
 </configuration>

--- a/src/AccessibilityInsights.Extensions.TelemetryTests/app.config
+++ b/src/AccessibilityInsights.Extensions.TelemetryTests/app.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
   </startup>
 </configuration>

--- a/src/AccessibilityInsights.SharedUxTests/app.config
+++ b/src/AccessibilityInsights.SharedUxTests/app.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
 </configuration>

--- a/src/AccessibilityInsights.VersionSwitcher/App.config
+++ b/src/AccessibilityInsights.VersionSwitcher/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup> 
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
   </startup>
 </configuration>

--- a/src/AccessibilityInsights/App.config
+++ b/src/AccessibilityInsights/App.config
@@ -6,7 +6,7 @@
     </sectionGroup>
   </configSections>
   <startup> 
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
   <runtime>
     <AppContextSwitchOverrides value="Switch.UseLegacyAccessibilityFeatures=false;Switch.UseLegacyAccessibilityFeatures.2=false;Switch.UseLegacyAccessibilityFeatures.3=false;Switch.UseLegacyAccessibilityFeatures.4=false;Switch.UseLegacyToolTipDisplay=false" />

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -25,7 +25,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <WixVariable Id="WixUIDialogBmp" Value="Resources\DialogBackground.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\WixDialogBanner.png" />
-    <WixVariable Id="WixUILicenseRtf" Value="..\AccessibilityInsights\bin\Release\net472\eula.rtf" />
+    <WixVariable Id="WixUILicenseRtf" Value="..\AccessibilityInsights\bin\Release\net48\eula.rtf" />
 
     <MediaTemplate EmbedCab="yes" />
 
@@ -38,10 +38,10 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <!--Until WIX_IS_NETFRAMEWORK_47_OR_LATER_INSTALLED property is supported,
     this is our workaround as suggested here: https://github.com/wixtoolset/issues/issues/5575 -->
-    <!-- .NET 4.7.2 value is taken from https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies -->
+    <!-- .NET 4.8 value is taken from https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies -->
     <PropertyRef Id="NETFRAMEWORK45" />
-    <Condition Message="[ProductName] requires .NET Framework 4.7.2 or later.">
-      <![CDATA[Installed OR (NETFRAMEWORK45 AND NETFRAMEWORK45 >= "#461808")]]>
+    <Condition Message="[ProductName] requires .NET Framework 4.8 or later.">
+      <![CDATA[Installed OR (NETFRAMEWORK45 AND NETFRAMEWORK45 >= "#528040")]]>
     </Condition>
 
     <Directory Id="TARGETDIR" Name="SourceDir">
@@ -49,91 +49,91 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
         <Directory Id="AccessibilityInsightsFolder" Name="AccessibilityInsights" >
           <Directory Id="INSTALLFOLDER" Name="1.1">
             <Component Id="ProductComponent" Guid="21CE5D3B-FE98-4B24-B1CE-FE2FE646B2A2">
-              <File Id="FileExe" Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.exe" KeyPath="yes" >
+              <File Id="FileExe" Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.exe" KeyPath="yes" >
                 <Shortcut Id="aiforwin" Directory="DesktopFolder" Name="Accessibility Insights For Windows"
                           Description="Accessibility Insights For Windows v1.1" WorkingDirectory='INSTALLFOLDER' Icon="AccessibilityInsights.exe" IconIndex="0" Advertise="yes" />
               </File>
-              <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.exe.config" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.exe.manifest" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.CommonUxComponents.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.AzureDevOps.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.GitHub.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.GitHubAutoUpdate.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Extensions.Telemetry.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.SetupLibrary.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.SharedUx.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.Win32.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Axe.Windows.Actions.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Axe.Windows.Core.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Axe.Windows.Desktop.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Axe.Windows.Rules.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Axe.Windows.RuleSelection.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Axe.Windows.SystemAbstractions.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Axe.Windows.Telemetry.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Axe.Windows.Win32.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Ben.Demystifier.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\CommandLine.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\HtmlAgilityPack.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.ApplicationInsights.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Azure.DevOps.Comments.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Bcl.AsyncInterfaces.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Deployment.WindowsInstaller.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.IdentityModel.Abstractions.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.IdentityModel.JsonWebTokens.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.IdentityModel.Logging.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.IdentityModel.Tokens.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.Build2.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.Common.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.Core.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.Dashboards.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.DistributedTask.Common.Contracts.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.Policy.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.SourceControl.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.Test.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.TestManagement.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.Wiki.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.Work.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.WorkItemTracking.Process.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.VisualStudio.Services.Client.Interactive.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.VisualStudio.Services.Common.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.VisualStudio.Services.TestResults.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.VisualStudio.Services.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Web.WebView2.Core.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Web.WebView2.WinForms.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Web.WebView2.Wpf.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Win32.Registry.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Xaml.Behaviors.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\Newtonsoft.Json.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Buffers.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Collections.Immutable.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Diagnostics.DiagnosticSource.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Drawing.Common.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.IdentityModel.Tokens.Jwt.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.IO.Packaging.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Memory.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Net.Http.Formatting.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Numerics.Vectors.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Reflection.Metadata.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Runtime.CompilerServices.Unsafe.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Security.AccessControl.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Security.Principal.Windows.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Text.Encodings.Web.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Text.Json.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Threading.Tasks.Extensions.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.ValueTuple.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Web.Http.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\System.Web.Http.WebHost.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\WebView2Loader.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net472\ThirdPartyNotices.html"/>
-              <File Source="..\AccessibilityInsights\bin\Release\net472\eula.rtf"/>
-              <File Source="..\AccessibilityInsights\bin\Release\net472\links.json"/>
-              <File Source="..\AccessibilityInsights\bin\Release\net472\UIAccess.cmd"/>
-              <File Source="..\AccessibilityInsights\bin\Release\net472\UIAccess_Disabled.manifest"/>
-              <File Source="..\AccessibilityInsights\bin\Release\net472\UIAccess_Enabled.manifest"/>
+              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.exe.config" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.exe.manifest" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.CommonUxComponents.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.Extensions.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.Extensions.AzureDevOps.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.Extensions.GitHub.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.Extensions.GitHubAutoUpdate.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.Extensions.Telemetry.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.SetupLibrary.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.SharedUx.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.Win32.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.Actions.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.Core.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.Desktop.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.Rules.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.RuleSelection.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.SystemAbstractions.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.Telemetry.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.Win32.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Ben.Demystifier.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\CommandLine.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\HtmlAgilityPack.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.ApplicationInsights.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Azure.DevOps.Comments.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Bcl.AsyncInterfaces.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Deployment.WindowsInstaller.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.IdentityModel.Abstractions.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.IdentityModel.JsonWebTokens.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.IdentityModel.Logging.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.IdentityModel.Tokens.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Build2.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Common.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Core.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Dashboards.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.DistributedTask.Common.Contracts.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Policy.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.SourceControl.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Test.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.TestManagement.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Wiki.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Work.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.WorkItemTracking.Process.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.VisualStudio.Services.Client.Interactive.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.VisualStudio.Services.Common.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.VisualStudio.Services.TestResults.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.VisualStudio.Services.WebApi.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Web.WebView2.Core.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Web.WebView2.WinForms.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Web.WebView2.Wpf.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Win32.Registry.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Xaml.Behaviors.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\Newtonsoft.Json.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Buffers.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Collections.Immutable.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Diagnostics.DiagnosticSource.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Drawing.Common.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.IdentityModel.Tokens.Jwt.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.IO.Packaging.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Memory.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Net.Http.Formatting.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Numerics.Vectors.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Reflection.Metadata.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Runtime.CompilerServices.Unsafe.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Security.AccessControl.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Security.Principal.Windows.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Text.Encodings.Web.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Text.Json.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Threading.Tasks.Extensions.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.ValueTuple.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Web.Http.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Web.Http.WebHost.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\WebView2Loader.dll" />
+              <File Source="..\AccessibilityInsights\bin\Release\net48\ThirdPartyNotices.html"/>
+              <File Source="..\AccessibilityInsights\bin\Release\net48\eula.rtf"/>
+              <File Source="..\AccessibilityInsights\bin\Release\net48\links.json"/>
+              <File Source="..\AccessibilityInsights\bin\Release\net48\UIAccess.cmd"/>
+              <File Source="..\AccessibilityInsights\bin\Release\net48\UIAccess_Disabled.manifest"/>
+              <File Source="..\AccessibilityInsights\bin\Release\net48\UIAccess_Enabled.manifest"/>
 
               <ProgId Id='A11y.Test' Description='Accessibility Insights For Windows Test file'>
                 <Extension Id='a11ytest' ContentType='AccessibilityInsights Test File'>
@@ -149,25 +149,25 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
             <Directory Id="IssueTemplates" Name="IssueTemplates">
               <Component Id="IssueTemplateComp" Guid="FEFD2999-2F07-4422-B0C7-BA349AF734B1">
-                <File Source="..\AccessibilityInsights\bin\Release\net472\IssueTemplates\IssueNoFailures.json"/>
-                <File Source="..\AccessibilityInsights\bin\Release\net472\IssueTemplates\IssueNoFailures.html"/>
-                <File Source="..\AccessibilityInsights\bin\Release\net472\IssueTemplates\IssueSingleFailure.json"/>
-                <File Source="..\AccessibilityInsights\bin\Release\net472\IssueTemplates\IssueSingleFailure.html"/>
-                <File Source="..\AccessibilityInsights\bin\Release\net472\IssueTemplates\IssueColorContrast.json"/>
-                <File Source="..\AccessibilityInsights\bin\Release\net472\IssueTemplates\IssueColorContrast.html"/>
+                <File Source="..\AccessibilityInsights\bin\Release\net48\IssueTemplates\IssueNoFailures.json"/>
+                <File Source="..\AccessibilityInsights\bin\Release\net48\IssueTemplates\IssueNoFailures.html"/>
+                <File Source="..\AccessibilityInsights\bin\Release\net48\IssueTemplates\IssueSingleFailure.json"/>
+                <File Source="..\AccessibilityInsights\bin\Release\net48\IssueTemplates\IssueSingleFailure.html"/>
+                <File Source="..\AccessibilityInsights\bin\Release\net48\IssueTemplates\IssueColorContrast.json"/>
+                <File Source="..\AccessibilityInsights\bin\Release\net48\IssueTemplates\IssueColorContrast.html"/>
               </Component>
             </Directory>
 
             <Directory Id="VersionSwitcher" Name="VersionSwitcher">
               <Component Id="VersionSwitcherComp" Guid="1AAD6099-09E1-4E8F-A28B-57806F4A29DF">
                 <!-- ID's are needed for these files, since several of them are also installed with the main app -->
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net472\AccessibilityInsights.VersionSwitcher.exe" Id="version_switcher"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net472\AccessibilityInsights.VersionSwitcher.exe.config" Id="version_switcher_config"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net472\AccessibilityInsights.SetupLibrary.dll" Id ="version_switcher_setuplibrary"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net472\AccessibilityInsights.Win32.dll" Id ="version_switcher_win32"/>
+                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\AccessibilityInsights.VersionSwitcher.exe" Id="version_switcher"/>
+                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\AccessibilityInsights.VersionSwitcher.exe.config" Id="version_switcher_config"/>
+                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\AccessibilityInsights.SetupLibrary.dll" Id ="version_switcher_setuplibrary"/>
+                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\AccessibilityInsights.Win32.dll" Id ="version_switcher_win32"/>
                 <!-- We sign the following assemblies in the main AccessibilityInsights project. To avoid duplicate signing, we reuse them below. -->
-                <File Source="..\AccessibilityInsights\bin\Release\net472\Microsoft.Deployment.WindowsInstaller.dll" Id ="version_switcher_deployment"/>
-                <File Source="..\AccessibilityInsights\bin\Release\net472\Newtonsoft.Json.dll" Id ="version_switcher_newtonsoft"/>
+                <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Deployment.WindowsInstaller.dll" Id ="version_switcher_deployment"/>
+                <File Source="..\AccessibilityInsights\bin\Release\net48\Newtonsoft.Json.dll" Id ="version_switcher_newtonsoft"/>
               </Component>
             </Directory>
 
@@ -180,7 +180,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
       </Directory>
     </Directory>
 
-    <Icon Id="AccessibilityInsights.exe" SourceFile="..\AccessibilityInsights\bin\Release\net472\AccessibilityInsights.exe" />
+    <Icon Id="AccessibilityInsights.exe" SourceFile="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.exe" />
 
     <Property Id="WixShellExecTarget" Value="[#FileExe]"/>
     <CustomAction Id="LaunchInstalledExe" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />

--- a/src/MsiFileTests/WxsValidationTests.cs
+++ b/src/MsiFileTests/WxsValidationTests.cs
@@ -28,9 +28,9 @@ namespace MsiFileTests
                 "Axe.Windows.Automation.dll",
             };
 
-            CompareWxsSectionToDropPath(repoRoot, @"AccessibilityInsights\bin\release\net472", wxsFile, "ProductComponent", productComponentExclusions);
-            CompareWxsSectionToDropPath(repoRoot, @"AccessibilityInsights\bin\release\net472\IssueTemplates", wxsFile, "IssueTemplates");
-            CompareWxsSectionToDropPath(repoRoot, @"AccessibilityInsights.VersionSwitcher\bin\release\net472", wxsFile, "VersionSwitcher");
+            CompareWxsSectionToDropPath(repoRoot, @"AccessibilityInsights\bin\release\net48", wxsFile, "ProductComponent", productComponentExclusions);
+            CompareWxsSectionToDropPath(repoRoot, @"AccessibilityInsights\bin\release\net48\IssueTemplates", wxsFile, "IssueTemplates");
+            CompareWxsSectionToDropPath(repoRoot, @"AccessibilityInsights.VersionSwitcher\bin\release\net48", wxsFile, "VersionSwitcher");
         }
 
         private static void CompareWxsSectionToDropPath(string repoRoot, string relativeDropPath,

--- a/src/UITests/app.config
+++ b/src/UITests/app.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
 </configuration>


### PR DESCRIPTION
#### Details

We need .NET Framework 4.8 to address some accessibility issues, because the required properties are not exposed in .NET 4.7.2. Telemetry indicates that 98.1% of our current users are running on systems where .NET Framework 4.8 is already installed and will not be impacted by this change. The remaining 1.9% will experience a failed upgrade until they install a newer version of .NET Framework 4.8. They can learn of this requirement in any of the following ways:
1. Read the release notes (accessible directly from the upgrade dialog)
2. Uninstall and reinstall AIWin (the installer will tell the user to install the new version)
3. Search for a GitHub issue that we will create after this PR merges

Note: The primary change is captured in the change to `build\NetFrameworkAll.targets`, then the other changes are the downstream effects or doc changes. The notable exception is that `CustomActions.Package.csproj` uses the old-format project file (WiX doesn't play nicely with the new format), so it needed to be explicitly updated as well. This was done via the IDE.

##### Motivation

Enable `AutomationProperties.SizeOfSet` and `AutomationProperties.PositionInSet` properties to address an accessibility issue.

##### Screenshots

The only differences are when running the installer, which informs the user which runtime is needed:

Old | New
--- | ---
![image](https://user-images.githubusercontent.com/45672944/199129698-3bb3bcee-2df6-4686-8a3c-8b9c219ba5ca.png) | ![image](https://user-images.githubusercontent.com/45672944/199130835-b266c16f-4ddb-4756-8c59-7694c52f68ee.png)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
Using the new properties will be in a separate PR to keep things clean.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
We considered moving all the way to .NET Framework 4.8.1 (released in August 2022), but telemetry showed that this would impact about 60% of our users. Since .NET Framework 4.8 exposes the properties that we need, we opted for the less intrusive option.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



