### PR TITLE
chore: Address analyzer suggestions

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -55,6 +55,7 @@ dotnet_style_prefer_auto_properties = true:silent
 dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent
 dotnet_remove_unnecessary_suppression_exclusions=all
+dotnet_style_prefer_compound_assignment = false
 ###############################
 # Naming Conventions          #
 ###############################

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
@@ -520,9 +520,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
             }
         }
 
-#pragma warning disable CA1801 // unused parameter
-        private void IssueConfigurationControl_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
-#pragma warning restore CA1801 // unused parameter
+        private void IssueConfigurationControl_IsVisibleChanged(object _, DependencyPropertyChangedEventArgs e)
         {
             if ((bool)e.NewValue)
             {

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
@@ -304,10 +304,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
             if (AutomationPeer.ListenerExists(AutomationEvents.AsyncContentLoaded))
             {
                 UserControlAutomationPeer peer = UIElementAutomationPeer.FromElement(this) as UserControlAutomationPeer;
-                if (peer != null)
-                {
-                    peer.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(state, state == AsyncContentLoadedState.Beginning ? 0 : 100));
-                }
+                peer?.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(state, state == AsyncContentLoadedState.Beginning ? 0 : 100));
             }
         }
 
@@ -369,10 +366,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                 if (starting)
                 {
                     var peer = FrameworkElementAutomationPeer.FromElement(ctrlProgressRing);
-                    if (peer != null)
-                    {
-                        peer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
-                    }
+                    peer?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
                 }
                 this.IsEnabled = InteractionAllowed;
             });

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ForcedDependencies.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ForcedDependencies.cs
@@ -17,7 +17,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         {
         }
 
-#pragma warning disable IDE0051 // These exist to help with transitive dependencies
+#pragma warning disable IDE0051 // Refer to class summary for why these are here
         private static void TestEnforcedDependencies()
         {
             // Types that we can detect via unit tests. Namespace generally matches the package.
@@ -42,6 +42,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
             ForceDependency(typeof(System.Net.Http.Formatting.BaseJsonMediaTypeFormatter));
             ForceDependency(typeof(System.Reflection.Metadata.ArrayShape));
         }
-#pragma warning restore IDE0051 // These exist to help with transitive dependencies
+#pragma warning restore IDE0051 // Refer to class summary for why these are here
     }
 }

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ForcedDependencies.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ForcedDependencies.cs
@@ -17,7 +17,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         {
         }
 
-#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable IDE0051 // These exist to help with transitive dependencies
         private static void TestEnforcedDependencies()
         {
             // Types that we can detect via unit tests. Namespace generally matches the package.
@@ -42,6 +42,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
             ForceDependency(typeof(System.Net.Http.Formatting.BaseJsonMediaTypeFormatter));
             ForceDependency(typeof(System.Reflection.Metadata.ArrayShape));
         }
-#pragma warning restore IDE0051 // Remove unused private members
+#pragma warning restore IDE0051 // These exist to help with transitive dependencies
     }
 }

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/ExceptionReporter.cs
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/ExceptionReporter.cs
@@ -17,10 +17,7 @@ namespace AccessibilityInsights.Extensions.GitHubAutoUpdate
         /// <param name="exception">The exception being reported</param>
         public void ReportException(Exception exception)
         {
-            if (exception != null)
-            {
-                exception.ReportException();
-            }
+            exception?.ReportException();
         }
     }
 }

