### PR TITLE
chore: Move deployment scripts into build artifact

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -79,12 +79,6 @@ jobs:
       configuration: release
       rerunFailedTests: true
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: deploy_scripts'
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\tools\scripts\pipeline\deploy'
-      ArtifactName: 'deploy_scripts'
-
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 
@@ -268,6 +262,12 @@ jobs:
     inputs:
       PathtoPublish: 'src\Manifest\bin\Release\net48'
       ArtifactName: 'manifest'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: deploy_scripts'
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)\tools\scripts\pipeline\deploy'
+      ArtifactName: 'deploy_scripts'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
     displayName: 'Run BinSkim'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -263,6 +263,12 @@ jobs:
       PathtoPublish: 'src\Manifest\bin\Release\net48'
       ArtifactName: 'manifest'
 
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: deploy_scripts'
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)\tools\scripts\pipeline\deploy'
+      ArtifactName: 'deploy_scripts'
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
     displayName: 'Run BinSkim'
     inputs:

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -79,6 +79,12 @@ jobs:
       configuration: release
       rerunFailedTests: true
 
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: deploy_scripts'
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)\tools\scripts\pipeline\deploy'
+      ArtifactName: 'deploy_scripts'
+
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 
@@ -262,12 +268,6 @@ jobs:
     inputs:
       PathtoPublish: 'src\Manifest\bin\Release\net48'
       ArtifactName: 'manifest'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: deploy_scripts'
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\tools\scripts\pipeline\deploy'
-      ArtifactName: 'deploy_scripts'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
     displayName: 'Run BinSkim'

--- a/tools/scripts/pipeline/deploy/Canary/prevent_version_backfilling.ps1
+++ b/tools/scripts/pipeline/deploy/Canary/prevent_version_backfilling.ps1
@@ -1,0 +1,130 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+<#
+.SYNOPSIS
+Release pipeline script that runs to prevent backfilling of Canary releases. It fails if any releases
+exist that are newer than this release.
+
+It consumes the following environment variables:
+    A11yInsightsVersion    is the version (e.g., 1.1.2227.01) begin published by the pipeline
+    OctokitVersion         is the version of OctoKit we've pinned to. A previous task will install this package
+
+The script is assumed to run from the default working directory of the pipeline.
+#>
+
+Set-StrictMode -Version Latest
+$script:ErrorActionPreference = 'Stop'
+
+# Constants
+$Owner = "Microsoft"
+$Repo = "accessibility-insights-windows"
+
+function CheckEnvironmentVariables()
+{
+    if ($null -eq $env:A11yInsightsVersion)
+    {
+        Write-Error "Could not find an environment variable for 'A11yInsightsVersion'"
+        exit 1
+    }
+    if ($null -eq $env:OctokitVersion)
+    {
+        Write-Error "Could not find an environment variable for 'OctokitVersion'"
+        exit 1
+    }
+}
+
+# Extracts a version from the release name.
+function Get-ReleaseVersion($specificRelease)
+{
+    $versionString = $specificRelease.Name
+    if($versionString -match ".*v(\d+\.\d+\.\d+\.\d+).*")
+    {
+        return $matches[1]
+    }
+    else
+    {
+        return [string]::Empty
+    }
+}
+
+# Dump the sorted releases for debugging
+function Write-ReleaseMap($releaseMap)
+{
+    Write-Host "==================================="
+    Write-Host "Sorted Releases"
+    Write-Host "Version       TagName         Name"
+    Write-Host "-------       -------         ----"
+    foreach($releaseKV in $releaseMap)
+    {
+        Write-Host $releaseKV.Key "  " $releaseKV.Value.TagName "  " $releaseKV.Value.Name
+    }
+    Write-Host "==================================="
+}
+
+# Sorts the releases based on the version number
+function SortReleases($releases)
+{
+    $releaseMap = @{}
+    foreach($release in $releases)
+    {
+        $releaseVersion = [System.Version](Get-ReleaseVersion $release)
+        if(-not [string]::IsNullOrEmpty($releaseVersion))
+        {
+            $releaseMap.Add($releaseVersion,$release)
+        }
+    }
+
+    $releaseMap = $releaseMap.GetEnumerator() | Sort-Object -Descending -Property Name
+
+    Write-ReleaseMap $releaseMap
+
+    return $releaseMap
+}
+
+# Return the newest release version
+function Get-NewestReleaseVersion($releaseMap)
+{
+    return $releaseMap[0].Key
+}
+
+# Fail the script if this would result in a backfill
+function DisallowBackfill($newestVersion)
+{
+    $releaseVersion = New-Object System.Version($env:A11yInsightsVersion)
+
+    Write-Host "Comparing release version" $releaseVersion "to newest release" $newestVersion
+
+    if ($newestVersion -gt $releaseVersion)
+    {
+        Write-Error "Backfill validation FAILED"
+    }
+    else
+    {
+        Write-Host "Backfill validation passed"
+    }
+}
+
+# Initialize the client
+function Get-Client()
+{
+    # Load the octokit dll
+    Add-Type -Path ((Get-Location).Path + "\Octokit.$($env:OctokitVersion)\lib\netstandard2.0\Octokit.dll")
+
+    # Get a new client
+    $productHeader = [Octokit.ProductHeaderValue]::new("Canary-Pipeline-PreValidation")
+    $client = [Octokit.GitHubClient]::new($productHeader)
+
+    return $client
+}
+
+# Main program
+CheckEnvironmentVariables
+$client = Get-Client
+$releases = $client.Repository.Release.GetAll($Owner, $Repo).Result
+
+Write-Host "Unsorted Releases:" 
+$releases | Select-Object -Property Name, TagName | Format-Table
+
+$releaseMap = SortReleases $releases
+$newestReleaseVersion = Get-NewestReleaseVersion($releaseMap)
+DisallowBackfill $newestReleaseVersion

