### PR TITLE
fix: Use size of and position in set for lower nav bar elements

### DIFF
--- a/src/AccessibilityInsights/MainWindow.xaml
+++ b/src/AccessibilityInsights/MainWindow.xaml
@@ -154,7 +154,9 @@
                             x:Name="btnAccountConfig"
                             Click="btnAccountConfig_Click"
                             AutomationProperties.Name="{x:Static properties:Resources.btnAccountConfigAutomationPropertiesName}"
-                            AutomationProperties.HelpText="{x:Static properties:Resources.btnAccountConfigAutomationPropertiesHelpText}">
+                            AutomationProperties.HelpText="{x:Static properties:Resources.btnAccountConfigAutomationPropertiesHelpText}"
+                            AutomationProperties.PositionInSet="1"
+                            AutomationProperties.SizeOfSet="2">
                             <Button.ToolTip>
                                 <ToolTip>
                                     <Run Text="{x:Static properties:Resources.btnAccountConfigToolTip}" />
@@ -174,6 +176,8 @@
                                 x:Name="btnConfig" Grid.Row="1"
                                 AutomationProperties.AutomationId="{x:Static sharedProps:AutomationIDs.MainWinSettingsButton}"
                                 AutomationProperties.Name="{x:Static properties:Resources.btnConfigAutomationPropertiesName}"
+                                AutomationProperties.SizeOfSet="2"
+                                AutomationProperties.PositionInSet="2"
                                 AutomationProperties.HelpText="{x:Static properties:Resources.btnConfigAutomationPropertiesHelpText}"
                                 Style="{StaticResource btnLeftNav}" Click="onbtnConfigClicked">
                             <Button.ToolTip>

--- a/src/AccessibilityInsights/MainWindow.xaml.cs
+++ b/src/AccessibilityInsights/MainWindow.xaml.cs
@@ -792,8 +792,7 @@ namespace AccessibilityInsights
             vmReporterLogo.FabricIconLogoName = isConfigured ? fabricIconName : null;
             string tooltipResource = isConfigured ? Properties.Resources.UpdateMainWindowLoginFieldsSignedInAs : Properties.Resources.HandleLogoutRequestSignIn;
             string tooltipText = string.Format(CultureInfo.InvariantCulture, tooltipResource, IssueReporter.DisplayName);
-            string automationName = string.Format(CultureInfo.InvariantCulture, Properties.Resources.btnAccountConfigAutomationPropertiesNameFormat, tooltipText);
-            AutomationProperties.SetName(btnAccountConfig, automationName);
+            AutomationProperties.SetName(btnAccountConfig, tooltipText);
             btnAccountConfig.ToolTip = new ToolTip() { Content = tooltipText };
         }
 

--- a/src/AccessibilityInsights/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights/Properties/Resources.Designer.cs
@@ -88,20 +88,11 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sign in 1 of 2.
+        ///   Looks up a localized string similar to Sign in.
         /// </summary>
         public static string btnAccountConfigAutomationPropertiesName {
             get {
                 return ResourceManager.GetString("btnAccountConfigAutomationPropertiesName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} 1 of 2.
-        /// </summary>
-        public static string btnAccountConfigAutomationPropertiesNameFormat {
-            get {
-                return ResourceManager.GetString("btnAccountConfigAutomationPropertiesNameFormat", resourceCulture);
             }
         }
         
@@ -160,7 +151,7 @@ namespace AccessibilityInsights.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Application Settings 2 of 2.
+        ///   Looks up a localized string similar to Application Settings.
         /// </summary>
         public static string btnConfigAutomationPropertiesName {
             get {

--- a/src/AccessibilityInsights/Properties/Resources.resx
+++ b/src/AccessibilityInsights/Properties/Resources.resx
@@ -121,7 +121,7 @@
     <value>Sign into AzureDevOps and configure sign in settings</value>
   </data>
   <data name="btnAccountConfigAutomationPropertiesName" xml:space="preserve">
-    <value>Sign in 1 of 2</value>
+    <value>Sign in</value>
   </data>
   <data name="btnAccountConfigToolTip" xml:space="preserve">
     <value>Sign in</value>
@@ -142,7 +142,7 @@
     <value>Configure settings of Accessibility Insights for Windows</value>
   </data>
   <data name="btnConfigAutomationPropertiesName" xml:space="preserve">
-    <value>Application Settings 2 of 2</value>
+    <value>Application Settings</value>
   </data>
   <data name="btnConfigToolTip" xml:space="preserve">
     <value>Change settings...</value>
@@ -581,10 +581,6 @@ Confidence: {1}</value>
   </data>
   <data name="NavBar_IssueFilingConfig_AccessText" xml:space="preserve">
     <value>_i</value>
-  </data>
-  <data name="btnAccountConfigAutomationPropertiesNameFormat" xml:space="preserve">
-    <value>{0} 1 of 2</value>
-    <comment>{0} is the text displayed in the tooltip</comment>
   </data>
   <data name="LiveModeControl_Keyboard" xml:space="preserve">
     <value>Use Tab or Shift+Tab to move between fields in the currently active pane. Use F6 or Shift+F6 to move between panes</value>


### PR DESCRIPTION
#### Details

Replace hardcoded "x of 2" in element automation name with proper UIA `SizeOfSet` and `PositionInSet` properties. This PR addresses the 2 elements at the bottom of the left hand nav bar, the account config and app settings buttons.

##### Motivation

Addresses part of https://github.com/microsoft/accessibility-insights-windows/issues/1514

##### Context

This is one of several PRs to address the various issues discussed in https://github.com/microsoft/accessibility-insights-windows/issues/1514

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, https://github.com/microsoft/accessibility-insights-windows/issues/1514
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.