### PR TITLE
fix: Prevent horizontal shifting in properties grid

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
@@ -272,33 +272,6 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         }
 
         /// <summary>
-        /// Finds object up parent hierarchy of specified type
-        /// </summary>
-        private DependencyObject GetParentElem<T>(DependencyObject obj)
-        {
-            try
-            {
-                var par = VisualTreeHelper.GetParent(obj);
-
-                if (par is T)
-                {
-                    return par;
-                }
-                else
-                {
-                    return GetParentElem<T>(par);
-                }
-            }
-#pragma warning disable CA1031 // Do not catch general exception types
-            catch (Exception e)
-            {
-                e.ReportException();
-                return null;
-            }
-#pragma warning restore CA1031 // Do not catch general exception types
-        }
-
-        /// <summary>
         /// Custom keyboard nav behavior
         /// </summary>
         private void lviResults_PreviewKeyDown(object sender, KeyEventArgs e)
@@ -314,7 +287,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
                 }
                 else
                 {
-                    var parent = GetParentElem<Expander>(sender as DependencyObject) as Expander;
+                    var parent = (sender as DependencyObject).GetParentElem<Expander>() as Expander;
                     var vb = GetFirstChildElement<Label>(parent as DependencyObject) as Label;
                     vb.Focus();
                 }
@@ -366,7 +339,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
                     }
                     else
                     {
-                        (GetParentElem<GroupItem>(sender as DependencyObject) as UIElement).Focus();
+                        ((sender as DependencyObject).GetParentElem<GroupItem>() as UIElement).Focus();
                     }
                 }
                 e.Handled = true;
@@ -457,7 +430,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         private void ListViewItem_Unselected(object sender, RoutedEventArgs e)
         {
             var lvi = sender as ListViewItem;
-            var exp = GetParentElem<Expander>(lvi) as Expander;
+            var exp = lvi.GetParentElem<Expander>() as Expander;
             var cb = GetFirstChildElement<CheckBox>(exp) as CheckBox;
             var srvm = lvi.DataContext as RuleResultViewModel;
 
@@ -468,7 +441,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
             }
 
             SelectedItems.Remove(srvm);
-            var groupitem = GetParentElem<GroupItem>(exp) as GroupItem;
+            var groupitem = exp.GetParentElem<GroupItem>() as GroupItem;
             var dc = cb.DataContext as CollectionViewGroup;
             var itms = dc.Items;
             var any = itms.Intersect(SelectedItems).Any();
@@ -512,7 +485,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
             var cb = sender as CheckBox;
             if (cb.IsEnabled)
             {
-                var exp = GetParentElem<Expander>(cb) as Expander;
+                var exp = cb.GetParentElem<Expander>() as Expander;
                 var lst = cb.DataContext as CollectionViewGroup;
                 var itemsSelected = SetItemsChecked(lst.Items, cb.IsChecked.Value);
                 if (!itemsSelected)
@@ -521,7 +494,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
                 }
 
                 // update tag for whether the group item has children highlighted or not
-                var groupitem = GetParentElem<GroupItem>(exp) as GroupItem;
+                var groupitem = exp.GetParentElem<GroupItem>() as GroupItem;
                 groupitem.Tag = cb.IsChecked.Value ? "all" : "zero";
             }
         }
@@ -542,7 +515,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
             if (ScreenshotAvailable)
             {
                 var lvi = sender as ListViewItem;
-                var exp = GetParentElem<Expander>(lvi) as Expander;
+                var exp = lvi.GetParentElem<Expander>() as Expander;
                 var cb = GetFirstChildElement<CheckBox>(exp) as CheckBox;
                 var itm = lvi.DataContext as RuleResultViewModel;
                 if (!SelectedItems.Contains(itm))
@@ -551,7 +524,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
                     UpdateSelectAll();
                     ImageOverlayDriver.GetDefaultInstance().AddElement(_controlContext.ElementContext.Id, itm.Element.UniqueId);
                 }
-                var groupitem = GetParentElem<GroupItem>(exp) as GroupItem;
+                var groupitem = exp.GetParentElem<GroupItem>() as GroupItem;
                 var dc = cb.DataContext as CollectionViewGroup;
                 var itms = dc.Items;
                 var any = itms.Except(SelectedItems).Any();