--- a/src/AccessibilityInsights.ExtensionsTests/ContainerUnitTests.cs
+++ b/src/AccessibilityInsights.ExtensionsTests/ContainerUnitTests.cs
@@ -18,7 +18,7 @@ namespace AccessibilityInsights.ExtensionsTests
     public class ContainerUnitTests
     {
         const string ExtensionsDoNotExistSearchPattern = null;
-        static string ExtensionsExistSearchPattern = Path.GetFileName(Assembly.GetExecutingAssembly().Location);
+        static readonly string ExtensionsExistSearchPattern = Path.GetFileName(Assembly.GetExecutingAssembly().Location);
 
         [TestMethod]
         [Timeout(1000)]

--- a/src/AccessibilityInsights.SetupLibrary/OverridableConfig.cs
+++ b/src/AccessibilityInsights.SetupLibrary/OverridableConfig.cs
@@ -37,10 +37,7 @@ namespace AccessibilityInsights.SetupLibrary
 #pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception e)
                 {
-                    if (exceptionReporter != null)
-                    {
-                        exceptionReporter.ReportException(e);
-                    }
+                    exceptionReporter?.ReportException(e);
                 }
 #pragma warning restore CA1031 // Do not catch general exception types
             }

--- a/src/AccessibilityInsights.SetupLibrary/SettingsDictionary.cs
+++ b/src/AccessibilityInsights.SetupLibrary/SettingsDictionary.cs
@@ -40,7 +40,7 @@ namespace AccessibilityInsights.SetupLibrary
                         var jArray = (JArray)(pair.Value);
 
                         List<int> list = new List<int>();
-                        foreach (int value in jArray)
+                        foreach (int value in jArray.Select(v => (int)v))
                         {
                             list.Add(value);
                         }

--- a/src/AccessibilityInsights.SharedUx/ActionViews/GeneralActionView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/GeneralActionView.xaml.cs
@@ -149,9 +149,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
             return !regex.IsMatch(text);
         }
 
