### PR TITLE
chore: Select unit tests correctly

### DIFF
--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -53,14 +53,14 @@ jobs:
     displayName: 'Publish Artifact: drop'
 
   - task: VSTest@2
-    displayName: 'Test Assemblies **\release\*test*.dll;-:**\obj\**'
+    displayName: 'Test Assemblies **\*test*.dll;-:**\obj\**'
     inputs:
       testAssemblyVer2: |
         **\*test*.dll
         !**\obj\**
       codeCoverageEnabled: true
       platform: '$(BuildPlatform)'
-      configuration: release
+      configuration: ${{ parameters.configuration }}
       rerunFailedTests: true
       runSettingsFile: $(Build.SourcesDirectory)/src/UITests//UITests.runsettings
       testFiltercriteria: 'TestCategory!=UITest'


### PR DESCRIPTION
#### Details

While investigating a test failure, I noticed that the debug leg of our PR tests is always using the release configuration. This PR changes the yml file to use the parameterized configuration

##### Motivation

Run all tests

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



