### PR TITLE
Make channel descriptions more accurate

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -884,7 +884,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Updated every few days, the Canary channel releases the latest builds. It has not been tested or used..
+        ///   Looks up a localized string similar to The Canary channel releases the latest builds, allowing users to try out new features under development. While these builds have passed limited testing, they may not be fully stable and should be considered alpha quality..
         /// </summary>
         public static string ChannelConfigControl_CanaryDescription {
             get {
@@ -893,7 +893,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Updated every 1 - 2 weeks, the Insiders channel allows users to try out new features under development. While this channel releases builds that have been tested, there may be some bugs and performance issues..
+        ///   Looks up a localized string similar to While usually identical to the production channel, the insider channel is used as a staging environment for upcoming production releases and should be considered beta quality..
         /// </summary>
         public static string ChannelConfigControl_InsiderDescription {
             get {
@@ -902,7 +902,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Updated every month, the Production channel releases stable builds that have been tested and verified by the Accessibility Insights team..
+        ///   Looks up a localized string similar to The Production channel releases stable builds that have been tested and verified by the Accessibility Insights team..
         /// </summary>
         public static string ChannelConfigControl_ProductionDescription {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -893,7 +893,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to While usually identical to the production channel, the insider channel is used as a staging environment for upcoming production releases..
+        ///   Looks up a localized string similar to The insider channel is used as a validation environment for upcoming production releases. While insider builds may not be fully stable, they can be considered near production quality..
         /// </summary>
         public static string ChannelConfigControl_InsiderDescription {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -884,7 +884,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Canary channel releases the latest builds, allowing users to try out new features under development. While these builds have passed limited testing, they may not be fully stable and should be considered alpha quality..
+        ///   Looks up a localized string similar to The Canary channel releases the latest builds, allowing users to try out new features under development. While these builds have passed limited testing, they may not be fully stable..
         /// </summary>
         public static string ChannelConfigControl_CanaryDescription {
             get {
@@ -893,7 +893,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to While usually identical to the production channel, the insider channel is used as a staging environment for upcoming production releases and should be considered beta quality..
+        ///   Looks up a localized string similar to While usually identical to the production channel, the insider channel is used as a staging environment for upcoming production releases..
         /// </summary>
         public static string ChannelConfigControl_InsiderDescription {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -893,7 +893,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The insider channel is used as a validation environment for upcoming production releases. While insider builds may not be fully stable, they can be considered near production quality..
+        ///   Looks up a localized string similar to The insider channel is used as a validation environment for upcoming production releases..
         /// </summary>
         public static string ChannelConfigControl_InsiderDescription {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -884,7 +884,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Canary channel releases the latest builds, allowing users to try out new features under development. While these builds have passed limited testing, they may not be fully stable..
+        ///   Looks up a localized string similar to The Canary channel releases frequently from the mainline development branch, allowing users to try out new features under development. While these builds have passed limited testing, they may not be fully stable..
         /// </summary>
         public static string ChannelConfigControl_CanaryDescription {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -884,7 +884,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Canary channel releases frequently from the mainline development branch, allowing users to try out new features under development. While these builds have passed limited testing, they may not be fully stable..
+        ///   Looks up a localized string similar to The Canary channel releases frequently from the mainline development branch. While these builds have passed limited testing, they may not be fully stable..
         /// </summary>
         public static string ChannelConfigControl_CanaryDescription {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1311,7 +1311,7 @@ We collect anonymized data to identify the top accessibility issues found by use
     <value>The insider channel is used as a validation environment for upcoming production releases. While insider builds may not be fully stable, they can be considered near production quality.</value>
   </data>
   <data name="ChannelConfigControl_CanaryDescription" xml:space="preserve">
-    <value>The Canary channel releases frequently from the mainline development branch, allowing users to try out new features under development. While these builds have passed limited testing, they may not be fully stable.</value>
+    <value>The Canary channel releases frequently from the mainline development branch. While these builds have passed limited testing, they may not be fully stable.</value>
   </data>
   <data name="RunTextHelpCommunity3" xml:space="preserve">
     <value>develop inclusive software.

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1311,7 +1311,7 @@ We collect anonymized data to identify the top accessibility issues found by use
     <value>The insider channel is used as a validation environment for upcoming production releases. While insider builds may not be fully stable, they can be considered near production quality.</value>
   </data>
   <data name="ChannelConfigControl_CanaryDescription" xml:space="preserve">
-    <value>The Canary channel releases the latest builds, allowing users to try out new features under development. While these builds have passed limited testing, they may not be fully stable.</value>
+    <value>The Canary channel releases frequently from the mainline development branch, allowing users to try out new features under development. While these builds have passed limited testing, they may not be fully stable.</value>
   </data>
   <data name="RunTextHelpCommunity3" xml:space="preserve">
     <value>develop inclusive software.

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1308,7 +1308,7 @@ We collect anonymized data to identify the top accessibility issues found by use
     <value>The Production channel releases stable builds that have been tested and verified by the Accessibility Insights team.</value>
   </data>
   <data name="ChannelConfigControl_InsiderDescription" xml:space="preserve">
-    <value>While usually identical to the production channel, the insider channel is used as a staging environment for upcoming production releases.</value>
+    <value>The insider channel is used as a validation environment for upcoming production releases. While insider builds may not be fully stable, they can be considered near production quality.</value>
   </data>
   <data name="ChannelConfigControl_CanaryDescription" xml:space="preserve">
     <value>The Canary channel releases the latest builds, allowing users to try out new features under development. While these builds have passed limited testing, they may not be fully stable.</value>

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1308,10 +1308,10 @@ We collect anonymized data to identify the top accessibility issues found by use
     <value>The Production channel releases stable builds that have been tested and verified by the Accessibility Insights team.</value>
   </data>
   <data name="ChannelConfigControl_InsiderDescription" xml:space="preserve">
-    <value>While usually identical to the production channel, the insider channel is used as a staging environment for upcoming production releases and should be considered beta quality.</value>
+    <value>While usually identical to the production channel, the insider channel is used as a staging environment for upcoming production releases.</value>
   </data>
   <data name="ChannelConfigControl_CanaryDescription" xml:space="preserve">
-    <value>The Canary channel releases the latest builds, allowing users to try out new features under development. While these builds have passed limited testing, they may not be fully stable and should be considered alpha quality.</value>
+    <value>The Canary channel releases the latest builds, allowing users to try out new features under development. While these builds have passed limited testing, they may not be fully stable.</value>
   </data>
   <data name="RunTextHelpCommunity3" xml:space="preserve">
     <value>develop inclusive software.

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1305,13 +1305,13 @@ We collect anonymized data to identify the top accessibility issues found by use
     <value>Channel</value>
   </data>
   <data name="ChannelConfigControl_ProductionDescription" xml:space="preserve">
-    <value>Updated every month, the Production channel releases stable builds that have been tested and verified by the Accessibility Insights team.</value>
+    <value>The Production channel releases stable builds that have been tested and verified by the Accessibility Insights team.</value>
   </data>
   <data name="ChannelConfigControl_InsiderDescription" xml:space="preserve">
-    <value>Updated every 1 - 2 weeks, the Insiders channel allows users to try out new features under development. While this channel releases builds that have been tested, there may be some bugs and performance issues.</value>
+    <value>While usually identical to the production channel, the insider channel is used as a staging environment for upcoming production releases and should be considered beta quality.</value>
   </data>
   <data name="ChannelConfigControl_CanaryDescription" xml:space="preserve">
-    <value>Updated every few days, the Canary channel releases the latest builds. It has not been tested or used.</value>
+    <value>The Canary channel releases the latest builds, allowing users to try out new features under development. While these builds have passed limited testing, they may not be fully stable and should be considered alpha quality.</value>
   </data>
   <data name="RunTextHelpCommunity3" xml:space="preserve">
     <value>develop inclusive software.

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -1308,7 +1308,7 @@ We collect anonymized data to identify the top accessibility issues found by use
     <value>The Production channel releases stable builds that have been tested and verified by the Accessibility Insights team.</value>
   </data>
   <data name="ChannelConfigControl_InsiderDescription" xml:space="preserve">
-    <value>The insider channel is used as a validation environment for upcoming production releases. While insider builds may not be fully stable, they can be considered near production quality.</value>
+    <value>The insider channel is used as a validation environment for upcoming production releases.</value>
   </data>
   <data name="ChannelConfigControl_CanaryDescription" xml:space="preserve">
     <value>The Canary channel releases frequently from the mainline development branch. While these builds have passed limited testing, they may not be fully stable.</value>


### PR DESCRIPTION
This commit updates the production, insider, and canary channel descriptions to reflect the reality of their current usage.

Closes #1548.