### PR TITLE
fix: Fix debug build errors

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml
@@ -121,7 +121,7 @@
                                                   GlyphName="Search" GlyphSize="Custom" FontSize="11" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}"/>
             </Grid>
             <Grid Grid.Row="2" Style="{DynamicResource ResourceKey=gridPartialOpacityWhenDisabled}" Height="200px" ScrollViewer.VerticalScrollBarVisibility="Auto" Margin="0 12">
-                <TreeView x:Name="serverTreeview" ItemsSource="{Binding Path=projects}" 
+                <TreeView x:Name="serverTreeview" ItemsSource="{Binding Path=Projects}" 
                                   SelectedItemChanged="serverTreeview_SelectedItemChanged" AutomationProperties.Name="{x:Static Properties:Resources.serverTreeviewAutomationPropertiesName}"
                                   VirtualizingStackPanel.IsVirtualizing="False">
                     <TreeView.ItemContainerStyle>

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
@@ -31,6 +31,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         {
             InitializeComponent();
             DataContext = VMConfig;
+            serverTreeview.ItemsSource = null;
         }
 
         private bool canSave;

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
@@ -31,7 +31,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         {
             InitializeComponent();
             DataContext = VMConfig;
-            serverTreeview.ItemsSource = null;
         }
 
         private bool canSave;
@@ -67,10 +66,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         /// </summary>
         public ConfigurationViewModel VMConfig { get; private set; } = new ConfigurationViewModel();
 
-        /// <summary>
-        /// List of team projects
-        /// </summary>
-        public BindingList<TeamProjectViewModel> projects { get; private set; } = new BindingList<TeamProjectViewModel>();
         public override Action UpdateSaveButton { get; set; }
 
         #region configuration updating code
@@ -250,11 +245,11 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                 try
                 {
                     ToggleLoading(true);
-                    Dispatcher.Invoke(projects.Clear);
+                    Dispatcher.Invoke(VMConfig.Projects.Clear);
                     var newProjectList = await UpdateTeamProjects().ConfigureAwait(true); // need to come back to original UI thread.
-                    Dispatcher.Invoke(() => newProjectList.ForEach(p => projects.Add(p)));
+                    Dispatcher.Invoke(() => newProjectList.ForEach(p => VMConfig.Projects.Add(p)));
                     ToggleLoading(false);
-                    Dispatcher.Invoke(() => serverTreeview.ItemsSource = projects);
+                    Dispatcher.Invoke(() => serverTreeview.ItemsSource = VMConfig.Projects);
                     Dispatcher.Invoke(() => serverTreeview.Focus());
                 }
 #pragma warning disable CA1031 // Do not catch general exception types

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ConfigurationControl.xaml.cs
@@ -249,7 +249,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
                     var newProjectList = await UpdateTeamProjects().ConfigureAwait(true); // need to come back to original UI thread.
                     Dispatcher.Invoke(() => newProjectList.ForEach(p => VMConfig.Projects.Add(p)));
                     ToggleLoading(false);
-                    Dispatcher.Invoke(() => serverTreeview.ItemsSource = VMConfig.Projects);
                     Dispatcher.Invoke(() => serverTreeview.Focus());
                 }
 #pragma warning disable CA1031 // Do not catch general exception types

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Models/ConfigurationViewModel.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Models/ConfigurationViewModel.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.ComponentModel;
 using System.Windows;
 using static AccessibilityInsights.Extensions.AzureDevOps.ConfigurationControl;
 
@@ -133,5 +134,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps.Models
                 return string.IsNullOrEmpty(email) ? Visibility.Collapsed : Visibility.Visible;
             }
         }
+
+        public BindingList<TeamProjectViewModel> Projects { get; } = new BindingList<TeamProjectViewModel>();
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ScannerResultCustomListControl.xaml
@@ -17,7 +17,6 @@
         <StackPanel>
             <Label Name="testHeader" Margin="10 20 10 3" Content="{Binding Path=TestHeader, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:ScannerResultCustomListControl}}" VerticalAlignment="Top" Style="{StaticResource lblLarge}"/>
             <ListView x:Name="lvDetails" SizeChanged="lvDetails_SizeChanged"
-                    AutomationProperties.LabeledBy="{Binding ElementName=labelResults}"
                     AutomationProperties.Name="{Binding Path=DataGridAccessibleName, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:ScannerResultCustomListControl}}"
                     AutomationProperties.AutomationId="{Binding Path=DataGridAutomationId, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:ScannerResultCustomListControl}}"
                     Background="Transparent"

