### PR TITLE
chore: Use existing link instead of new one

### DIFF
--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml
@@ -68,7 +68,7 @@
                         <Run Text="{x:Static properties:Resources.LiveModeControl_Keyboard}"/>
                         <Run Name="runhkKeyboard"/><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
                         <TextBlock TextWrapping="Wrap">
-                            <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2219444" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
+                            <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2073853" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
                                  <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreKeyboard}" />
                             </Hyperlink><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
                         </TextBlock>


### PR DESCRIPTION
#### Details

In #1512, we added a new way to discover keyboard shortcuts. In doing so, we created a new link instead of using the one that already existed and was used at https://github.com/microsoft/accessibility-insights-windows/blob/main/src/AccessibilityInsights.SharedUx/Dialogs/StartUpModeControl.xaml#L159. This converts both locations to using the existing link. I'll delete the newly created link after this deploys to the Canary release channel.

Verified by clicking link from Live Inspect page and confirming that it ends up where expected.

##### Motivation

Avoid redundancy

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



