### PR TITLE
chore: Flush telemetry at app shutdown

### DIFF
--- a/src/AccessibilityInsights.Extensions.DiskLoggingTelemetry/LocalTelemetry.cs
+++ b/src/AccessibilityInsights.Extensions.DiskLoggingTelemetry/LocalTelemetry.cs
@@ -89,5 +89,13 @@ namespace AccessibilityInsights.Extensions.DiskLoggingTelemetry
             _logWriter.LogThisData("Exception was reported",
                 JsonConvert.SerializeObject(exceptionData, Formatting.Indented));
         }
+
+        /// <summary>
+        /// Application is shutting down, so flush any pending telemetry
+        /// </summary>
+        public void FlushAndShutDown()
+        {
+            // We never cache telemetry, so this does nothing
+        }
     }
 }

--- a/src/AccessibilityInsights.Extensions.DiskLoggingTelemetryTests/LocalTelemetryUnitTests.cs
+++ b/src/AccessibilityInsights.Extensions.DiskLoggingTelemetryTests/LocalTelemetryUnitTests.cs
@@ -269,5 +269,12 @@ namespace AccessibilityInsights.Extensions.DiskLoggingTelemetryTests
             AssertDictionariesAreEquivalent(ContextProperties, exceptionData.ContextProperties);
             _logWriterMock.VerifyAll();
         }
+
+        [TestMethod]
+        public void FlushAndShutDown_DoesNothing()
+        {
+            _testSubject.FlushAndShutDown();
+            _logWriterMock.VerifyAll();
+        }
     }
 }

--- a/src/AccessibilityInsights.Extensions.Telemetry/AITelemetry.cs
+++ b/src/AccessibilityInsights.Extensions.Telemetry/AITelemetry.cs
@@ -128,5 +128,13 @@ namespace AccessibilityInsights.Extensions.Telemetry
 #pragma warning restore CA1031 // Do not catch general exception types
             }
         }
+
+        /// <summary>
+        /// Application is shutting down, so flush any pending telemetry
+        /// </summary>
+        public void FlushAndShutDown()
+        {
+            _clientWrapper.FlushAndShutDown();
+        }
     }
 }

--- a/src/AccessibilityInsights.Extensions.Telemetry/ITelemetryClientWrapper.cs
+++ b/src/AccessibilityInsights.Extensions.Telemetry/ITelemetryClientWrapper.cs
@@ -13,5 +13,6 @@ namespace AccessibilityInsights.Extensions.Telemetry
     {
         void TrackEvent(EventTelemetry data);
         void TrackException(Exception e, Dictionary<string, string> contextProperties);
+        void FlushAndShutDown();
     }
 }

--- a/src/AccessibilityInsights.Extensions.Telemetry/TelemetryClientWrapper.cs
+++ b/src/AccessibilityInsights.Extensions.Telemetry/TelemetryClientWrapper.cs
@@ -26,5 +26,10 @@ namespace AccessibilityInsights.Extensions.Telemetry
         {
             await Task.Run(new Action(() => _client.TrackException(e, contextProperties))).ConfigureAwait(false);
         }
+
+        public void FlushAndShutDown()
+        {
+            _client.Flush();
+        }
     }
 }

--- a/src/AccessibilityInsights.Extensions.TelemetryTests/AITelemetryTests.cs
+++ b/src/AccessibilityInsights.Extensions.TelemetryTests/AITelemetryTests.cs
@@ -147,5 +147,19 @@ namespace AccessibilityInsights.Extensions.TelemetryTests
 
             wrapperMock.VerifyAll();
         }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void FlushAndShutDown_CallsWrapper()
+        {
+            Mock<ITelemetryClientWrapper> wrapperMock = new Mock<ITelemetryClientWrapper>(MockBehavior.Strict);
+            wrapperMock.Setup(x => x.FlushAndShutDown());
+
+            var aiTelemetry = new AITelemetry(wrapperMock.Object);
+
+            aiTelemetry.FlushAndShutDown();
+
+            wrapperMock.VerifyAll();
+        }
     }
 }

--- a/src/AccessibilityInsights.Extensions.TelemetryTests/TelemetryClientWrapperUnitTests.cs
+++ b/src/AccessibilityInsights.Extensions.TelemetryTests/TelemetryClientWrapperUnitTests.cs
@@ -43,5 +43,14 @@ namespace AccessibilityInsights.Extensions.TelemetryTests
 
             wrapper.TrackException(new InvalidOperationException(), new Dictionary<string, string>());
         }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void FlushAndShutDown_DoesNotThrow()
