### PR TITLE
feat(audio-feedback): Set scanner sound correctly

### DIFF
--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -525,7 +525,6 @@
             <modecontrols:DialogContainerModeControl Grid.RowSpan="2" Grid.ColumnSpan="2" x:Name="ctrlDialogContainer" HorizontalAlignment="Stretch" Width="Auto" Height="Auto" VerticalAlignment="Stretch" Panel.ZIndex="2" Margin="0" Visibility="Collapsed"/>
             <fabric:ProgressRingControl Size="40" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.ColumnSpan="2"
                             x:Name="ctrlProgressRing"
-                            SelectedSound="Scanner"
                             Panel.ZIndex="3"
                             Visibility="Collapsed"/>
         </Grid>

--- a/src/AccessibilityInsights/Modes/TestModeControl.xaml
+++ b/src/AccessibilityInsights/Modes/TestModeControl.xaml
@@ -49,6 +49,7 @@
         </Border>
         <fabric:ProgressRingControl Size="30"
                                    x:Name="ctrlProgressRing"
+                                   SelectedSound="Scanner"
                                    Visibility="Collapsed"
                                    WithSound="{Binding Path=(Util:HelperMethods.ShouldPlaySound)}"
                                    Grid.Row="1" Grid.Column="1" Background="{DynamicResource ResourceKey=PrimaryBGBrush}"/>


### PR DESCRIPTION
#### Details

PR #1523 added the ability to choose sounds to the `ProgressRingControl`, where the default sound was `NoSound`. That change set the `Scanner` sound to the wrong `ProgressRingControl`, effectively removing the sound while scanning. This PR simply moves the scanning sound to the appropriate `ProgressRingControl`. Confirmed that it plays the scanning sound when scanning takes a long time.

##### Motivation

Fix regression

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



