### PR TITLE
chore: Run unit tests before Roslyn Analyzers

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -127,6 +127,18 @@ jobs:
     inputs:
       ArtifactName: 'Compliance'
 
+  - task: VSTest@2
+    displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
+    inputs:
+      testAssemblyVer2: |
+        **\*test*.dll
+        !**\obj\**
+      testFiltercriteria: 'TestCategory!=RequiresNetwork'
+      codeCoverageEnabled: false
+      platform: '$(BuildPlatform)'
+      configuration: debug
+      rerunFailedTests: true
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-autoapplicability.AutoApplicability@1
     displayName: 'Run AutoApplicability'
 
@@ -190,18 +202,6 @@ jobs:
       uploadModernCop: false
       uploadPREfast: false
       uploadTSLint: false
-
-  - task: VSTest@2
-    displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
-    inputs:
-      testAssemblyVer2: |
-        **\*test*.dll
-        !**\obj\**
-      testFiltercriteria: 'TestCategory!=RequiresNetwork'
-      codeCoverageEnabled: false
-      platform: '$(BuildPlatform)'
-      configuration: debug
-      rerunFailedTests: true
 
 - job: SignedRelease
   dependsOn: 


### PR DESCRIPTION
#### Details

Our current pipeline runs unit tests as the last step in the `ComplianceDebug` job. Unfortunately, running the Roslyn Analyzers task causes a rebuild of the assemblies, meaning that the assemblies being tested in the pipeline may be subtly different than the assemblies being tested locally. This PR simply shifts the unit test execution a bit sooner, so that it occurs after copying artifacts but before running the compliance tools.

Validation build: https://dev.azure.com/mseng/1ES/_build/results?buildId=19506945&view=results. The `ComplianceDebug` phase has completed, which is the point of the validation build.

##### Motivation

Make local testing and pipeline testing more consistent

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