--- a/tools/scripts/pipeline/deploy/Canary/set_variables.ps1
+++ b/tools/scripts/pipeline/deploy/Canary/set_variables.ps1
@@ -9,7 +9,6 @@ Set build variables that will be consumed by downstream scripts. It sets the fol
     A11yInsightsTagName    is the associated tag name (e.g., v1.1.2227.01) for this release
 
 This script is assumed to run from $(Release.PrimaryArtifactSourceAlias)
-
 #>
 
 Set-StrictMode -Version Latest

--- a/tools/scripts/pipeline/deploy/Canary/set_variables.ps1
+++ b/tools/scripts/pipeline/deploy/Canary/set_variables.ps1
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+<#
+.SYNOPSIS
+Set build variables that will be consumed by downstream scripts. It sets the following variables:
+
+    A11yInsightsMsiFile    is the relative path to the MSI file (e.g., 1.1.2227.01\AccessibilityInsights.msi)
+    A11yInsightsVersion    is the version (e.g., 1.1.2227.01) for this release
+    A11yInsightsTagName    is the associated tag name (e.g., v1.1.2227.01) for this release
+
+This script is assumed to run from $(Release.PrimaryArtifactSourceAlias)
+
+#>
+
+Set-StrictMode -Version Latest
+$script:ErrorActionPreference = 'Stop'
+
+$msiFolder = ".\msi"
+$a11yInsightsVersion = Get-ChildItem -Name -Directory $($msiFolder)
+$a11yInsightsTagName = "v" + $($a11yInsightsVersion)
+$a11yInsightsMsiFile = $($a11yInsightsVersion) + "\" + "AccessibilityInsights.msi"
+
+# Diagnostic use only--does NOT set environment variables
+Write-Host "Diagnostics values:"
+Write-Host ("A11yInsightsVersion = " + $($a11yInsightsVersion))
+Write-Host ("A11yInsightsTagName = " + $($a11yInsightsTagName))
+Write-Host ("A11yInsightsMsiFile= " + $($a11yInsightsMsiFile))
+
+# Set the environment variables
+Write-Host "##vso[task.setvariable variable=A11yInsightsVersion]$($a11yInsightsVersion)"
+Write-Host "##vso[task.setvariable variable=A11yInsightsTagName]$($a11yInsightsTagName)"
+Write-Host "##vso[task.setvariable variable=A11yInsightsMsiFile]$($a11yInsightsMsiFile)"

--- a/tools/scripts/pipeline/deploy/Prod/cleanup_old_releases.ps1
+++ b/tools/scripts/pipeline/deploy/Prod/cleanup_old_releases.ps1
@@ -59,7 +59,7 @@ function Get-Client()
     Add-Type -Path ((Get-Location).Path + "\Octokit.$($env:OctokitVersion)\lib\netstandard2.0\Octokit.dll")
 
     # Get a new client
-    $productHeader = [Octokit.ProductHeaderValue]::new("Production-Pipeline-PreValidation")
+    $productHeader = [Octokit.ProductHeaderValue]::new("Production-Old-Release-Cleanup")
     $client = [Octokit.GitHubClient]::new($productHeader)
 
     # Add credentials for authentication

