### PR TITLE
feat(audio-feedback): Add support for selectable sounds in ProgressRingControl

### DIFF
--- a/src/AccessibilityInsights.CommonUxComponents/Controls/ProgressRingControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/ProgressRingControl.xaml.cs
@@ -99,6 +99,7 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
                 case SelectedSound.Scanner:
                     return ".Resources.Sound.scanner_sound.wav";
                 default:
+                    // Please refer to comments in https://github.com/microsoft/accessibility-insights-windows/pull/1523 if this is thrown
                     throw new ArgumentException($"No sound loaded for {selectedSound}", nameof(selectedSound));
             }
         }

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/ProgressRingControl.xaml.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/ProgressRingControl.xaml.cs
@@ -65,10 +65,43 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
         /// <summary>
         /// Private variables used
         /// </summary>
-        private SoundPlayer player;
+        private readonly SoundPlayer player;
         private Timer timer;
         private bool isPlayingSound;
         private bool withSound;
+        private SelectedSound _selectedSound;
+
+        public SelectedSound SelectedSound
+        {
+            get => _selectedSound;
+            set
+            {
+                if (value == _selectedSound) return;
+
+                // Enforce that we only allow the property to be changed once
+                if (_selectedSound != SelectedSound.NoSound)
+                {
+                    throw new ArgumentException("SelectedSound can only be changed once", nameof(value));
+                }
+
+                Assembly assembly = Assembly.GetExecutingAssembly();
+                Stream stream = assembly.GetManifestResourceStream(assembly.GetName().Name + GetResourceForSound(value));
+                player.Stream = stream;
+
+                _selectedSound = value;
+            }
+        }
+
+        private static string GetResourceForSound(SelectedSound selectedSound)
+        {
+            switch (selectedSound)
+            {
+                case SelectedSound.Scanner:
+                    return ".Resources.Sound.scanner_sound.wav";
+                default:
+                    throw new ArgumentException($"No sound loaded for {selectedSound}", nameof(selectedSound));
+            }
+        }
 
         /// <summary>
         /// Check whether to play sound feedback while scanning
@@ -197,34 +230,13 @@ namespace AccessibilityInsights.CommonUxComponents.Controls
             }
         }
 
-        private void LoadDefaultScanningSound()
-        {
-            // load default scanning sound file
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            // no sound by default
-            withSound = false;
-            isPlayingSound = false;
-            try
-            {
-                Stream stream = assembly.GetManifestResourceStream(assembly.GetName().Name + ".Resources.Sound.scanner_sound.wav");
-                player = new SoundPlayer(stream);
-            }
-#pragma warning disable CA1031 // Do not catch general exception types
-            catch
-            {
-                // TODO : Report this Exception?
-                player = new SoundPlayer();
-            }
-#pragma warning restore CA1031 // Do not catch general exception types
-        }
-
         /// <summary>
         /// Constructor
         /// </summary>
         public ProgressRingControl()
         {
             InitializeComponent();
-            LoadDefaultScanningSound();
+            player = new SoundPlayer();
         }
     }
 }

--- a/src/AccessibilityInsights.CommonUxComponents/Controls/SelectedSound.cs
+++ b/src/AccessibilityInsights.CommonUxComponents/Controls/SelectedSound.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace AccessibilityInsights.CommonUxComponents.Controls
+{
+    /// <summary>
+    /// Identifies the sound to play if sounds are enabled
+    /// </summary>
+    public enum SelectedSound
+    {
+        NoSound, // Keep this first so it is the default value!
+        Scanner,
+    }
+}

--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -525,6 +525,7 @@
             <modecontrols:DialogContainerModeControl Grid.RowSpan="2" Grid.ColumnSpan="2" x:Name="ctrlDialogContainer" HorizontalAlignment="Stretch" Width="Auto" Height="Auto" VerticalAlignment="Stretch" Panel.ZIndex="2" Margin="0" Visibility="Collapsed"/>
             <fabric:ProgressRingControl Size="40" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.ColumnSpan="2"
                             x:Name="ctrlProgressRing"
+                            SelectedSound="Scanner"
                             Panel.ZIndex="3"
                             Visibility="Collapsed"/>
         </Grid>


### PR DESCRIPTION
#### Details

The `ProgressRingControl` is currently hardcoded to play the same sound resource, regardless of where it's used. This PR adds support for different sounds in different contexts, all controllable by XAML. Changing the SelectedSound value more than once will throw an Exception. These are the steps to add a new sound in a `ProgressRingControl`; steps 1-3 make the sound available to XAML, and step 4 enables the sound for the control:

1. Add the new sound resource to `CommonUxCompoenents.csproj`
2. Add a corresponding entry to the `SelectedSound` enum
3. Update `ProgressRingControl.GetResourceForSound` to map the new `SelectedSound` enum to the name of the new sound resource
4. Add the `SelectedSound` attribute in the XAML that identifies the `ProgressRingControl`

##### Motivation

Part of work to improve audio feedback

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
I've confirmed that the XAML properties are set just after the control is constructed, and well before any user interaction that could lead to the sound to begin playing. Any Exceptions that are thrown from a bad resource bubble up to the control creation stack. I intentionally left them uncaught since that's a coding error that we should catch while adding new sounds.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



