### PR TITLE
fix: Move the keyboard help hint to the beginning of the tab order

### DIFF
--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml
@@ -52,7 +52,7 @@
                         </TextBlock>
                     </TextBlock>
 
-                    <TextBlock Name="tbInstructions" Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
+                    <TextBlock Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
                         <Run Text="{x:Static properties:Resources.LiveModeControl_HoverOverElement}"/>
                         <Run Name="runHkActivate"/><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
                         <TextBlock TextWrapping="Wrap">

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml
@@ -42,6 +42,16 @@
                                         VerticalAlignment="Stretch"/>
             <ScrollViewer Name ="svInstructions" VerticalScrollBarVisibility="Auto" Grid.Row="1">
                 <StackPanel Name="spInstructions" Grid.Row="1" KeyboardNavigation.IsTabStop="True">
+                    <TextBlock Name="tbKeyboard" Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
+                        <Run Text="{x:Static properties:Resources.LiveModeControl_Keyboard}"/>
+                        <Run Name="runhkKeyboard"/><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
+                        <TextBlock TextWrapping="Wrap">
+                            <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2073853" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
+                                 <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreKeyboard}" />
+                            </Hyperlink><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
+                        </TextBlock>
+                    </TextBlock>
+
                     <TextBlock Name="tbInstructions" Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
                         <Run Text="{x:Static properties:Resources.LiveModeControl_HoverOverElement}"/>
                         <Run Name="runHkActivate"/><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
@@ -60,16 +70,6 @@
                         <TextBlock TextWrapping="Wrap">
                             <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2077027" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
                                  <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreAutomated}" />
-                            </Hyperlink><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
-                        </TextBlock>
-                    </TextBlock>
-
-                    <TextBlock Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="16" FontStyle="Italic" FontSize="{DynamicResource StandardTextSize}" Style="{StaticResource TbFocusable}">
-                        <Run Text="{x:Static properties:Resources.LiveModeControl_Keyboard}"/>
-                        <Run Name="runhkKeyboard"/><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
-                        <TextBlock TextWrapping="Wrap">
-                            <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2073853" RequestNavigate="Hyperlink_RequestNavigate" FocusVisualStyle="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" Style="{StaticResource hLink}">
-                                 <Run Text="{x:Static properties:Resources.LiveModeControl_LearnMoreKeyboard}" />
                             </Hyperlink><Run Text="{x:Static properties:Resources.SentenceEndPeriod}"/>
                         </TextBlock>
                     </TextBlock>

--- a/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
+++ b/src/AccessibilityInsights/Modes/LiveModeControl.xaml.cs
@@ -431,7 +431,7 @@ namespace AccessibilityInsights.Modes
             }
             else
             {
-                this.tbInstructions.Focus();
+                this.tbKeyboard.Focus();
             }
         }
 


### PR DESCRIPTION
#### Details
This PR improves discoverability of the keyboard control scheme by moving the usage hint to earlier in the tab order and causing it to focus immediately on app launch.

##### Motivation
Closes #1512.

##### Context
See linked issue.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #1512
- [x] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge.