### PR TITLE
fix: replace hardcoded checked/ unchecked names with toggle pattern

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/CheckableTreeViewDataItemAutomationPeer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using AccessibilityInsights.SharedUx.Utilities;
 using AccessibilityInsights.SharedUx.ViewModels;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
@@ -32,24 +33,14 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
         {
             get
             {
-                return ConvertToToggleState(_owner.IsChecked);
+                return ExtensionMethods.ConvertToToggleState(_owner.IsChecked);
             }
         }
 
         public void Toggle()
         {
             _owner.IsChecked = !_owner.IsChecked;
-            RaisePropertyChangedEvent(TogglePatternIdentifiers.ToggleStateProperty, ConvertToToggleState(!_owner.IsChecked), ConvertToToggleState(_owner.IsChecked));
-        }
-
-        private static ToggleState ConvertToToggleState(bool? value)
-        {
-            switch (value)
-            {
-                case (true): return ToggleState.On;
-                case (false): return ToggleState.Off;
-                default: return ToggleState.Indeterminate;
-            }
+            RaisePropertyChangedEvent(TogglePatternIdentifiers.ToggleStateProperty, ExtensionMethods.ConvertToToggleState(!_owner.IsChecked), ExtensionMethods.ConvertToToggleState(_owner.IsChecked));
         }
     }
 }

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ToggleMenuItem.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ToggleMenuItem.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+
+namespace AccessibilityInsights.SharedUx.Controls.CustomControls
+{
+    internal class ToggleMenuItem : MenuItem
+    {
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new ToggleMenuItemAutomationPeer(this);
+        }
+
+        protected override DependencyObject GetContainerForItemOverride()
+        {
+            return new ToggleMenuItem();
+        }
+
+        protected override bool IsItemItsOwnContainerOverride(object item)
+        {
+            return item is ToggleMenuItem;
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ToggleMenuItemAutomationPeer.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ToggleMenuItemAutomationPeer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AccessibilityInsights.SharedUx.Utilities;
+using System.IO;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
@@ -17,6 +18,10 @@ namespace AccessibilityInsights.SharedUx.Controls.CustomControls
             : base(item)
         {
             _radioButton = item.Header as RadioButton;
+            if (_radioButton == null)
+            {
+                throw new InvalidDataException("Invalid menu item header");
+            }
         }
 
         public override object GetPattern(PatternInterface patternInterface)

--- a/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ToggleMenuItemAutomationPeer.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/CustomControls/ToggleMenuItemAutomationPeer.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using AccessibilityInsights.SharedUx.Utilities;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Controls;
+
+namespace AccessibilityInsights.SharedUx.Controls.CustomControls
+{
+    internal class ToggleMenuItemAutomationPeer : MenuItemAutomationPeer, IToggleProvider
+    {
+        private readonly RadioButton _radioButton;
+
+        public ToggleMenuItemAutomationPeer(MenuItem item)
+            : base(item)
+        {
+            _radioButton = item.Header as RadioButton;
+        }
+
+        public override object GetPattern(PatternInterface patternInterface)
+        {
+            if (patternInterface == PatternInterface.Toggle)
+            {
+                return this;
+            }
+
+            return base.GetPattern(patternInterface);
+        }
+
+        public ToggleState ToggleState
+        {
+            get
+            {
+                return ExtensionMethods.ConvertToToggleState(_radioButton.IsChecked);
+            }
+        }
+
+        public void Toggle()
+        {
+            _radioButton.IsChecked = !_radioButton.IsChecked;
+            RaisePropertyChangedEvent(TogglePatternIdentifiers.ToggleStateProperty, ExtensionMethods.ConvertToToggleState(!_radioButton.IsChecked), ExtensionMethods.ConvertToToggleState(_radioButton.IsChecked));
+        }
+    }
+}

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -9,6 +9,7 @@
              xmlns:controls="clr-namespace:AccessibilityInsights.CommonUxComponents.Controls;assembly=AccessibilityInsights.CommonUxComponents"
              xmlns:behaviors="clr-namespace:AccessibilityInsights.SharedUx.Behaviors"
              xmlns:local="clr-namespace:AccessibilityInsights.SharedUx.Controls"
+             xmlns:cc="clr-namespace:AccessibilityInsights.SharedUx.Controls.CustomControls"
              xmlns:converters="clr-namespace:AccessibilityInsights.SharedUx.Converters"
              xmlns:Properties="clr-namespace:AccessibilityInsights.SharedUx.Properties"
              mc:Ignorable="d"
@@ -133,24 +134,24 @@
                 <Button.ContextMenu>
                     <ContextMenu FlowDirection="LeftToRight" x:Name="cmHierarchySettings" Style="{StaticResource ctxMenuDefault}">
                         <MenuItem Header="{x:Static Properties:Resources.HierarchyControl_Menu_TreeView}">
-                            <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRaw_Click"
+                            <cc:ToggleMenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRaw_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName1}">
                                 <MenuItem.Header>
                                     <RadioButton x:Name="rbRaw" Content="{x:Static Properties:Resources.HierarchyControl_Raw}" Loaded="mniRaw_Loaded" Click="rbRaw_Click" Focusable="False" />
                                 </MenuItem.Header>
-                            </MenuItem>
-                            <MenuItem x:Name="mniControl" IsCheckable="False" Click="mniControl_Click" 
+                            </cc:ToggleMenuItem>
+                            <cc:ToggleMenuItem x:Name="mniControl" IsCheckable="False" Click="mniControl_Click" 
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniControlAutomationPropertiesName}">
                                 <MenuItem.Header>
                                     <RadioButton x:Name="rbControl" Content="{x:Static Properties:Resources.HierarchyControl_Control}" Loaded="mniControl_Loaded" Click="rbControl_Click" Focusable="False" />
                                 </MenuItem.Header>
