### PR TITLE
feat(upgrader-security): Improve manifest handling

### DIFF
--- a/src/Manifest/Manifest.csproj
+++ b/src/Manifest/Manifest.csproj
@@ -16,8 +16,12 @@
     <EmbeddedResource Include="$(MSBuildProjectDirectory)\..\bld\ReleaseInfo.json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Octokit" Version="5.0.0" />
+  </ItemGroup>
+
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\create-json-for-manifest.ps1 -Verbose -MsiBasePath $(SolutionDir)MSI\bin\Release\msi -MinimumProductionVersion $(MinimumProdVersion) -OutputPath $(MSBuildProjectDirectory)\..\bld -OutputFile ReleaseInfo.json" />
+    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\create-json-for-manifest.ps1 -Verbose -MsiBasePath $(SolutionDir)MSI\bin\Release\msi -IsMandatoryProdUpdate $(IsMandatoryProdUpdate) -OutputPath $(MSBuildProjectDirectory)\..\bld -OutputFile ReleaseInfo.json" />
   </Target>
 
 </Project>

--- a/src/Manifest/Manifest.csproj
+++ b/src/Manifest/Manifest.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- NOTE: If you update this version, please also update the version in tools\scripts\create-json-for-manifest.ps1 -->
     <PackageReference Include="Octokit" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Manifest/Manifest.csproj
+++ b/src/Manifest/Manifest.csproj
@@ -13,7 +13,7 @@
   <Import Project="..\..\build\NetFrameworkRelease.targets" />
 
   <ItemGroup>
-    <EmbeddedResource Include="$(MSBuildProjectDirectory)\..\bld\ReleaseInfo.json" />
+    <EmbeddedResource Include="$(TargetDir)ReleaseInfo.json" LogicalName="AccessibilityInsights.Manifest.ReleaseInfo.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,7 +21,11 @@
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\create-json-for-manifest.ps1 -Verbose -MsiBasePath $(SolutionDir)MSI\bin\Release\msi -IsMandatoryProdUpdate $(IsMandatoryProdUpdate) -OutputPath $(MSBuildProjectDirectory)\..\bld -OutputFile ReleaseInfo.json" />
+    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\create-json-for-manifest.ps1 -Verbose -MsiBasePath $(SolutionDir)MSI\bin\Release\msi -IsMandatoryProdUpdate $(IsMandatoryProdUpdate) -OutputPath $(TargetDir) -OutputFile ReleaseInfo.json" />
+  </Target>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="del $(TargetDir)Octokit.dll" />
   </Target>
 
 </Project>

--- a/src/ManifestTests/IntegrationTests.cs
+++ b/src/ManifestTests/IntegrationTests.cs
@@ -5,14 +5,16 @@ using AccessibilityInsights.SetupLibrary;
 using AccessibilityInsights.VersionSwitcher;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace ManifestTests
 {
     [TestClass]
     public class IntegrationTests
     {
-        private static readonly string RawManifestFilePath = Path.GetFullPath(Path.Combine(@"..\..\..\..", @"bld\ReleaseInfo.json"));
+        private static readonly string RawManifestFilePath = Path.GetFullPath(Path.Combine(@"..\..\..\..", @"Manifest\bin\Release\net48\ReleaseInfo.json"));
         private static readonly string SignedManifestFilePath = Path.GetFullPath(Path.Combine(@"..\..\..\..", @"Manifest\bin\Release\net48\AccessibilityInsights.Manifest.dll"));
         private static readonly string MsiFilePath = Path.GetFullPath(Path.Combine(@"..\..\..\..", @"MSI\bin\Release\AccessibilityInsights.msi"));
         private static readonly ChannelInfo rawInfo = FileHelpers.LoadDataFromJSON<ChannelInfo>(RawManifestFilePath);
@@ -76,6 +78,25 @@ namespace ManifestTests
                 Assert.AreEqual(rawInfo.ProductionMinimumVersion, signedInfo.ProductionMinimumVersion);
                 Assert.AreEqual(rawInfo.MinimumVersion, signedInfo.MinimumVersion);
             }
+        }
+
+        [TestMethod]
+        public void ArtifactContentsAreCorrect()
+        {
+            string folder = Path.GetDirectoryName(Path.GetFullPath(SignedManifestFilePath));
+            HashSet<string> expectedFiles = new HashSet<string>(new string[] 
+            {
+                Path.Combine(folder, "AccessibilityInsights.Manifest.dll"), 
+                Path.Combine(folder, "ReleaseInfo.json"),
+            });
+
+            foreach (string file in Directory.EnumerateFiles(folder, "*.*", SearchOption.AllDirectories))
+            {
+                Assert.IsTrue(expectedFiles.Contains(file), $"Did not expect '{file}' in output folder");
+                expectedFiles.Remove(file);
+            }
+
+            Assert.AreEqual(0, expectedFiles.Count, $"Missing files: {string.Join(", ", expectedFiles)}");
         }
     }
 }

--- a/src/props/prod-version.props
+++ b/src/props/prod-version.props
@@ -1,7 +1,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <!-- If this is a required update, set this to the same version as what we're building.
-	     If this is an optional update, set this to the most recently released prod version. -->
-    <MinimumProdVersion Condition="$(MinimumProdVersion) == ''">1.1.2089.01</MinimumProdVersion>
+    <!-- If this is a mandatory update for the Production ReleaseChannel, set this to true, otherwise leave it as false.
+         This should only be set to true for things like a security update, and should be reset to false immediately
+         after that version has released to Production-->
+    <IsMandatoryProdUpdate Condition="$(IsMandatoryProdUpdate) == ''">false</IsMandatoryProdUpdate>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### Details

This improves upgrade manifest _handling_ (content and structure are unmodified) in 2 ways:
1. Rather than needing to manually edit the value of `MinimumProdVersion` in [version.props](https://github.com/microsoft/accessibility-insights-windows/blob/main/src/props/prod-version.props) after each production release, we now populate the manifest's `production_minimum_version` field automatically based on the value of `IsMandatoryProdUpdate`, which will only need to changed if a mandatory upgrade released (which has happened **exactly once since 2019**):
    - If `IsMandatoryProdUpdate` is `false` (the usual state), then `production_minimum_version` is the same as the latest non-prerelease release from GitHub. This allows production clients to remain 1 version behind the latest release when this is released to production, consistent with our existing policy.
    - If `IsMandatoryProdUpdate` is `true`, then `production_minimum_version` is the same as `current_version`. This forces all production clients running earlier versions to upgrade when this is released to production.
2. We will now include the unsigned manifest in the `Manifest` build artifact. The objective is to replace human-provided data (specified when creating the Production release) with data from the `Manifest` build artifact. This reduces the risk of human error at release creation time.

##### Motivation

Streamline the release process

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
This creates a new potential failure point, since the release build will fail if the GitHub API is down. Most local builds are debug (which does _not_ build the manifest), so the risk here is very low. The build pipeline might break, but if the GitHub API is down, it will probably break much earlier in the process. Altogether, the risk seems acceptably low. If we encounter too many build breaks with this new dependency, we can consider options to provide a workaround, possibly as a pipeline variable. YAGNI until proven otherwise.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



