### PR TITLE
fix: Add dark mode styling for nested menu items

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/EventRecordControl.xaml
@@ -118,19 +118,19 @@
                     <Button.ContextMenu>
                         <ContextMenu FlowDirection="LeftToRight" Loaded="ContextMenu_Loaded" Unloaded="ContextMenu_Unloaded" Style="{StaticResource ctxMenuDefault}">
                             <MenuItem Header="{x:Static Properties:Resources.EventRecordControlScopeHeader}">
-                                <customcontrols:ToggleMenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRB_Click" Style="{StaticResource miBoldOnSelection}"
+                                <customcontrols:ToggleMenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRB_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName}">
                                     <MenuItem.Header>
                                         <RadioButton x:Name="radiobuttonScopeSelf" GroupName="groupScope" Content="{x:Static Properties:Resources.mniRawAutomationPropertiesName}" Focusable="False"/>
                                     </MenuItem.Header>
                                 </customcontrols:ToggleMenuItem>
-                                <customcontrols:ToggleMenuItem x:Name="mniControl" IsCheckable="False" Click="mniRB_Click" Style="{StaticResource miBoldOnSelection}"
+                                <customcontrols:ToggleMenuItem x:Name="mniControl" IsCheckable="False" Click="mniRB_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.radiobuttonScopeSubtreeContent}">
                                     <MenuItem.Header>
                                         <RadioButton x:Name="radiobuttonScopeSubtree" GroupName="groupScope" Content="{x:Static Properties:Resources.radiobuttonScopeSubtreeContent}" Focusable="False"/>
                                     </MenuItem.Header>
                                 </customcontrols:ToggleMenuItem>
-                                <customcontrols:ToggleMenuItem x:Name="mniContent" IsCheckable="False" Click="mniRB_Click" Style="{StaticResource miBoldOnSelection}"
+                                <customcontrols:ToggleMenuItem x:Name="mniContent" IsCheckable="False" Click="mniRB_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniContentAutomationPropertiesName}">
                                     <MenuItem.Header>
                                         <RadioButton x:Name="radiobuttonScopeDescendents" GroupName="groupScope" Content="{x:Static Properties:Resources.mniContentAutomationPropertiesName}" Focusable="False"/>

--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -134,19 +134,19 @@
                 <Button.ContextMenu>
                     <ContextMenu FlowDirection="LeftToRight" x:Name="cmHierarchySettings" Style="{StaticResource ctxMenuDefault}">
                         <MenuItem Header="{x:Static Properties:Resources.HierarchyControl_Menu_TreeView}">
-                            <cc:ToggleMenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRaw_Click" Style="{StaticResource miBoldOnSelection}"
+                            <cc:ToggleMenuItem x:Name="mniRaw" IsCheckable="False" Click="mniRaw_Click"
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniRawAutomationPropertiesName1}">
                                 <MenuItem.Header>
                                     <RadioButton x:Name="rbRaw" Content="{x:Static Properties:Resources.HierarchyControl_Raw}" Loaded="mniRaw_Loaded" Click="rbRaw_Click" Focusable="False" />
                                 </MenuItem.Header>
                             </cc:ToggleMenuItem>
-                            <cc:ToggleMenuItem x:Name="mniControl" IsCheckable="False" Click="mniControl_Click" Style="{StaticResource miBoldOnSelection}"
+                            <cc:ToggleMenuItem x:Name="mniControl" IsCheckable="False" Click="mniControl_Click" 
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniControlAutomationPropertiesName}">
                                 <MenuItem.Header>
                                     <RadioButton x:Name="rbControl" Content="{x:Static Properties:Resources.HierarchyControl_Control}" Loaded="mniControl_Loaded" Click="rbControl_Click" Focusable="False" />
                                 </MenuItem.Header>
                             </cc:ToggleMenuItem>
-                            <cc:ToggleMenuItem x:Name="mniContent" IsCheckable="False" Click="mniContent_Click" Style="{StaticResource miBoldOnSelection}"
+                            <cc:ToggleMenuItem x:Name="mniContent" IsCheckable="False" Click="mniContent_Click" 
                                   AutomationProperties.Name="{x:Static Properties:Resources.mniContentAutomationPropertiesName1}">
                                 <MenuItem.Header>
                                     <RadioButton x:Name="rbContent" Content="{x:Static Properties:Resources.HierarchyControl_Content}" Loaded="mniContent_Loaded" Click="rbContent_Click" Focusable="False" />

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1278,7 +1278,7 @@
         </Setter>
     </Style>
     <ControlTemplate x:Key="{x:Static MenuItem.SubmenuItemTemplateKey}" TargetType="{x:Type MenuItem}">
-        <Border x:Name="Border" Background="{DynamicResource ResourceKey=SecondaryBGBrush}" BorderBrush="Gray" Padding="8,4" BorderThickness="1">
+        <Border x:Name="Border" BorderBrush="Gray" Padding="8,4" BorderThickness="1">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="24"/>
@@ -1290,8 +1290,8 @@
         </Border>
         <ControlTemplate.Triggers>
             <Trigger Property="IsHighlighted" Value="True">
