### PR TITLE
fix: convert radio button menu items to implement toggle pattern

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -118,24 +118,24 @@
                     <Button.ContextMenu>
                         <ContextMenu FlowDirection="LeftToRight" Loaded="ContextMenu_Loaded" Unloaded="ContextMenu_Unloaded" Style="{StaticResource ctxMenuDefault}">
                             <MenuItem Header="{x:Static Properties:Resources.EventRecordControlScopeHeader}">
-                                <MenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRB_Click"
+                                <customcontrols:ToggleMenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRB_Click" Style="{StaticResource miBoldOnSelection}"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName}">
                                     <MenuItem.Header>
                                         <RadioButton x:Name="radiobuttonScopeSelf" GroupName="groupScope" Content="{x:Static Properties:Resources.mniRawAutomationPropertiesName}" Focusable="False"/>
                                     </MenuItem.Header>
-                                </MenuItem>
-                                <MenuItem x:Name="mniControl" IsCheckable="False" Click="mniRB_Click"
+                                </customcontrols:ToggleMenuItem>
+                                <customcontrols:ToggleMenuItem x:Name="mniControl" IsCheckable="False" Click="mniRB_Click" Style="{StaticResource miBoldOnSelection}"
                                   AutomationProperties.Name="{x:Static Properties:Resources.radiobuttonScopeSubtreeContent}">
                                     <MenuItem.Header>
                                         <RadioButton x:Name="radiobuttonScopeSubtree" GroupName="groupScope" Content="{x:Static Properties:Resources.radiobuttonScopeSubtreeContent}" Focusable="False"/>
                                     </MenuItem.Header>
-                                </MenuItem>
-                                <MenuItem x:Name="mniContent" IsCheckable="False" Click="mniRB_Click"
+                                </customcontrols:ToggleMenuItem>
+                                <customcontrols:ToggleMenuItem x:Name="mniContent" IsCheckable="False" Click="mniRB_Click" Style="{StaticResource miBoldOnSelection}"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniContentAutomationPropertiesName}">
                                     <MenuItem.Header>
                                         <RadioButton x:Name="radiobuttonScopeDescendents" GroupName="groupScope" Content="{x:Static Properties:Resources.mniContentAutomationPropertiesName}" Focusable="False"/>
                                     </MenuItem.Header>
-                                </MenuItem>
+                                </customcontrols:ToggleMenuItem>
                             </MenuItem>
                             <MenuItem Header="{x:Static Properties:Resources.EventRecordControl_Menu_RecordAutomationFocusChanged}" x:Name="mniFocusChanged" IsCheckable="True"/>
                         </ContextMenu>


### PR DESCRIPTION
#### Details

Expand on fix in https://github.com/microsoft/accessibility-insights-windows/pull/1529. I found another set of radio buttons which were not properly announcing their state/ implementing the toggle pattern. This PR leverages with ToggleMenuItem control added in https://github.com/microsoft/accessibility-insights-windows/pull/1529 to ensure that checked/ unchecked states are announced. 

Steps to repro:
- Live inspect any app with AI win
- Go to "More options" and "listen to events"
- Select event settings button (beside recording button)
- Expand "Event recording scope" menu item and observe 3 radio buttons that do not announce their state to screenreaders

##### Motivation

Address another instance of improper implementation of UIA patterns that was missed in https://github.com/microsoft/accessibility-insights-windows/issues/1514

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.