### PR TITLE
feat(upgrader-security): Deprecate unsigned manifests

### DIFF
--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/AutoUpdate.cs
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdate/AutoUpdate.cs
@@ -12,17 +12,15 @@ namespace AccessibilityInsights.Extensions.GitHubAutoUpdate
 {
     /// <summary>
     /// GitHub-based implementation of IAutoUpdate. Basic strategy is as follows:
-    /// 1) Fetch a JSON file from a specified web location (typically in the GitHub repo)
-    /// 2) Extract the version information from the JSON file, then compare that to the
+    /// 1) Fetch a signed DLL from a specified web location (typically Azure blobs)
+    /// 2) Validate that the DLL has not been tampered
+    /// 3) Extract a JSON file that is an embedded resource within the DLL
+    /// 3) Extract the version information from the JSON file, then compare that to the
     ///    version of the currently installed app
-    /// 3) Cache the information needed to get the installer and release notes, then return
+    /// 4) Cache the information needed to get the installer and release notes, then return
     ///    the upgrade status to the caller
-    /// 4) If requested, use the cached information to download the installer, which will
+    /// 5) If requested, use the cached information to download the installer, which will
     ///    be stored locally and validate before is it launched.
-    ///
-    /// To allow multiple Release Channels, the JSON file can report back more than one
-    /// set of information (each ChannelInfo object holds the data for one channel). The
-    /// code defaults to the "default" channel, but this can be overridden by the caller.
     ///
     /// A note about timing: Due to the way that extensions get loaded, our constructor may get
     /// called some time before the app requests the upgrade status. Since we need to make

--- a/src/AccessibilityInsights.SetupLibrary/VersionSwitcherWrapper.cs
+++ b/src/AccessibilityInsights.SetupLibrary/VersionSwitcherWrapper.cs
@@ -18,8 +18,8 @@ namespace AccessibilityInsights.SetupLibrary
         /// Installs a more recent version in response to an upgrade (retain the same channel)
         /// </summary>
         /// <param name="installerUri">The URI to the web-hosted installer</param>
-        /// <param name="msiSizeInBytes">The byte count of the MSI on disk, or 0 if unknown</param>
-        /// <param name="msiSha512">The SHA512 of the MSI on disk, or null if unknown</param>
+        /// <param name="msiSizeInBytes">The byte count of the MSI on disk</param>
+        /// <param name="msiSha512">The SHA512 of the MSI on disk</param>
         public static void InstallUpgrade(Uri installerUri, int msiSizeInBytes, string msiSha512)
         {
             DownloadAndInstall(installerUri, null, msiSizeInBytes, msiSha512);
@@ -48,8 +48,8 @@ namespace AccessibilityInsights.SetupLibrary
         /// </summary>
         /// <param name="installerUrl">The URL to the web-hosted installer</param>
         /// <param name="newChannel">If not null, the new channel to select</param>
-        /// <param name="msiSizeInBytes">The byte count of the MSI on disk, or 0 if unknown</param>
-        /// <param name="msiSha512">The SHA512 of the MSI on disk, or null if unknown</param>
+        /// <param name="msiSizeInBytes">The byte count of the MSI on disk</param>
+        /// <param name="msiSha512">The SHA512 of the MSI on disk</param>
         private static void DownloadAndInstall(Uri installerUri, ReleaseChannel? newChannel, int msiSizeInBytes, string msiSha512)
         {
             List<FileStream> fileLocks = new List<FileStream>();
@@ -164,14 +164,14 @@ namespace AccessibilityInsights.SetupLibrary
         /// </summary>
         /// <param name="installerUri">The URI to the web-hosted installer</param>
         /// <param name="newChannel">If not null, the new channel to select</param>
-        /// <param name="msiSizeInBytes">The byte count of the MSI on disk, or 0 if unknown</param>
-        /// <param name="msiSha512">The SHA512 of the MSI on disk, or null if unknown</param>
+        /// <param name="msiSizeInBytes">The byte count of the MSI on disk</param>
+        /// <param name="msiSha512">The SHA512 of the MSI on disk</param>
         private static string GetVersionSwitcherArguments(Uri installerUri, ReleaseChannel? newChannel, int msiSizeInBytes, string msiSha512)
         {
             return string.Format(CultureInfo.InvariantCulture, "{0} {1} {2} {3}",
                 installerUri.ToString(),
                 msiSizeInBytes,
-                string.IsNullOrWhiteSpace(msiSha512) ? "none" : msiSha512,
+                msiSha512,
                 newChannel.HasValue ? newChannel.Value.ToString() : string.Empty
                 );
         }

--- a/src/AccessibilityInsights.SetupLibraryUnitTests/ChannelInfoUtilitiesUnitTests.cs
+++ b/src/AccessibilityInsights.SetupLibraryUnitTests/ChannelInfoUtilitiesUnitTests.cs
@@ -11,41 +11,6 @@ namespace AccessibilityInsights.SetupLibraryUnitTests
     [TestClass]
     public class ChannelInfoUtilitiesUnitTests
     {
-        private static readonly Version Version1000 = new Version(1, 1, 1000);
-        private static readonly Version Version1234 = new Version(1, 1, 1234);
-        private static readonly Version Version1300 = new Version(1, 1, 1300);
-        private static readonly Version Version1330 = new Version(1, 1, 1330);
-        private const string TestCaseContents =
-@"{
-  ""default"": {
-    ""current_version"": ""1.1.1234"",
-    ""minimum_version"": ""1.1.1000"",
-    ""installer_url"": ""https://somehost.com/somepath/1.1.1234/installer.msi"",
-    ""release_notes_url"": ""https://somehost.com/somepath/1.1.1234/releasenotes.html""
-  },
-  ""Insider"": {
-    ""current_version"": ""1.1.1330"",
-    ""minimum_version"": ""1.1.1300"",
-    ""installer_url"": ""https://somehost.com/somepath/1.1.1330/installer.msi"",
-    ""release_notes_url"": ""https://somehost.com/somepath/1.1.1330/releasenotes.html""
-    },
-  ""invalid"": {
-    ""minimum_version"": ""1.1.1300"",
-    ""installer_url"": ""https://somehost.com/somepath/1.1.1330/installer.msi"",
-    ""release_notes_url"": ""https://somehost.com/somepath/1.1.1330/releasenotes.html""
-    }
-}";
-
-        private string ExpectedInstaller(Version version)
-        {
-            return "https://somehost.com/somepath/" + version.ToString() + "/installer.msi";
-        }
-
-        private string ExpectedReleaseNotes(Version version)
-        {
-            return "https://somehost.com/somepath/" + version.ToString() + "/releasenotes.html";
-        }
-
         private static Stream PopulateStream(string contents)
         {
             Stream stream = new MemoryStream();
@@ -64,82 +29,13 @@ namespace AccessibilityInsights.SetupLibraryUnitTests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(NullReferenceException))]
+        [ExpectedException(typeof(InvalidDataException))]
         [Timeout(2000)]
-        public void GetChannelFromStream_StreamIsEmpty_ThrowsNullReferenceException()
+        public void GetChannelFromStream_StreamIsEmpty_ThrowsInvalidDataException()
         {
             using (Stream stream = PopulateStream(string.Empty))
             {
                 ChannelInfoUtilities.GetChannelFromStream(stream);
-            }
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(InvalidDataException))]
-        [Timeout(2000)]
-        public void GetChannelFromStream_StreamDoesNotContainChannel_ThrowsInvalidDataException()
-        {
-            using (Stream stream = PopulateStream(TestCaseContents))
-            {
-                ChannelInfoUtilities.GetChannelFromStream(stream, "key does not exist");
-            }
-        }
-
-        [TestMethod]
-        [Timeout(2000)]
-        public void GetChannelFromStream_DefaultChannel_ReturnsCorrectData()
-        {
-            using (Stream stream = PopulateStream(TestCaseContents))
-            {
-                ChannelInfo channelInfo = ChannelInfoUtilities.GetChannelFromStream(stream);
-
-                Assert.IsNotNull(channelInfo);
-                Assert.IsTrue(channelInfo.IsValid);
-                Assert.AreEqual(Version1234, channelInfo.CurrentVersion);
-                Assert.AreEqual(Version1000, channelInfo.MinimumVersion);
-                Assert.AreEqual(ExpectedInstaller(Version1234), channelInfo.InstallAsset);
-                Assert.AreEqual(ExpectedReleaseNotes(Version1234), channelInfo.ReleaseNotesAsset);
-            }
-        }
-
-        [TestMethod]
-        [Timeout(2000)]
-        public void GetChannelFromStream_InsiderChannel_ReturnsCorrectData()
-        {
-            using (Stream stream = PopulateStream(TestCaseContents))
-            {
-                ChannelInfo channelInfo = ChannelInfoUtilities.GetChannelFromStream(stream, "Insider");
-
-                Assert.IsNotNull(channelInfo);
-                Assert.IsTrue(channelInfo.IsValid);
-                Assert.AreEqual(Version1330, channelInfo.CurrentVersion);
-                Assert.AreEqual(Version1300, channelInfo.MinimumVersion);
-                Assert.AreEqual(ExpectedInstaller(Version1330), channelInfo.InstallAsset);
-                Assert.AreEqual(ExpectedReleaseNotes(Version1330), channelInfo.ReleaseNotesAsset);
-            }
-        }
-
-        [TestMethod]
-        [Timeout(2000)]
-        public void GetChannelFromStream_StreamIsValid_StreamIsNotClosed()
-        {
-            using (Stream stream = PopulateStream(TestCaseContents))
-            {
-                long originalLength = stream.Length;
-                ChannelInfoUtilities.GetChannelFromStream(stream);
-                Assert.AreEqual(originalLength, stream.Length);
-                Assert.AreNotEqual(0, originalLength);
-            }
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(InvalidDataException))]
-        [Timeout(2000)]
-        public void GetChannelFromStream_StreamIsInvalid_ThrowsInvalidDataException()
-        {
-            using (Stream stream = PopulateStream(TestCaseContents))
-            {
-                ChannelInfoUtilities.GetChannelFromStream(stream, "invalid");
             }
         }
     }