-#pragma warning disable CA1801 // unused parameter
-        private void UserControl_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
-#pragma warning restore CA1801 // unused parameter
+        private void UserControl_IsVisibleChanged(object _, DependencyPropertyChangedEventArgs _1)
         {
             lock (_lockObject)
             {

--- a/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml.cs
@@ -378,7 +378,9 @@ namespace AccessibilityInsights.SharedUx.ActionViews
         }
 
 #pragma warning disable CA1801 // unused parameter
+#pragma warning disable IDE0060 // Remove unused parameter
         private void UserControl_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+#pragma warning restore IDE0060 // Remove unused parameter
 #pragma warning restore CA1801 // unused parameter
         {
             lock (_lockObject)

--- a/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/ReturnA11yElementsView.xaml.cs
@@ -377,11 +377,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
             e.Handled = !e.Text.IsTextAllowed();
         }
 
-#pragma warning disable CA1801 // unused parameter
-#pragma warning disable IDE0060 // Remove unused parameter
-        private void UserControl_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
-#pragma warning restore IDE0060 // Remove unused parameter
-#pragma warning restore CA1801 // unused parameter
+        private void UserControl_IsVisibleChanged(object _, DependencyPropertyChangedEventArgs _1)
         {
             lock (_lockObject)
             {

--- a/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/ActionViews/TextRangeActionView.xaml.cs
@@ -149,9 +149,7 @@ namespace AccessibilityInsights.SharedUx.ActionViews
             e.Handled = e.Text.IsTextAllowed();
         }
 
-#pragma warning disable CA1801 // unused parameter
-        private void UserControl_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
-#pragma warning restore CA1801 // unused parameter
+        private void UserControl_IsVisibleChanged(object _, DependencyPropertyChangedEventArgs _1)
         {
             lock (_lockObject)
             {

--- a/src/AccessibilityInsights.SharedUx/Behaviors/DropDownButtonBehavior.cs
+++ b/src/AccessibilityInsights.SharedUx/Behaviors/DropDownButtonBehavior.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
 using AccessibilityInsights.SharedUx.Utilities;
@@ -118,10 +118,7 @@ namespace AccessibilityInsights.SharedUx.Behaviors
 
             isContextMenuOpen = false;
             var contextMenu = sender as ContextMenu;
-            if (contextMenu != null)
-            {
-                contextMenu.RemoveHandler(ContextMenu.ClosedEvent, new RoutedEventHandler(ContextMenu_Closed));
-            }
+            contextMenu?.RemoveHandler(ContextMenu.ClosedEvent, new RoutedEventHandler(ContextMenu_Closed));
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
@@ -382,7 +382,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         private bool SetItemsChecked(IReadOnlyCollection<Object> lst, bool check)
         {
             var ret = true;
-            foreach (RuleResultViewModel itm in lst.AsParallel())
+            foreach (RuleResultViewModel itm in lst.AsParallel().Cast<RuleResultViewModel>())
             {
                 if (check && !SelectedItems.Contains(itm))
                 {

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
@@ -84,7 +84,6 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         public static void OnDataGridExpandAllAutomationIdChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
         {
             AutomatedChecksCustomListControl sender = o as AutomatedChecksCustomListControl;
-
             sender?.btnExpandAll.SetValue(AutomationProperties.AutomationIdProperty, sender.DataGridExpandAllAutomationId);
         }
 

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/AutomatedChecksCustomListControl.xaml.cs
@@ -85,10 +85,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         {
             AutomatedChecksCustomListControl sender = o as AutomatedChecksCustomListControl;
 
-            if (sender != null)
-            {
-                sender.btnExpandAll.SetValue(AutomationProperties.AutomationIdProperty, sender.DataGridExpandAllAutomationId);
-            }
+            sender?.btnExpandAll.SetValue(AutomationProperties.AutomationIdProperty, sender.DataGridExpandAllAutomationId);
         }
 
         #endregion

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
@@ -10,7 +10,7 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
 {
     internal class CheckableTreeViewDataItemAutomationPeer : TreeViewDataItemAutomationPeer, IToggleProvider
     {
-        private EventConfigNodeViewModel _owner;
+        private readonly EventConfigNodeViewModel _owner;
 
         public CheckableTreeViewDataItemAutomationPeer(object item, ItemsControlAutomationPeer itemsControlAutomationPeer, TreeViewDataItemAutomationPeer parentDataItemAutomationPeer)
             : base(item, itemsControlAutomationPeer, parentDataItemAutomationPeer)

--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigurationControl.xaml.cs
@@ -260,10 +260,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             if (AutomationPeer.ListenerExists(AutomationEvents.AsyncContentLoaded))
             {
                 UserControlAutomationPeer peer = UIElementAutomationPeer.FromElement(this) as UserControlAutomationPeer;
-                if (peer != null)
-                {
-                    peer.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(AsyncContentLoadedState.Completed, 100));
-                }
+                peer?.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(AsyncContentLoadedState.Completed, 100));
             }
         }
 

--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml.cs
@@ -347,10 +347,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             if (AutomationPeer.ListenerExists(AutomationEvents.AsyncContentLoaded))
             {
                 ListBoxAutomationPeer peer = UIElementAutomationPeer.FromElement(this.dgEvents) as ListBoxAutomationPeer;
-                if (peer != null)
-                {
-                    peer.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(AsyncContentLoadedState.Completed, 100));
-                }
+                peer?.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(AsyncContentLoadedState.Completed, 100));
             }
         }
 

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -331,10 +331,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             if (AutomationPeer.ListenerExists(AutomationEvents.AsyncContentLoaded))
             {
                 TreeViewAutomationPeer peer = UIElementAutomationPeer.FromElement(this.treeviewHierarchy) as TreeViewAutomationPeer;
-                if (peer != null)
-                {
-                    peer.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(AsyncContentLoadedState.Completed, 100));
-                }
+                peer?.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(AsyncContentLoadedState.Completed, 100));
             }
         }
 

--- a/src/AccessibilityInsights.SharedUx/Controls/NPISlider.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/NPISlider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Axe.Windows.Core.Types;
 using System;