--- a/tools/scripts/pipeline/deploy/Prod/cleanup_old_releases.ps1
+++ b/tools/scripts/pipeline/deploy/Prod/cleanup_old_releases.ps1
@@ -1,0 +1,205 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+<#
+.SYNOPSIS
+Pipeline script that runs to perform cleanup of old releases. We want to keep the following:
+  - All draft releases newer than the version being promoted to Production
+  - The 2 (or 1 if IsForcedProdUpdate is true) most recent non-draft releases
+  - The tags associated with non-draft releases that we are removing
+
+It consumes the following environment variables:
+    GITHUB_TOKEN                     is the R/W PAT to access the repo
+    OctokitVersion                   is the version of OctoKit we've pinned to. A previous task will install this package
+    DeleteReleases                   is true if cleanup should actually delete (if false, just report what would be cleaned up)
+    A11yInsightsMinProdVersionTag    is the tag of the oldest prod release that we will retain
+
+The script is assumed to run from the default working directory of the pipeline.
+#>
+
+Set-StrictMode -Version Latest
+$script:ErrorActionPreference = 'Stop'
+
+# Constants
+$Owner = "Microsoft"
+$Repo = "accessibility-insights-windows"
+
+function CheckEnvironmentVariables()
+{
+    if ($null -eq $env:GITHUB_TOKEN)
+    {
+        Write-Error "Could not find an environment variable for 'GITHUB_TOKEN'"
+        exit 1
+    }
+    if ($null -eq $env:OctokitVersion)
+    {
+        Write-Error "Could not find an environment variable for 'OctokitVersion'"
+        exit 1
+    }
+    if ($null -eq $env:DeleteReleases)
+    {
+        Write-Error "Could not find an environment variable for 'DeleteReleases'"
+        exit 1
+    }
+    if ($null -eq $env:A11yInsightsMinProdVersionTag)
+    {
+        Write-Error "Could not find an environment variable for 'A11yInsightsMinProdVersionTag'"
+        exit 1
+    }
+}
+
+# Initialize the client
+function Get-Client()
+{
+    if ($null -eq $env:GITHUB_TOKEN)
+    {
+        throw "Run this script with the GITHUB_TOKEN environment variable set to a GitHub Personal Access Token with 'repo' permissions"
+    }
+
+    # Load the octokit dll
+    Add-Type -Path ((Get-Location).Path + "\Octokit.$($env:OctokitVersion)\lib\netstandard2.0\Octokit.dll")
+
+    # Get a new client
+    $productHeader = [Octokit.ProductHeaderValue]::new("Production-Pipeline-PreValidation")
+    $client = [Octokit.GitHubClient]::new($productHeader)
+
+    # Add credentials for authentication
+    $client.Credentials = [Octokit.Credentials]::new($env:GITHUB_TOKEN)
+    return $client
+}
+
+# Extracts a version from the release name.
+function Get-ReleaseVersion($specificRelease)
+{
+    $versionString = $specificRelease.Name
+    if($versionString -match ".*v(\d+\.\d+\.\d+\.\d+).*")
+    {
+        return $matches[1]
+    }
+    else
+    {
+        return [string]::Empty
+    }
+}
+
+# Dump the sorted releases for debugging
+function Write-ReleaseMap($releaseMap)
+{
+    Write-Host "==================================="
+    Write-Host "Sorted Releases"
+    Write-Host "Version       Name"
+    Write-Host "-------       ----"
+    foreach($releaseKV in $releaseMap)
+    {
+        Write-Host $releaseKV.Key "  " $releaseKV.Value.Name
+    }
+    Write-Host "==================================="
+}
+
+# Sorts the releases based on the version number
+function SortReleases($releases)
+{
+    $releaseMap = @{}
+    foreach($release in $releases.Result)
+    {
+        $releaseVersion = [System.Version](Get-ReleaseVersion $release)
+        if(-Not [string]::IsNullOrEmpty($releaseVersion))
+        {
+            $releaseMap.Add($releaseVersion,$release)
+        }
+    }
+
+    $releaseMap = $releaseMap.GetEnumerator() | Sort-Object -Descending -Property Name
+
+    Write-ReleaseMap $releaseMap
+
+    return $releaseMap
+}
+
+# Delete a release
+function Remove-ReleaseAndPerhapsItsTag($client, $release, $deleteReleases)
+{
+    # Null checks
+    if([string]::IsNullOrEmpty($release.Id))
+    {
+        Write-Host "No Release Id found"
+        return;
+    }
+
+    $wasPrerelease = $release.Prerelease
+    if($deleteReleases -eq $true)
+    {
+        Write-Host "Deleting release '$($release.Name)'"
+        $response = $client.Repository.Release.Delete($Owner, $Repo, $release.Id);
+
+        if (-Not ($response.Result -eq "NoContent" -And $response.IsCompleted -eq $True))
+        {
+            Write-Host "Failed to delete release '$($release.Name)'"
+        }
+        else 
+        {
+            if ($wasPrerelease)
+            {
+                Write-Host "Deleting prerelease tag '$($release.TagName)"
+                $client.Git.Reference.Delete($Owner, $Repo, "tags/$($release.TagName)").Wait()
+            }
+            else
+            {
+                Write-Host "Retaining release tag '$($release.TagName)'"
+            }
+        }
+    }
+    else
+    {
+        Write-Host "Would have deleted release '$($release.Name)'"
+        if ($wasPrerelease)
+        {
+            Write-Host "Would have deleted prerelease tag '$($release.TagName)'"
+        }
+        else
+        {
+            Write-Host "Would have retained release tag '$($release.TagName)'"
+        }
+    }
+}
+
+
+# Main program
+CheckEnvironmentVariables
+$client = Get-Client
+$releases = $client.Repository.Release.GetAll($Owner, $Repo)
+$deleteReleases = $env:DeleteReleases -eq "true"
+$minProdVersionTag = $env:A11yInsightsMinProdVersionTag
+
+Write-Host "Releases found" 
+$releases.Result | Select-Object -Property Name, TagName | Format-Table
+
+$releaseMap = SortReleases $releases
+
+$foundMinProdVersion = $false
+
+foreach($releaseKV in $releaseMap)
+{
+    $release = $releaseKV.Value
+    if ($foundMinProdVersion -eq $true)
+    {
+        $deleteList += $release
+        continue
+    }
+
+    if (($release.Prerelease -eq $false) -and (($($release.TagName) -eq $($minProdVersionTag))))
+    {
+        $foundMinProdVersion = $true
+    }
+}
+
+Write-Host "A11yInsightsMinProdVersionTag = $($minProdVersionTag)"
+Write-Host "Delete releases option is set to $($deleteReleases)" 
+
+if($deleteList.Count -eq 0)
+{
+    Write-Host "No releases to delete."
+}
+else
+{
+    $deleteList | ForEach-Object { Remove-ReleaseAndPerhapsItsTag $client $_ $deleteReleases }
+}

