### PR TITLE
fix: Announce tree view item as checked/unchecked

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeView.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeView.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeView.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeView.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+
+namespace AccessibilityInsights.SharedUx.Controls.CustomControls
+{
+    internal class CheckableTreeView : TreeView
+    {
+        public CheckableTreeView()
+        {}
+
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return base.OnCreateAutomationPeer();
+        }
+
+        protected override DependencyObject GetContainerForItemOverride()
+        {
+            return new CheckableTreeViewItem();
+        }
+
+        protected override bool IsItemItsOwnContainerOverride(object item)
+        {
+            return item is CheckableTreeViewItem;
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Windows.Automation;
+﻿using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Controls;
@@ -19,7 +18,9 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         public override object GetPattern(PatternInterface patternInterface)
         {
             if (patternInterface == PatternInterface.Toggle)
+            {
                 return this;
+            }
 
             return base.GetPattern(patternInterface);
         }
@@ -34,7 +35,17 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
 
         public void Toggle()
         {
-            throw new NotImplementedException();
+            RaisePropertyChangedEvent(TogglePatternIdentifiers.ToggleStateProperty, ConvertToToggleState(!_checkBox.IsChecked), ConvertToToggleState(_checkBox.IsChecked));
+        }
+
+        private static ToggleState ConvertToToggleState(bool? value)
+        {
+            switch (value)
+            {
+                case (true): return ToggleState.On;
+                case (false): return ToggleState.Off;
+                default: return ToggleState.Indeterminate;
+            }
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
@@ -32,7 +32,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         {
             get
             {
-                return _owner.IsChecked == true ? ToggleState.On : ToggleState.Off;
+                return ConvertToToggleState(_owner.IsChecked);
             }
         }
 

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
@@ -1,18 +1,18 @@
-﻿using System.Windows.Automation;
+﻿using AccessibilityInsights.SharedUx.ViewModels;
+using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
-using System.Windows.Controls;
 
 namespace AccessibilityInsights.SharedUx.Controls.CustomControls
 {
     internal class CheckableTreeViewDataItemAutomationPeer : TreeViewDataItemAutomationPeer, IToggleProvider
     {
-        private CheckBox _checkBox;
+        private EventConfigNodeViewModel _owner;
 
-        public CheckableTreeViewDataItemAutomationPeer(object item, ItemsControlAutomationPeer itemsControlAutomationPeer, TreeViewDataItemAutomationPeer parentDataItemAutomationPeer, CheckBox checkBox)
+        public CheckableTreeViewDataItemAutomationPeer(object item, ItemsControlAutomationPeer itemsControlAutomationPeer, TreeViewDataItemAutomationPeer parentDataItemAutomationPeer)
             : base(item, itemsControlAutomationPeer, parentDataItemAutomationPeer)
         {
-            _checkBox = checkBox;
+            _owner = item as EventConfigNodeViewModel;
         }
 
         public override object GetPattern(PatternInterface patternInterface)
@@ -29,13 +29,14 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         {
             get
             {
-                return _checkBox.IsChecked == true ? ToggleState.On : ToggleState.Off;
+                return _owner.IsChecked == true ? ToggleState.On : ToggleState.Off;
             }
         }
 
         public void Toggle()
         {
-            RaisePropertyChangedEvent(TogglePatternIdentifiers.ToggleStateProperty, ConvertToToggleState(!_checkBox.IsChecked), ConvertToToggleState(_checkBox.IsChecked));
+            _owner.IsChecked = !_owner.IsChecked;
+            RaisePropertyChangedEvent(TogglePatternIdentifiers.ToggleStateProperty, ConvertToToggleState(!_owner.IsChecked), ConvertToToggleState(_owner.IsChecked));
         }
 
         private static ToggleState ConvertToToggleState(bool? value)

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
@@ -1,4 +1,7 @@
-﻿using AccessibilityInsights.SharedUx.ViewModels;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using AccessibilityInsights.SharedUx.ViewModels;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Controls;
+
+namespace AccessibilityInsights.SharedUx.Controls.CustomControls
+{
+    internal class CheckableTreeViewDataItemAutomationPeer : TreeViewDataItemAutomationPeer, IToggleProvider
+    {
+        private CheckBox _checkBox;
+
+        public CheckableTreeViewDataItemAutomationPeer(object item, ItemsControlAutomationPeer itemsControlAutomationPeer, TreeViewDataItemAutomationPeer parentDataItemAutomationPeer, CheckBox checkBox)
+            : base(item, itemsControlAutomationPeer, parentDataItemAutomationPeer)
+        {
+            _checkBox = checkBox;
+        }
+
+        public override object GetPattern(PatternInterface patternInterface)
+        {
+            if (patternInterface == PatternInterface.Toggle)
+                return this;
+
+            return base.GetPattern(patternInterface);
+        }
+
+        public ToggleState ToggleState
+        {
+            get
+            {
+                return _checkBox.IsChecked == true ? ToggleState.On : ToggleState.Off;
+            }
+        }
+
+        public void Toggle()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItem.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItem.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows;
+﻿using System;
+using System.Collections.Generic;
+using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -17,33 +19,9 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
             return item is CheckableTreeViewItem;
         }
 
-        private static T FindDescendant<T>(DependencyObject parent) where T : DependencyObject
-        {
-            if (parent == null) return null;
-
-            var childCount = VisualTreeHelper.GetChildrenCount(parent);
-            if (childCount < 1) return null;
-
-            for (int i = 0; i < childCount; i++)
-            {
-                var child = VisualTreeHelper.GetChild(parent, i);
-                if (child is T)
-                    return child as T;
-
-                var descendant = FindDescendant<T>(child);
-                if (descendant != null)
-                    return descendant;
-            }
-
-            return null;
-        }
-
         protected override AutomationPeer OnCreateAutomationPeer()
         {
-            var checkbox = FindDescendant<CheckBox>(this);
-            if (checkbox == null) return base.OnCreateAutomationPeer();
-
-            return new CheckableTreeViewItemAutomationPeer(this, checkbox);
+            return new CheckableTreeViewItemAutomationPeer(this);
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItem.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItem.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
-using System.Windows.Media;
 
 namespace AccessibilityInsights.SharedUx.Controls.CustomControls
 {

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItem.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItem.cs
@@ -9,6 +9,11 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
 {
     internal class CheckableTreeViewItem : TreeViewItem
     {
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new CheckableTreeViewItemAutomationPeer(this);
+        }
+
         protected override DependencyObject GetContainerForItemOverride()
         {
             return new CheckableTreeViewItem();
@@ -17,11 +22,6 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         protected override bool IsItemItsOwnContainerOverride(object item)
         {
             return item is CheckableTreeViewItem;
-        }
-
-        protected override AutomationPeer OnCreateAutomationPeer()
-        {
-            return new CheckableTreeViewItemAutomationPeer(this);
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItem.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItem.cs
@@ -1,0 +1,49 @@
+﻿using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace AccessibilityInsights.SharedUx.Controls.CustomControls
+{
+    internal class CheckableTreeViewItem : TreeViewItem
+    {
+        protected override DependencyObject GetContainerForItemOverride()
+        {
+            return new CheckableTreeViewItem();
+        }
+
+        protected override bool IsItemItsOwnContainerOverride(object item)
+        {
+            return item is CheckableTreeViewItem;
+        }
+
+        private static T FindDescendant<T>(DependencyObject parent) where T : DependencyObject
+        {
+            if (parent == null) return null;
+
+            var childCount = VisualTreeHelper.GetChildrenCount(parent);
+            if (childCount < 1) return null;
+
+            for (int i = 0; i < childCount; i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T)
+                    return child as T;
+
+                var descendant = FindDescendant<T>(child);
+                if (descendant != null)
+                    return descendant;
+            }
+
+            return null;
+        }
+
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            var checkbox = FindDescendant<CheckBox>(this);
+            if (checkbox == null) return base.OnCreateAutomationPeer();
+
+            return new CheckableTreeViewItemAutomationPeer(this, checkbox);
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItemAutomationPeer.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItemAutomationPeer.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+using System.Diagnostics;
+using System.Windows.Automation.Provider;
+
+namespace AccessibilityInsights.SharedUx.Controls.CustomControls
+{
+    internal class CheckableTreeViewItemAutomationPeer : TreeViewItemAutomationPeer
+    {
+        private CheckBox _checkBox;
+
+        public CheckableTreeViewItemAutomationPeer(TreeViewItem owner, CheckBox checkBox)
+            : base(owner)
+        {
+            if (checkBox == null) throw new ArgumentNullException(nameof(checkBox));
+
+            _checkBox = checkBox;
+        }
+
+        protected override ItemAutomationPeer CreateItemAutomationPeer(object item)
+        {
+            return new CheckableTreeViewDataItemAutomationPeer(item, this, base.EventsSource as CheckableTreeViewDataItemAutomationPeer, _checkBox);
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItemAutomationPeer.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItemAutomationPeer.cs
@@ -1,56 +1,16 @@
 ﻿using System;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
-using System.Windows;
-using AccessibilityInsights.SharedUx.ViewModels;
-using System.Windows.Media;
 
 namespace AccessibilityInsights.SharedUx.Controls.CustomControls
 {
     internal class CheckableTreeViewItemAutomationPeer : TreeViewItemAutomationPeer
     {
-        private TreeViewItem _owner;
-
-        public CheckableTreeViewItemAutomationPeer(TreeViewItem owner)
-            : base(owner)
-        {
-            if (owner == null) throw new ArgumentNullException(nameof(owner));
-
-            _owner = owner;
-        }
-
-        private static CheckBox FindMatchingCheckBox(DependencyObject parent, EventConfigNodeViewModel evm)
-        {
-            if (parent == null) return null;
-
-            var childCount = VisualTreeHelper.GetChildrenCount(parent);
-            if (childCount < 1) return null;
-
-            var candidateChild = VisualTreeHelper.GetChild(parent, 0);
-            if (candidateChild is CheckBox)
-            {
-                var text = (VisualTreeHelper.GetChild(parent, 1) as TextBlock).Text;
-                if (text == evm.Header)
-                {
-                    return candidateChild as CheckBox;
-                }
-            }
-
-            for (int i = 0; i < childCount; i++)
-            {
-                var child = VisualTreeHelper.GetChild(parent, i);
-                var descendant = FindMatchingCheckBox(child, evm);
-                if (descendant != null)
-                    return descendant;
-            }
-
-            return null;
-        }
+        public CheckableTreeViewItemAutomationPeer(TreeViewItem owner) : base(owner) {}
 
         protected override ItemAutomationPeer CreateItemAutomationPeer(object item)
         {
-            var checkbox = FindMatchingCheckBox(_owner, item as EventConfigNodeViewModel);
-            return new CheckableTreeViewDataItemAutomationPeer(item, this, base.EventsSource as CheckableTreeViewDataItemAutomationPeer, checkbox);
+            return new CheckableTreeViewDataItemAutomationPeer(item, this, base.EventsSource as CheckableTreeViewDataItemAutomationPeer);
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItemAutomationPeer.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItemAutomationPeer.cs
@@ -1,27 +1,56 @@
 ﻿using System;
-using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
-using System.Diagnostics;
-using System.Windows.Automation.Provider;
+using System.Windows;
+using AccessibilityInsights.SharedUx.ViewModels;
+using System.Windows.Media;
 
 namespace AccessibilityInsights.SharedUx.Controls.CustomControls
 {
     internal class CheckableTreeViewItemAutomationPeer : TreeViewItemAutomationPeer
     {
-        private CheckBox _checkBox;
+        private TreeViewItem _owner;
 
-        public CheckableTreeViewItemAutomationPeer(TreeViewItem owner, CheckBox checkBox)
+        public CheckableTreeViewItemAutomationPeer(TreeViewItem owner)
             : base(owner)
         {
-            if (checkBox == null) throw new ArgumentNullException(nameof(checkBox));
+            if (owner == null) throw new ArgumentNullException(nameof(owner));
 
-            _checkBox = checkBox;
+            _owner = owner;
+        }
+
+        private static CheckBox FindMatchingCheckBox(DependencyObject parent, EventConfigNodeViewModel evm)
+        {
+            if (parent == null) return null;
+
+            var childCount = VisualTreeHelper.GetChildrenCount(parent);
+            if (childCount < 1) return null;
+
+            var candidateChild = VisualTreeHelper.GetChild(parent, 0);
+            if (candidateChild is CheckBox)
+            {
+                var text = (VisualTreeHelper.GetChild(parent, 1) as TextBlock).Text;
+                if (text == evm.Header)
+                {
+                    return candidateChild as CheckBox;
+                }
+            }
+
+            for (int i = 0; i < childCount; i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                var descendant = FindMatchingCheckBox(child, evm);
+                if (descendant != null)
+                    return descendant;
+            }
+
+            return null;
         }
 
         protected override ItemAutomationPeer CreateItemAutomationPeer(object item)
         {
-            return new CheckableTreeViewDataItemAutomationPeer(item, this, base.EventsSource as CheckableTreeViewDataItemAutomationPeer, _checkBox);
+            var checkbox = FindMatchingCheckBox(_owner, item as EventConfigNodeViewModel);
+            return new CheckableTreeViewDataItemAutomationPeer(item, this, base.EventsSource as CheckableTreeViewDataItemAutomationPeer, checkbox);
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItemAutomationPeer.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewItemAutomationPeer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
@@ -7,6 +7,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:converters="clr-namespace:AccessibilityInsights.SharedUx.Converters"
              xmlns:local="clr-namespace:AccessibilityInsights.SharedUx.Controls"
+             xmlns:cc="clr-namespace:AccessibilityInsights.SharedUx.Controls.CustomControls"
              xmlns:vm="clr-namespace:AccessibilityInsights.SharedUx.ViewModels"
              xmlns:fabric="clr-namespace:AccessibilityInsights.CommonUxComponents.Controls;assembly=AccessibilityInsights.CommonUxComponents"
              xmlns:Properties="clr-namespace:AccessibilityInsights.SharedUx.Properties"
@@ -49,7 +50,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <TreeView Grid.Row="0" Name="trviewConfigEvents" BorderThickness="0" AutomationProperties.Name="{x:Static Properties:Resources.trviewConfigEventsAutomationPropertiesName}" Margin="2"
+                <cc:CheckableTreeView Grid.Row="0" x:Name="trviewConfigEvents" BorderThickness="0" AutomationProperties.Name="{x:Static Properties:Resources.trviewConfigEventsAutomationPropertiesName}" Margin="2"
                           ScrollViewer.CanContentScroll="False" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">
                     <TreeView.Resources>
                         <Style TargetType="TreeView">
@@ -80,7 +81,7 @@
                             <EventSetter Event="KeyDown" Handler="TreeViewItem_KeyDown"/>
                         </Style>
                     </TreeView.ItemContainerStyle>
-                </TreeView>
+                </cc:CheckableTreeView>
                 <CheckBox Grid.Row="1" Content="{x:Static Properties:Resources.EventConfigTabControl_ckbxAllEvents}"
                           Margin="27,2" FontSize="11" Name="ckbxAllEvents" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"
                           Checked="ckbxAllEvents_Checked" Unchecked="ckbxAllEvents_Unchecked" Style="{StaticResource CheckBoxContastingBorder}"

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
@@ -226,8 +226,6 @@ namespace AccessibilityInsights.SharedUx.Controls
             {
                 if (evm.IsEditEnabled)
                 {
-                    evm.IsChecked = !evm.IsChecked;
-
                     CheckableTreeViewItemAutomationPeer peer = UIElementAutomationPeer.FromElement(sender as TreeViewItem) as CheckableTreeViewItemAutomationPeer;
                     if (peer != null && peer.EventsSource is CheckableTreeViewDataItemAutomationPeer)
                     {

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
+using AccessibilityInsights.SharedUx.Controls.CustomControls;
 using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.SharedUx.Settings;
@@ -226,6 +227,12 @@ namespace AccessibilityInsights.SharedUx.Controls
                 if (evm.IsEditEnabled)
                 {
                     evm.IsChecked = !evm.IsChecked;
+
+                    CheckableTreeViewItemAutomationPeer peer = UIElementAutomationPeer.FromElement(sender as TreeViewItem) as CheckableTreeViewItemAutomationPeer;
+                    if (peer != null && peer.EventsSource is CheckableTreeViewDataItemAutomationPeer)
+                    {
+                        (peer.EventsSource as CheckableTreeViewDataItemAutomationPeer).Toggle();
+                    }
                 }
                 e.Handled = true;
             }

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -1542,24 +1542,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to  checked.
-        /// </summary>
-        public static string EventConfigNodeViewModel_ToString_checked {
-            get {
-                return ResourceManager.GetString("EventConfigNodeViewModel_ToString_checked", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to  unchecked.
-        /// </summary>
-        public static string EventConfigNodeViewModel_ToString_unchecked {
-            get {
-                return ResourceManager.GetString("EventConfigNodeViewModel_ToString_unchecked", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Listen to All Events.
         /// </summary>
         public static string EventConfigTabControl_ckbxAllEvents {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1128,12 +1128,6 @@
   <data name="ExtensionMethods_CopyStringToClipboard_Error_copying_to_clipboard" xml:space="preserve">
     <value>Error copying to clipboard: </value>
   </data>
-  <data name="EventConfigNodeViewModel_ToString_checked" xml:space="preserve">
-    <value> checked</value>
-  </data>
-  <data name="EventConfigNodeViewModel_ToString_unchecked" xml:space="preserve">
-    <value> unchecked</value>
-  </data>
   <data name="HierarchyNodeViewModel_AutomationNameFailedResultsInDescendentsFormat" xml:space="preserve">
     <value>{0} has failed test results in descendants.</value>
     <comment>{0} is the glimpse</comment>

--- a/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
+++ b/src/AccessibilityInsights.SharedUx/ViewModels/EventConfigNodeViewModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.Enums;
 using AccessibilityInsights.SharedUx.Properties;
@@ -434,10 +434,7 @@ namespace AccessibilityInsights.SharedUx.ViewModels
         {
             if (this.TextVisibility == Visibility.Visible)
             {
-                var check = (this.IsChecked.HasValue && this.IsChecked.Value)
-                    ? Resources.EventConfigNodeViewModel_ToString_checked
-                    : Resources.EventConfigNodeViewModel_ToString_unchecked;
-                return this.Header + check;
+                return this.Header;
             }
             else
             {


### PR DESCRIPTION
#### Details

Building off of @RobGallo's branch to fix https://github.com/microsoft/accessibility-insights-windows/issues/1323 by implementing the TogglePattern in order to ensure that checkboxes in the event configuration report being checked/ unchecked with a screenreader. Tested with NVDA.

Supersedes https://github.com/microsoft/accessibility-insights-windows/pull/1464.

##### Motivation

Addresses https://github.com/microsoft/accessibility-insights-windows/issues/1323

#### Pull request checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, [#1323](https://github.com/microsoft/accessibility-insights-windows/issues/1323)
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.