-                <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
-                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TSRowSelectedFGBrush}"/>
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource ResourceKey=TSRowSelectedBGBrush}"/>
                 <Setter Property="TextBlock.LayoutTransform">
                     <Setter.Value>
                         <ScaleTransform ScaleX=".97"/>
@@ -1300,8 +1300,8 @@
                 <Setter Property="FontWeight" Value="Bold"/>
             </Trigger>
             <Trigger Property="IsHighlighted" Value="False">
-                <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
-                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource ResourceKey=PrimaryBGBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                 <Setter Property="FontWeight" Value="Regular"/>
             </Trigger>
             <Trigger Property="IsChecked" Value="True">
@@ -1321,7 +1321,7 @@
         </ControlTemplate.Resources>
     </ControlTemplate>
     <ControlTemplate x:Key="{x:Static MenuItem.SubmenuHeaderTemplateKey}" TargetType="{x:Type MenuItem}">
-        <Border x:Name="Border" Background="{DynamicResource ResourceKey=SecondaryBGBrush}" BorderBrush="Gray" Padding="8,4" BorderThickness="1">
+        <Border x:Name="Border" BorderBrush="Gray" Padding="8,4" BorderThickness="1">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="24"/>
@@ -1331,7 +1331,7 @@
                 <ContentPresenter VerticalAlignment="Center" Grid.Column="1" ContentSource="Header" RecognizesAccessKey="True" LayoutTransform="{TemplateBinding LayoutTransform}"/>
                 <Path Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Center" Data="M 0 0 L 0 7 L 4 3.5 Z" Fill="Gray"/>
                 <Popup x:Name="Popup" IsOpen="{TemplateBinding IsSubmenuOpen}" Focusable="False" Placement="Right" HorizontalOffset="9" VerticalOffset="-6">
-                    <Border x:Name="SubmenuBorder" Background="{DynamicResource ResourceKey=SecondaryBGBrush}" BorderBrush="Gray" BorderThickness="1">
+                    <Border x:Name="SubmenuBorder" BorderBrush="Gray" BorderThickness="1">
                         <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
                     </Border>
                 </Popup>
@@ -1339,8 +1339,8 @@
         </Border>
         <ControlTemplate.Triggers>
             <Trigger Property="IsHighlighted" Value="True">
-                <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
-                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TSRowSelectedFGBrush}"/>
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource ResourceKey=TSRowSelectedBGBrush}"/>
                 <Setter Property="TextBlock.LayoutTransform">
                     <Setter.Value>
                         <ScaleTransform ScaleX=".97"/>
@@ -1349,8 +1349,8 @@
                 <Setter Property="FontWeight" Value="Bold"/>
             </Trigger>
             <Trigger Property="IsHighlighted" Value="False">
-                <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
-                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource ResourceKey=PrimaryBGBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                 <Setter Property="FontWeight" Value="Regular"/>
             </Trigger>
         </ControlTemplate.Triggers>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1277,10 +1277,94 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <ControlTemplate x:Key="{x:Static MenuItem.SubmenuItemTemplateKey}" TargetType="{x:Type MenuItem}">
+        <Border x:Name="Border" Background="{DynamicResource ResourceKey=SecondaryBGBrush}" BorderBrush="Gray" Padding="8,4" BorderThickness="1">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="24"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <CheckBox x:Name="CheckMark" Visibility="Hidden" Focusable="False" IsHitTestVisible="False" Style="{StaticResource CheckBoxContastingBorder}"/>
+                <ContentPresenter VerticalAlignment="Center" Grid.Column="1" ContentSource="Header" RecognizesAccessKey="True" LayoutTransform="{TemplateBinding LayoutTransform}"/>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
+                <Setter Property="TextBlock.LayoutTransform">
+                    <Setter.Value>
+                        <ScaleTransform ScaleX=".97"/>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="FontWeight" Value="Bold"/>
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="False">
+                <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
+                <Setter Property="FontWeight" Value="Regular"/>
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter TargetName="CheckMark" Property="IsChecked" Value="True" />
+            </Trigger>
+            <Trigger Property="IsChecked" Value="False">
+                <Setter TargetName="CheckMark" Property="IsChecked" Value="False" />
+            </Trigger>
+            <Trigger Property="IsCheckable" Value="True">
+                <Setter TargetName="CheckMark" Property="Visibility" Value="Visible" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+        <ControlTemplate.Resources>
+            <Style TargetType="{x:Type RadioButton}">
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
+            </Style>
+        </ControlTemplate.Resources>
+    </ControlTemplate>
+    <ControlTemplate x:Key="{x:Static MenuItem.SubmenuHeaderTemplateKey}" TargetType="{x:Type MenuItem}">
+        <Border x:Name="Border" Background="{DynamicResource ResourceKey=SecondaryBGBrush}" BorderBrush="Gray" Padding="8,4" BorderThickness="1">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="24"/>
+                    <ColumnDefinition Width="auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <ContentPresenter VerticalAlignment="Center" Grid.Column="1" ContentSource="Header" RecognizesAccessKey="True" LayoutTransform="{TemplateBinding LayoutTransform}"/>
+                <Path Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Center" Data="M 0 0 L 0 7 L 4 3.5 Z" Fill="Gray"/>
+                <Popup x:Name="Popup" IsOpen="{TemplateBinding IsSubmenuOpen}" Focusable="False" Placement="Right" HorizontalOffset="9" VerticalOffset="-6">
+                    <Border x:Name="SubmenuBorder" Background="{DynamicResource ResourceKey=SecondaryBGBrush}" BorderBrush="Gray" BorderThickness="1">
+                        <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
+                    </Border>
+                </Popup>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
+                <Setter Property="TextBlock.LayoutTransform">
+                    <Setter.Value>
+                        <ScaleTransform ScaleX=".97"/>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="FontWeight" Value="Bold"/>
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="False">
+                <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
+                <Setter Property="FontWeight" Value="Regular"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
     <Style TargetType="{x:Type ContextMenu}" x:Key="ctxMenuDefault">