--- a/tools/scripts/pipeline/deploy/Prod/confirm_release_is_ready_for_prod.ps1
+++ b/tools/scripts/pipeline/deploy/Prod/confirm_release_is_ready_for_prod.ps1
@@ -1,0 +1,103 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+<#
+.SYNOPSIS
+Pipeline script that runs to confirm that the targeted release is ready to release to Production.
+It returns an error if any of the following conditions are true:
+  - The latest release does not exist
+  - The latest release's TagName property does not match A11yInsightsTagName
+  - The latest release's Prerelease property is true
+  - The latest release's Draft property is true
+  - The latest release's Name property does not contain the string "Production Release"
+  - The latest release's Body property does not contain the string "Production Release"
+
+It consumes the following environment variables:
+    A11yInsightsTagName    is the name of the tag (e.g., v1.1.2227.01) associated with this release
+    OctokitVersion         is the version of OctoKit we've pinned to. A previous task will install this package
+
+The script is assumed to run from the default working directory of the pipeline.
+#>
+
+Set-StrictMode -Version Latest
+$script:ErrorActionPreference = 'Stop'
+
+# Constants
+$Owner = "Microsoft"
+$Repo = "accessibility-insights-windows"
+
+function CheckEnvironmentVariables()
+{
+    if ($null -eq $env:A11yInsightsTagName)
+    {
+        Write-Error "Could not find an environment variable for 'A11yInsightsTagName'"
+        exit 1
+    }
+    if ($null -eq $env:OctokitVersion)
+    {
+        Write-Error "Could not find an environment variable for 'OctokitVersion'"
+        exit 1
+    }
+}
+
+# Initialize the client
+function Get-Client()
+{
+    # Load the octokit dll
+    Add-Type -Path ((Get-Location).Path + "\Octokit.$($env:OctokitVersion)\lib\netstandard2.0\Octokit.dll")
+
+    # Get a new client
+    $productHeader = [Octokit.ProductHeaderValue]::new("Production-Pipeline-PreValidation")
+    $client = [Octokit.GitHubClient]::new($productHeader)
+
+    return $client
+}
+
+# Main program
+CheckEnvironmentVariables
+$productionReleaseMarker = "Production Release"
+
+$client = Get-Client
+$latestRelease = $client.Repository.Release.GetLatest($Owner, $Repo).Result
+
+if ($null -eq $latestRelease)
+{
+    Write-Error "Unable to obtain the latest release!"
+    Exit
+}
+
+Write-Host "===== Begin Latest Release Dump ====="
+$latestRelease
+Write-Host "=====  End Latest Release Dump  ====="
+
+
+if ($latestRelease.TagName -ne $env:A11yInsightsTagName)
+{
+    Write-Error "Target tag '($($env:A11yInsightsTagName))' does not match latest release tag of '($($latestRelease.TagName))'"
+    Exit
+}
+
+if ($latestRelease.Prerelease -eq $true)
+{
+    Write-Error "Target release '$($latestRelease.Name)' must not be marked as prerelease"
+    Exit
+}
+
+if ($latestRelease.Draft -eq $true)
+{
+    Write-Error "Target release '$($latestRelease.Name)' must not be marked as draft"
+    Exit
+}
+
+if (-Not ($latestRelease.Name -Match $ProductionReleaseMarker))
+{
+    Write-Error "Release Name must contain '$($ProductionReleaseMarker)'"
+    Exit
+}
+
+if (-Not ($latestRelease.Body -Match $ProductionReleaseMarker))
+{
+    Write-Error "Release Body must contain '$($ProductionReleaseMarker)'"
+    Exit
+}
+
+Write-Host "Release Prevalidation Succeeded"