+        {
+            ITelemetryClientWrapper wrapper = new TelemetryClientWrapper(new TelemetryClient());
+
+            wrapper.FlushAndShutDown();
+        }
     }
 }

--- a/src/AccessibilityInsights.Extensions/Interfaces/Telemetry/ITelemetry.cs
+++ b/src/AccessibilityInsights.Extensions/Interfaces/Telemetry/ITelemetry.cs
@@ -31,5 +31,10 @@ namespace AccessibilityInsights.Extensions.Interfaces.Telemetry
         /// </summary>
         /// <param name="e">The Exception to report</param>
         void ReportException(Exception e);
+
+        /// <summary>
+        /// Application is shutting down, so flush any pending telemetry
+        /// </summary>
+        void FlushAndShutDown();
     }
 }

--- a/src/AccessibilityInsights.ExtensionsTests/DummyClasses/DummyTelemetry.cs
+++ b/src/AccessibilityInsights.ExtensionsTests/DummyClasses/DummyTelemetry.cs
@@ -19,6 +19,11 @@ namespace AccessibilityInsights.ExtensionsTests.DummyClasses
             throw new NotImplementedException();
         }
 
+        public void FlushAndShutDown()
+        {
+            throw new NotImplementedException();
+        }
+
         public void PublishEvent(string eventName, IReadOnlyDictionary<string, string> properties)
         {
             throw new NotImplementedException();

--- a/src/AccessibilityInsights.SharedUx/Telemetry/ITelemetrySink.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/ITelemetrySink.cs
@@ -50,5 +50,10 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         /// </summary>
         /// <param name="e">The Exception to report</param>
         void ReportException(Exception e);
+
+        /// <summary>
+        /// Application is shutting down, so flush any pending telemetry
+        /// </summary>
+        void FlushAndShutDown();
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Telemetry/Logger.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/Logger.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using System.Collections.Generic;
@@ -108,6 +108,17 @@ namespace AccessibilityInsights.SharedUx.Telemetry
                 return;
 
             Sink.ReportException(e);
+        }
+
+        /// <summary>
+        /// Application is shutting down, so flush any pending telemetry
+        /// </summary>
+        public static void FlushAndShutDown()
+        {
+            if (IsEnabled)
+            {
+                Sink.FlushAndShutDown();
+            }
         }
 
         internal static IReadOnlyDictionary<string, string> ConvertFromProperties(IReadOnlyDictionary<TelemetryProperty, string> properties)

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetrySink.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetrySink.cs
@@ -134,5 +134,22 @@ namespace AccessibilityInsights.SharedUx.Telemetry
 #pragma warning restore CA1031 // Do not catch general exception types
             }
         }
+
+        /// <summary>
+        /// Application is shutting down, so flush any pending telemetry
+        /// </summary>
+        public void FlushAndShutDown()
+        {
+            foreach (ITelemetry telemetry in _telemetry)
+            {
+                try
+                {
+                    telemetry.FlushAndShutDown();
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception) { }  // Silently eat this exception (nothing we could do about it anyway)
+#pragma warning restore CA1031 // Do not catch general exception types
+            }
+        }
     } // class
 } // namespace

--- a/src/AccessibilityInsights.SharedUxTests/Telemetry/LoggerUnitTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Telemetry/LoggerUnitTests.cs
@@ -239,5 +239,28 @@ namespace AccessibilityInsights.SharedUXTests.Telemetry
                 Assert.AreEqual(pair.Value, actual[pair.Key.ToString()]);
             }
         }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void FlushAndShutDown_SinkIsNotEnabled_DoesNotChainToSink()
+        {
+            _sinkMock.Setup(x => x.IsEnabled).Returns(false);
+
+            Logger.FlushAndShutDown();
+
+            _sinkMock.VerifyAll();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void FlushAndShutDown_SinkIsEnabled_ChainsToSink()
+        {
+            _sinkMock.Setup(x => x.IsEnabled).Returns(true);
+            _sinkMock.Setup(x => x.FlushAndShutDown());
+
+            Logger.FlushAndShutDown();
+
+            _sinkMock.VerifyAll();
+        }
     }
 }

--- a/src/AccessibilityInsights.SharedUxTests/Telemetry/TelemetrySinkUnitTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Telemetry/TelemetrySinkUnitTests.cs
@@ -359,5 +359,45 @@ namespace AccessibilityInsights.SharedUxTests.Telemetry
             _telemetryMock1.VerifyAll();
             _telemetryMock2.VerifyAll();
         }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void FlushAndShutDown_TelemetryIsNotAllowed_DoesNotChain()
