### PR TITLE
chore: Update compliance tools to the next generation

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -114,7 +114,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectName)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;Policheck" -OutputFile" "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectName)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;Policheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
   
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
@@ -239,7 +239,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectName)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "BinSkim" -OutputFile" "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectName)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "BinSkim" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
   
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -203,10 +203,10 @@ jobs:
       script: 'xcopy /HIS %AGENT_BUILDDIRECTORY%\.gdn %BUILD_ARTIFACTSTAGINGDIRECTORY%\.gdn'
 
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: Guardian'
+    displayName: 'Publish Artifact: Guardian (from $(Build.ArtifactStagingDirectory)\.gdn)'
     inputs:
       ArtifactName: 'Guardian'
-      PathtoPublish: '.gdn'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\.gdn'
 
   - task: CmdLine@2
     displayName: 'Show _sdt folders'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -114,7 +114,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectName)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectNameV2)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
   
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
@@ -239,7 +239,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectName)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "BinSkim" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectNameV2)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "BinSkim" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
   
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -168,26 +168,19 @@ jobs:
       RoslynAnalyzers: true
       PoliCheck: true
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
-    displayName: 'TSA upload (CredScan, RoslynAnalyzers, and PoliCheck)'
+  - task: PowerShell@2
+    displayName: 'Create tsa.config file (CredScan, Roslyn, and PoliCheck)'
+    inputs:
+      targetType: "filePath"
+      filePath: tools\scripts\verification.scripts\pipeline\build\create-tsa-config.ps1
+      arguments: '-InstanceUrl $(TSAInstanceUrl) -ProjectName $(TSAProjectName) -CodeBaseName $(TSACodeBaseName) -CodeBaseAdmins $(TSACodeBaseAdmins) -AreaPath "$(TSAV2AreaPath)" -IterationPath $(TSAV2IterationPath) -NotificationAliases $(TSANotificationAlias) -Tools CredScan;Roslyn;Policheck -OutputFile $(Build.SourcesDirectory)\tsa.config'
+  
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
+    displayName: 'TSA upload (CredScan, Roslyn, and PoliCheck)'
     condition: false
     inputs:
-      tsaVersion: TsaV2
-      codebase: NewOrUpdate
-      codeBaseName: $(TSACodeBaseName)
-      notificationAlias: $(TSANotificationAlias)
-      codeBaseAdmins: $(TSACodeBaseAdmins)
-      instanceUrlForTsaV2: $(TSAInstance)
-      projectNameMSENG: $(TSAProjectName)
-      areaPath: $(TSAAreaPath)
-      iterationPath: $(TSAIterationPath)
-      uploadAPIScan: false
-      uploadBinSkim: false
-      uploadFortifySCA: false
-      uploadFxCop: false
-      uploadModernCop: false
-      uploadPREfast: false
-      uploadTSLint: false
+      GdnPublishTsaOnboard: true
+      GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'
 
   - task: VSTest@2
     displayName: 'Test Assemblies **\debug\*test*.dll;-:**\obj\**'
@@ -315,28 +308,19 @@ jobs:
       rerunFailedTests: true
       testFiltercriteria: 'TestCategory!=NoStrongName'
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+  - task: PowerShell@2
+    displayName: 'Create tsa.config file (BinSkim)'
+    inputs:
+      targetType: "filePath"
+      filePath: tools\scripts\verification.scripts\pipeline\build\create-tsa-config.ps1
+      arguments: '-InstanceUrl $(TSAInstanceUrl) -ProjectName $(TSAProjectName) -CodeBaseName $(TSACodeBaseName) -CodeBaseAdmins $(TSACodeBaseAdmins) -AreaPath "$(TSAV2AreaPath)" -IterationPath $(TSAV2IterationPath) -NotificationAliases $(TSANotificationAlias) -Tools BinSkim -OutputFile '$(Build.SourcesDirectory)\tsa.config'
+  
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (BinSkim)'
     condition: false
     inputs:
-      tsaVersion: TsaV2
-      codebase: NewOrUpdate
-      codeBaseName: $(TSACodeBaseName)
-      notificationAlias: $(TSANotificationAlias)
-      codeBaseAdmins: $(TSACodeBaseAdmins)
-      instanceUrlForTsaV2: $(TSAInstance)
-      projectNameMSENG: $(TSAProjectName)
-      areaPath: $(TSAAreaPath)
-      iterationPath: $(TSAIterationPath)
-      uploadAPIScan: false
-      uploadCredScan: false
-      uploadFortifySCA: false
-      uploadFxCop: false
-      uploadModernCop: false
-      uploadPoliCheck: false
-      uploadPREfast: false
-      uploadRoslyn: false
-      uploadTSLint: false
+      GdnPublishTsaOnboard: true
+      GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'
 
   - task: CopyFiles@2
     displayName: 'Copy Files for Signing Validation'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -114,7 +114,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectName)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;Policheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectName)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
   
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -197,6 +197,18 @@ jobs:
     inputs:
       script: 'dir /s %AGENT_BUILDDIRECTORY%\.gdn'
 