@@ -28,14 +28,10 @@ namespace AccessibilityInsights.SharedUx.Controls
             if (AutomationPeer.ListenerExists(AutomationEvents.PropertyChanged))
             {
                 var peer = UIElementAutomationPeer.FromElement(this) as NPISliderAutomationPeer;
-                if (peer != null)
-                {
-                    peer.RaisePropertyChangedEvent(
-                        AutomationProperty.LookupById(PropertyType.UIA_ValuePattern_ValuePropertyId),
-                        oldValue.ToString(CultureInfo.InvariantCulture),
-                        newValue.ToString(CultureInfo.InvariantCulture)
-                    );
-                }
+                peer?.RaisePropertyChangedEvent(
+                    AutomationProperty.LookupById(PropertyType.UIA_ValuePattern_ValuePropertyId),
+                    oldValue.ToString(CultureInfo.InvariantCulture),
+                    newValue.ToString(CultureInfo.InvariantCulture));
             }
         }
     }

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -353,7 +353,9 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         /// Call show/hide when tab changes
         /// </summary>
 #pragma warning disable CA1801 // unused parameter
+#pragma warning disable IDE0060 // Remove unused parameter
         private void UserControl_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+#pragma warning restore IDE0060 // Remove unused parameter
 #pragma warning restore CA1801 // unused parameter
         {
             if ((bool)e.NewValue == true)

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/AutomatedChecksControl.xaml.cs
@@ -352,11 +352,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         /// <summary>
         /// Call show/hide when tab changes
         /// </summary>
-#pragma warning disable CA1801 // unused parameter
-#pragma warning disable IDE0060 // Remove unused parameter
-        private void UserControl_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
-#pragma warning restore IDE0060 // Remove unused parameter
-#pragma warning restore CA1801 // unused parameter
+        private void UserControl_IsVisibleChanged(object _, DependencyPropertyChangedEventArgs e)
         {
             if ((bool)e.NewValue == true)
             {

--- a/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/TestTabs/TabStopControl.xaml.cs
@@ -525,11 +525,7 @@ namespace AccessibilityInsights.SharedUx.Controls.TestTabs
         /// <summary>
         /// Call show/hide when tab changes
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-#pragma warning disable CA1801 // unused parameter
-        private void UserControl_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
-#pragma warning restore CA1801 // unused parameter
+        private void UserControl_IsVisibleChanged(object _, DependencyPropertyChangedEventArgs e)
         {
             if ((bool)e.NewValue == true)
             {

--- a/src/AccessibilityInsights.SharedUx/Highlighting/OverlayHighlighter.cs
+++ b/src/AccessibilityInsights.SharedUx/Highlighting/OverlayHighlighter.cs
@@ -137,10 +137,7 @@ namespace AccessibilityInsights.SharedUx.Highlighting
         {
             try
             {
-                if (canvas != null)
-                {
-                    canvas.Children.Remove(brd);
-                }
+                canvas?.Children.Remove(brd);
             }
             catch (InvalidOperationException)
             {

--- a/src/AccessibilityInsights.VersionSwitcher/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/MainWindow.xaml.cs
@@ -65,10 +65,7 @@ namespace AccessibilityInsights.VersionSwitcher
                 progressBar.Value = percentage;
                 statusText.Text = newText;
                 var peer = FrameworkElementAutomationPeer.FromElement(statusText);
-                if (peer != null)
-                {
-                    peer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
-                }
+                peer?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
             }
         }
 

--- a/src/AccessibilityInsights/Modes/EventModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/EventModeControl.xaml.cs
@@ -307,11 +307,7 @@ namespace AccessibilityInsights.Modes
         /// <summary>
         /// Set focus when visible
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-#pragma warning disable CA1801
         private void UserControl_IsVisibleChanged(object _, DependencyPropertyChangedEventArgs e)
-#pragma warning restore CA1801
         {
             if ((bool)e.NewValue)
             {

--- a/src/AccessibilityInsights/Modes/EventModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/EventModeControl.xaml.cs
@@ -303,7 +303,7 @@ namespace AccessibilityInsights.Modes
             return enabled;
         }
 
-#pragma warning disable IDE0051 // TODO: Is this really unused?
+#pragma warning disable IDE0051 // This is referenced in the XAML file
         /// <summary>
         /// Set focus when visible
         /// </summary>
@@ -317,7 +317,7 @@ namespace AccessibilityInsights.Modes
                 }, DispatcherPriority.Render);
             }
         }
-#pragma warning restore IDE0051
+#pragma warning restore IDE0051 // This is referenced in the XAML file
 
         /// <summary>
         /// Set focus on default control for mode

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
 using AccessibilityInsights.CommonUxComponents.Dialogs;
@@ -253,10 +253,7 @@ namespace AccessibilityInsights.Modes
             if (AutomationPeer.ListenerExists(AutomationEvents.AsyncContentLoaded))
             {
                 UserControlAutomationPeer peer = UIElementAutomationPeer.FromElement(this) as UserControlAutomationPeer;
-                if (peer != null)
-                {
-                    peer.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(AsyncContentLoadedState.Completed, 100));
-                }
+                peer?.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(AsyncContentLoadedState.Completed, 100));
             }
         }
 

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
@@ -319,24 +319,6 @@ namespace AccessibilityInsights.Modes
             this.ctrlTabs.CurrentMode = (TestView)(MainWin.CurrentView) == TestView.ElementHowToFix ? InspectTabMode.TestHowToFix : InspectTabMode.TestProperties;
         }
 
