### PR TITLE
fix: Use size of and position in set for top nav bar elements

### DIFF
--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -117,8 +117,14 @@ namespace AccessibilityInsights
         private void UpdateNavigationBarAutomationName()
         {
             AutomationProperties.SetName(btnInspect, AutomationPropertiesNameInspect);
+            AutomationProperties.SetPositionInSet(btnInspect, 1);
+            AutomationProperties.SetSizeOfSet(btnInspect, 3);
             AutomationProperties.SetName(btnTest, AutomationPropertiesNameTest);
+            AutomationProperties.SetPositionInSet(btnTest, 2);
+            AutomationProperties.SetSizeOfSet(btnTest, 3);
             AutomationProperties.SetName(btnCCA, AutomationPropertiesNameCCA);
+            AutomationProperties.SetPositionInSet(btnCCA, 3);
+            AutomationProperties.SetSizeOfSet(btnCCA, 3);
         }
 
         /// <summary>

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -115,7 +115,7 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Color contrast analyzer 3 of 3.
+        ///   Looks up a localized string similar to Color contrast analyzer.
         /// </summary>
         public static string btnCCAAutomationPropertiesName {
             get {
@@ -232,7 +232,7 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Inspect mode 1 of 3.
+        ///   Looks up a localized string similar to Inspect mode.
         /// </summary>
         public static string btnInspectAutomationPropertiesName {
             get {
@@ -340,7 +340,7 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Tests FastPass mode 2 of 3.
+        ///   Looks up a localized string similar to Tests FastPass mode.
         /// </summary>
         public static string btnTestAutomationPropertiesName {
             get {

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -127,7 +127,7 @@
     <value>Sign in</value>
   </data>
   <data name="btnCCAAutomationPropertiesName" xml:space="preserve">
-    <value>Color contrast analyzer 3 of 3</value>
+    <value>Color contrast analyzer</value>
   </data>
   <data name="btnCCAToolTip" xml:space="preserve">
     <value>Contrast</value>
@@ -166,7 +166,7 @@
     <value>Highlighter On</value>
   </data>
   <data name="btnInspectAutomationPropertiesName" xml:space="preserve">
-    <value>Inspect mode 1 of 3</value>
+    <value>Inspect mode</value>
   </data>
   <data name="btnInspectToolTip" xml:space="preserve">
     <value>Inspect</value>
@@ -199,7 +199,7 @@
     <value>Save</value>
   </data>
   <data name="btnTestAutomationPropertiesName" xml:space="preserve">
-    <value>Tests FastPass mode 2 of 3</value>
+    <value>Tests FastPass mode</value>
   </data>
   <data name="btnTestToolTip" xml:space="preserve">
     <value>Test</value>


### PR DESCRIPTION
#### Details

Replace hardcoded "x of 3" in element automation name with proper UIA `SizeOfSet` and `PositionInSet` properties. This PR addresses the 3 elements in the left hand side navigation bar (the `Inspect mode`, `Fastpass mode` and `Color contrast analyzer` buttons)

##### Motivation

Addresses part of https://github.com/microsoft/accessibility-insights-windows/issues/1514

##### Context

This is one of several PRs to address the various issues discussed in https://github.com/microsoft/accessibility-insights-windows/issues/1514

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, https://github.com/microsoft/accessibility-insights-windows/issues/1514
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.