+        {
+            _telemetrySink.FlushAndShutDown();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void FlushAndShutDown_MultipleClasses_ChainsToAll()
+        {
+            SetupMultipleTelemetryClasses();
+
+            _telemetrySink.HasUserOptedIntoTelemetry = true;
+            _telemetryMock1.Setup(x => x.FlushAndShutDown());
+            _telemetryMock2.Setup(x => x.FlushAndShutDown());
+
+            _telemetrySink.FlushAndShutDown();
+
+            _telemetryMock1.VerifyAll();
+            _telemetryMock2.VerifyAll();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void FlushAndShutDown_MultipleClasses_FirstMockThrows_SecondMockIsStillCalled()
+        {
+            SetupMultipleTelemetryClasses();
+
+            _telemetrySink.HasUserOptedIntoTelemetry = true;
+            _telemetryMock1.Setup(x => x.FlushAndShutDown())
+                .Throws(new OutOfMemoryException());
+            _telemetryMock2.Setup(x => x.FlushAndShutDown());
+
+            _telemetrySink.FlushAndShutDown();
+
+            _telemetryMock1.VerifyAll();
+            _telemetryMock2.VerifyAll();
+        }
     }
 }

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -422,6 +422,7 @@ namespace AccessibilityInsights
                     this.ctrlTestMode.Clear();
 
                     PageTracker.TrackPage(this.CurrentPage, null);
+                    Logger.FlushAndShutDown();
                 }
 #pragma warning disable CA1031 // Do not catch general exception types
                 catch


### PR DESCRIPTION
#### Details

We use [ApplicationInsights](https://www.nuget.org/packages/Microsoft.ApplicationInsights) for our telemetry, which buffers telemetry events for about 30 seconds, then sends them in a burst. This works fine most of the time, but we lose telemetry events that occur in the last few seconds of the app's lifetime. This is especially noticeable with updates, since the app exits within milliseconds of creating the event.

This PR connects the MainWindow's existing onClosed handler to the `Flush` method from ApplicationInsights. Due to how the code is structured, it goes through the following layers:
- `MainWindow.onClosed` calls `Logger.FlushAndShutDown`
- `Logger.FlushAndShutDown` calls (through an interface) into `AITelemetrySink.FlushAndShutDown`
- `AITelemetrySink.FlushAndShutDown` calls into each available implementation of `ITelemetry.FlushAndShutDown` inside a try/catch loop
- `AITelemetry.FlushAndShutDown` calls the ApplicationInsights `Flush` method, which immediately uploads any buffered telemetry events

Unit test are also updated. This was validated by creating a scenario where a locally built AIWin would update, then checking the uploaded telemetry to confirm that the `Upgrade_DoInstallation` event (which occurs immediately before shutdown) is correctly uploaded via ApplicationInsights

##### Motivation

Telemetry that we can't capture isn't very useful ☹️ 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
One potential problem to note: Uploading telemetry requires a network call, so uploading any buffered data will introduce a nonzero delay when exiting the app. This won't be user-perceivable because it occurs _after_ the window has closed. It does, however, create the following potential race condition:
- When updating, AIWin triggers the VersionSwitcher then exits after the VersionSwitcher is successfully running
- AIWin tries to flush buffered telemetry on shutdown. This is normally very fast, but suppose it takes an exceptionally long time
- If VersionSwitcher gets to the point where it needs to run the MSI install, the MSI install will fail if AIWin is still running
- Update will fail

Given that VersionSwitcher downloads the MSI (currently 7MB) from the web, then does work to ensure that the MSI signature chain is still trustworthy, the telemetry upload should normally take _much_ less time than the time to download and validate the MSI. It could still happen, however, in the unlikely scenario that the ApplicationInsights  geo-redundant collection points were _all_ offline. Should that occur, any of the following mitigations would unblock the user:
- Restart the app and don't accept the upgrade (we allow Prod to stay 1 version back unless there's a critical fix that we need to get out)
- Install the most recent Canary version from https://github.com/microsoft/accessibility-insights-windows/releases
- Uninstall AIWin and reinstall it from www.AccessibilityInsights.io (this ensure the most current production version)
- Try again later in a few minutes on the assumption that the collection points will be back online
- Run the app without telemetry

If we see this race condition happening frequently in the wild, the `onClosed` handler could esaily wrap the call to `Logger.FlushAndShutDown` in a `Task`, then specify a maximum time (maybe 1 second) that it's willing wait for that `Task` to complete. My inclination is to take a YAGNI approach on this until we have a demonstrated need, but I could possibly be convinced otherwise.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