--- a/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
@@ -104,7 +104,7 @@ namespace AccessibilityInsights.VersionSwitcher
                     {
                         _history.AddLocalDetail("Option: New channel = {0}", newChannel);
                     }
-                    return new InstallationOptions(msiPath, msiSizeInBytes, (msiSha512 == "none") ? null : msiSha512, newChannel, enableUIAccess);
+                    return new InstallationOptions(msiPath, msiSizeInBytes, msiSha512, newChannel, enableUIAccess);
                 });
         }
 
@@ -218,12 +218,12 @@ namespace AccessibilityInsights.VersionSwitcher
             _history.ActualMsiSizeInBytes = (int)new FileInfo(filePath).Length;
             _history.ActualMsiSha512 = ComputeSha512(filePath);
 
-            if (expectedFileSize != 0 && expectedFileSize != _history.ActualMsiSizeInBytes)
+            if (expectedFileSize != _history.ActualMsiSizeInBytes)
             {
                 throw new ResultBearingException(ExecutionResult.ErrorMsiSizeMismatch, Properties.Resources.InstallerFileIsWrongSize);
             }
 
-            if (expectedFileSha512 != null && !expectedFileSha512.Equals(_history.ActualMsiSha512, StringComparison.OrdinalIgnoreCase))
+            if (!expectedFileSha512.Equals(_history.ActualMsiSha512, StringComparison.OrdinalIgnoreCase))
             {
                 throw new ResultBearingException(ExecutionResult.ErrorMsiSha512Mismatch, Properties.Resources.InstallerFileHasWrongHash);
             }

