### PR TITLE
fix: Run license header checks earlier

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -17,6 +17,13 @@ jobs:
   variables:
     PublicRelease: 'false'
   steps:
+  - task: PowerShell@2
+    displayName: 'License Header Check'
+    inputs:
+      targetType: "filePath"
+      filePath: tools\scripts\verification.scripts\LicenseHeaderVerification.ps1
+      arguments: '-target  $(Build.Repository.LocalPath) -licenseHeaderPath tools\scripts\verification.scripts\LicenseHeader.txt -extensions *.xaml,*.xml,*.cs,*.ps1 -addIfAbsent $false'
+
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'
     inputs:
@@ -32,13 +39,6 @@ jobs:
       projects: |
         **\*.csproj
         !**\CustomActions.Package.csproj
-
-  - task: PowerShell@2
-    displayName: 'License Header Check'
-    inputs:
-      targetType: "filePath"
-      filePath: tools\scripts\verification.scripts\LicenseHeaderVerification.ps1
-      arguments: '-target  $(Build.Repository.LocalPath) -licenseHeaderPath tools\scripts\verification.scripts\LicenseHeader.txt -extensions *.xaml,*.xml,*.cs,*.ps1 -addIfAbsent $false'
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'


### PR DESCRIPTION
#### Details

#1480 moved our build-generated files from `$(TEMP)` to `.\src\bld`, which was a good thing. It had the unexpected side effect of making the compliance release job of the signed pipeline fail. This happens because now these generated files are being checked for a copyright header...which they lack.

The PR build, which also performs the same check, had no such problem. Comparing the two pipelines, the PR pipeline checks for copyright headers immediately, while the signed pipeline checks a little later. This PR modifies the signed pipeline to perform the copyright header check immediately, so we have parity between the pipelines.

##### Motivation

Fix signed pipeline

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
My first thought was to add the copyright headers to the generated files, then I wondered why we had a difference between the 2 pipelines. The better option seemed to be to make the checks uniform.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



