### PR TITLE
chore: Enable write permissions for combine-dependabot-prs

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -7,6 +7,10 @@ on:
     - cron: '0 13 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   combine-prs:
     if: github.event_name != 'schedule' || github.repository_owner == 'microsoft'


### PR DESCRIPTION
#### Details

Enable write permissions for combine-dependabot-prs

##### Motivation

The repo is configured to only allow read permissions to workflows. The combined-dependabot-prs action requires write permissions to create PRs

##### Context

Tested in [accessibility-insights-web](https://github.com/microsoft/accessibility-insights-web/actions/runs/3499742576)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