--- a/src/AccessibilityInsights.SharedUx/Controls/EventDetailControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventDetailControl.xaml
@@ -19,8 +19,7 @@
         <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Stretch" >
             <Grid >
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="{Binding Path=Width, 
-           RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UIElement},Mode=OneWayToSource}"/>
+                    <ColumnDefinition Width="{Binding Path=Width, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UIElement}}"/>
                 </Grid.ColumnDefinitions>
                 <customcontrols:CustomDataGrid x:Name="dgEvents" GotKeyboardFocus="dgEvents_GotKeyboardFocus"
                   AutomationProperties.Name="{x:Static Properties:Resources.EventDetailControlAutomationPropertiesName}"

--- a/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/PropertyInfoControl.xaml
@@ -24,7 +24,7 @@
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="{Binding Path=Width, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UIElement},Mode=OneWayToSource}"/>
+                    <ColumnDefinition Width="{Binding Path=Width, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UIElement}}"/>
                 </Grid.ColumnDefinitions>
                 <Border Background="{DynamicResource ResourceKey=DataGridBGBrush}" x:Name="dpFilter" Grid.Row="0" HorizontalAlignment="Stretch" BorderBrush="LightGray" BorderThickness="0" Height="28" Margin="4,0,2,5">
                     <DockPanel>

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml
@@ -29,7 +29,7 @@
                     <behaviors:ExpanderBehavior/>
                 </i:Interaction.Behaviors>
                 <Expander.Header>
-                    <Label  Margin="4" Style="{StaticResource ResourceKey=lblAccordionHeader}" x:Name="labelResults" Content="{x:Static Properties:Resources.ScannerResultControlAutomationPropertiesName}"/>
+                    <Label Margin="4" Style="{StaticResource ResourceKey=lblAccordionHeader}" x:Name="labelResults" Content="{x:Static Properties:Resources.ScannerResultControlAutomationPropertiesName}"/>
                 </Expander.Header>
                 <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Focusable="False" >
                     <StackPanel Focusable="False">

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -37,7 +37,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             InitializeComponent();
             _list = new List<ScanListViewItemViewModel>();
             Resources.Source = new Uri(@"pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml", UriKind.Absolute);
-            this.spHowToFix.DataContext = null;
+            spHowToFix.DataContext = null;
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/ScannerResultControl.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CommonUxComponents.Controls;
 using AccessibilityInsights.SharedUx.Controls.CustomControls;
@@ -37,6 +37,7 @@ namespace AccessibilityInsights.SharedUx.Controls
             InitializeComponent();
             _list = new List<ScanListViewItemViewModel>();
             Resources.Source = new Uri(@"pack://application:,,,/AccessibilityInsights.SharedUx;component/Resources/Styles.xaml", UriKind.Absolute);
+            this.spHowToFix.DataContext = null;
         }
 
         /// <summary>


### PR DESCRIPTION
#### Details

Fix the first batch of debug errors from https://github.com/microsoft/accessibility-insights-windows/issues/1477:

| Error | Change | Notes |
|---|---|---|
| `BindingExpression path error: 'SnippetLink' property not found on 'object'...` | `ScannerResultControl.xaml.cs` | Explicitly set data context to null on start up so it doesn't try to populate properties that do not exist yet | 
| `BindingExpression path error: 'projects' property not found on 'object'...` | `ConfigurationControl.xaml.cs` | Explicitly set items source to null on start up so it doesn't try to populate properties that do not exist yet |
| `Cannot create default converter to perform 'two-way' conversions...` | `EventDetailControl.xaml` and `PropertyInfoControl.xaml` | I can't discern a reason that the `OneWayToSource` mode is necessary, so removing it. |
| `Cannot save value from target back to source. BindingExpression:Path=Width;` | Same as above | Same as above |
| `Cannot find source for binding with reference 'ElementName=labelResults'...` | `ScannerResultCustomListControl.xaml` | This line seems to have been missed in a prior refactoring: https://github.com/microsoft/accessibility-insights-windows/commit/15fd62773c826fd33a5d302731f8f4398cf3f416|

There are several more errors that this PR does not cover, so leaving the original issue open for that reason. 

##### Motivation

Address https://github.com/microsoft/accessibility-insights-windows/issues/1477

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, https://github.com/microsoft/accessibility-insights-windows/issues/1477
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.