### PR TITLE
fix: Fix invalid value debug error

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Converters/ColumnMaxWidthSpacingConverter.cs
+++ b/src/AccessibilityInsights.SharedUx/Converters/ColumnMaxWidthSpacingConverter.cs
@@ -19,7 +19,11 @@ namespace AccessibilityInsights.SharedUx.Converters
 
         public ColumnMaxWidthSpacingConverter() { }
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => (double)value - SpacingConstant;
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var candidateResult = (double)value - SpacingConstant;
+            return candidateResult >= 0 ? candidateResult : 0;
+        }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => (double)value + SpacingConstant;
 


### PR DESCRIPTION
#### Details

Address the following debug error:

```
System.Windows.Data Error: 5 : Value produced by BindingExpression is not valid for target property.; Value='-4' BindingExpression:Path=ActualWidth; DataItem='LiveModeControl' (Name='ctrlLiveMode'); target element is 'ColumnDefinition' (HashCode=25265097); target property is 'MaxWidth' (type 'Double')
```

##### Motivation

Address another debug error from https://github.com/microsoft/accessibility-insights-windows/issues/1477

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, https://github.com/microsoft/accessibility-insights-windows/issues/1477
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.