### PR TITLE
fix: Take searchbar height into account for vertical scroll

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml.cs
@@ -253,15 +253,17 @@ namespace AccessibilityInsights.SharedUx.Controls
             var scrollViewer = (sender as Grid).GetParentElem<ScrollViewer>() as ScrollViewer;
 
             // If target rectangle is out of view vertically, scroll to it
-            var topIsVisible = e.TargetRect.Top >= scrollViewer.VerticalOffset;
-            var bottomIsVisible = e.TargetRect.Bottom <= (scrollViewer.ViewportHeight + scrollViewer.VerticalOffset);
+            var top = this.dpFilter.Visibility == Visibility.Visible ? e.TargetRect.Top + this.dpFilter.Height + this.dpFilter.Margin.Top : e.TargetRect.Top;
+            var bottom = this.dpFilter.Visibility == Visibility.Visible ? e.TargetRect.Bottom + this.dpFilter.Height + this.dpFilter.Margin.Bottom : e.TargetRect.Bottom;
+            var topIsVisible = top >= scrollViewer.VerticalOffset;
+            var bottomIsVisible = bottom <= (scrollViewer.ViewportHeight + scrollViewer.VerticalOffset);
             if (!topIsVisible)
             {
-                scrollViewer.ScrollToVerticalOffset(e.TargetRect.Top);
+                scrollViewer.ScrollToVerticalOffset(top);
             }
             else if (!bottomIsVisible)
             {
-                scrollViewer.ScrollToVerticalOffset(e.TargetRect.Bottom - scrollViewer.ViewportHeight);
+                scrollViewer.ScrollToVerticalOffset(bottom - scrollViewer.ViewportHeight);
             }
 
             e.Handled = true;


### PR DESCRIPTION
#### Details

Fix bug in https://github.com/microsoft/accessibility-insights-windows/pull/1475 in which search bar height was not taken into account in vertical scrolling logic.

Behavior after this PR:
[Description: Gif of AIWin in live inspect mode. User navigates arounds property grid, which has the search bar visible at the top. Navigation is the same as before but horizontal jumps have been removed.]
![Accessibility Insights for Windows - Inspect - Live 2022-11-10 14-14-34](https://user-images.githubusercontent.com/16010855/201217821-805ee741-7c9a-495c-99dc-9cbebdbc79af.gif)

##### Motivation

Fix bug

#### Pull request checklist

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.