@@ -573,7 +546,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         /// </summary>
         private void GroupItem_PreviewKeyDown(object sender, KeyEventArgs e)
         {
-            var listViewItemParent = GetParentElem<ListViewItem>(Keyboard.FocusedElement as DependencyObject);
+            var listViewItemParent = (Keyboard.FocusedElement as DependencyObject).GetParentElem<ListViewItem>();
             if (Keyboard.FocusedElement is ListViewItem || listViewItemParent != null)
             {
                 // Let it be handled by the listviewitem previewkeydown handler
@@ -583,7 +556,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
 
             var gi = sender as GroupItem;
             var sp = GetFirstChildElement<StackPanel>(gi) as StackPanel;
-            var exp = GetParentElem<Expander>(sp) as Expander;
+            var exp = sp.GetParentElem<Expander>() as Expander;
 
             if (e.Key == Key.Right)
             {

--- a/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
@@ -18,7 +18,7 @@
     </UserControl.Resources>
     <Grid>
         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Stretch" >
-            <Grid >
+            <Grid RequestBringIntoView="Grid_RequestBringIntoView">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>

--- a/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml.cs
@@ -1,9 +1,10 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
 using AccessibilityInsights.SharedUx.Dialogs;
 using AccessibilityInsights.SharedUx.Interfaces;
 using AccessibilityInsights.SharedUx.Settings;
+using AccessibilityInsights.SharedUx.Utilities;
 using AccessibilityInsights.SharedUx.ViewModels;
 using Axe.Windows.Core.Bases;
 using Axe.Windows.Core.Types;
@@ -15,6 +16,7 @@ using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
+using System.Windows.Media;
 
 namespace AccessibilityInsights.SharedUx.Controls
 {
@@ -238,6 +240,31 @@ namespace AccessibilityInsights.SharedUx.Controls
                 ApplicationCommands.Copy.Execute(null, lvProperties);
                 e.Handled = true;
             }
+        }
+
+        /// <summary>
+        /// Override WPF's behavior to automatically bring elements into focus via horizontal scrolling, since we treat this
+        /// grid as a list and it causes a jumpy appearance.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void Grid_RequestBringIntoView(object sender, RequestBringIntoViewEventArgs e)
+        {
+            var scrollViewer = (sender as Grid).GetParentElem<ScrollViewer>() as ScrollViewer;
+
+            // If target rectangle is out of view vertically, scroll to it
+            var topIsVisible = e.TargetRect.Top >= scrollViewer.VerticalOffset;
+            var bottomIsVisible = e.TargetRect.Bottom <= (scrollViewer.ViewportHeight + scrollViewer.VerticalOffset);
+            if (!topIsVisible)
+            {
+                scrollViewer.ScrollToVerticalOffset(e.TargetRect.Top);
+            }
+            else if (!bottomIsVisible)
+            {
+                scrollViewer.ScrollToVerticalOffset(e.TargetRect.Bottom - scrollViewer.ViewportHeight);
+            }
+
+            e.Handled = true;
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
@@ -305,5 +305,32 @@ namespace AccessibilityInsights.SharedUx.Utilities
                     where s.Bounds.Contains(p)
                     select s).Any();
         }
+
+        /// <summary>
+        /// Finds object up parent hierarchy of specified type
+        /// </summary>
+        internal static DependencyObject GetParentElem<T>(this DependencyObject obj)
+        {
+            try
+            {
+                var par = VisualTreeHelper.GetParent(obj);
+
+                if (par is T)
+                {
+                    return par;
+                }
+                else
+                {
+                    return GetParentElem<T>(par);
+                }
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception e)
+            {
+                e.ReportException();
+                return null;
+            }
+#pragma warning restore CA1031 // Do not catch general exception types
+        }
     }
 }


### PR DESCRIPTION
#### Details

By default when a `ScrollViewer` is wrapping a `Grid`, WPF scrolls to focus on the element being selected in the grid. This is the behavior we want for vertical scrolling, but this causes some jumpy behavior in the horizontal scrollbar, as described in #1150. The horizonal jumps would make more sense if the user were navigating between cells horizontally, but since we treat the properties grid as a list and only allow navigation between rows (as opposed to between cells), the default behavior just looks odd. As a result, this PR overrides WPF default behavior by keeping vertical navigation the same but removing the horizontal component.

##### Motivation

Addresses issue https://github.com/microsoft/accessibility-insights-windows/issues/1150

##### Context

Behavior after this change:
[Description: Gif of AIWin in live inspect mode. User navigates arounds property grid with keyboard. Navigation is the same as before but horizontal jumps have been removed.]

![Accessibility Insights for Windows - Inspect - Live 2022-11-09 09-33-19](https://user-images.githubusercontent.com/16010855/200900956-87ccd20d-a93e-48a4-a276-5530c7d554f3.gif)

#### Pull request checklist

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, https://github.com/microsoft/accessibility-insights-windows/issues/1150
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.