### PR TITLE
fix: Use size of and position in set for event config dialog tabs

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Dialogs/EventConfigDialog.xaml
+++ b/src/AccessibilityInsights.SharedUx/Dialogs/EventConfigDialog.xaml
@@ -21,7 +21,7 @@
         <DockPanel Grid.Row="0">
             <TabControl SelectedIndex="0">
                 <TabItem x:Name="tabEvents" Header="{x:Static Properties:Resources.EventConfigDialog_Events_Header}" AutomationProperties.Name="{x:Static Properties:Resources.tabEventsAutomationPropertiesName}"
-                         AutomationProperties.HelpText="{x:Static Properties:Resources.tabEventsAutomationPropertiesHelpText}">
+                         AutomationProperties.HelpText="{x:Static Properties:Resources.tabEventsAutomationPropertiesHelpText}" AutomationProperties.PositionInSet="1" AutomationProperties.SizeOfSet="2">
                     <Grid Grid.IsSharedSizeScope="True" Margin="10">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
@@ -35,7 +35,7 @@
                     </Grid>
                 </TabItem>
                 <TabItem x:Name="tabProperties" Header="{x:Static Properties:Resources.EventConfigDialog_Properties_Header}" AutomationProperties.Name="{x:Static Properties:Resources.tabPropertiesAutomationPropertiesName}"
-                         AutomationProperties.HelpText="{x:Static Properties:Resources.tabPropertiesAutomationPropertiesHelpText}">
+                         AutomationProperties.HelpText="{x:Static Properties:Resources.tabPropertiesAutomationPropertiesHelpText}" AutomationProperties.PositionInSet="2" AutomationProperties.SizeOfSet="2">
                     <Grid Grid.IsSharedSizeScope="True" Margin="10">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -4094,7 +4094,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Events 2 of 3.
+        ///   Looks up a localized string similar to Events.
         /// </summary>
         public static string tabEventsAutomationPropertiesName {
             get {
@@ -4121,7 +4121,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Properties 3 of 3.
+        ///   Looks up a localized string similar to Properties.
         /// </summary>
         public static string tabPropertiesAutomationPropertiesName {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -898,7 +898,7 @@
     <value>Settings for recording events</value>
   </data>
   <data name="tabEventsAutomationPropertiesName" xml:space="preserve">
-    <value>Events 2 of 3</value>
+    <value>Events</value>
   </data>
   <data name="tabEventsAutomationPropertiesHelpText" xml:space="preserve">
     <value>with this tab, select events to record</value>
@@ -907,7 +907,7 @@
     <value>Events configuration</value>
   </data>
   <data name="tabPropertiesAutomationPropertiesName" xml:space="preserve">
-    <value>Properties 3 of 3</value>
+    <value>Properties</value>
   </data>
   <data name="tabPropertiesAutomationPropertiesHelpText" xml:space="preserve">
     <value>With this tab, select properties to record changes.</value>


### PR DESCRIPTION
#### Details

Replace hardcoded "x of 3" in element automation name with proper UIA `SizeOfSet` and `PositionInSet` properties. This PR addresses the 2 tabs in in the event config dialog, which can be found as follows:

- Open AI win in live view and inspect any app
- Select 'More options" and "Listen to events" in drop downs.
- In right hand side "Configuration" pane, expand the "My Events" item in the events list
- Select the "Edit my events..." link under "My Events"
- See event configuration dialog pop up. Observe the 2 "Events" and "Properties" tabs in the dialog

Note that this PR changed the size of set value from 3 to 2. There are only 2 tabs so I am not sure why this was ever 'x of 3'. If I'm missing something here, please let me know and I will change it back.

##### Motivation

Addresses part of https://github.com/microsoft/accessibility-insights-windows/issues/1514

##### Context

This is one of several PRs to address the various issues discussed in https://github.com/microsoft/accessibility-insights-windows/issues/1514

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, https://github.com/microsoft/accessibility-insights-windows/issues/1514
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.