### PR TITLE
chore: Limit TSA uploads to main branch

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -9,6 +9,7 @@ variables:
   TeamName: 'Accessibility Insights Windows'
   system.debug: 'true' #set to true in case our signed build flakes out again
   runCodesignValidationInjection: 'false'
+  isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
 
 jobs:
 - job: ComplianceRelease
@@ -181,6 +182,7 @@ jobs:
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (CredScan, Roslyn, and PoliCheck)'
+    condition: and(succeeded(), eq(variables.isMain, true))
     inputs:
       GdnPublishTsaOnboard: true
       GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'
@@ -310,6 +312,7 @@ jobs:
   
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload (BinSkim)'
+    condition: and(succeeded(), eq(variables.isMain, true))
     inputs:
       GdnPublishTsaOnboard: true
       GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\tsa.config'


### PR DESCRIPTION
#### Details

The old version of TSA automatically added the branch name to the database, which was kind of wasteful since new databases were created from each non-main branch used for a signed test build. The new version of TSA uses the same database name for all branches, which means that builds from any branch could create noise in the production version. To solve both problems, this PR restricts the TSA upload to just the main branch. All TSA artifacts are created as usual, but the upload task gets skipped. This is based on the method shown [here](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml%2Cstages). Using a couple of recent builds as reference,

build | branch | `Build.SourceBranch` variable
--- | --- | ---
[2023-03-21.03](https://dev.azure.com/mseng/1ES/_build/results?buildId=19564135&view=logs&j=efe68385-d402-5492-a2cf-bc47ec32e784&t=dfb879f2-51dd-59f9-c85b-7dd6984519b6&l=100) | DaveTryon/publish-release-scripts | `refs/heads/DaveTryon/publish-release-scripts`
[2023-04-22.01](https://dev.azure.com/mseng/1ES/_build/results?buildId=19566424&view=logs&j=efe68385-d402-5492-a2cf-bc47ec32e784&t=dfb879f2-51dd-59f9-c85b-7dd6984519b6&l=100) | main | `refs/heads/main`

The validation build for this change is [here](https://dev.azure.com/mseng/1ES/_build/results?buildId=19567653&view=results). The TSA upload task gets skipped in both [ComplianceDebug](https://dev.azure.com/mseng/1ES/_build/results?buildId=19567653&view=logs&j=efe68385-d402-5492-a2cf-bc47ec32e784&t=67bda85c-2f91-5baa-629c-687e4d53737c&l=1) and [SignedRelease](https://dev.azure.com/mseng/1ES/_build/results?buildId=19567653&view=logs&j=7c3ebc89-e7dd-5791-8c02-2ea1f3a27b50&t=e3d820ac-b555-5998-c763-65ae73427349&l=1) jobs.

##### Motivation

Maintain a single clean copy of the TSA database for the repo.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