-        <Style.Resources>
-            <Style x:Key="{x:Type MenuItem}" TargetType="{x:Type MenuItem}" BasedOn="{StaticResource miBoldOnSelection}"/>
-        </Style.Resources>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border Background="{DynamicResource ResourceKey=SecondaryBGBrush}" BorderBrush="Gray" BorderThickness="1">
+                        <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
     <Style TargetType="{x:Type Menu}" x:Key="menuDefault">
         <Style.Resources>

--- a/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Styles.xaml
@@ -1263,8 +1263,6 @@
                             <Setter TargetName="fbIcn" Property="Foreground" Value="{DynamicResource ResourceKey=IconBrush}"/>
                         </Trigger>
                         <Trigger Property="IsHighlighted" Value="True">
-                            <Setter Property="Background" Value="{DynamicResource ResourceKey=SelectedBrush}"/>
-                            <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.5"/>
@@ -1316,7 +1314,14 @@
         </ControlTemplate.Triggers>
         <ControlTemplate.Resources>
             <Style TargetType="{x:Type RadioButton}">
-                <Setter Property="Foreground" Value="{DynamicResource ResourceKey=SelectedTextBrush}"/>
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}, Path=IsHighlighted}" Value="True">
+                        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=TSRowSelectedFGBrush}" />
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}, Path=IsHighlighted}" Value="False">
+                        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=PrimaryFGBrush}" />
+                    </DataTrigger>
+                </Style.Triggers>
             </Style>
         </ControlTemplate.Resources>
     </ControlTemplate>


### PR DESCRIPTION
#### Details

Update styling for menu items such that they adhere to dark mode. This effects the hierarchy settings and event settings menus that were identified in https://github.com/microsoft/accessibility-insights-windows/issues/1528.

##### Motivation

Addresses issue https://github.com/microsoft/accessibility-insights-windows/issues/1528

##### Context

[Image grid description: Screenshots of each menu before and after the styling change in dark and light modes]
| | Before | After |
| - | ------- | ------ |
| Hierarchy settings in light mode | <img width="667" alt="light-livesettings-before" src="https://user-images.githubusercontent.com/16010855/214106081-7250b713-ff0b-43c3-94a2-7306e595333b.png"> | <img width="667" alt="Light-livesettings-after" src="https://user-images.githubusercontent.com/16010855/214106022-723384d7-d4a5-465e-88bb-52b0a8a581bb.png"> |
| Hierarchy settings in dark mode | <img width="667" alt="dark-livesettings-before" src="https://user-images.githubusercontent.com/16010855/214106294-884ec43b-5423-474f-97a6-574f942e7941.png"> | <img width="667" alt="dark-livesettings-after" src="https://user-images.githubusercontent.com/16010855/214106246-c665eb5d-3f27-4417-b109-b334030c9b85.png"> |
| Event settings in light mode | <img width="667" alt="light-eventsettings-before" src="https://user-images.githubusercontent.com/16010855/214105995-47f35f87-6bba-4971-a440-81627f1269e3.png"> | <img width="667" alt="light-eventsettings-after" src="https://user-images.githubusercontent.com/16010855/214105948-ad6312a3-9726-42a5-9e2b-4f02c94b1789.png"> |
| Event settings in dark mode | <img width="667" alt="dark-eventsettings-before" src="https://user-images.githubusercontent.com/16010855/214106217-becac53f-4082-49c0-a8ba-d0e0767891e3.png"> | <img width="667" alt="dark-eventsettings-after" src="https://user-images.githubusercontent.com/16010855/214106188-12ca3269-73e4-4e19-a8ef-c8c639ef4de8.png"> |

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, https://github.com/microsoft/accessibility-insights-windows/issues/1528
- [x] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.