### PR TITLE
fix: Use size of and position in set for main window visible elements

### DIFF
--- a/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/ControlHelper.cs
@@ -219,9 +219,8 @@ namespace AccessibilityInsights
             int count = 1;
             foreach (var elem in visibleCommands)
             {
-                string name = elem.GetValue(AutomationProperties.NameProperty) as string;
-                var len = name.IndexOf(':') == -1 ? name.Length : name.IndexOf(':');
-                elem.SetValue(AutomationProperties.NameProperty, string.Format(CultureInfo.InvariantCulture, Properties.Resources.MainWindow_UpdateMainCommandButtons_0_1_of_2, name.Substring(0, len), count, visibleCommands.Count));
+                elem.SetValue(AutomationProperties.PositionInSetProperty, count);
+                elem.SetValue(AutomationProperties.SizeOfSetProperty, visibleCommands.Count);
                 count++;
             }
         }

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -836,15 +836,6 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: {1} of {2}.
-        /// </summary>
-        public static string MainWindow_UpdateMainCommandButtons_0_1_of_2 {
-            get {
-                return ResourceManager.GetString("MainWindow_UpdateMainCommandButtons_0_1_of_2", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Accessibility Insights for Windows - {0}.
         /// </summary>
         public static string MainWindow_UpdateTitleString_Accessibility_Insights_for_Windows_0 {

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -443,10 +443,6 @@ Please ensure that you are opening a valid test file using the most recent relea
     <value>Glimpse: {0}</value>
     <comment>{0} is the glimpse</comment>
   </data>
-  <data name="MainWindow_UpdateMainCommandButtons_0_1_of_2" xml:space="preserve">
-    <value>{0}: {1} of {2}</value>
-    <comment>{0} is a command name; {1} is the index of the current command; {2} is the total number of commands</comment>
-  </data>
   <data name="MainWindow_UpdateTitleString_Accessibility_Insights_for_Windows_0" xml:space="preserve">
     <value>Accessibility Insights for Windows - {0}</value>
     <comment>Title String. {0} describes the current POI and view</comment>


### PR DESCRIPTION
#### Details

Replace hardcoded "x of 5" in element automation name with proper UIA `SizeOfSet` and `PositionInSet` properties. This PR addresses the elements along the top level live inspect menu (the "what to select menu", the highlighter on button, the pause/ resume button, the timer button, and the load test or event file button)

##### Motivation

Addresses part of https://github.com/microsoft/accessibility-insights-windows/issues/1514

##### Context

This is one of several PRs to address the various issues discussed in https://github.com/microsoft/accessibility-insights-windows/issues/1514

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, https://github.com/microsoft/accessibility-insights-windows/issues/1514
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.