### PR TITLE
fix: Correct checkable tree view style target

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventConfigTabControl.xaml
@@ -53,7 +53,7 @@
                 <cc:CheckableTreeView Grid.Row="0" x:Name="trviewConfigEvents" BorderThickness="0" AutomationProperties.Name="{x:Static Properties:Resources.trviewConfigEventsAutomationPropertiesName}" Margin="2"
                           ScrollViewer.CanContentScroll="False" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}">
                     <TreeView.Resources>
-                        <Style TargetType="TreeView">
+                        <Style TargetType="cc:CheckableTreeView">
                             <Setter Property="Template">
                                 <Setter.Value>
                                     <ControlTemplate TargetType="TreeView">


### PR DESCRIPTION
#### Details

Fix bug introduced in https://github.com/microsoft/accessibility-insights-windows/pull/1471 with dark mode style for event config tree view. 

Before this change:
[Description: screenshot of AI win event config tree view in dark mode. Tree view is too light and unreadable.]
<img width="661" alt="DarkModeBroken" src="https://user-images.githubusercontent.com/16010855/205690751-b753daa1-9052-49a1-8f44-554da5a6b664.png">


After this change:
[Description: screenshot of AI win event config tree view in dark mode. Tree view is appropriately dark.]
<img width="662" alt="FixedDarkMode" src="https://user-images.githubusercontent.com/16010855/205690745-c8cf3a8b-41ca-48bb-8426-7d1e4d492111.png">

##### Motivation

Address issue https://github.com/microsoft/accessibility-insights-windows/issues/1503

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, https://github.com/microsoft/accessibility-insights-windows/issues/1503
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.