### PR TITLE
chore: Update to newer NetAnalyzers

### DIFF
--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0-preview1.22518.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
#### Details

Current builds are cluttered with the following warning:
```
The .NET SDK has newer analyzers with version '7.0.0' than what version '6.0.0' of 'Microsoft.CodeAnalysis.NetAnalyzers' package provides. Update or remove this package reference.
```

https://www.nuget.org/packages/Microsoft.CodeAnalysis.NetAnalyzers has been in v7 preview for about 9 months but hasn't yet shipped. This PR bumps to the most recent preview version to reduce the clutter, with the expectation that dependabot will notify us when v7 is officially released. These changes were made by directly editing the .targets file, but are based on IDE-generated changes from https://github.com/microsoft/axe-windows/pull/853.

##### Motivation

Reduce noise in builds (local and pipeline), use latest tools

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
We want to pin our versions (as opposed to just using `latest`) to avoid random errors that suddenly appear for no obvious reason, and because dev machines and pipeline machines aren't necessarily on the same version of Visual Studio.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