-                            </MenuItem>
-                            <MenuItem x:Name="mniContent" IsCheckable="False" Click="mniContent_Click"
+                            </cc:ToggleMenuItem>
+                            <cc:ToggleMenuItem x:Name="mniContent" IsCheckable="False" Click="mniContent_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniContentAutomationPropertiesName1}">
                                 <MenuItem.Header>
                                     <RadioButton x:Name="rbContent" Content="{x:Static Properties:Resources.HierarchyControl_Content}" Loaded="mniContent_Loaded" Click="rbContent_Click" Focusable="False" />
                                 </MenuItem.Header>
-                            </MenuItem>
+                            </cc:ToggleMenuItem>
                         </MenuItem>
                         <MenuItem Header="{x:Static Properties:Resources.HierarchyControl_Menu_ShowAncestry}" x:Name="mniShowAncestry" IsCheckable="True" 
                                   Loaded="mniShowAncestry_Loaded" Click="mniShowAncestry_Click"/>

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -134,19 +134,19 @@
                 <Button.ContextMenu>
                     <ContextMenu FlowDirection="LeftToRight" x:Name="cmHierarchySettings" Style="{StaticResource ctxMenuDefault}">
                         <MenuItem Header="{x:Static Properties:Resources.HierarchyControl_Menu_TreeView}">
-                            <cc:ToggleMenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRaw_Click"
+                            <cc:ToggleMenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRaw_Click" Style="{StaticResource miBoldOnSelection}"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName1}">
                                 <MenuItem.Header>
                                     <RadioButton x:Name="rbRaw" Content="{x:Static Properties:Resources.HierarchyControl_Raw}" Loaded="mniRaw_Loaded" Click="rbRaw_Click" Focusable="False" />
                                 </MenuItem.Header>
                             </cc:ToggleMenuItem>
-                            <cc:ToggleMenuItem x:Name="mniControl" IsCheckable="False" Click="mniControl_Click" 
+                            <cc:ToggleMenuItem x:Name="mniControl" IsCheckable="False" Click="mniControl_Click" Style="{StaticResource miBoldOnSelection}"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniControlAutomationPropertiesName}">
                                 <MenuItem.Header>
                                     <RadioButton x:Name="rbControl" Content="{x:Static Properties:Resources.HierarchyControl_Control}" Loaded="mniControl_Loaded" Click="rbControl_Click" Focusable="False" />
                                 </MenuItem.Header>
                             </cc:ToggleMenuItem>
-                            <cc:ToggleMenuItem x:Name="mniContent" IsCheckable="False" Click="mniContent_Click"
+                            <cc:ToggleMenuItem x:Name="mniContent" IsCheckable="False" Click="mniContent_Click" Style="{StaticResource miBoldOnSelection}"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniContentAutomationPropertiesName1}">
                                 <MenuItem.Header>
                                     <RadioButton x:Name="rbContent" Content="{x:Static Properties:Resources.HierarchyControl_Content}" Loaded="mniContent_Loaded" Click="rbContent_Click" Focusable="False" />

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml.cs
@@ -508,11 +508,6 @@ namespace AccessibilityInsights.SharedUx.Controls
                 this.mniRaw.IsEnabled = false;
                 this.rbRaw.IsChecked = this.ElementContext.Element.TreeWalkerMode == TreeViewMode.Raw;
             }
-            bool isChecked = this.rbRaw.IsChecked.HasValue && this.rbRaw.IsChecked.Value;
-            this.mniRaw.SetValue(AutomationProperties.NameProperty,
-                isChecked ?
-                    Properties.Resources.HierarchyControl_RawView_Checked :
-                    Properties.Resources.HierarchyControl_RawView_Unchecked);
         }
 
         /// <summary>
@@ -532,11 +527,6 @@ namespace AccessibilityInsights.SharedUx.Controls
                 this.mniContent.IsEnabled = false;
                 this.rbContent.IsChecked = this.ElementContext.Element.TreeWalkerMode == TreeViewMode.Content;
             }