+  - task: CopyFiles@2
+    displayName: 'Copy .gdn files to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      Contents: '$(Agent.BuildDirectory)/.gdn/**'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Guardian'
+    inputs:
+      ArtifactName: 'Guardian'
+      PathtoPublish: '.gdn'
+
   - task: CmdLine@2
     displayName: 'Show _sdt folders'
     inputs:

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -185,7 +185,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectNameV2)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
   
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (CredScan, Roslyn, and PoliCheck)'
@@ -312,7 +312,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectNameV2)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "BinSkim" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "BinSkim" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
   
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (BinSkim)'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -200,7 +200,7 @@ jobs:
   - task: CopyFiles@2
     displayName: 'Copy .gdn files to: $(Build.ArtifactStagingDirectory)'
     inputs:
-      Contents: '$(Agent.BuildDirectory)/.gdn/**'
+      Contents: '$(Agent.BuildDirectory)\.gdn\**\**'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
   - task: PublishBuildArtifacts@1

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -185,7 +185,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;.NET Analyzers;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
   
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (CredScan, Roslyn, and PoliCheck)'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -109,13 +109,6 @@ jobs:
         **\*.csproj
         !**\CustomActions.Package.csproj
 
-  - task: PowerShell@2
-    displayName: 'Create tsa.config file (CredScan, Roslyn, and PoliCheck)'
-    inputs:
-      targetType: "filePath"
-      filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectNameV2)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
-  
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
     inputs:
@@ -187,6 +180,13 @@ jobs:
       RoslynAnalyzers: true
       PoliCheck: true
 
+  - task: PowerShell@2
+    displayName: 'Create tsa.config file (CredScan, Roslyn, and PoliCheck)'
+    inputs:
+      targetType: "filePath"
+      filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectNameV2)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+  
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (CredScan, Roslyn, and PoliCheck)'
     inputs:
@@ -233,13 +233,6 @@ jobs:
         **\*.csproj
         !**\CustomActions.Package.csproj
 
-  - task: PowerShell@2
-    displayName: 'Create tsa.config file (BinSkim)'
-    inputs:
-      targetType: "filePath"
-      filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectNameV2)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "BinSkim" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
-  
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 
@@ -314,6 +307,13 @@ jobs:
       rerunFailedTests: true
       testFiltercriteria: 'TestCategory!=NoStrongName'
 
+  - task: PowerShell@2
+    displayName: 'Create tsa.config file (BinSkim)'
+    inputs:
+      targetType: "filePath"
+      filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectNameV2)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "BinSkim" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+  
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (BinSkim)'
     inputs:

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -142,7 +142,6 @@ jobs:
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
     displayName: 'Run CredScan'
     inputs:
-      toolMajorVersion: V3
       verboseOutput: true
       debugMode: false
 
@@ -186,12 +185,18 @@ jobs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
       arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;.NET Analyzers;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
-  
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (CredScan, Roslyn, and PoliCheck)'
     inputs:
       GdnPublishTsaOnboard: true
       GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'
+
+  - task: PowerShell@2
+    displayName: 'Show guardian folders and abort'
+    inputs:
+      targetType: "inline"
+      script: "dir -s $(AGENT_BUILDDIRECTORY)/.gdn;Write-Error 'Intentionally aborting';Exit 1"
 
 - job: SignedRelease
   dependsOn: 

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -170,10 +170,6 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
     displayName: 'Post Analysis (CredScan, RoslynAnalyzers, and PoliCheck)'
-    inputs:
-      CredScan: true
-      RoslynAnalyzers: true
-      PoliCheck: true
 
   - task: PowerShell@2
     displayName: 'Create tsa.config file (CredScan, Roslyn, and PoliCheck)'
@@ -290,16 +286,12 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@2
     displayName: 'Create Security Analysis Report (BinSkim)'
-    inputs:
-      BinSkim: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
     displayName: 'Publish Security Analysis Logs (BinSkim)'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
     displayName: 'Post Analysis (BinSkim)'
-    inputs:
-      BinSkim: true
 
   - task: VSTest@2
     displayName: 'Test Assemblies **\release\*test*.dll;-:**\obj\**'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -170,6 +170,7 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
     displayName: 'TSA upload (CredScan, RoslynAnalyzers, and PoliCheck)'
+    condition: false
     inputs:
       tsaVersion: TsaV2
       codebase: NewOrUpdate
@@ -316,6 +317,7 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
     displayName: 'TSA upload (BinSkim)'
+    condition: false
     inputs:
       tsaVersion: TsaV2
       codebase: NewOrUpdate

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -164,10 +164,6 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@2
     displayName: 'Create Security Analysis Report (CredScan, RoslynAnalyzers, and PoliCheck)'
-    inputs:
-      CredScan: true
-      RoslynAnalyzers: true
-      PoliCheck: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
     displayName: 'Publish Security Analysis Logs (CredScan, RoslynAnalyzers, and PoliCheck)'
@@ -193,28 +189,12 @@ jobs:
       GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'
 
   - task: CmdLine@2
-    displayName: 'Show $(Agent.BuildDirectory)\.gdn folders'
+    displayName: 'Show $(Agent.BuildDirectory)\.gdn folders (for diagnostics)'
     inputs:
       script: 'dir /s %AGENT_BUILDDIRECTORY%\.gdn'
 
-  - task: CmdLine@2
-    displayName: 'xcopy /HIS $(Agent.BuildDirectory)\.gdn $(Build.ArtifactStagingDirectory)\.gdn'
-    inputs:
-      script: 'xcopy /HIS %AGENT_BUILDDIRECTORY%\.gdn %BUILD_ARTIFACTSTAGINGDIRECTORY%\.gdn'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: Guardian (from $(Build.ArtifactStagingDirectory)\.gdn)'
-    inputs:
-      ArtifactName: 'Guardian'
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\.gdn'
-
-  - task: CmdLine@2
-    displayName: 'Show _sdt folders'
-    inputs:
-      script: 'dir /s %AGENT_BUILDDIRECTORY%\_sdt'
-
   - task: PowerShell@2
-    displayName: 'Abort'
+    displayName: 'Abort the build to save resources'
     inputs:
       targetType: "inline"
       script: "Write-Error 'Intentionally aborting';Exit 1"

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -193,15 +193,14 @@ jobs:
       GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'
 
   - task: CmdLine@2
-    displayName: 'Show .gdn folders'
+    displayName: 'Show $(Agent.BuildDirectory)\.gdn folders'
     inputs:
       script: 'dir /s %AGENT_BUILDDIRECTORY%\.gdn'
 
-  - task: CopyFiles@2
-    displayName: 'Copy .gdn files to: $(Build.ArtifactStagingDirectory)'
+  - task: CmdLine@2
+    displayName: 'xcopy /HIS $(Agent.BuildDirectory)\.gdn $(Build.ArtifactStagingDirectory)\.gdn'
     inputs:
-      Contents: '$(Agent.BuildDirectory)\.gdn\**\**'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      script: 'xcopy /HIS %AGENT_BUILDDIRECTORY%\.gdn %BUILD_ARTIFACTSTAGINGDIRECTORY%\.gdn'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Guardian'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -189,7 +189,6 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (CredScan, Roslyn, and PoliCheck)'
-    condition: false
     inputs:
       GdnPublishTsaOnboard: true
       GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -184,7 +184,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;.NET Analyzers;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAV2ProjectName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;RoslynAnalyzers;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (CredScan, Roslyn, and PoliCheck)'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -109,6 +109,13 @@ jobs:
         **\*.csproj
         !**\CustomActions.Package.csproj
 
+  - task: PowerShell@2
+    displayName: 'Create tsa.config file (CredScan, Roslyn, and PoliCheck)'
+    inputs:
+      targetType: "filePath"
+      filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
+      arguments: '-InstanceUrl $(TSAInstanceUrl) -ProjectName $(TSAProjectName) -CodeBaseName $(TSACodeBaseName) -CodeBaseAdmins $(TSACodeBaseAdmins) -AreaPath "$(TSAV2AreaPath)" -IterationPath $(TSAV2IterationPath) -NotificationAliases $(TSANotificationAlias) -Tools CredScan;Roslyn;Policheck -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+  
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
     inputs:
@@ -180,13 +187,6 @@ jobs:
       RoslynAnalyzers: true
       PoliCheck: true
 
-  - task: PowerShell@2
-    displayName: 'Create tsa.config file (CredScan, Roslyn, and PoliCheck)'
-    inputs:
-      targetType: "filePath"
-      filePath: tools\scripts\verification.scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl $(TSAInstanceUrl) -ProjectName $(TSAProjectName) -CodeBaseName $(TSACodeBaseName) -CodeBaseAdmins $(TSACodeBaseAdmins) -AreaPath "$(TSAV2AreaPath)" -IterationPath $(TSAV2IterationPath) -NotificationAliases $(TSANotificationAlias) -Tools CredScan;Roslyn;Policheck -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
-  
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (CredScan, Roslyn, and PoliCheck)'
     condition: false
@@ -234,6 +234,13 @@ jobs:
         **\*.csproj
         !**\CustomActions.Package.csproj
 
+  - task: PowerShell@2
+    displayName: 'Create tsa.config file (BinSkim)'
+    inputs:
+      targetType: "filePath"
+      filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
+      arguments: '-InstanceUrl $(TSAInstanceUrl) -ProjectName $(TSAProjectName) -CodeBaseName $(TSACodeBaseName) -CodeBaseAdmins $(TSACodeBaseAdmins) -AreaPath "$(TSAV2AreaPath)" -IterationPath $(TSAV2IterationPath) -NotificationAliases $(TSANotificationAlias) -Tools BinSkim -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+  
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 
@@ -308,13 +315,6 @@ jobs:
       rerunFailedTests: true
       testFiltercriteria: 'TestCategory!=NoStrongName'
 
-  - task: PowerShell@2
-    displayName: 'Create tsa.config file (BinSkim)'
-    inputs:
-      targetType: "filePath"
-      filePath: tools\scripts\verification.scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl $(TSAInstanceUrl) -ProjectName $(TSAProjectName) -CodeBaseName $(TSACodeBaseName) -CodeBaseAdmins $(TSACodeBaseAdmins) -AreaPath "$(TSAV2AreaPath)" -IterationPath $(TSAV2IterationPath) -NotificationAliases $(TSANotificationAlias) -Tools BinSkim -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
-  
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (BinSkim)'
     condition: false

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -146,7 +146,7 @@ jobs:
       configuration: debug
       rerunFailedTests: true
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
     displayName: 'Run CredScan'
     inputs:
       toolMajorVersion: V3

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -317,7 +317,6 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (BinSkim)'
-    condition: false
     inputs:
       GdnPublishTsaOnboard: true
       GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -141,7 +141,7 @@ jobs:
         msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
         msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AccessibilityInsights.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
-        rulesetName: recommended
+        rulesetName: Recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest
 

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -284,11 +284,11 @@ jobs:
     inputs:
       InputType: Basic
       # Double-quote syntax with trailing backslash on each line concatenates lines without spaces
-      AnalyzeTarget: "src\\AccessibilityInsights\\bin\\Release\\net48\\*.exe;\
-                      src\\AccessibilityInsights\\bin\\Release\\net48\\AccessibilityInsights.*.dll;\
-                      src\\AccessibilityInsights.VersionSwitcher\\bin\\Release\\net48\\*.exe;\
-                      src\\AccessibilityInsights.VersionSwitcher\\bin\\Release\\net48\\AccessibilityInsights.*.dll;\
-                      src\\Manifest\\bin\\Release\\net48\\AccessibilityInsights.*.dll;"
+      AnalyzeTargetGlob: "src\\AccessibilityInsights\\bin\\Release\\net48\\*.exe;\
+                          src\\AccessibilityInsights\\bin\\Release\\net48\\AccessibilityInsights.*.dll;\
+                          src\\AccessibilityInsights.VersionSwitcher\\bin\\Release\\net48\\*.exe;\
+                          src\\AccessibilityInsights.VersionSwitcher\\bin\\Release\\net48\\AccessibilityInsights.*.dll;\
+                          src\\Manifest\\bin\\Release\\net48\\AccessibilityInsights.*.dll;"
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@2
     displayName: 'Create Security Analysis Report (BinSkim)'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -192,11 +192,21 @@ jobs:
       GdnPublishTsaOnboard: true
       GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'
 
+  - task: CmdLine@2
+    displayName: 'Show .gdn folders'
+    inputs:
+      script: 'dir /s %AGENT_BUILDDIRECTORY%\.gdn'
+
+  - task: CmdLine@2
+    displayName: 'Show _sdt folders'
+    inputs:
+      script: 'dir /s %AGENT_BUILDDIRECTORY%\_sdt'
+
   - task: PowerShell@2
-    displayName: 'Show guardian folders and abort'
+    displayName: 'Abort'
     inputs:
       targetType: "inline"
-      script: "dir -s $(AGENT_BUILDDIRECTORY)/.gdn;Write-Error 'Intentionally aborting';Exit 1"
+      script: "Write-Error 'Intentionally aborting';Exit 1"
 
 - job: SignedRelease
   dependsOn: 

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -185,7 +185,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectNameV2)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectNameV2)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;PoliCheck" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
   
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (CredScan, Roslyn, and PoliCheck)'
@@ -312,7 +312,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectNameV2)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "BinSkim" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectNameV2)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "BinSkim" -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
   
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (BinSkim)'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -127,51 +127,48 @@ jobs:
     inputs:
       ArtifactName: 'Compliance'
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-autoapplicability.AutoApplicability@1
-    displayName: 'Run AutoApplicability'
-
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
     displayName: 'Run CredScan'
     inputs:
-      toolMajorVersion: V2
+      toolMajorVersion: V3
       verboseOutput: true
       debugMode: false
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
     displayName: 'Run Roslyn analyzers'
     inputs:
         userProvideBuildInfo: msBuildInfo
-        msbuildVersion: 16.0
+        msbuildVersion: 17.0
         msBuildArchitecture: '$(BuildPlatform)'
-        msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AccessibilityInsights.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="16.0"'
+        msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" "$(Build.SourcesDirectory)\src\AccessibilityInsights.sln" /p:platform="$(BuildPlatform)" /p:configuration="debug" /p:VisualStudioVersion="17.0"'
         rulesetName: recommended
         internalAnalyzersVersion: Latest
         microsoftAnalyzersVersion: Latest
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
     displayName: 'Run PoliCheck'
     inputs:
       targetType: F
     continueOnError: true
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@2
     displayName: 'Create Security Analysis Report (CredScan, RoslynAnalyzers, and PoliCheck)'
     inputs:
       CredScan: true
       RoslynAnalyzers: true
       PoliCheck: true
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
     displayName: 'Publish Security Analysis Logs (CredScan, RoslynAnalyzers, and PoliCheck)'
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
     displayName: 'Post Analysis (CredScan, RoslynAnalyzers, and PoliCheck)'
     inputs:
       CredScan: true
       RoslynAnalyzers: true
       PoliCheck: true
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (CredScan, RoslynAnalyzers, and PoliCheck)'
     inputs:
       tsaVersion: TsaV2
@@ -281,7 +278,7 @@ jobs:
       PathtoPublish: 'src\Manifest\bin\Release\net48'
       ArtifactName: 'manifest'
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
     displayName: 'Run BinSkim'
     inputs:
       InputType: Basic
@@ -292,15 +289,15 @@ jobs:
                       src\\AccessibilityInsights.VersionSwitcher\\bin\\Release\\net48\\AccessibilityInsights.*.dll;\
                       src\\Manifest\\bin\\Release\\net48\\AccessibilityInsights.*.dll;"
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@2
     displayName: 'Create Security Analysis Report (BinSkim)'
     inputs:
       BinSkim: true
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
     displayName: 'Publish Security Analysis Logs (BinSkim)'
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
     displayName: 'Post Analysis (BinSkim)'
     inputs:
       BinSkim: true
@@ -317,7 +314,7 @@ jobs:
       rerunFailedTests: true
       testFiltercriteria: 'TestCategory!=NoStrongName'
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (BinSkim)'
     inputs:
       tsaVersion: TsaV2

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -168,7 +168,7 @@ jobs:
       RoslynAnalyzers: true
       PoliCheck: true
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
     displayName: 'TSA upload (CredScan, RoslynAnalyzers, and PoliCheck)'
     inputs:
       tsaVersion: TsaV2
@@ -314,7 +314,7 @@ jobs:
       rerunFailedTests: true
       testFiltercriteria: 'TestCategory!=NoStrongName'
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
     displayName: 'TSA upload (BinSkim)'
     inputs:
       tsaVersion: TsaV2

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -142,6 +142,7 @@ jobs:
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
     displayName: 'Run CredScan'
     inputs:
+      outputFormat: 'pre'
       verboseOutput: true
       debugMode: false
 

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -114,7 +114,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl $(TSAInstanceUrl) -ProjectName $(TSAProjectName) -CodeBaseName $(TSACodeBaseName) -CodeBaseAdmins $(TSACodeBaseAdmins) -AreaPath "$(TSAV2AreaPath)" -IterationPath $(TSAV2IterationPath) -NotificationAliases $(TSANotificationAlias) -Tools CredScan;Roslyn;Policheck -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectName)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "CredScan;Roslyn;Policheck" -OutputFile" "$(Build.SourcesDirectory)\tsa.config"'
   
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
@@ -239,7 +239,7 @@ jobs:
     inputs:
       targetType: "filePath"
       filePath: tools\scripts\pipeline\build\create-tsa-config.ps1
-      arguments: '-InstanceUrl $(TSAInstanceUrl) -ProjectName $(TSAProjectName) -CodeBaseName $(TSACodeBaseName) -CodeBaseAdmins $(TSACodeBaseAdmins) -AreaPath "$(TSAV2AreaPath)" -IterationPath $(TSAV2IterationPath) -NotificationAliases $(TSANotificationAlias) -Tools BinSkim -OutputFile "$(Build.SourcesDirectory)\tsa.config"'
+      arguments: '-InstanceUrl "$(TSAInstanceUrl)" -ProjectName "$(TSAProjectName)" -CodeBaseName "$(TSACodeBaseName)" -CodeBaseAdmins "$(TSACodeBaseAdmins)" -AreaPath "$(TSAV2AreaPath)" -IterationPath "$(TSAV2IterationPath)" -NotificationAliases "$(TSANotificationAlias)" -Tools "BinSkim" -OutputFile" "$(Build.SourcesDirectory)\tsa.config"'
   
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -185,17 +185,6 @@ jobs:
       GdnPublishTsaOnboard: true
       GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'
 
-  - task: CmdLine@2
-    displayName: 'Show $(Agent.BuildDirectory)\.gdn folders (for diagnostics)'
-    inputs:
-      script: 'dir /s %AGENT_BUILDDIRECTORY%\.gdn'
-
-  - task: PowerShell@2
-    displayName: 'Abort the build to save resources'
-    inputs:
-      targetType: "inline"
-      script: "Write-Error 'Intentionally aborting';Exit 1"
-
 - job: SignedRelease
   dependsOn: 
   - ComplianceRelease

--- a/tools/scripts/pipeline/build/create-tsa-config.ps1
+++ b/tools/scripts/pipeline/build/create-tsa-config.ps1
@@ -71,7 +71,7 @@ function Get-ConfigObject([string]$codeBaseName,[string]$codeBaseAdmins,[string]
     $config | Add-Member -Name "tsaStamp" -Type NoteProperty "DevDiv"
     $config | Add-Member -Name "tsaEnvironment" -Type NoteProperty "Prod"
     $config | Add-Member -Name "template" -Type NoteProperty "TFSPowerBI"
-    $config | Add-Member -Name "codebaseName" -Type NoteProperty $codeBaseName
+    $config | Add-Member -Name "codebaseName" -Type NoteProperty "accessibility-insights-windows"
     $config | Add-Member -Name "notificationAliases" -Type NoteProperty $notificationAliasesArray
     $config | Add-Member -Name "codebaseAdmins" -Type NoteProperty $codebaseAdminsArray
     $config | Add-Member -Name "instanceUrl" -Type NoteProperty $instanceUrl

--- a/tools/scripts/pipeline/build/create-tsa-config.ps1
+++ b/tools/scripts/pipeline/build/create-tsa-config.ps1
@@ -1,0 +1,86 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+<#
+.SYNOPSIS
+Create the tsa.config file based on the parameters. Paramteters will be stored as pipeline variables for confidentiality reasons
+
+.PARAMETER InstanceUrl
+The Url to the TSA instance of the database
+
+.PARAMETER ProjectName
+The name of the TSA project
+
+.PARAMETER CodeBaseName
+The name of the TSA database
+
+.PARAMETER CodeBaseAdmins
+The admin[s] of the TSA database, as a semicolon delimited list
+
+.PARAMETER AreaPath
+The Area Path that will be attached to new TSA work items
+
+.PARAMETER IterationPath
+The iteration path that will be attached to new TSA work items
+
+.PARAMETER NotificationAliases
+The email alias[es] that will be used for TSA notifications, as a semicolon delimited list
+
+.PARAMETER Tools
+The tool[s] for which uploads are expected, as a semicolon delimited list
+
+.PARAMETER OutputFile
+The fully qualified path to the output file. Assumes that the folder already exists
+
+.Example Usage 
+.\create-tsa-config.ps1 -InstanceUrl MyInstancUrl -ProjectName MyProject -CodeBaseName MyCodeBaseName -CodeBaseAdmins Domain/user1;Domain/user2 -AreaPath MyAreaPath -IterationPath -MyIterationPath -NotificationAliases MyTeam@MyCompany.com -Tools CredScan;Roslyn -OutputFolder .\tsa.config
+#>
+
+param(
+    [Parameter(Mandatory=$true)][string]$InstanceUrl,
+    [Parameter(Mandatory=$true)][string]$ProjectName,
+    [Parameter(Mandatory=$true)][string]$CodeBaseName,
+    [Parameter(Mandatory=$true)][string]$CodeBaseAdmins,
+    [Parameter(Mandatory=$true)][string]$AreaPath,
+    [Parameter(Mandatory=$true)][string]$IterationPath,
+    [Parameter(Mandatory=$true)][string]$NotificationAliases,
+    [Parameter(Mandatory=$true)][string]$Tools,
+    [Parameter(Mandatory=$true)][string]$OutputFile
+)
+
+Set-StrictMode -Version Latest
+$script:ErrorActionPreference = 'Stop'
+
+# Uncomment the next line for debugging
+$VerbosePreference='continue'
+
+function Get-ItemsFromSemicolonSeparatedList([string]$inputList)
+{
+    $test = @($inputList.Split(";"))
+    return $test
+}
+
+function Get-ConfigObject([string]$codeBaseName,[string]$codeBaseAdmins,[string]$notificationAliases,[string]$instanceUrl,[string]$projectName,[string]$areaPath,[string]$iterationPath,[string]$tools)
+{
+    $notificationAliasesArray = @(Get-ItemsFromSemicolonSeparatedList $notificationAliases)
+    $codebaseAdminsArray = @(Get-ItemsFromSemicolonSeparatedList $codeBaseAdmins)
+    $toolsArray = @(Get-ItemsFromSemicolonSeparatedList $tools) 
+    
+    $config = @{}
+    $config | Add-Member -Name "codebaseName" -Type NoteProperty $codeBaseName
+    $config | Add-Member -Name "notificationAliases" -Type NoteProperty $notificationAliasesArray
+    $config | Add-Member -Name "codebaseAdmins" -Type NoteProperty $codebaseAdminsArray
+    $config | Add-Member -Name "instanceUrl" -Type NoteProperty $instanceUrl
+    $config | Add-Member -Name "projectName" -Type NoteProperty $projectName
+    $config | Add-Member -Name "areaPath" -Type NoteProperty $areaPath
+    $config | Add-Member -Name "iterationPath" -Type NoteProperty $iterationpath
+    $config | Add-Member -Name "tools" -Type NoteProperty $toolsArray
+
+    return $config
+}
+
+$config = Get-ConfigObject $CodeBaseName $CodeBaseAdmins $NotificationAliases $InstanceUrl $ProjectName $AreaPath $IterationPath $Tools
+
+$config | ConvertTo-Json | Out-File $OutputFile -Encoding "utf8"
+
+Write-Host "Output to ${OutputFile}:"
+Get-Content $OutputFile | Write-Host

--- a/tools/scripts/pipeline/build/create-tsa-config.ps1
+++ b/tools/scripts/pipeline/build/create-tsa-config.ps1
@@ -28,8 +28,16 @@ The tool[s] for which uploads are expected, as a semicolon delimited list
 .PARAMETER OutputFile
 The fully qualified path to the output file. Assumes that the folder already exists
 
-.Example Usage 
-.\create-tsa-config.ps1 -InstanceUrl MyInstancUrl -ProjectName MyProject -CodeBaseAdmins Domain/user1;Domain/user2 -AreaPath MyAreaPath -IterationPath -MyIterationPath -NotificationAliases MyTeam@MyCompany.com -Tools CredScan;Roslyn -OutputFolder .\tsa.config
+.EXAMPLE
+PS> .\create-tsa-config.ps1 `
+        -InstanceUrl "MyInstanceUrl" `
+        -ProjectName "MyProject" `
+        -CodeBaseAdmins "Domain/user1;Domain/user2" `
+        -AreaPath "MyAreaPath" `
+        -IterationPath "MyIterationPath" `
+        -NotificationAliases "MyTeam@MyCompany.com" `
+        -Tools "CredScan;Roslyn" `
+        -OutputFile ".\tsa.config"
 #>
 
 param(

--- a/tools/scripts/pipeline/build/create-tsa-config.ps1
+++ b/tools/scripts/pipeline/build/create-tsa-config.ps1
@@ -70,6 +70,7 @@ function Get-ConfigObject([string]$codeBaseName,[string]$codeBaseAdmins,[string]
     $config | Add-Member -Name "codebase" -Type NoteProperty "NewOrUpdate"
     $config | Add-Member -Name "tsaStamp" -Type NoteProperty "DevDiv"
     $config | Add-Member -Name "tsaEnvironment" -Type NoteProperty "Prod"
+    $config | Add-Member -Name "template" -Type NoteProperty "TFSPowerBI"
     $config | Add-Member -Name "codebaseName" -Type NoteProperty $codeBaseName
     $config | Add-Member -Name "notificationAliases" -Type NoteProperty $notificationAliasesArray
     $config | Add-Member -Name "codebaseAdmins" -Type NoteProperty $codebaseAdminsArray

--- a/tools/scripts/pipeline/build/create-tsa-config.ps1
+++ b/tools/scripts/pipeline/build/create-tsa-config.ps1
@@ -66,14 +66,19 @@ function Get-ConfigObject([string]$codeBaseName,[string]$codeBaseAdmins,[string]
     $toolsArray = @(Get-ItemsFromSemicolonSeparatedList $tools) 
     
     $config = @{}
+    $config | Add-Member -Name "tsaVersion" -Type NoteProperty "TsaV2"
+    $config | Add-Member -Name "codebase" -Type NoteProperty "NewOrUpdate"
+    $config | Add-Member -Name "tsaStamp" -Type NoteProperty "DevDiv"
+    $config | Add-Member -Name "tsaEnvironment" -Type NoteProperty "PROD"
     $config | Add-Member -Name "codebaseName" -Type NoteProperty $codeBaseName
     $config | Add-Member -Name "notificationAliases" -Type NoteProperty $notificationAliasesArray
     $config | Add-Member -Name "codebaseAdmins" -Type NoteProperty $codebaseAdminsArray
     $config | Add-Member -Name "instanceUrl" -Type NoteProperty $instanceUrl
     $config | Add-Member -Name "projectName" -Type NoteProperty $projectName
     $config | Add-Member -Name "areaPath" -Type NoteProperty $areaPath
-    $config | Add-Member -Name "iterationPath" -Type NoteProperty $iterationpath
+    $config | Add-Member -Name "iterationPath" -Type NoteProperty $iterationPath
     $config | Add-Member -Name "tools" -Type NoteProperty $toolsArray
+    $config | Add-Member -Name "repositoryName" -Type NoteProperty "accessibility-insights-windows"
 
     return $config
 }

--- a/tools/scripts/pipeline/build/create-tsa-config.ps1
+++ b/tools/scripts/pipeline/build/create-tsa-config.ps1
@@ -69,7 +69,7 @@ function Get-ConfigObject([string]$codeBaseName,[string]$codeBaseAdmins,[string]
     $config | Add-Member -Name "tsaVersion" -Type NoteProperty "TsaV2"
     $config | Add-Member -Name "codebase" -Type NoteProperty "NewOrUpdate"
     $config | Add-Member -Name "tsaStamp" -Type NoteProperty "DevDiv"
-    $config | Add-Member -Name "tsaEnvironment" -Type NoteProperty "PROD"
+    $config | Add-Member -Name "tsaEnvironment" -Type NoteProperty "Prod"
     $config | Add-Member -Name "codebaseName" -Type NoteProperty $codeBaseName
     $config | Add-Member -Name "notificationAliases" -Type NoteProperty $notificationAliasesArray
     $config | Add-Member -Name "codebaseAdmins" -Type NoteProperty $codebaseAdminsArray

--- a/tools/scripts/pipeline/build/create-tsa-config.ps1
+++ b/tools/scripts/pipeline/build/create-tsa-config.ps1
@@ -10,9 +10,6 @@ The Url to the TSA instance of the database
 .PARAMETER ProjectName
 The name of the TSA project
 
-.PARAMETER CodeBaseName
-The name of the TSA database
-
 .PARAMETER CodeBaseAdmins
 The admin[s] of the TSA database, as a semicolon delimited list
 
@@ -32,13 +29,12 @@ The tool[s] for which uploads are expected, as a semicolon delimited list
 The fully qualified path to the output file. Assumes that the folder already exists
 
 .Example Usage 
-.\create-tsa-config.ps1 -InstanceUrl MyInstancUrl -ProjectName MyProject -CodeBaseName MyCodeBaseName -CodeBaseAdmins Domain/user1;Domain/user2 -AreaPath MyAreaPath -IterationPath -MyIterationPath -NotificationAliases MyTeam@MyCompany.com -Tools CredScan;Roslyn -OutputFolder .\tsa.config
+.\create-tsa-config.ps1 -InstanceUrl MyInstancUrl -ProjectName MyProject -CodeBaseAdmins Domain/user1;Domain/user2 -AreaPath MyAreaPath -IterationPath -MyIterationPath -NotificationAliases MyTeam@MyCompany.com -Tools CredScan;Roslyn -OutputFolder .\tsa.config
 #>
 
 param(
     [Parameter(Mandatory=$true)][string]$InstanceUrl,
     [Parameter(Mandatory=$true)][string]$ProjectName,
-    [Parameter(Mandatory=$true)][string]$CodeBaseName,
     [Parameter(Mandatory=$true)][string]$CodeBaseAdmins,
     [Parameter(Mandatory=$true)][string]$AreaPath,
     [Parameter(Mandatory=$true)][string]$IterationPath,
@@ -59,32 +55,32 @@ function Get-ItemsFromSemicolonSeparatedList([string]$inputList)
     return $test
 }
 
-function Get-ConfigObject([string]$codeBaseName,[string]$codeBaseAdmins,[string]$notificationAliases,[string]$instanceUrl,[string]$projectName,[string]$areaPath,[string]$iterationPath,[string]$tools)
+function Get-ConfigObject([string]$codeBaseAdmins,[string]$notificationAliases,[string]$instanceUrl,[string]$projectName,[string]$areaPath,[string]$iterationPath,[string]$tools)
 {
     $notificationAliasesArray = @(Get-ItemsFromSemicolonSeparatedList $notificationAliases)
     $codebaseAdminsArray = @(Get-ItemsFromSemicolonSeparatedList $codeBaseAdmins)
     $toolsArray = @(Get-ItemsFromSemicolonSeparatedList $tools) 
     
     $config = @{}
-    $config | Add-Member -Name "tsaVersion" -Type NoteProperty "TsaV2"
-    $config | Add-Member -Name "codebase" -Type NoteProperty "NewOrUpdate"
-    $config | Add-Member -Name "tsaStamp" -Type NoteProperty "DevDiv"
-    $config | Add-Member -Name "tsaEnvironment" -Type NoteProperty "Prod"
-    $config | Add-Member -Name "template" -Type NoteProperty "TFSPowerBI"
-    $config | Add-Member -Name "codebaseName" -Type NoteProperty "accessibility-insights-windows"
+    $config | Add-Member -Name "codebaseName"        -Type NoteProperty "accessibility-insights-windows"
+    $config | Add-Member -Name "repositoryName"      -Type NoteProperty "accessibility-insights-windows"
+    $config | Add-Member -Name "tsaVersion"          -Type NoteProperty "TsaV2"
+    $config | Add-Member -Name "codebase"            -Type NoteProperty "NewOrUpdate"
+    $config | Add-Member -Name "tsaStamp"            -Type NoteProperty "DevDiv"
+    $config | Add-Member -Name "tsaEnvironment"      -Type NoteProperty "Prod"
+    $config | Add-Member -Name "template"            -Type NoteProperty "TFSPowerBI"
+    $config | Add-Member -Name "instanceUrl"         -Type NoteProperty $instanceUrl
+    $config | Add-Member -Name "projectName"         -Type NoteProperty $projectName
+    $config | Add-Member -Name "areaPath"            -Type NoteProperty $areaPath
+    $config | Add-Member -Name "iterationPath"       -Type NoteProperty $iterationPath
     $config | Add-Member -Name "notificationAliases" -Type NoteProperty $notificationAliasesArray
-    $config | Add-Member -Name "codebaseAdmins" -Type NoteProperty $codebaseAdminsArray
-    $config | Add-Member -Name "instanceUrl" -Type NoteProperty $instanceUrl
-    $config | Add-Member -Name "projectName" -Type NoteProperty $projectName
-    $config | Add-Member -Name "areaPath" -Type NoteProperty $areaPath
-    $config | Add-Member -Name "iterationPath" -Type NoteProperty $iterationPath
-    $config | Add-Member -Name "tools" -Type NoteProperty $toolsArray
-    $config | Add-Member -Name "repositoryName" -Type NoteProperty "accessibility-insights-windows"
+    $config | Add-Member -Name "codebaseAdmins"      -Type NoteProperty $codebaseAdminsArray
+    $config | Add-Member -Name "tools"               -Type NoteProperty $toolsArray
 
     return $config
 }
 
-$config = Get-ConfigObject $CodeBaseName $CodeBaseAdmins $NotificationAliases $InstanceUrl $ProjectName $AreaPath $IterationPath $Tools
+$config = Get-ConfigObject $CodeBaseAdmins $NotificationAliases $InstanceUrl $ProjectName $AreaPath $IterationPath $Tools
 
 $config | ConvertTo-Json | Out-File $OutputFile -Encoding "utf8"
 


### PR DESCRIPTION
#### Details

The compliance tools that we use are being revised, as shown in the following warnings (adapted from this morning's signed build)

Job | Task | Warning
--- | --- | ---
ComplianceDebug | Run AutoApplicability | This tool is no longer supported. Please remove this build task from your build definition.
ComplianceDebug | Run CredScan | Please upgrade the version of this build task in your build to major version: 3.
ComplianceDebug | Run Roslyn analyzers | Please upgrade the version of this build task in your build to major version: 3.
ComplianceDebug | Run PoliCheck | Please upgrade the version of this build task in your build to major version: 2.
ComplianceDebug | Create Security Analysis Report (CredScan, RoslynAnalyzers, and PoliCheck) | Please upgrade the version of this build task in your build to major version: 2.
ComplianceDebug | Publish Security Analysis Logs (CredScan, RoslynAnalyzers, and PoliCheck) | Please upgrade the version of this build task in your build to major version: 3.
ComplianceDebug | Post Analysis (CredScan, RoslynAnalyzers, and PoliCheck) | Please upgrade the version of this build task in your build to major version: 2.
ComplianceDebug | TSA upload (CredScan, RoslynAnalyzers, and PoliCheck) | Please upgrade the version of this build task in your build to major version: 2.
SignedRelease | Run BinSkim | Please upgrade the version of this build task in your build to major version: 4.
SignedRelease | Create Security Analysis Report (BinSkim) | Please upgrade the version of this build task in your build to major version: 2.
SignedRelease | Publish Security Analysis Logs (BinSkim) | Please upgrade the version of this build task in your build to major version: 3.
SignedRelease | Post Analysis (BinSkim) | Please upgrade the version of this build task in your build to major version: 2.
SignedRelease | TSA upload (BinSkim) | lease upgrade the version of this build task in your build to major version: 2.

This PR makes the specified changes, with some variations:
1. The RoslynAnalyzers task also includes changes to reflect the use of VS17, as well as changing an input value that is case-sensitive in the new tool version.
2. The new TSA uploader task requires its input via a config file instead of via command line parameters. Some of this information (emails, etc.) should be protected and is stored as pipeline variables. We build `tsa.config` on the fly. This script is intended to be easily modified for use in our other pipelines.
3. The new CredScan task default to `sarif` upload format, which doesn't get picked up by the TSA uploader. We need to specify the `pre` output format for consumption by the TSA uploader.

##### Motivation

The current version of security tools will soon be deprecated and we need to keep this functionality for compliance reasons.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



