### PR TITLE
chore: Enforce SSL security check

### DIFF
--- a/src/AccessibilityInsights.SetupLibrary/REST/GitHubClient.cs
+++ b/src/AccessibilityInsights.SetupLibrary/REST/GitHubClient.cs
@@ -45,6 +45,9 @@ namespace AccessibilityInsights.SetupLibrary.REST
             {
                 using (InterceptingWebClient client = new InterceptingWebClient())
                 {
+                    // Enforce SSL certificate checks
+                    ServicePointManager.CheckCertificateRevocationList = true;
+
                     client.DownloadDataCompleted += DownloadCompleted;
                     client.DownloadProgressChanged += ProgressChanged;
                     client.DownloadDataAsync(uri, state);


### PR DESCRIPTION
#### Details

This CodeQL [alert](https://onees.lgtm.microsoft.com/projects/u/gh/microsoft%2Faccessibility-insights-windows%2Ftree%2Fmain?mode=list) is calling out the fact that when we make web calls, we're not asking for SSL certificates to be checked. This PR simply adds the flag to request the SSL check. It's a global state for all `WebClient` objects in the entire process.

Validated against manifest files both in GitHub repos and in Azure blob storage.

##### Motivation

Fix issue found by CodeQL

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