--- a/src/AccessibilityInsights.VersionSwitcher/InstallationOptions.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/InstallationOptions.cs
@@ -50,8 +50,8 @@ namespace AccessibilityInsights.VersionSwitcher
         /// constructor
         /// </summary>
         /// <param name="msiPath">The uri to the web-hosted installer</param>
-        /// <param name="msiSizeInBytes">The byte count of the MSI on disk, or 0 if unknown</param>
-        /// <param name="msiSha512">The SHA512 of the MSI on disk, or null if unknown</param>
+        /// <param name="msiSizeInBytes">The byte count of the MSI on disk</param>
+        /// <param name="msiSha512">The SHA512 of the MSI on disk</param>
         /// <param name="newChannel">String indicating the value for NewChannel</param>
         /// <param name="enableUIAccess">True only if we need to enable UIAccess post-install"</param>
         internal InstallationOptions(Uri msiPath, int msiSizeInBytes, string msiSha512, string newChannel, bool enableUIAccess)

--- a/src/AccessibilityInsights.VersionSwitcherUnitTests/InstallationEngineUnitTests.cs
+++ b/src/AccessibilityInsights.VersionSwitcherUnitTests/InstallationEngineUnitTests.cs
@@ -103,20 +103,6 @@ namespace AccessibilityInsights.VersionSwitcherUnitTests
         }
 
         [TestMethod]
