### PR TITLE
feat(upgrader-security): Validate and publish the signed manifest

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -275,6 +275,12 @@ jobs:
       PathtoPublish: 'src\MSI\bin\Release\msi'
       ArtifactName: 'msi'
 
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: manifest'
+    inputs:
+      PathtoPublish: 'src\Manifest\bin\Releasee\net48'
+      ArtifactName: 'manifest'
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
     displayName: 'Run BinSkim'
     inputs:
@@ -283,7 +289,8 @@ jobs:
       AnalyzeTarget: "src\\AccessibilityInsights\\bin\\Release\\net48\\*.exe;\
                       src\\AccessibilityInsights\\bin\\Release\\net48\\AccessibilityInsights.*.dll;\
                       src\\AccessibilityInsights.VersionSwitcher\\bin\\Release\\net48\\*.exe;\
-                      src\\AccessibilityInsights.VersionSwitcher\\bin\\Release\\net48\\AccessibilityInsights.*.dll;"
+                      src\\AccessibilityInsights.VersionSwitcher\\bin\\Release\\net48\\AccessibilityInsights.*.dll;\
+                      src\\Manifest\\bin\\Release\\net48\\AccessibilityInsights.*.dll;"
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
     displayName: 'Create Security Analysis Report (BinSkim)'
@@ -341,6 +348,7 @@ jobs:
        AccessibilityInsights.VersionSwitcher\bin\Release\net48\**\?(*.exe|*.dll)
        !AccessibilityInsights.VersionSwitcher\bin\Release\net48\**\?(Microsoft.Deployment.WindowsInstaller.dll|Newtonsoft.Json.dll)
        MSI\bin\Release\msi\**\AccessibilityInsights.msi
+       Manifest\bin\Release\net48\AccessibilityInsights.Manifest.dll
       TargetFolder: '$(Build.ArtifactStagingDirectory)\SigningValidation'
 
   - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -278,7 +278,7 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: manifest'
     inputs:
-      PathtoPublish: 'src\Manifest\bin\Releasee\net48'
+      PathtoPublish: 'src\Manifest\bin\Release\net48'
       ArtifactName: 'manifest'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3


### PR DESCRIPTION
#### Details

This PR adds 2 things:
1. Include the signed manifest in BinSkim and signing validation (not strictly necessary since we don't directly ship the assembly, but it seemed appropriate since we rely on the contents being secured)
2. Publish the manifest as a build artifact so that the release pipeline can easily consume it

The manifest is published as the `manifest` artifact of this test build of the signed pipeline: https://dev.azure.com/mseng/1ES/_build/results?buildId=18867199&view=artifacts&pathAsName=false&type=publishedArtifacts 

##### Motivation

Part of the upgrader security work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



