### PR TITLE
feat(upgrader-security): Use redirectable links to obtain the upgrade manifests

### DIFF
--- a/src/AccessibilityInsights.SetupLibrary/GitHubWrapper.cs
+++ b/src/AccessibilityInsights.SetupLibrary/GitHubWrapper.cs
@@ -17,9 +17,9 @@ namespace AccessibilityInsights.SetupLibrary
         private readonly Uri _canaryConfigFileUri;
         private readonly TimeSpan _timeout;
 
-        private const string DefaultProductionConfigFileUrl = "https://www.github.com/Microsoft/accessibility-insights-windows/blob/Control/Channels/Production/release_info.json?raw=true";
-        private const string DefaultInsiderConfigFileUrl = "https://www.github.com/Microsoft/accessibility-insights-windows/blob/Control/Channels/Insider/release_info.json?raw=true";
-        private const string DefaultCanaryConfigFileUrl = "https://www.github.com/Microsoft/accessibility-insights-windows/blob/Canary/Channels/Canary/release_info.json?raw=true";
+        private const string DefaultProductionConfigFileUrl = "https://go.microsoft.com/fwlink/?linkid=2216117";
+        private const string DefaultInsiderConfigFileUrl = "https://go.microsoft.com/fwlink/?linkid=2216312";
+        private const string DefaultCanaryConfigFileUrl = "https://go.microsoft.com/fwlink/?linkid=2216313";
 
         /// <summary>
         /// constructor


### PR DESCRIPTION
#### Details

We currently use hardcoded links to fetch our upgrade manifests. We're changing these to fwlink values that we can later redirect to the signed manifests once that work is complete. For the moment, the redirects point to the same locations as the old hardcoded links. This is easy to validate by 


Tested locally and confirmed that redirects and updates work as expected.
##### Motivation

Part of the feature to improve security of our upgrader.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
I have a branch with 49 updated files. The hope is to break that set of changes down into smaller pieces to make it more manageable. You can confirm that the redirects are the same by copying/pasting the old and new links into your browser and comparing the resulting JSON that gets returned.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



