### PR TITLE
fix: Override default indexing values in test mode

### DIFF
--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml
@@ -37,10 +37,12 @@
                         </Grid>
                     </TabItem.Header>
                 </TabItem>
-                <TabItem x:Name="tbiAutomatedChecks" Header="{x:Static properties:Resources.tbiAutomatedChecksHeader}" AutomationProperties.Name="{x:Static properties:Resources.tbiAutomatedChecksAutomationPropertiesName}" IsSelected="True">
+                <TabItem x:Name="tbiAutomatedChecks" Header="{x:Static properties:Resources.tbiAutomatedChecksHeader}" AutomationProperties.Name="{x:Static properties:Resources.tbiAutomatedChecksAutomationPropertiesName}"
+                         AutomationProperties.PositionInSet="1" AutomationProperties.SizeOfSet="2" IsSelected="True">
                     <TestTabViews:AutomatedChecksControl x:Name="ctrlAutomatedChecks" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"/>
                 </TabItem>
-                <TabItem x:Name="tbiTabStop" Header="{x:Static properties:Resources.tbiTabStopHeader}" AutomationProperties.Name="{x:Static properties:Resources.tbiTabStopAutomationPropertiesName}">
+                <TabItem x:Name="tbiTabStop" Header="{x:Static properties:Resources.tbiTabStopHeader}" AutomationProperties.Name="{x:Static properties:Resources.tbiTabStopAutomationPropertiesName}"
+                         AutomationProperties.PositionInSet="2" AutomationProperties.SizeOfSet="2">
                     <TestTabViews:TabStopControl x:Name="ctrlTabStop" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"/>
                 </TabItem>
             </TabControl>


### PR DESCRIPTION
#### Details

Bug [1998198](https://mseng.visualstudio.com/DefaultCollection/1ES/_workitems/edit/1998198) points out that the test model control reports the wrong information in the test nav bar. Screen readers report "Automated checks 2 of 3" and "Tab stops 3 of 3". This is because the non-focusable item in the list is getting counted. We can't prevent the first item from getting counted, but we can override the `PositionInSet` and `SizeOfSet` properties so the properties are reported as "Automated checks 1 of 2" and "Tab stops 2 of 2"

Validated with NVDA

##### Motivation

Fix accessibility bug

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue [#1998198](https://mseng.visualstudio.com/DefaultCollection/1ES/_workitems/edit/1998198)
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