--- a/tools/scripts/pipeline/deploy/Prod/set_variables.ps1
+++ b/tools/scripts/pipeline/deploy/Prod/set_variables.ps1
@@ -8,7 +8,6 @@ Set build variables that will be consumed by downstream scripts. It sets the fol
     A11yInsightsMinProdVersionTag    is the minimum supported Prod Release once this version deploys to Prod
 
 The script is assumed to run from $(Release.PrimaryArtifactSourceAlias)
-
 #>
 
 Set-StrictMode -Version Latest

--- a/tools/scripts/pipeline/deploy/Prod/set_variables.ps1
+++ b/tools/scripts/pipeline/deploy/Prod/set_variables.ps1
@@ -1,0 +1,35 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+<#
+.SYNOPSIS
+Set build variables that will be consumed by downstream scripts. It sets the following variables:
+
+    A11yInsightsTagName              is the associated tag name (e.g., v1.1.2227.01) for this release
+    A11yInsightsMinProdVersionTag    is the minimum supported Prod Release once this version deploys to Prod
+
+The script is assumed to run from $(Release.PrimaryArtifactSourceAlias)
+
+#>
+
+Set-StrictMode -Version Latest
+$script:ErrorActionPreference = 'Stop'
+
+$unsignedManifestFile = Join-Path "manifest" "ReleaseInfo.json"
+Write-Host $unsignedManifestFile
+$json = Get-Content $unsignedManifestFile | Out-String
+$info = $json | ConvertFrom-Json
+
+Write-Host "Unaigned Manifest:"
+Write-Host $json
+
+$a11yInsightsTagName = "v" + $info.current_version
+$a11yInsightsMinProdVersionTag = "v" + $info.production_minimum_version
+
+# Diagnostic use only--does NOT set environment variables
+Write-Host "Diagnostics values:"
+Write-Host ("A11yInsightsTagName = " + $($a11yInsightsTagName))
+Write-Host ("A11yInsightsMinProdVersionTag = " + $($a11yInsightsMinProdVersionTag))
+
+# Set the environment variables
+Write-Host "##vso[task.setvariable variable=A11yInsightsTagName]$($a11yInsightsTagName)"
+Write-Host "##vso[task.setvariable variable=A11yInsightsMinProdVersionTag]$($a11yInsightsMinProdVersionTag)"


### PR DESCRIPTION
#### Details

ADO release pipelines are limited to classic pipeline definitions, with no YAML support. Our current release pipelines include 5 inline PowerShell scripts, which are hard to discover and harder to review when changes are needed. After discussion as a team, we opted to add the scripts to the repo, publish them as build artifacts, then have the release pipelines execute the scripts that we consume from the build artifacts. This PR completes the first 2 steps, then we'll change the release pipelines once the artifact exists.

Note that while the consumption pattern will change from inline to an artifact, the scripts themselves will not be changing (caveat: 2 non-functional tweaks were made). The publishing of the `deploy_scripts` artifact occurs in the SignedRelease step, so it happens at the very end of the build. It was earlier in a test build just for the sake of efficiency.

##### Motivation

Take advantage of code tools to manage our release pipelines.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
The pipeline changes will take effect after this is merged and the `deploy_scripts` artifact becomes available.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



