### PR TITLE
fix: Improve handling of non-breaking spaces in ADO issues

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/AzureDevOpsIntegration.cs
@@ -479,6 +479,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         /// </summary>
         private static readonly IReadOnlyDictionary<char, char> CharacterSubstitutions = new Dictionary<char, char>()
         {
+            { '\u00a0', ' ' }, // non-breaking space (160) to regular space (32)
             { '\u00b7', '-' }, // middle dot (183) to dash (45)
         };
 
@@ -488,7 +489,7 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         /// </summary>
         /// <param name="str"></param>
         /// <returns></returns>
-        private static string EscapeForUrl(string str)
+        internal static string EscapeForUrl(string str)
         {
             // characters such as the middle dot can
             // cause issues during navigation, so we only allow

--- a/src/AccessibilityInsights.Extensions.AzureDevOpsTests/AzureDevOpsIntegrationTests.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOpsTests/AzureDevOpsIntegrationTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.Extensions.AzureDevOps;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -52,6 +52,54 @@ namespace AccessibilityInsights.Extensions.AzureDevOpsTests
 
             Assert.AreEqual(expectedUri,
                 AzureDevOpsIntegration.GetTeamProjectUriInternal(TestProject, null, SlashTestUri).AbsoluteUri);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void EscapeForUrl_InputHasNoSubstitutions_ReturnsExpectedUri()
+        {
+            const string inputUri = "https://www.github.com/accessibility-insights-windows/issues?text=This is some text";
+            const string expectedUri = "https%3A%2F%2Fwww.github.com%2Faccessibility-insights-windows%2Fissues%3Ftext%3DThis%20is%20some%20text";
+
+            string outputUri = AzureDevOpsIntegration.EscapeForUrl(inputUri);
+
+            Assert.AreEqual(expectedUri, outputUri);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void EscapeForUrl_InputHasMiddleDots_ReturnsExpectedUri()
+        {
+            const string inputUri = "https://www.github.com/accessibility-insights-windows/issues?text=This·has·middle·dots";
+            const string expectedUri = "https%3A%2F%2Fwww.github.com%2Faccessibility-insights-windows%2Fissues%3Ftext%3DThis-has-middle-dots";
+
+            string outputUri = AzureDevOpsIntegration.EscapeForUrl(inputUri);
+
+            Assert.AreEqual(expectedUri, outputUri);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void EscapeForUrl_InputHasNonBreakingSpaces_ReturnsExpectedUri()
+        {
+            const string inputUri = "https://www.github.com/accessibility-insights-windows/issues?text=This\u00a0has\u00a0non-breaking\u00a0spaces";
+            const string expectedUri = "https%3A%2F%2Fwww.github.com%2Faccessibility-insights-windows%2Fissues%3Ftext%3DThis%20has%20non-breaking%20spaces";
+
+            string outputUri = AzureDevOpsIntegration.EscapeForUrl(inputUri);
+
+            Assert.AreEqual(expectedUri, outputUri);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void EscapeForUrl_InputHasHighCharacters_ReturnsExpectedUri()
+        {
+            const string inputUri = "https://www.github.com/accessibility-insights-windows/issues?text=This\u0080has\u0090high\u00b0characters";
+            const string expectedUri = "https%3A%2F%2Fwww.github.com%2Faccessibility-insights-windows%2Fissues%3Ftext%3DThis%3Fhas%3Fhigh%3Fcharacters";
+
+            string outputUri = AzureDevOpsIntegration.EscapeForUrl(inputUri);
+
+            Assert.AreEqual(expectedUri, outputUri);
         }
     }
 }


### PR DESCRIPTION
#### Details

Replace non-breaking spaces with breaking spaces when filing ADO bugs

##### Motivation

Addresses #1545

##### Context

ADO issue test before and after the change
When | Link | Text
--- | --- | ---
Before | [#346](https://dev.azure.com/ada-cat/accessibility/_workitems/edit/346/) | Provide a UI Automation Name property for the element that: -?Concisely identifies the element, AND -?Does not include the same text as the elemen...open attached A11y test file for full details.
After | [#347](https://dev.azure.com/ada-cat/accessibility/_workitems/edit/347) | Provide a UI Automation Name property for the element that: - Concisely identifies the element, AND - Does not include the same text as the elemen...open attached A11y test file for full details.

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue #1545
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