-#pragma warning disable IDE0051 // TODO: Is this really unused?
-        /// <summary>
-        /// Update current view based on tab selection
-        /// </summary>
-        /// <param name="mode"></param>
-        private static void UpdateMainWinView(InspectTabType type)
-        {
-            if (type == InspectTabType.HowToFix)
-            {
-                MainWin.SetCurrentViewAndUpdateUI(TestView.ElementHowToFix);
-            }
-            else if (type == InspectTabType.Details)
-            {
-                MainWin.SetCurrentViewAndUpdateUI(TestView.ElementDetails);
-            }
-        }
-#pragma warning restore IDE0051
-
         /// <summary>
         /// Clear UI
         /// </summary>

--- a/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/SnapshotModeControl.xaml.cs
@@ -274,10 +274,7 @@ namespace AccessibilityInsights.Modes
             if (AutomationPeer.ListenerExists(AutomationEvents.AsyncContentLoaded))
             {
                 UserControlAutomationPeer peer = UIElementAutomationPeer.FromElement(this) as UserControlAutomationPeer;
-                if (peer != null)
-                {
-                    peer.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(state, state == AsyncContentLoadedState.Beginning ? 0 : 100));
-                }
+                peer?.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(state, state == AsyncContentLoadedState.Beginning ? 0 : 100));
             }
         }
 

--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
 using AccessibilityInsights.CommonUxComponents.Dialogs;
@@ -304,10 +304,7 @@ namespace AccessibilityInsights.Modes
             if (AutomationPeer.ListenerExists(AutomationEvents.AsyncContentLoaded))
             {
                 UserControlAutomationPeer peer = UIElementAutomationPeer.FromElement(this) as UserControlAutomationPeer;
-                if (peer != null)
-                {
-                    peer.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(state, state == AsyncContentLoadedState.Beginning ? 0 : 100));
-                }
+                peer?.RaiseAsyncContentLoadedEvent(new AsyncContentLoadedEventArgs(state, state == AsyncContentLoadedState.Beginning ? 0 : 100));
             }
         }
 


### PR DESCRIPTION
#### Details

This PR addresses some issues around analyzer suggestions:

1. Suppress suggestions from [IDE0054 and IDE0074](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0054-ide0074), since they require C# version 8.0 and .NET Framework 4.8 defaults to C# version 7.3
2. Use null propagation as suggested by [IDE0031](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0031)
3. Rename unused method parameters as described in the docs for [CA1801](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1801) and [IDE0060](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0060). This allows us to remove the pragmas that existed to disable CA1801. If we had empty parameter comments that became out of date, remove the comments
4. Review places where we were suppressing IDE0051. Remove the code where it's not needed, add comments where it is
5. Add some `readonly` modifiers where the analyzer suggested them
6. The analyzer identified 2 places where an implicit conversion was occurring, and suggested an explicit conversion operation. This uses the analyzer-suggested conversion.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