-            bool isChecked = this.rbContent.IsChecked.HasValue && this.rbContent.IsChecked.Value;
-            this.mniContent.SetValue(AutomationProperties.NameProperty,
-                isChecked ?
-                    Properties.Resources.HierarchyControl_ContentView_Checked :
-                    Properties.Resources.HierarchyControl_ContentView_Unchecked);
         }
 
         /// <summary>
@@ -556,11 +546,6 @@ namespace AccessibilityInsights.SharedUx.Controls
                 this.mniControl.IsEnabled = false;
                 this.rbControl.IsChecked = this.ElementContext.Element.TreeWalkerMode == TreeViewMode.Control;
             }
-            bool isChecked = this.rbControl.IsChecked.HasValue && this.rbControl.IsChecked.Value;
-            this.mniControl.SetValue(AutomationProperties.NameProperty,
-                isChecked ?
-                    Properties.Resources.HierarchyControl_ControlView_Checked :
-                    Properties.Resources.HierarchyControl_ControlView_Unchecked);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -2031,47 +2031,11 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Content view Checked.
-        /// </summary>
-        public static string HierarchyControl_ContentView_Checked {
-            get {
-                return ResourceManager.GetString("HierarchyControl_ContentView_Checked", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Content view.
-        /// </summary>
-        public static string HierarchyControl_ContentView_Unchecked {
-            get {
-                return ResourceManager.GetString("HierarchyControl_ContentView_Unchecked", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to _Control.
         /// </summary>
         public static string HierarchyControl_Control {
             get {
                 return ResourceManager.GetString("HierarchyControl_Control", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Control view Checked.
-        /// </summary>
-        public static string HierarchyControl_ControlView_Checked {
-            get {
-                return ResourceManager.GetString("HierarchyControl_ControlView_Checked", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Control view.
-        /// </summary>
-        public static string HierarchyControl_ControlView_Unchecked {
-            get {
-                return ResourceManager.GetString("HierarchyControl_ControlView_Unchecked", resourceCulture);
             }
         }
         
@@ -2136,24 +2100,6 @@ namespace AccessibilityInsights.SharedUx.Properties {
         public static string HierarchyControl_Raw {
             get {
                 return ResourceManager.GetString("HierarchyControl_Raw", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Raw view Checked.
-        /// </summary>
-        public static string HierarchyControl_RawView_Checked {
-            get {
-                return ResourceManager.GetString("HierarchyControl_RawView_Checked", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Raw view.
-        /// </summary>
-        public static string HierarchyControl_RawView_Unchecked {
-            get {
-                return ResourceManager.GetString("HierarchyControl_RawView_Unchecked", resourceCulture);
             }
         }
         

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1548,27 +1548,9 @@ URL: {0}</value>
     <value>Couldn't save the event record file: {0}</value>
     <comment>{0} is the error message of the Exception</comment>
   </data>
-  <data name="HierarchyControl_ContentView_Checked" xml:space="preserve">
-    <value>Content view Checked</value>
-  </data>
-  <data name="HierarchyControl_ContentView_Unchecked" xml:space="preserve">
-    <value>Content view</value>
-  </data>
-  <data name="HierarchyControl_ControlView_Checked" xml:space="preserve">
-    <value>Control view Checked</value>
-  </data>
-  <data name="HierarchyControl_ControlView_Unchecked" xml:space="preserve">
-    <value>Control view</value>
-  </data>
   <data name="HierarchyControl_LiveMode_InvokeToTestFormat" xml:space="preserve">
     <value>Invoke to test {0} and descendants</value>
     <comment>{0} is the glimpse of the current element</comment>
-  </data>
-  <data name="HierarchyControl_RawView_Checked" xml:space="preserve">
-    <value>Raw view Checked</value>
-  </data>
-  <data name="HierarchyControl_RawView_Unchecked" xml:space="preserve">
-    <value>Raw view</value>
   </data>
   <data name="PatternInfoControl_AvailablePatterns" xml:space="preserve">
     <value>Available Patterns:</value>

--- a/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
+++ b/src/AccessibilityInsights.SharedUx/Utilities/ExtensionMethods.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Interop;
@@ -331,6 +332,16 @@ namespace AccessibilityInsights.SharedUx.Utilities
                 return null;
             }
 #pragma warning restore CA1031 // Do not catch general exception types
+        }
+
+        internal static ToggleState ConvertToToggleState(bool? value)
+        {
+            switch (value)
+            {
+                case (true): return ToggleState.On;
+                case (false): return ToggleState.Off;
+                default: return ToggleState.Indeterminate;
+            }
         }
     }
 }


### PR DESCRIPTION
#### Details

Fixes the checked/ unchecked instances in https://github.com/microsoft/accessibility-insights-windows/issues/1514

##### Motivation

Addresses issue https://github.com/microsoft/accessibility-insights-windows/issues/1514

##### Context

While checking that this did not disrupt any existing styling, I noticed/ filed https://github.com/microsoft/accessibility-insights-windows/issues/1528 to be addressed separately. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, https://github.com/microsoft/accessibility-insights-windows/issues/1514
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.