### PR TITLE
chore: Fix gap in WxsValidationTests

### DIFF
--- a/src/MsiFileTests/WxsValidationTests.cs
+++ b/src/MsiFileTests/WxsValidationTests.cs
@@ -29,8 +29,8 @@ namespace MsiFileTests
             };
 
             CompareWxsSectionToDropPath(repoRoot, @"AccessibilityInsights\bin\release\net48", wxsFile, "ProductComponent", productComponentExclusions);
-            CompareWxsSectionToDropPath(repoRoot, @"AccessibilityInsights\bin\release\net48\IssueTemplates", wxsFile, "IssueTemplates");
-            CompareWxsSectionToDropPath(repoRoot, @"AccessibilityInsights.VersionSwitcher\bin\release\net48", wxsFile, "VersionSwitcher");
+            CompareWxsSectionToDropPath(repoRoot, @"AccessibilityInsights\bin\release\net48\IssueTemplates", wxsFile, "IssueTemplateComp");
+            CompareWxsSectionToDropPath(repoRoot, @"AccessibilityInsights.VersionSwitcher\bin\release\net48", wxsFile, "VersionSwitcherComp");
         }
 
         private static void CompareWxsSectionToDropPath(string repoRoot, string relativeDropPath,
@@ -38,11 +38,14 @@ namespace MsiFileTests
         {
             string dropPath = Path.Combine(repoRoot, relativeDropPath);
             HashSet<string> filesInDropPath = GetNonSymbolFilesInPath(dropPath, intentionalExclusions);
-            HashSet<string> filesInWxsComponent = GetFilesIncludedInWxsComponent(repoRoot, wxsFile, wxsComponentId);
+            HashSet<string> filesInWxsComponent = GetFilesIncludedInWxsComponent(wxsFile, wxsComponentId);
+
+            Assert.AreNotEqual(0, filesInDropPath.Count, $"No files found under {dropPath}");
+            Assert.AreNotEqual(0, filesInWxsComponent.Count, $"No files in Component {wxsComponentId}");
 
             filesInDropPath.ExceptWith(filesInWxsComponent);
 
-            Assert.IsFalse(filesInDropPath.Any(), $"Drop files not in \"{wxsComponentId}\" of WXS: {string.Join(", ", filesInDropPath)}");
+            Assert.IsFalse(filesInDropPath.Any(), $"{filesInDropPath.Count} drop files are missing from \"{wxsComponentId}\" of WXS: {string.Join(", ", filesInDropPath)}");
         }
 
         private static HashSet<string> GetNonSymbolFilesInPath(string path, HashSet<string> intentionalExclusions)
@@ -51,12 +54,12 @@ namespace MsiFileTests
 
             foreach (string file in Directory.EnumerateFiles(path))
             {
-                if (intentionalExclusions != null && !intentionalExclusions.Contains(Path.GetFileName(file)))
+                if (intentionalExclusions == null || !intentionalExclusions.Contains(Path.GetFileName(file)))
                 {
                     string extension = Path.GetExtension(file);
                     if (extension != ".pdb")
                     {
-                        filesInPath.Add(Path.GetFullPath(file));
+                        filesInPath.Add(Path.GetFileName(file));
                     }
                 }
             }
@@ -64,7 +67,7 @@ namespace MsiFileTests
             return filesInPath;
         }
 
-        private static HashSet<string> GetFilesIncludedInWxsComponent(string repoRoot, string wxsFile, string componentId)
+        private static HashSet<string> GetFilesIncludedInWxsComponent(string wxsFile, string componentId)
         {
             HashSet<string> filesInSection = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -84,7 +87,7 @@ namespace MsiFileTests
                         else if (reader.Name == "File" && thisIsTheCorrectComponent)
                         {
                             string relativeFile = reader.GetAttribute("Source");
-                            filesInSection.Add(repoRoot + relativeFile.Substring(2));
+                            filesInSection.Add(Path.GetFileName(relativeFile.Substring(2)));
                         }
                     }
                 }


### PR DESCRIPTION
#### Details

This fixes some issues with the MSI checker--I discovered these when I added a file to the VersionSwitcher but the test still succeeded:
1. Due to a logic error, files were returned _only_ if a set of excluded files was provided. This empty set was not caught as a problem. These have both been fixed.
2. We weren't passing the correct component names in 2 places, so we were returning empty sets of files. This empty set was also not caught as a problem. These have been fixed.
3. As written, the checker assumed that everything in a component comes from the same build folder, which we intentionally don't do because of signing requirements. Now we ignore the path and use just the file name (with extension) to ensure that the correct set of files is found.

##### Motivation

Make test detect errors (which is why it's there)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



