### PR TITLE
chore: Show environment variables in pipelines

### DIFF
--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -25,6 +25,11 @@ jobs:
     inputs:
       versionSpec: '5.x'
 
+  - task: CmdLine@2
+    displayName: 'Show environment variables'
+    inputs:
+      script: set
+
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
 

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -29,6 +29,11 @@ jobs:
     inputs:
       versionSpec: '5.x'
 
+  - task: CmdLine@2
+    displayName: 'Show environment variables'
+    inputs:
+      script: set
+
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
 
@@ -87,6 +92,11 @@ jobs:
     displayName: 'Use NuGet 5.x'
     inputs:
       versionSpec: '5.x'
+
+  - task: CmdLine@2
+    displayName: 'Show environment variables'
+    inputs:
+      script: set
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
@@ -216,6 +226,11 @@ jobs:
     displayName: 'Use NuGet 5.x'
     inputs:
       versionSpec: '5.x'
+
+  - task: CmdLine@2
+    displayName: 'Show environment variables'
+    inputs:
+      script: set
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'


### PR DESCRIPTION
#### Details

It's hard to tell what environment variables are available in the pipeline. This adds a task that displays the variables so it's easier to create scripts. I used this while working on the signed manifest and felt that it offered good value for almost no cost (it adds about 2 seconds to each build), so I opted to apply it generally.

##### Motivation

Make it easier to understand available inputs for writing scripts

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



