### PR TITLE
fix: Fix debug errors

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -113,6 +113,7 @@ namespace AccessibilityInsights.SharedUx.Controls
         public HierarchyControl()
         {
             InitializeComponent();
+            btnMenu.DataContext = this;
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/InspectTabsControl.xaml
@@ -76,7 +76,8 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-                                <Label Grid.Column="0" Margin="4" Style="{StaticResource ResourceKey=lblAccordionHeader}" Target="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ToggleButton}}}" Content="{x:Static Properties:Resources.ExpanderAutomationPropertiesNameProps}" />
+                                <Label Grid.Column="0" Margin="4" Style="{StaticResource ResourceKey=lblAccordionHeader}"
+                                       Content="{x:Static Properties:Resources.ExpanderAutomationPropertiesNameProps}" />
                                 <Button x:Name="btnSetting" Grid.Column="2"
                                         BorderThickness="0"  HorizontalAlignment="Right" VerticalAlignment="Center" VerticalContentAlignment="Center"
                                         Height="22" Width="22" Padding="0"


### PR DESCRIPTION
#### Details

Fix final debug warnings in https://github.com/microsoft/accessibility-insights-windows/issues/1477:

- Changes in [HierarchyControl.xaml.cs](https://github.com/microsoft/accessibility-insights-windows/compare/main...sfoslund:FixDebugErrs?expand=1#diff-e370bcbcf4e6b44f06f8a02fc81900781a8c9bf05fc716144476745d3524d4c2)
  - Addresses error: `System.Windows.Data Error: 40 : BindingExpression path error: 'IsLiveMode' property not found on 'object' ''ElementDataContext' (HashCode=25763023)'. BindingExpression:Path=IsLiveMode; DataItem='ElementDataContext' (HashCode=25763023); target element is 'Button' (Name='btnMenu'); target property is 'NoTarget' (type 'Object')`
  - Explanation: btnMenu's data context is eventually assigned [here](https://github.com/microsoft/accessibility-insights-windows/blob/main/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs#L704), but this fix provides a default data context on initialization.
- Changes in [InspectTabsControl.xaml](https://github.com/microsoft/accessibility-insights-windows/compare/main...sfoslund:FixDebugErrs?expand=1#diff-9de1f0d73fe427faef989a95df6e1e7fe09702759f133e197d7ed4a21ca7562a)
  - Addresses error: `System.Windows.Data Error: 4 : Cannot find source for binding with reference 'RelativeSource FindAncestor, AncestorType='System.Windows.Controls.Primitives.ToggleButton', AncestorLevel='1''. BindingExpression:(no path); DataItem=null; target element is 'Label' (Name=''); target property is 'Target' (type 'UIElement')`
  - Explanation: the `Target="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ToggleButton}}}"` section of this line is unnecessary and can be removed without functionally changing the behavior here. This logic appears to be 4+ years old and I suspect that the original intention was to send tab focus to the drop expand/minimize toggle instead of the label itself, but I'm not sure why that behavior would be necessary/ preferable over the existing behavior. 

##### Motivation

Addresses issue [#1477](https://github.com/microsoft/accessibility-insights-windows/issues/1477)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, https://github.com/microsoft/accessibility-insights-windows/issues/1477 
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.