### PR TITLE
chore: Workaround for broken thirdpartynotice generator

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -246,8 +246,17 @@ jobs:
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 
+  - task: CopyFiles@2
+    displayName: 'TEMPORARY - Copy Prebuilt ThirdPartyNotices to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      SourceFolder: 'src\PrebuiltThirdPartyNotices'
+      Contents: 'thirdpartynotices.html'
+      TargetFolder: '$(System.DefaultWorkingDirectory)'
+      OverWrite: true
+      
   - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
     displayName: 'generate thirdpartynotices.html file'
+    continueOnError: true  # notice generator is currently not reliable
     inputs:
         outputfile: '$(System.DefaultWorkingDirectory)/thirdpartynotices.html'
         outputformat: html

--- a/src/PrebuiltThirdPartyNotices/thirdpartynotices.html
+++ b/src/PrebuiltThirdPartyNotices/thirdpartynotices.html
@@ -1,0 +1,1176 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>NOTICES AND INFORMATION</title>
+        <style>
+            pre {
+                white-space: pre-wrap;
+                background: #eee;
+                padding: 24px;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>NOTICES AND INFORMATION</h1>
+        <p><strong>Do Not Translate or Localize</strong></p>
+        <p>
+            This software incorporates material from third parties.
+            Microsoft makes certain open source code available at <a href="https://3rdpartysource.microsoft.com">https://3rdpartysource.microsoft.com</a>,
+            or you may send a check or money order for US $5.00, including the product name,
+            the open source component name, platform, and version number, to:
+        </p>
+        <address>
+            Source Code Compliance Team<br />
+            Microsoft Corporation<br />
+            One Microsoft Way<br />
+            Redmond, WA 98052<br />
+            USA
+        </address>
+        <p>
+            Notwithstanding any other terms, you may reverse engineer this software to the extent
+            required to debug changes to any libraries licensed under the GNU Lesser General Public License.
+        </p>
+        <ol>
+            <li>
+    <details>
+        <summary>
+            Ben.Demystifier 0.1.2 - Apache-2.0
+        </summary>
+        
+        <ul>
+<li>Copyright (c) Ben A Adams.</li>
+<li>Copyright (c) .NET Foundation.</li></ul>
+        <pre>
+        Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+      
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+      
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, &quot;control&quot; means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+      
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+      
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+      
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+      
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+      
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+      
+
+      &quot;Contribution&quot; shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, &quot;submitted&quot; means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability. END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets &quot;[]&quot; replaced with your own identifying information. (Don&#39;t include the brackets!) The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same &quot;printed page&quot; as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            CommandLineParser 2.9.1 - MIT
+        </summary>
+        
+        
+        <pre>
+        The MIT License (MIT)
+
+Copyright (c) 2005 - 2015 Giacomo Stelluti Scala &amp; Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            HtmlAgilityPack 1.11.46 - MIT
+        </summary>
+        
+        
+        <pre>
+        MIT License
+
+Copyright (c) &lt;year&gt; &lt;copyright holders&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            Microsoft.ApplicationInsights 2.21.0 - MIT
+        </summary>
+        
+        
+        <pre>
+        MIT License
+
+Copyright (c) &lt;year&gt; &lt;copyright holders&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            Microsoft.Bcl.AsyncInterfaces 1.1.0 - MIT
+        </summary>
+        
+        <ul>
+<li>(c) Microsoft Corporation.</li>
+<li>Copyright (c) .NET Foundation.</li>
+<li>Copyright (c) 2011, Google Inc.</li>
+<li>(c) 1997-2005 Sean Eron Anderson.</li>
+<li>Copyright (c) 2007 James Newton-King</li>
+<li>Copyright (c) 1991-2017 Unicode, Inc.</li>
+<li>Copyright (c) 2013-2017, Alfred Klomp</li>
+<li>Copyright (c) 2015-2017, Wojciech Mula</li>
+<li>Copyright (c) 2005-2007, Nick Galbreath</li>
+<li>Portions (c) International Organization</li>
+<li>Copyright (c) 2015 The Chromium Authors.</li>
+<li>Copyright (c) 2004-2006 Intel Corporation</li>
+<li>Copyright (c) 2016-2017, Matthieu Darbois</li>
+<li>Copyright (c) .NET Foundation Contributors</li>
+<li>Copyright (c) .NET Foundation and Contributors</li>
+<li>Copyright (c) 2011 Novell, Inc (http://www.novell.com)</li>
+<li>Copyright (c) 1995-2017 Jean-loup Gailly and Mark Adler</li>
+<li>Copyright (c) 2015 Xamarin, Inc (http://www.xamarin.com)</li>
+<li>Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors.</li>
+<li>Copyright (c) YEAR W3C(r) (MIT, ERCIM, Keio, Beihang). Disclaimers THIS WORK IS PROVIDED AS</li></ul>
+        <pre>
+        The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            Microsoft.Build.Tasks.Git 1.1.1 - MIT
+        </summary>
+        
+        <ul>
+<li>(c) Microsoft Corporation.</li></ul>
+        <pre>
+        MIT License
+
+Copyright (c) &lt;year&gt; &lt;copyright holders&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            Microsoft.IdentityModel.Clients.ActiveDirectory 5.2.6 - MIT
+        </summary>
+        
+        <ul>
+<li>(c) Microsoft Corporation.</li>
+<li>Copyright (c) Microsoft Corporation</li></ul>
+        <pre>
+        MIT License
+
+Copyright (c) &lt;year&gt; &lt;copyright holders&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            Microsoft.SourceLink.Common 1.1.1 - MIT
+        </summary>
+        
+        <ul>
+<li>(c) Microsoft Corporation.</li></ul>
+        <pre>
+        MIT License
+
+Copyright (c) &lt;year&gt; &lt;copyright holders&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            Microsoft.SourceLink.GitHub 1.1.1 - MIT
+        </summary>
+        
+        <ul>
+<li>(c) Microsoft Corporation.</li></ul>
+        <pre>
+        MIT License
+
+Copyright (c) &lt;year&gt; &lt;copyright holders&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            Microsoft.Xaml.Behaviors.Wpf 1.1.39 - MIT
+        </summary>
+        
+        <ul>
+<li>(c) Microsoft Corporation.</li></ul>
+        <pre>
+        MIT License
+
+Copyright (c) &lt;year&gt; &lt;copyright holders&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            Newtonsoft.Json 13.0.2 - MIT
+        </summary>
+        
+        <ul><li>Copyright James Newton-King 2008</li>
+<li>Copyright (c) 2007 James Newton-King</li>
+<li>Copyright (c) James Newton-King 2008</li>
+<li>Copyright James Newton-King 2008 Json.NET</li></ul>
+        <pre>
+        The MIT License (MIT)
+
+Copyright (c) 2007 James Newton-King
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the &quot;Software&quot;), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            System.Drawing.Common 7.0.0 - MIT
+        </summary>
+        
+        <ul><li>(c) Microsoft Corporation</li>
+<li>Copyright (c) Andrew Arnott</li>
+<li>Copyright 2019 LLVM Project</li>
+<li>Copyright 2018 Daniel Lemire</li>
+<li>Copyright (c) .NET Foundation</li>
+<li>Copyright (c) 2011, Google Inc.</li>
+<li>Copyright (c) 2020 Dan Shechter</li>
+<li>(c) 1997-2005 Sean Eron Anderson</li>
+<li>Copyright (c) 1998 Microsoft. To</li>
+<li>Copyright (c) 2017 Yoshifumi Kawai</li>
+<li>Copyright (c) 2005-2020 Rich Felker</li>
+<li>Copyright (c) Microsoft Corporation</li>
+<li>Copyright (c) 2007 James Newton-King</li>
+<li>Copyright (c) 2012-2014, Yann Collet</li>
+<li>Copyright (c) 1991-2022 Unicode, Inc.</li>
+<li>Copyright (c) 2013-2017, Alfred Klomp</li>
+<li>Copyright 2012 the V8 project authors</li>
+<li>Copyright (c) 1999 Lucent Technologies</li>
+<li>Copyright (c) 2008-2016, Wojciech Mula</li>
+<li>Copyright (c) 2011-2020 Microsoft Corp</li>
+<li>Copyright (c) 2015-2017, Wojciech Mula</li>
+<li>Copyright (c) 2021 csFastFloat authors</li>
+<li>Copyright (c) 2005-2007, Nick Galbreath</li>
+<li>Copyright (c) 2015 The Chromium Authors</li>
+<li>Copyright (c) 2018 Alexander Chermyanin</li>
+<li>Copyright (c) The Internet Society 1997</li>
+<li>Portions (c) International Organization</li>
+<li>Copyright (c) 2004-2006 Intel Corporation</li>
+<li>Copyright (c) 2013-2017, Milosz Krajewski</li>
+<li>Copyright (c) 2016-2017, Matthieu Darbois</li>
+<li>Copyright (c) The Internet Society (2003)</li>
+<li>Copyright (c) .NET Foundation Contributors</li>
+<li>Copyright (c) 2020 Mara Bos &lt;m-ou.se@m-ou.se&gt;</li>
+<li>Copyright (c) .NET Foundation and Contributors</li>
+<li>Copyright (c) 2008-2020 Advanced Micro Devices, Inc.</li>
+<li>Copyright (c) 2019 Microsoft Corporation, Daan Leijen</li>
+<li>Copyright (c) 2011 Novell, Inc (http://www.novell.com)</li>
+<li>Copyright (c) 1995-2022 Jean-loup Gailly and Mark Adler</li>
+<li>Copyright (c) 2015 Xamarin, Inc (http://www.xamarin.com)</li>
+<li>Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors</li>
+<li>Copyright (c) 2014 Ryan Juckett http://www.ryanjuckett.com</li>
+<li>Copyright (c) 1990- 1993, 1996 Open Software Foundation, Inc.</li>
+<li>Copyright (c) YEAR W3C(r) (MIT, ERCIM, Keio, Beihang). Disclaimers</li>
+<li>Copyright (c) 2015 THL A29 Limited, a Tencent company, and Milo Yip</li>
+<li>Copyright (c) 1980, 1986, 1993 The Regents of the University of California</li>
+<li>Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018 The Regents of the University of California</li>
+<li>Copyright (c) 1989 by Hewlett-Packard Company, Palo Alto, Ca. &amp; Digital Equipment Corporation, Maynard, Mass</li>
+<li>Copyright (c) 1989 by Hewlett-Packard Company, Palo Alto, Ca. &amp; Digital Equipment Corporation, Maynard, Mass. To</li></ul>
+        <pre>
+        The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            System.IO.Packaging 7.0.0 - MIT
+        </summary>
+        
+        <ul><li>(c) Microsoft Corporation</li>
+<li>Copyright (c) Andrew Arnott</li>
+<li>Copyright 2019 LLVM Project</li>
+<li>Copyright 2018 Daniel Lemire</li>
+<li>Copyright (c) .NET Foundation</li>
+<li>Copyright (c) 2011, Google Inc.</li>
+<li>Copyright (c) 2020 Dan Shechter</li>
+<li>(c) 1997-2005 Sean Eron Anderson</li>
+<li>Copyright (c) 1998 Microsoft. To</li>
+<li>Copyright (c) 2017 Yoshifumi Kawai</li>
+<li>Copyright (c) 2005-2020 Rich Felker</li>
+<li>Copyright (c) Microsoft Corporation</li>
+<li>Copyright (c) 2007 James Newton-King</li>
+<li>Copyright (c) 2012-2014, Yann Collet</li>
+<li>Copyright (c) 1991-2022 Unicode, Inc.</li>
+<li>Copyright (c) 2013-2017, Alfred Klomp</li>
+<li>Copyright 2012 the V8 project authors</li>
+<li>Copyright (c) 1999 Lucent Technologies</li>
+<li>Copyright (c) 2008-2016, Wojciech Mula</li>
+<li>Copyright (c) 2011-2020 Microsoft Corp</li>
+<li>Copyright (c) 2015-2017, Wojciech Mula</li>
+<li>Copyright (c) 2021 csFastFloat authors</li>
+<li>Copyright (c) 2005-2007, Nick Galbreath</li>
+<li>Copyright (c) 2015 The Chromium Authors</li>
+<li>Copyright (c) 2018 Alexander Chermyanin</li>
+<li>Copyright (c) The Internet Society 1997</li>
+<li>Portions (c) International Organization</li>
+<li>Copyright (c) 2004-2006 Intel Corporation</li>
+<li>Copyright (c) 2013-2017, Milosz Krajewski</li>
+<li>Copyright (c) 2016-2017, Matthieu Darbois</li>
+<li>Copyright (c) The Internet Society (2003)</li>
+<li>Copyright (c) .NET Foundation Contributors</li>
+<li>Copyright (c) 2020 Mara Bos &lt;m-ou.se@m-ou.se&gt;</li>
+<li>Copyright (c) .NET Foundation and Contributors</li>
+<li>Copyright (c) 2008-2020 Advanced Micro Devices, Inc.</li>
+<li>Copyright (c) 2019 Microsoft Corporation, Daan Leijen</li>
+<li>Copyright (c) 2011 Novell, Inc (http://www.novell.com)</li>
+<li>Copyright (c) 1995-2022 Jean-loup Gailly and Mark Adler</li>
+<li>Copyright (c) 2015 Xamarin, Inc (http://www.xamarin.com)</li>
+<li>Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors</li>
+<li>Copyright (c) 2014 Ryan Juckett http://www.ryanjuckett.com</li>
+<li>Copyright (c) 1990- 1993, 1996 Open Software Foundation, Inc.</li>
+<li>Copyright (c) YEAR W3C(r) (MIT, ERCIM, Keio, Beihang). Disclaimers</li>
+<li>Copyright (c) 2015 THL A29 Limited, a Tencent company, and Milo Yip</li>
+<li>Copyright (c) 1980, 1986, 1993 The Regents of the University of California</li>
+<li>Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018 The Regents of the University of California</li>
+<li>Copyright (c) 1989 by Hewlett-Packard Company, Palo Alto, Ca. &amp; Digital Equipment Corporation, Maynard, Mass</li>
+<li>Copyright (c) 1989 by Hewlett-Packard Company, Palo Alto, Ca. &amp; Digital Equipment Corporation, Maynard, Mass. To</li></ul>
+        <pre>
+        The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            System.Memory 4.5.5 - MIT
+        </summary>
+        
+        <ul><li>(c) 2022 GitHub, Inc.</li>
+
+<li>(c) Microsoft Corporation</li>
+<li>Copyright (c) 2011, Google Inc.</li>
+<li>(c) 1997-2005 Sean Eron Anderson</li>
+<li>Copyright (c) 1991-2017 Unicode, Inc.</li>
+<li>Copyright (c) 2015 The Chromium Authors</li>
+<li>Portions (c) International Organization</li>
+<li>Copyright (c) 2004-2006 Intel Corporation</li>
+<li>Copyright (c) .NET Foundation Contributors</li>
+<li>Copyright (c) .NET Foundation and Contributors</li>
+<li>Copyright (c) 2011 Novell, Inc (http://www.novell.com)</li>
+<li>Copyright (c) 1995-2017 Jean-loup Gailly and Mark Adler</li>
+<li>Copyright (c) 2015 Xamarin, Inc (http://www.xamarin.com)</li>
+<li>Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors</li>
+<li>Copyright (c) YEAR W3C(r) (MIT, ERCIM, Keio, Beihang). Disclaimers</li></ul>
+        <pre>
+        The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            System.Reflection.MetadataLoadContext 7.0.0 - MIT
+        </summary>
+        
+        <ul><li>(c) Microsoft Corporation</li>
+<li>Copyright (c) Andrew Arnott</li>
+<li>Copyright 2019 LLVM Project</li>
+<li>Copyright 2018 Daniel Lemire</li>
+<li>Copyright (c) .NET Foundation</li>
+<li>Copyright (c) 2011, Google Inc.</li>
+<li>Copyright (c) 2020 Dan Shechter</li>
+<li>(c) 1997-2005 Sean Eron Anderson</li>
+<li>Copyright (c) 1998 Microsoft. To</li>
+<li>Copyright (c) 2017 Yoshifumi Kawai</li>
+<li>Copyright (c) 2005-2020 Rich Felker</li>
+<li>Copyright (c) Microsoft Corporation</li>
+<li>Copyright (c) 2007 James Newton-King</li>
+<li>Copyright (c) 2012-2014, Yann Collet</li>
+<li>Copyright (c) 1991-2022 Unicode, Inc.</li>
+<li>Copyright (c) 2013-2017, Alfred Klomp</li>
+<li>Copyright 2012 the V8 project authors</li>
+<li>Copyright (c) 1999 Lucent Technologies</li>
+<li>Copyright (c) 2008-2016, Wojciech Mula</li>
+<li>Copyright (c) 2011-2020 Microsoft Corp</li>
+<li>Copyright (c) 2015-2017, Wojciech Mula</li>
+<li>Copyright (c) 2021 csFastFloat authors</li>
+<li>Copyright (c) 2005-2007, Nick Galbreath</li>
+<li>Copyright (c) 2015 The Chromium Authors</li>
+<li>Copyright (c) 2018 Alexander Chermyanin</li>
+<li>Copyright (c) The Internet Society 1997</li>
+<li>Portions (c) International Organization</li>
+<li>Copyright (c) 2004-2006 Intel Corporation</li>
+<li>Copyright (c) 2013-2017, Milosz Krajewski</li>
+<li>Copyright (c) 2016-2017, Matthieu Darbois</li>
+<li>Copyright (c) The Internet Society (2003)</li>
+<li>Copyright (c) .NET Foundation Contributors</li>
+<li>Copyright (c) 2020 Mara Bos &lt;m-ou.se@m-ou.se&gt;</li>
+<li>Copyright (c) .NET Foundation and Contributors</li>
+<li>Copyright (c) 2008-2020 Advanced Micro Devices, Inc.</li>
+<li>Copyright (c) 2019 Microsoft Corporation, Daan Leijen</li>
+<li>Copyright (c) 2011 Novell, Inc (http://www.novell.com)</li>
+<li>Copyright (c) 1995-2022 Jean-loup Gailly and Mark Adler</li>
+<li>Copyright (c) 2015 Xamarin, Inc (http://www.xamarin.com)</li>
+<li>Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors</li>
+<li>Copyright (c) 2014 Ryan Juckett http://www.ryanjuckett.com</li>
+<li>Copyright (c) 1990- 1993, 1996 Open Software Foundation, Inc.</li>
+<li>Copyright (c) YEAR W3C(r) (MIT, ERCIM, Keio, Beihang). Disclaimers</li>
+<li>Copyright (c) 2015 THL A29 Limited, a Tencent company, and Milo Yip</li>
+<li>Copyright (c) 1980, 1986, 1993 The Regents of the University of California</li>
+<li>Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018 The Regents of the University of California</li>
+<li>Copyright (c) 1989 by Hewlett-Packard Company, Palo Alto, Ca. &amp; Digital Equipment Corporation, Maynard, Mass</li>
+<li>Copyright (c) 1989 by Hewlett-Packard Company, Palo Alto, Ca. &amp; Digital Equipment Corporation, Maynard, Mass. To</li></ul>
+        <pre>
+        The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            System.Runtime.CompilerServices.Unsafe 6.0.0 - MIT
+        </summary>
+        
+        <ul>
+<li>(c) Microsoft Corporation.</li>
+<li>Copyright (c) Andrew Arnott</li>
+<li>Copyright 2018 Daniel Lemire</li>
+<li>Copyright 2012 the V8 project</li>
+<li>Copyright (c) .NET Foundation.</li>
+<li>Copyright (c) 2011, Google Inc.</li>
+<li>Copyright (c) 1998 Microsoft. To</li>
+<li>(c) 1997-2005 Sean Eron Anderson.</li>
+<li>Copyright (c) 2017 Yoshifumi Kawai</li>
+<li>Copyright (c) Microsoft Corporation</li>
+<li>Copyright (c) 2007 James Newton-King</li>
+<li>Copyright (c) 2012-2014, Yann Collet</li>
+<li>Copyright (c) 2013-2017, Alfred Klomp</li>
+<li>Copyright (c) 2015-2017, Wojciech Mula</li>
+<li>Copyright (c) 2005-2007, Nick Galbreath</li>
+<li>Copyright (c) 2018 Alexander Chermyanin</li>
+<li>Portions (c) International Organization</li>
+<li>Copyright (c) 2015 The Chromium Authors.</li>
+<li>Copyright (c) The Internet Society 1997.</li>
+<li>Copyright (c) 2004-2006 Intel Corporation</li>
+<li>Copyright (c) 2013-2017, Milosz Krajewski</li>
+<li>Copyright (c) 2016-2017, Matthieu Darbois</li>
+<li>Copyright (c) .NET Foundation Contributors</li>
+<li>Copyright (c) The Internet Society (2003).</li>
+<li>Copyright (c) .NET Foundation and Contributors</li>
+<li>Copyright (c) 2019 Microsoft Corporation, Daan Leijen</li>
+<li>Copyright (c) 2011 Novell, Inc (http://www.novell.com)</li>
+<li>Copyright (c) 1995-2017 Jean-loup Gailly and Mark Adler</li>
+<li>Copyright (c) 2015 Xamarin, Inc (http://www.xamarin.com)</li>
+<li>Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors.</li>
+<li>Copyright (c) 2014 Ryan Juckett http://www.ryanjuckett.com</li>
+<li>Copyright (c) 1990- 1993, 1996 Open Software Foundation, Inc.</li>
+<li>Copyright (c) 2015 THL A29 Limited, a Tencent company, and Milo Yip.</li>
+<li>Copyright (c) YEAR W3C(r) (MIT, ERCIM, Keio, Beihang). Disclaimers THIS WORK IS PROVIDED AS</li>
+<li>Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018 The Regents of the University of California.</li>
+<li>Copyright (c) 1989 by Hewlett-Packard Company, Palo Alto, Ca. &amp; Digital Equipment Corporation, Maynard, Mass.</li>
+<li>Copyright (c) 1989 by Hewlett-Packard Company, Palo Alto, Ca. &amp; Digital Equipment Corporation, Maynard, Mass. To</li></ul>
+        <pre>
+        The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            System.Text.Encodings.Web 4.7.2 - MIT
+        </summary>
+        
+        <ul>
+<li>(c) Microsoft Corporation.</li>
+<li>Copyright (c) .NET Foundation.</li>
+<li>Copyright (c) 2011, Google Inc.</li>
+<li>(c) 1997-2005 Sean Eron Anderson.</li>
+<li>Copyright (c) 2007 James Newton-King</li>
+<li>Copyright (c) 1991-2017 Unicode, Inc.</li>
+<li>Copyright (c) 2013-2017, Alfred Klomp</li>
+<li>Copyright (c) 2015-2017, Wojciech Mula</li>
+<li>Copyright (c) 2005-2007, Nick Galbreath</li>
+<li>Portions (c) International Organization</li>
+<li>Copyright (c) 2015 The Chromium Authors.</li>
+<li>Copyright (c) 2004-2006 Intel Corporation</li>
+<li>Copyright (c) 2016-2017, Matthieu Darbois</li>
+<li>Copyright (c) .NET Foundation Contributors</li>
+<li>Copyright (c) .NET Foundation and Contributors</li>
+<li>Copyright (c) 2011 Novell, Inc (http://www.novell.com)</li>
+<li>Copyright (c) 1995-2017 Jean-loup Gailly and Mark Adler</li>
+<li>Copyright (c) 2015 Xamarin, Inc (http://www.xamarin.com)</li>
+<li>Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors.</li>
+<li>Copyright (c) YEAR W3C(r) (MIT, ERCIM, Keio, Beihang). Disclaimers THIS WORK IS PROVIDED AS</li></ul>
+        <pre>
+        The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            System.Text.Json 4.7.2 - MIT
+        </summary>
+        
+        <ul>
+<li>(c) Microsoft Corporation.</li>
+<li>Copyright (c) .NET Foundation.</li>
+<li>Copyright (c) 2011, Google Inc.</li>
+<li>(c) 1997-2005 Sean Eron Anderson.</li>
+<li>Copyright (c) 2007 James Newton-King</li>
+<li>Copyright (c) 1991-2017 Unicode, Inc.</li>
+<li>Copyright (c) 2013-2017, Alfred Klomp</li>
+<li>Copyright (c) 2015-2017, Wojciech Mula</li>
+<li>Copyright (c) 2005-2007, Nick Galbreath</li>
+<li>Portions (c) International Organization</li>
+<li>Copyright (c) 2015 The Chromium Authors.</li>
+<li>Copyright (c) 2004-2006 Intel Corporation</li>
+<li>Copyright (c) 2016-2017, Matthieu Darbois</li>
+<li>Copyright (c) .NET Foundation Contributors</li>
+<li>Copyright (c) .NET Foundation and Contributors</li>
+<li>Copyright (c) 2011 Novell, Inc (http://www.novell.com)</li>
+<li>Copyright (c) 1995-2017 Jean-loup Gailly and Mark Adler</li>
+<li>Copyright (c) 2015 Xamarin, Inc (http://www.xamarin.com)</li>
+<li>Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors.</li>
+<li>Copyright (c) YEAR W3C(r) (MIT, ERCIM, Keio, Beihang). Disclaimers THIS WORK IS PROVIDED AS</li></ul>
+        <pre>
+        The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            System.ValueTuple 4.5.0 - MIT
+        </summary>
+        
+        <ul>
+<li>(c) Microsoft Corporation.</li>
+<li>Copyright (c) 2011, Google Inc.</li>
+<li>(c) 1997-2005 Sean Eron Anderson.</li>
+<li>Copyright (c) 1991-2017 Unicode, Inc.</li>
+<li>Portions (c) International Organization</li>
+<li>Copyright (c) 2015 The Chromium Authors.</li>
+<li>Copyright (c) 2004-2006 Intel Corporation</li>
+<li>Copyright (c) .NET Foundation Contributors</li>
+<li>Copyright (c) .NET Foundation and Contributors</li>
+<li>Copyright (c) 2011 Novell, Inc (http://www.novell.com)</li>
+<li>Copyright (c) 1995-2017 Jean-loup Gailly and Mark Adler</li>
+<li>Copyright (c) 2015 Xamarin, Inc (http://www.xamarin.com)</li>
+<li>Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors.</li>
+<li>Copyright (c) YEAR W3C(r) (MIT, ERCIM, Keio, Beihang). Disclaimers THIS WORK IS PROVIDED AS</li></ul>
+        <pre>
+        The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            Microsoft.TeamFoundation.DistributedTask.Common.Contracts 16.170.0
+        </summary>
+        
+        <ul>
+<li>(c) Microsoft Corporation.</li></ul>
+        <pre>
+        MICROSOFT SOFTWARE LICENSE TERMS
+
+MICROSOFT .NET LIBRARY
+
+These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. They apply to the software named above. The terms also apply to any Microsoft services or updates for the software, except to the extent those have different terms.
+
+IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
+
+1.    INSTALLATION AND USE RIGHTS.
+You may install and use any number of copies of the software to design, develop and test you�re applications.  You may modify, copy, distribute or deploy any .js files contained in the software as part of your applications.
+
+2.    THIRD PARTY COMPONENTS. The software may include third party components with separate legal notices or governed by other agreements, as may be described in the ThirdPartyNotices file(s) accompanying the software.
+3.    ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.
+a.     DISTRIBUTABLE CODE.  In addition to the .js files described above, the software is comprised of Distributable Code. �Distributable Code� is code that you are permitted to distribute in programs you develop if you comply with the terms below.
+i.      Right to Use and Distribute.
+�        You may copy and distribute the object code form of the software.
+
+�        Third Party Distribution. You may permit distributors of your programs to copy and distribute the Distributable Code as part of those programs.
+
+ii.     Distribution Requirements. For any Distributable Code you distribute, you must
+�        use the Distributable Code in your programs and not as a standalone distribution;
+
+�        require distributors and external end users to agree to terms that protect it at least as much as this agreement;
+
+�        display your valid copyright notice on your programs; and
+
+�        indemnify, defend, and hold harmless Microsoft from any claims, including attorneys� fees, related to the distribution or use of your applications, except to the extent that any claim is based solely on the Distributable Code.
+
+iii.   Distribution Restrictions. You may not
+�        alter any copyright, trademark or patent notice in the Distributable Code;
+
+�        use Microsoft�s trademarks in your programs� names or in a way that suggests your programs come from or are endorsed by Microsoft;
+
+�        include Distributable Code in malicious, deceptive or unlawful programs; or
+
+�        modify or distribute the source code of any Distributable Code so that any part of it becomes subject to an Excluded License. An Excluded License is one that requires, as a condition of use, modification or distribution, that
+
+�        the code be disclosed or distributed in source code form; or
+
+�        others have the right to modify it.
+
+4.    DATA.
+a.     Data Collection. The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to provide services and improve our products and services.  You may opt-out of many of these scenarios, but not all, as described in the product documentation.  There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft�s privacy statement. Our privacy statement is located at https://go.microsoft.com/fwlink/?LinkID=824704. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+b.    Processing of Personal Data. To the extent Microsoft is a processor or subprocessor of personal data in connection with the software, Microsoft makes the commitments in the European Union General Data Protection Regulation Terms of the Online Services Terms to all customers effective May 25, 2018, at http://go.microsoft.com/?linkid=9840733.
+5.    SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
+�        work around any technical limitations in the software;
+
+�        reverse engineer, decompile or disassemble the software, or otherwise attempt to derive the source code for the software, except and to the extent required by third party licensing terms governing use of certain open source components that may be included in the software;
+
+�        remove, minimize, block or modify any notices of Microsoft or its suppliers in the software;
+
+�        use the software in any way that is against the law; or
+
+�        share, publish, rent or lease the software, provide the software as a stand-alone offering for others to use, or transfer the software or this agreement to any third party.
+
+6.    EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the software, which include restrictions on destinations, end users, and end use. For further information on export restrictions, visit www.microsoft.com/exporting.  
+7.    SUPPORT SERVICES. Because this software is �as is,� we may not provide support services for it.
+8.    ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
+9.    APPLICABLE LAW.  If you acquired the software in the United States, Washington law applies to interpretation of and claims for breach of this agreement, and the laws of the state where you live apply to all other claims. If you acquired the software in any other country, its laws apply.
+10. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including consumer rights, under the laws of your state or country. Separate and apart from your relationship with Microsoft, you may also have rights with respect to the party from which you acquired the software. This agreement does not change those other rights if the laws of your state or country do not permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory country law applies, then the following provisions apply to you:
+a)    Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to affect those rights.
+b)    Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to turn off updates for your specific device or software.
+c)    Germany and Austria.
+(i)        Warranty. The software will perform substantially as described in any Microsoft materials that accompany it. However, Microsoft gives no contractual guarantee in relation to the software.
+
+(ii)       Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as well as in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
+
+Subject to the foregoing clause (ii), Microsoft will only be liable for slight negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called &quot;cardinal obligations&quot;). In other cases of slight negligence, Microsoft will not be liable for slight negligence
+11. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED �AS-IS.� YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+12. LIMITATION ON AND EXCLUSION OF REMEDIES AND DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
+This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet sites, or third party applications; and (b) claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
+
+It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your state or country may not allow the exclusion or limitation of incidental, consequential or other damages.
+
+Please note: As this software is distributed in Quebec, Canada, some of the clauses in this agreement are provided below in French.
+
+ 
+
+Remarque : Ce logiciel �tant distribu� au Qu�bec, Canada, certaines des clauses dans ce contrat sont fournies ci-dessous en fran�ais.
+
+ 
+
+EXON�RATION DE GARANTIE. Le logiciel vis� par une licence est offert � tel quel �. Toute utilisation de ce logiciel est � votre seule risque et p�ril. Microsoft n�accorde aucune autre garantie expresse. Vous pouvez b�n�ficier de droits additionnels en vertu du droit local sur la protection des consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par le droit locale, les garanties implicites de qualit� marchande, d�ad�quation � un usage particulier et d�absence de contrefa�on sont exclues.
+
+ 
+
+LIMITATION DES DOMMAGES-INT�R�TS ET EXCLUSION DE RESPONSABILIT� POUR LES DOMMAGES. Vous pouvez obtenir de Microsoft et de ses fournisseurs une indemnisation en cas de dommages directs uniquement � hauteur de 5,00 $ US. Vous ne pouvez pr�tendre � aucune indemnisation pour les autres dommages, y compris les dommages sp�ciaux, indirects ou accessoires et pertes de b�n�fices.
+
+ 
+
+Cette limitation concerne:
+
+�     tout ce qui est reli� au logiciel, aux services ou au contenu (y compris le code) figurant sur des sites Internet tiers ou dans des programmes tiers ; et
+
+�     les r�clamations au titre de violation de contrat ou de garantie, ou au titre de responsabilit� stricte, de n�gligence ou d�une autre faute dans la limite autoris�e par la loi en vigueur.
+
+ 
+
+Elle s�applique �galement, m�me si Microsoft connaissait ou devrait conna�tre l��ventualit� d�un tel dommage. Si votre pays n�autorise pas l�exclusion ou la limitation de responsabilit� pour les dommages indirects, accessoires ou de quelque nature que ce soit, il se peut que la limitation ou l�exclusion ci-dessus ne s�appliquera pas � votre �gard.
+
+ 
+
+EFFET JURIDIQUE. Le pr�sent contrat d�crit certains droits juridiques. Vous pourriez avoir d�autres droits pr�vus par les lois de votre pays. Le pr�sent contrat ne modifie pas les droits que vous conf�rent les lois de votre pays si celles-ci ne le permettent pas.
+
+ 
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            Microsoft.VisualStudio.Services.InteractiveClient 16.170.0
+        </summary>
+        
+        <ul>
+<li>(c) Microsoft Corporation.</li></ul>
+        <pre>
+        MICROSOFT SOFTWARE LICENSE TERMS
+
+MICROSOFT .NET LIBRARY
+
+These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. They apply to the software named above. The terms also apply to any Microsoft services or updates for the software, except to the extent those have different terms.
+
+IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
+
+1.    INSTALLATION AND USE RIGHTS.
+You may install and use any number of copies of the software to design, develop and test you�re applications.  You may modify, copy, distribute or deploy any .js files contained in the software as part of your applications.
+
+2.    THIRD PARTY COMPONENTS. The software may include third party components with separate legal notices or governed by other agreements, as may be described in the ThirdPartyNotices file(s) accompanying the software.
+3.    ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.
+a.     DISTRIBUTABLE CODE.  In addition to the .js files described above, the software is comprised of Distributable Code. �Distributable Code� is code that you are permitted to distribute in programs you develop if you comply with the terms below.
+i.      Right to Use and Distribute.
+�        You may copy and distribute the object code form of the software.
+
+�        Third Party Distribution. You may permit distributors of your programs to copy and distribute the Distributable Code as part of those programs.
+
+ii.     Distribution Requirements. For any Distributable Code you distribute, you must
+�        use the Distributable Code in your programs and not as a standalone distribution;
+
+�        require distributors and external end users to agree to terms that protect it at least as much as this agreement;
+
+�        display your valid copyright notice on your programs; and
+
+�        indemnify, defend, and hold harmless Microsoft from any claims, including attorneys� fees, related to the distribution or use of your applications, except to the extent that any claim is based solely on the Distributable Code.
+
+iii.   Distribution Restrictions. You may not
+�        alter any copyright, trademark or patent notice in the Distributable Code;
+
+�        use Microsoft�s trademarks in your programs� names or in a way that suggests your programs come from or are endorsed by Microsoft;
+
+�        include Distributable Code in malicious, deceptive or unlawful programs; or
+
+�        modify or distribute the source code of any Distributable Code so that any part of it becomes subject to an Excluded License. An Excluded License is one that requires, as a condition of use, modification or distribution, that
+
+�        the code be disclosed or distributed in source code form; or
+
+�        others have the right to modify it.
+
+4.    DATA.
+a.     Data Collection. The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to provide services and improve our products and services.  You may opt-out of many of these scenarios, but not all, as described in the product documentation.  There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft�s privacy statement. Our privacy statement is located at https://go.microsoft.com/fwlink/?LinkID=824704. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+b.    Processing of Personal Data. To the extent Microsoft is a processor or subprocessor of personal data in connection with the software, Microsoft makes the commitments in the European Union General Data Protection Regulation Terms of the Online Services Terms to all customers effective May 25, 2018, at http://go.microsoft.com/?linkid=9840733.
+5.    SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
+�        work around any technical limitations in the software;
+
+�        reverse engineer, decompile or disassemble the software, or otherwise attempt to derive the source code for the software, except and to the extent required by third party licensing terms governing use of certain open source components that may be included in the software;
+
+�        remove, minimize, block or modify any notices of Microsoft or its suppliers in the software;
+
+�        use the software in any way that is against the law; or
+
+�        share, publish, rent or lease the software, provide the software as a stand-alone offering for others to use, or transfer the software or this agreement to any third party.
+
+6.    EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the software, which include restrictions on destinations, end users, and end use. For further information on export restrictions, visit www.microsoft.com/exporting.  
+7.    SUPPORT SERVICES. Because this software is �as is,� we may not provide support services for it.
+8.    ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
+9.    APPLICABLE LAW.  If you acquired the software in the United States, Washington law applies to interpretation of and claims for breach of this agreement, and the laws of the state where you live apply to all other claims. If you acquired the software in any other country, its laws apply.
+10. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including consumer rights, under the laws of your state or country. Separate and apart from your relationship with Microsoft, you may also have rights with respect to the party from which you acquired the software. This agreement does not change those other rights if the laws of your state or country do not permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory country law applies, then the following provisions apply to you:
+a)    Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to affect those rights.
+b)    Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to turn off updates for your specific device or software.
+c)    Germany and Austria.
+(i)        Warranty. The software will perform substantially as described in any Microsoft materials that accompany it. However, Microsoft gives no contractual guarantee in relation to the software.
+
+(ii)       Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as well as in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
+
+Subject to the foregoing clause (ii), Microsoft will only be liable for slight negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called &quot;cardinal obligations&quot;). In other cases of slight negligence, Microsoft will not be liable for slight negligence
+11. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED �AS-IS.� YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+12. LIMITATION ON AND EXCLUSION OF REMEDIES AND DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
+This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet sites, or third party applications; and (b) claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
+
+It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your state or country may not allow the exclusion or limitation of incidental, consequential or other damages.
+
+Please note: As this software is distributed in Quebec, Canada, some of the clauses in this agreement are provided below in French.
+
+ 
+
+Remarque : Ce logiciel �tant distribu� au Qu�bec, Canada, certaines des clauses dans ce contrat sont fournies ci-dessous en fran�ais.
+
+ 
+
+EXON�RATION DE GARANTIE. Le logiciel vis� par une licence est offert � tel quel �. Toute utilisation de ce logiciel est � votre seule risque et p�ril. Microsoft n�accorde aucune autre garantie expresse. Vous pouvez b�n�ficier de droits additionnels en vertu du droit local sur la protection des consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par le droit locale, les garanties implicites de qualit� marchande, d�ad�quation � un usage particulier et d�absence de contrefa�on sont exclues.
+
+ 
+
+LIMITATION DES DOMMAGES-INT�R�TS ET EXCLUSION DE RESPONSABILIT� POUR LES DOMMAGES. Vous pouvez obtenir de Microsoft et de ses fournisseurs une indemnisation en cas de dommages directs uniquement � hauteur de 5,00 $ US. Vous ne pouvez pr�tendre � aucune indemnisation pour les autres dommages, y compris les dommages sp�ciaux, indirects ou accessoires et pertes de b�n�fices.
+
+ 
+
+Cette limitation concerne:
+
+�     tout ce qui est reli� au logiciel, aux services ou au contenu (y compris le code) figurant sur des sites Internet tiers ou dans des programmes tiers ; et
+
+�     les r�clamations au titre de violation de contrat ou de garantie, ou au titre de responsabilit� stricte, de n�gligence ou d�une autre faute dans la limite autoris�e par la loi en vigueur.
+
+ 
+
+Elle s�applique �galement, m�me si Microsoft connaissait ou devrait conna�tre l��ventualit� d�un tel dommage. Si votre pays n�autorise pas l�exclusion ou la limitation de responsabilit� pour les dommages indirects, accessoires ou de quelque nature que ce soit, il se peut que la limitation ou l�exclusion ci-dessus ne s�appliquera pas � votre �gard.
+
+ 
+
+EFFET JURIDIQUE. Le pr�sent contrat d�crit certains droits juridiques. Vous pourriez avoir d�autres droits pr�vus par les lois de votre pays. Le pr�sent contrat ne modifie pas les droits que vous conf�rent les lois de votre pays si celles-ci ne le permettent pas.
+
+ 
+        </pre>
+    </details>
+</li>
+        </ol>
+    </body>
+</html>


### PR DESCRIPTION
#### Details

The API that we use to generate the `thirdpartynotices.html` has recently developed problems that may or may not be fixed in the near future. The recommendation from the team who owns the API is to commit the file into the repo and maintain it manually. This is far from ideal, but our options are pretty limited. In order to get the best balance, we do the following:

1. The manually curated version of `thirdpartynotices.html` is from the last build that successfully called the API
2. Local builds continue to use the placeholder file
3. The signed build copies the manually curated version over the placeholder version before calling the API
4. If the API succeeds, we get the newly generated file. If it fails, we get the manually curated file
5. Errors from the API are surfaced in the build logs

Dependabot changes will need to update the manually curated file
When the API is reliably fixed, we delete the manually curated file and revert the changes in `signedbuild.yml`

Validation build is at https://dev.azure.com/mseng/1ES/_build/results?buildId=19301482&view=results. The API failed, but the `thirdpartynotices.html` file in the artifacts and in the MSI are both correct.

##### Motivation

Unblock our build pipeline

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue:
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