-        public void GetInstallationOptions_ShaIsNone_OptionsAreCorrect()
-        {
-            _commandLineArgs = new string[] { CommandIgnored, CommandMsiPath, CommandMsiSize, "none" };
-            var options = _engine.GetInstallationOptions();
-
-            Assert.AreEqual(CommandMsiPath, options.MsiPath.ToString());
-            Assert.AreEqual(TestFileSize, options.MsiSizeInBytes);
-            Assert.IsNull(options.MsiSha512);
-            Assert.IsNull(options.NewChannel);
-
-            Assert.AreEqual(ExecutionResult.Unknown, _history.TypedExecutionResult);
-        }
-
-        [TestMethod]
         public void GetInstallationOptions_ChannelIsSet_OptionsAreCorrect()
         {
             _commandLineArgs = new string[] { CommandIgnored, CommandMsiPath, CommandMsiSize, TestFileSha512, CommandNewChannel };
@@ -176,34 +162,10 @@ namespace AccessibilityInsights.VersionSwitcherUnitTests
         }
 
         [TestMethod]
-        public void ValidateFileProperties_SizeIsOmitted_ShaIsOmitted_Passes()
-        {
-            _engine.ValidateFileProperties(TestFile, 0, null);
-            Assert.AreEqual(ExecutionResult.Unknown, _history.TypedExecutionResult);
-            AssertCorrectTelemetryValuesForValidateFileProperties();
-        }
-
-        [TestMethod]
-        public void ValidateFileProperties_SizeIsOmitted_ShaIsCorrect_Passes()
-        {
-            _engine.ValidateFileProperties(TestFile, 0, TestFileSha512);
-            Assert.AreEqual(ExecutionResult.Unknown, _history.TypedExecutionResult);
-            AssertCorrectTelemetryValuesForValidateFileProperties();
-        }
-
-        [TestMethod]
         public void ValidateFileProperties_SizeIsOmitted_ShaIsBad_ThrowsResultBearingException()
         {
             ResultBearingException e = Assert.ThrowsException<ResultBearingException>(() => _engine.ValidateFileProperties(TestFile, TestFileSize, BadTestFileSha512));
             Assert.AreEqual(ExecutionResult.ErrorMsiSha512Mismatch, e.Result);
-            AssertCorrectTelemetryValuesForValidateFileProperties();
-        }
-
-        [TestMethod]
-        public void ValidateFileProperties_SizeIsCorrect_ShaIsOmitted_Passes()
-        {
-            _engine.ValidateFileProperties(TestFile, TestFileSize, null);
-            Assert.AreEqual(ExecutionResult.Unknown, _history.TypedExecutionResult);
             AssertCorrectTelemetryValuesForValidateFileProperties();
         }
 


### PR DESCRIPTION
#### Details

Now that all channels are using signed manifests, we can deprecate client support for unsigned manifests. This PR removes the code and tests that supported unsigned manifests. It also adds a test to be sure that we can always read the sign Canary manifest. Strictly speaking, this test is an integration test instead of a unit test, but the unit test class is so small that it seemed reasonable to put both types of tests into the same class.

##### Motivation

Complete upgrader security migration.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 
