### PR TITLE
Upgrade WixToolset to v4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can find more information on how to set up your development environment [her
 #### 4. Build the MSI project
 The MSI project is used to package all the code into an installer that can be used to install Accessibility Insights for Windows. This is not a required step. By default the MSI project is not built in either configuration.
 Note: The MSI can only be built in the `Release` config.
-- The MSI project requires WIX. Download and install the Wix toolset from http://wixtoolset.org/.
+- The MSI project requires WIX. WiX is a modern SDK that restore will automatically download from NuGet. Learn about the Wix toolset from http://wixtoolset.org/.
 - To build the MSI locally, set build configuration to `Release`.
 - Find the MSI project in the solution explorer under the `packages` folder.
 - Right click on the MSI project and select `Build`.

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -255,13 +255,19 @@ jobs:
       Contents: '**\bin\release\**'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
+  - task: CopyFiles@2
+    displayName: 'Copy MSI file to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      Contents: '**\MSI\bin\x86\Release\**'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: msi'
     inputs:
-      PathtoPublish: 'src\MSI\bin\Release\msi'
+      PathtoPublish: 'src\MSI\bin\x86\Release\msi'
       ArtifactName: 'msi'
 
   - task: PublishBuildArtifacts@1

--- a/docs/SetUpDevEnv.md
+++ b/docs/SetUpDevEnv.md
@@ -8,7 +8,7 @@
    - Add ".NET Framework 4.8 development tools"
 
 ### Install Wix tools
-To build the MSI project, you need to install the HeatWave extension for Visual Studio from FireGiant. The extension is available in the Visual Studio marketplace and can be found [here](http://wixtoolset.org/docs/intro/#vs).
+To build the MSI project, you need to install the HeatWave extension for Visual Studio. The extension is can be downloaded from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=FireGiant.FireGiantHeatWaveDev17).
 
 ### Install WinAppDriver
 1. To run the UI tests, install WinAppDriver from [here](https://github.com/Microsoft/WinAppDriver/releases)

--- a/docs/SetUpDevEnv.md
+++ b/docs/SetUpDevEnv.md
@@ -8,7 +8,7 @@
    - Add ".NET Framework 4.8 development tools"
 
 ### Install Wix tools
-To build the MSI project, you need to install the Wix Toolset extension for Visual Studio. The extension is available in the Visual Studio marketplace and can be found [here](http://wixtoolset.org/releases/).
+To build the MSI project, you need to install the HeatWave extension for Visual Studio from FireGiant. The extension is available in the Visual Studio marketplace and can be found [here](http://wixtoolset.org/docs/intro/#vs).
 
 ### Install WinAppDriver
 1. To run the UI tests, install WinAppDriver from [here](https://github.com/Microsoft/WinAppDriver/releases)

--- a/src/AccessibilityInsights.CustomActions.Package/CustomActions.Package.csproj
+++ b/src/AccessibilityInsights.CustomActions.Package/CustomActions.Package.csproj
@@ -1,87 +1,36 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!--
-  This project exists to produce the AccessibilityInsights.CustomActions.CA.dll file that is
-  consumed by the MSI installer. It's a very non-standard project, so exercise extreme care
-  when modifying it.
--->
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{01426834-55CE-4942-8445-194E4E1BE22A}</ProjectGuid>
-    <OutputType>Library</OutputType>
     <RootNamespace>AccessibilityInsights.CustomActions.Package</RootNamespace>
     <AssemblyName>AccessibilityInsights.CustomActions</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\WiX.3.11.2\build\wix.props" Condition="Exists('..\packages\WiX.3.11.2\build\wix.props')" />
-  <Import Project="$(WixCATargetsPath)" Condition=" '$(WixCATargetsPath)' != '' " />
-  <Import Project="..\packages\WiX.3.11.2\tools\sdk\wix.ca.targets" Condition=" '$(WixCATargetsPath)' == '' AND Exists('..\packages\WiX.3.11.2\tools\sdk\wix.ca.targets') " />
-  <!--
-  ==================================================================================================
-  AfterCompile (redefinition of what is set up in wix.ca.targets)
-  ==================================================================================================
-  -->
-  <Target Name="AfterCompile" DependsOnTargets="OverwriteWithSignedAssemblies;PackCustomAction" />
-  <Target Name="OverwriteWithSignedAssemblies">
+
+  <ItemGroup>
+    <Content Include="CustomAction.config" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Dtf.CustomAction" Version="4.0.0" />
+  </ItemGroup>
+
+  <Target Name="OverwriteWithSignedAssemblies" BeforeTargets="PackCustomAction">
     <!-- Manually overwrite assemblies with signed versions before packing everything up -->
     <ItemGroup>
       <SignedOverwriteFiles Include="$(SolutionDir)AccessibilityInsights.CustomActions\bin\$(Configuration)\net48\AccessibilityInsights.CustomActions.*" />
-      <SignedOverwriteFiles Include="$(SolutionDir)AccessibilityInsights\bin\$(Configuration)\net48\Microsoft.Deployment.WindowsInstaller.dll" />
+      <SignedOverwriteFiles Include="$(SolutionDir)AccessibilityInsights\bin\$(Configuration)\net48\WixToolset.Dtf.WindowsInstaller.dll" />
       <SignedOverwriteFiles Include="$(SolutionDir)AccessibilityInsights\bin\$(Configuration)\net48\Newtonsoft.Json.dll" />
     </ItemGroup>
     <Copy SourceFiles="@(SignedOverwriteFiles)" DestinationFolder="$(IntermediateOutputPath)" />
     <PropertyGroup>
-      <CustomActionContents>$(IntermediateOutputPath)Microsoft.Deployment.WindowsInstaller.dll</CustomActionContents>
+      <CustomActionContents>$(IntermediateOutputPath)WixToolset.Dtf.WindowsInstaller.dll</CustomActionContents>
     </PropertyGroup>
   </Target>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core">
-      <Version>1.0.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="WiX" Version="3.11.2" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="PlaceholderClass.cs" />
-    <Content Include="CustomAction.config" />
-  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\AccessibilityInsights.SetupLibrary\SetupLibrary.csproj">
       <Project>{b1ded5b2-fa82-4b17-8e10-7b3b6f6a14fb}</Project>
       <Name>SetupLibrary</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="..\..\build\settings.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\WiX.3.11.2\build\wix.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WiX.3.11.2\build\wix.props'))" />
-  </Target>
+  <Import Project="..\..\build\NetFrameworkRelease.targets" />
 </Project>

--- a/src/AccessibilityInsights.CustomActions/ConfigFileCleaner.cs
+++ b/src/AccessibilityInsights.CustomActions/ConfigFileCleaner.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SetupLibrary;
-using Microsoft.Deployment.WindowsInstaller;
+using WixToolset.Dtf.WindowsInstaller;
 using System;
 
 namespace AccessibilityInsights.CustomActions

--- a/src/AccessibilityInsights.CustomActions/CustomActions.csproj
+++ b/src/AccessibilityInsights.CustomActions/CustomActions.csproj
@@ -9,10 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="WiX" Version="3.11.2" />
-    <Reference Include="Microsoft.Deployment.WindowsInstaller" Version="3.0.0.0">
-      <HintPath>..\packages\WiX.3.11.2\tools\Microsoft.Deployment.WindowsInstaller.dll</HintPath>
-    </Reference>
+    <PackageReference Include="WixToolset.Dtf.WindowsInstaller" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AccessibilityInsights.CustomActions/SystemShim.cs
+++ b/src/AccessibilityInsights.CustomActions/SystemShim.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.Deployment.WindowsInstaller;
+using WixToolset.Dtf.WindowsInstaller;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/src/AccessibilityInsights.CustomActionsUnitTests/ConfigFileCleanerUnitTests.cs
+++ b/src/AccessibilityInsights.CustomActionsUnitTests/ConfigFileCleanerUnitTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.CustomActions;
 using AccessibilityInsights.SetupLibrary;
-using Microsoft.Deployment.WindowsInstaller;
+using WixToolset.Dtf.WindowsInstaller;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;

--- a/src/AccessibilityInsights.CustomActionsUnitTests/CustomActionsUnitTests.csproj
+++ b/src/AccessibilityInsights.CustomActionsUnitTests/CustomActionsUnitTests.csproj
@@ -9,12 +9,6 @@
   <Import Project="..\..\build\NetFrameworkTest.targets" />
 
   <ItemGroup>
-    <Reference Include="Microsoft.Deployment.WindowsInstaller" Version="3.0.0.0">
-      <HintPath>..\packages\WiX.3.11.2\tools\Microsoft.Deployment.WindowsInstaller.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Codecov" Version="1.13.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/AccessibilityInsights.SetupLibrary/MsiUtilities.cs
+++ b/src/AccessibilityInsights.SetupLibrary/MsiUtilities.cs
@@ -1,6 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Microsoft.Deployment.WindowsInstaller;
+using WixToolset.Dtf.WindowsInstaller;
 using Microsoft.Win32;
 using System;
 using System.Collections.Generic;

--- a/src/AccessibilityInsights.SetupLibrary/SetupLibrary.csproj
+++ b/src/AccessibilityInsights.SetupLibrary/SetupLibrary.csproj
@@ -11,10 +11,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
-    <PackageReference Include="WiX" Version="3.11.2" />
-    <Reference Include="Microsoft.Deployment.WindowsInstaller" Version="3.0.0.0">
-      <HintPath>..\packages\WiX.3.11.2\tools\Microsoft.Deployment.WindowsInstaller.dll</HintPath>
-    </Reference>
+    <PackageReference Include="WixToolset.Dtf.WindowsInstaller" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
+++ b/src/AccessibilityInsights.VersionSwitcher/InstallationEngine.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SetupLibrary;
 using AccessibilityInsights.SetupLibrary.REST;
-using Microsoft.Deployment.WindowsInstaller;
+using WixToolset.Dtf.WindowsInstaller;
 using Microsoft.Win32;
 using System;
 using System.Diagnostics;

--- a/src/AccessibilityInsights.VersionSwitcher/VersionSwitcher.csproj
+++ b/src/AccessibilityInsights.VersionSwitcher/VersionSwitcher.csproj
@@ -12,10 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="WiX" Version="3.11.2" />
-    <Reference Include="Microsoft.Deployment.WindowsInstaller" Version="3.0.0.0">
-      <HintPath>..\packages\WiX.3.11.2\tools\Microsoft.Deployment.WindowsInstaller.dll</HintPath>
-    </Reference>
+    <PackageReference Include="WixToolset.Dtf.WindowsInstaller" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AccessibilityInsights.sln
+++ b/src/AccessibilityInsights.sln
@@ -4,7 +4,7 @@ VisualStudioVersion = 17.2.32602.215
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedUxTests", "AccessibilityInsights.SharedUxTests\SharedUxTests.csproj", "{F595A9C3-E625-40C9-82A5-79F05804F535}"
 EndProject
-Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "MSI", "MSI\MSI.wixproj", "{137DB774-6464-48BC-B577-091ABEAF0178}"
+Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "MSI", "MSI\MSI.wixproj", "{137DB774-6464-48BC-B577-091ABEAF0178}"
 	ProjectSection(ProjectDependencies) = postProject
 		{01426834-55CE-4942-8445-194E4E1BE22A} = {01426834-55CE-4942-8445-194E4E1BE22A}
 		{1D4F9843-B1CB-4CCC-A13A-D132336750F2} = {1D4F9843-B1CB-4CCC-A13A-D132336750F2}
@@ -108,7 +108,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Manifest", "Manifest\Manife
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VersionSwitcherUnitTests", "AccessibilityInsights.VersionSwitcherUnitTests\VersionSwitcherUnitTests.csproj", "{02164CBE-FBFB-407B-BE18-827FAE8E798E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ManifestTests", "ManifestTests\ManifestTests.csproj", "{88B007FA-E7F2-4E3F-8124-83F89A84296E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ManifestTests", "ManifestTests\ManifestTests.csproj", "{88B007FA-E7F2-4E3F-8124-83F89A84296E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -474,18 +474,18 @@ Global
 		{7A7C04EA-8279-4D69-959D-E804DD81BC70}.SignedRelease|Any CPU.ActiveCfg = Release|Any CPU
 		{7A7C04EA-8279-4D69-959D-E804DD81BC70}.SignedRelease|x64.ActiveCfg = Release|Any CPU
 		{7A7C04EA-8279-4D69-959D-E804DD81BC70}.SignedRelease|x86.ActiveCfg = Release|Any CPU
-		{01426834-55CE-4942-8445-194E4E1BE22A}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{01426834-55CE-4942-8445-194E4E1BE22A}.Debug|Any CPU.Build.0 = Debug|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01426834-55CE-4942-8445-194E4E1BE22A}.Debug|x64.ActiveCfg = Debug|x86
-		{01426834-55CE-4942-8445-194E4E1BE22A}.Debug|x86.ActiveCfg = Debug|x86
-		{01426834-55CE-4942-8445-194E4E1BE22A}.Debug|x86.Build.0 = Debug|x86
-		{01426834-55CE-4942-8445-194E4E1BE22A}.Release|Any CPU.ActiveCfg = Release|x86
-		{01426834-55CE-4942-8445-194E4E1BE22A}.Release|Any CPU.Build.0 = Release|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Debug|x86.Build.0 = Debug|Any CPU
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01426834-55CE-4942-8445-194E4E1BE22A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{01426834-55CE-4942-8445-194E4E1BE22A}.Release|x64.ActiveCfg = Release|x86
 		{01426834-55CE-4942-8445-194E4E1BE22A}.Release|x86.ActiveCfg = Release|x86
 		{01426834-55CE-4942-8445-194E4E1BE22A}.Release|x86.Build.0 = Release|x86
-		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|Any CPU.ActiveCfg = Release|x86
-		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|Any CPU.Build.0 = Release|x86
+		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|Any CPU.Build.0 = Release|Any CPU
 		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|x64.ActiveCfg = Release|x86
 		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|x64.Build.0 = Release|x86
 		{01426834-55CE-4942-8445-194E4E1BE22A}.SignedRelease|x86.ActiveCfg = Release|x86

--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <Drop3PartySignedFile Include="$(TargetDir)\CommandLine.dll" />
     <Drop3PartySignedFile Include="$(TargetDir)\HtmlAgilityPack.dll" />
-    <Drop3PartySignedFile Include="$(TargetDir)\Microsoft.Deployment.WindowsInstaller.dll" />
+    <Drop3PartySignedFile Include="$(TargetDir)\WixToolset.Dtf.WindowsInstaller.dll" />
     <Drop3PartySignedFile Include="$(TargetDir)\Newtonsoft.Json.dll" />
   </ItemGroup>
 

--- a/src/AccessibilityInsights/AccessibilityInsights.csproj
+++ b/src/AccessibilityInsights/AccessibilityInsights.csproj
@@ -13,8 +13,8 @@
   <ItemGroup>
     <Drop3PartySignedFile Include="$(TargetDir)\CommandLine.dll" />
     <Drop3PartySignedFile Include="$(TargetDir)\HtmlAgilityPack.dll" />
-    <Drop3PartySignedFile Include="$(TargetDir)\WixToolset.Dtf.WindowsInstaller.dll" />
     <Drop3PartySignedFile Include="$(TargetDir)\Newtonsoft.Json.dll" />
+    <Drop3PartySignedFile Include="$(TargetDir)\WixToolset.Dtf.WindowsInstaller.dll" />
   </ItemGroup>
 
   <Import Project="..\..\build\NetFrameworkRelease.targets" />

--- a/src/MSI/MSI.wixproj
+++ b/src/MSI/MSI.wixproj
@@ -1,87 +1,44 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" Condition="Exists('..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" />
+﻿<Project>
+  <Import Project="Sdk.props" Sdk="WixToolset.Sdk" Version="4.0.1" />
   <PropertyGroup>
-    <!-- We use the toolset from NuGet, instead of requiring it to be installed. This silences an "error" that isn't really an error. -->
-    <WixTargetsImported>true</WixTargetsImported>
-  </PropertyGroup>
-  <Import Project="..\packages\WiX.3.11.2\build\wix.props" Condition="Exists('..\packages\WiX.3.11.2\build\wix.props')" />
-  <Import Project="..\packages\Microsoft.Wix3.Tools.3.10.1.2213\build\Microsoft.Wix3.Tools.props" Condition="Exists('..\packages\Microsoft.Wix3.Tools.3.10.1.2213\build\Microsoft.Wix3.Tools.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>3.10</ProductVersion>
-    <ProjectGuid>137db774-6464-48bc-b577-091abeaf0178</ProjectGuid>
-    <SchemaVersion>2.0</SchemaVersion>
     <OutputName>AccessibilityInsights</OutputName>
-    <OutputType>Package</OutputType>
     <Revision Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER.Substring($(BUILD_BUILDNUMBER.LastIndexOf(`.`))))</Revision>
     <Revision Condition=" '$(BUILD_BUILDNUMBER)' == '' ">.1</Revision>
     <CurrentDateString Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER.Substring(0, $(BUILD_BUILDNUMBER.LastIndexOf(`.`))))</CurrentDateString>
     <CurrentDateString Condition=" '$(BUILD_BUILDNUMBER)' == '' ">$([System.DateTime]::Now.ToString(`yyyy-MM-dd`))</CurrentDateString>
     <CountDate>$([System.DateTime]::ParseExact(`2017-01-01`,`yyyy-MM-dd`,null))</CountDate>
     <BuildNumber>1.1.$([System.Math]::Round($([System.DateTime]::ParseExact($(CurrentDateString),`yyyy-MM-dd`,null).Subtract($(CountDate)).TotalDays)).ToString(`0000`))$(Revision)</BuildNumber>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
     <IsPackage>true</IsPackage>
     <SignOutput>true</SignOutput>
     <Name>MSI</Name>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants>Debug;BuildVer=$(BuildNumber);</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants>BuildVer=$(BuildNumber);</DefineConstants>
     <SuppressSpecificWarnings>1076;69</SuppressSpecificWarnings>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="Product.wxs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
+  <!--<ItemGroup>
     <Folder Include="bin\" />
     <Folder Include="bin\Debug\" />
+  </ItemGroup>-->
+  <ItemGroup>
+    <PackageReference Include="WixToolset.NetFx.wixext" Version="4.0.1" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.1" />
+    <PackageReference Include="WixToolset.Util.wixext" Version="4.0.1" />
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <WixExtension Include="WixNetFxExtension">
-      <HintPath>..\packages\WiX.3.11.0\tools\WixNetFxExtension.dll</HintPath>
-      <Name>WixNetFxExtension</Name>
-    </WixExtension>
-    <WixExtension Include="WixUIExtension">
-      <HintPath>$(WixExtDir)\WixUIExtension.dll</HintPath>
-      <Name>WixUIExtension</Name>
-    </WixExtension>
-    <WixExtension Include="WixUtilExtension">
-      <HintPath>$(WixExtDir)\WixUtilExtension.dll</HintPath>
-      <Name>WixUtilExtension</Name>
-    </WixExtension>
+    <ProjectReference Include="..\AccessibilityInsights.CustomActions.Package\CustomActions.Package.csproj" />
+    <ProjectReference Include="..\AccessibilityInsights.VersionSwitcher\VersionSwitcher.csproj" />
+    <ProjectReference Include="..\AccessibilityInsights\AccessibilityInsights.csproj" />
   </ItemGroup>
-  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
-  <!--
-    To modify your build process, add your task inside one of the targets below and uncomment it.
-    Other similar extension points exist, see Wix.targets.
-    <Target Name="BeforeBuild">
-    </Target>
-    <Target Name="AfterBuild">
-    </Target>
-  -->
+  <Import Project="Sdk.targets" Sdk="WixToolset.Sdk" Version="4.0.1" />
   <Target Name="AfterBuild">
     <Copy SourceFiles="$(OutputPath)AccessibilityInsights.msi" DestinationFolder="$(OutputPath)\msi\$(BuildNumber)" ContinueOnError="true" />
   </Target>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\WiX.3.11.2\build\wix.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WiX.3.11.2\build\wix.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets'))" />
-  </Target>
-  <Import Project="..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />
 </Project>

--- a/src/MSI/MSI.wixproj
+++ b/src/MSI/MSI.wixproj
@@ -1,5 +1,6 @@
 ﻿<Project>
   <Import Project="Sdk.props" Sdk="WixToolset.Sdk" Version="4.0.1" />
+
   <PropertyGroup>
     <OutputName>AccessibilityInsights</OutputName>
     <Revision Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER.Substring($(BUILD_BUILDNUMBER.LastIndexOf(`.`))))</Revision>
@@ -12,17 +13,21 @@
     <SignOutput>true</SignOutput>
     <Name>MSI</Name>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DefineConstants>Debug;BuildVer=$(BuildNumber);</DefineConstants>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DefineConstants>BuildVer=$(BuildNumber);</DefineConstants>
     <SuppressSpecificWarnings>1076;69</SuppressSpecificWarnings>
   </PropertyGroup>
+
   <!--<ItemGroup>
     <Folder Include="bin\" />
     <Folder Include="bin\Debug\" />
   </ItemGroup>-->
+
   <ItemGroup>
     <PackageReference Include="WixToolset.NetFx.wixext" Version="4.0.1" />
     <PackageReference Include="WixToolset.UI.wixext" Version="4.0.1" />
@@ -32,12 +37,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\AccessibilityInsights.CustomActions.Package\CustomActions.Package.csproj" />
     <ProjectReference Include="..\AccessibilityInsights.VersionSwitcher\VersionSwitcher.csproj" />
     <ProjectReference Include="..\AccessibilityInsights\AccessibilityInsights.csproj" />
   </ItemGroup>
+
   <Import Project="Sdk.targets" Sdk="WixToolset.Sdk" Version="4.0.1" />
+
   <Target Name="AfterBuild">
     <Copy SourceFiles="$(OutputPath)AccessibilityInsights.msi" DestinationFolder="$(OutputPath)\msi\$(BuildNumber)" ContinueOnError="true" />
   </Target>

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (c) Microsoft. All rights reserved.
 Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
@@ -6,12 +6,15 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
            Manufacturer="Microsoft"
            UpgradeCode="0D760959-F713-46C4-9A3D-4E73619EE3B5"
            InstallerVersion="200">
+
     <MajorUpgrade Schedule="afterInstallInitialize" RemoveFeatures="All"
                   AllowDowngrades="no"
-                  DowngradeErrorMessage="A newer version of [ProductName] is already installed."
-                  AllowSameVersionUpgrades="no" />
+                  DowngradeErrorMessage="A newer version of [ProductName] is already installed." 
+                  AllowSameVersionUpgrades="no"/>
+
     <Binary Id="CustomActions"
             SourceFile="AccessibilityInsights.CustomActions.CA.dll" />
+
     <UI>
       <ui:WixUI Id="WixUI_InstallDir" />
       <Publish Dialog="ExitDialog"
@@ -19,6 +22,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
             Event="DoAction"
             Value="LaunchInstalledExe" Condition="NOT Installed" />
     </UI>
+
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
 
     <WixVariable Id="WixUIDialogBmp" Value="Resources\DialogBackground.png" />
@@ -42,7 +46,8 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
         <Directory Id="INSTALLFOLDER" Name="1.1">
           <Component Id="ProductComponent" Guid="21CE5D3B-FE98-4B24-B1CE-FE2FE646B2A2">
             <File Id="FileExe" Source="AccessibilityInsights.exe" KeyPath="yes">
-              <Shortcut Id="aiforwin" Directory="DesktopFolder" Name="Accessibility Insights For Windows" Description="Accessibility Insights For Windows v1.1" WorkingDirectory="INSTALLFOLDER" Icon="AccessibilityInsights.exe" IconIndex="0" Advertise="yes" />
+              <Shortcut Id="aiforwin" Directory="DesktopFolder" Name="Accessibility Insights For Windows"
+                        Description="Accessibility Insights For Windows v1.1" WorkingDirectory="INSTALLFOLDER" Icon="AccessibilityInsights.exe" IconIndex="0" Advertise="yes" />
             </File>
             <File Id="AccessibilityInsights.exe.config" Source="AccessibilityInsights.exe.config" />
             <File Id="AccessibilityInsights.exe.manifest" Source="AccessibilityInsights.exe.manifest" />
@@ -133,6 +138,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                 <Verb Id="open" Command="Open" TargetFile="FileExe" Argument="&quot;%1&quot;" />
               </Extension>
             </ProgId>
+
             <ProgId Id="A11y.Event" Description="Accessibility Insights For Windows Events file">
               <Extension Id="a11yevent" ContentType="AccessibilityInsights Events File">
                 <Verb Id="open" Command="Open" TargetFile="FileExe" Argument="&quot;%1&quot;" />
@@ -179,11 +185,12 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
       <Directory Id="ApplicationProgramsFolder" Name="AccessibilityInsights" />
     </StandardDirectory>
 
+    <!-- Note that, while the Icon's Id must have the same file extension as the shortcut's target, the source can be an ICO file (does not have to be a PE file). This change reduces the size of your MSI file -->
     <Icon Id="AccessibilityInsights.exe" SourceFile="..\AccessibilityInsights.SharedUx\Resources\Icons\BrandIconDesktop.ico" />
 
     <Property Id="WixShellExecTarget" Value="[#FileExe]"/>
-    <CustomAction Id="LaunchInstalledExe" DllEntry="WixShellExec" Impersonate="yes" BinaryRef="Wix4UtilCA_X86" />
-    <CustomAction Id="RemoveUserConfigFiles" DllEntry="RemoveUserConfigFiles" Impersonate="yes" BinaryRef="CustomActions" />
+    <CustomAction Id="LaunchInstalledExe" BinaryRef="Wix4UtilCA_X86" DllEntry="WixShellExec" Impersonate="yes" />
+    <CustomAction Id="RemoveUserConfigFiles" BinaryRef="CustomActions" DllEntry="RemoveUserConfigFiles" Impersonate="yes" />
 
     <InstallExecuteSequence>
       <Custom Action="RemoveUserConfigFiles" After="InstallFinalize" Condition="Installed and (REMOVE=&quot;ALL&quot;) and NOT UPGRADINGPRODUCTCODE" />

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -1,31 +1,29 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft. All rights reserved.
 Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
-     xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension">
-  <Product Id="*"
-           Name="Accessibility Insights For Windows v1.1" Language="1033" Version="$(var.BuildVer)" 
-           Manufacturer="Microsoft" 
-           UpgradeCode="0D760959-F713-46C4-9A3D-4E73619EE3B5">
-    <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" Platform="x86"/>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package Name="Accessibility Insights For Windows v1.1" Language="1033" Version="$(var.BuildVer)"
+           Manufacturer="Microsoft"
+           UpgradeCode="0D760959-F713-46C4-9A3D-4E73619EE3B5"
+           InstallerVersion="200">
     <MajorUpgrade Schedule="afterInstallInitialize" RemoveFeatures="All"
                   AllowDowngrades="no"
-                  DowngradeErrorMessage="A newer version of [ProductName] is already installed." 
-                  AllowSameVersionUpgrades="no"/>
+                  DowngradeErrorMessage="A newer version of [ProductName] is already installed."
+                  AllowSameVersionUpgrades="no" />
     <Binary Id="CustomActions"
-            SourceFile="..\AccessibilityInsights.CustomActions.Package\bin\Release\AccessibilityInsights.CustomActions.CA.dll" />
+            SourceFile="AccessibilityInsights.CustomActions.CA.dll" />
     <UI>
-      <UIRef Id="WixUI_InstallDir"/>
+      <ui:WixUI Id="WixUI_InstallDir" />
       <Publish Dialog="ExitDialog"
             Control="Finish"
             Event="DoAction"
-            Value="LaunchInstalledExe">NOT Installed</Publish>
+            Value="LaunchInstalledExe" Condition="NOT Installed" />
     </UI>
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
 
     <WixVariable Id="WixUIDialogBmp" Value="Resources\DialogBackground.png" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\WixDialogBanner.png" />
-    <WixVariable Id="WixUILicenseRtf" Value="..\AccessibilityInsights\bin\Release\net48\eula.rtf" />
+    <WixVariable Id="WixUILicenseRtf" Value="eula.rtf" />
 
     <MediaTemplate EmbedCab="yes" />
 
@@ -36,168 +34,160 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
       <ComponentRef Id="ApplicationShortcut" />
     </Feature>
 
-    <!--Until WIX_IS_NETFRAMEWORK_47_OR_LATER_INSTALLED property is supported,
-    this is our workaround as suggested here: https://github.com/wixtoolset/issues/issues/5575 -->
-    <!-- .NET 4.8 value is taken from https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies -->
-    <PropertyRef Id="NETFRAMEWORK45" />
-    <Condition Message="[ProductName] requires .NET Framework 4.8 or later.">
-      <![CDATA[Installed OR (NETFRAMEWORK45 AND NETFRAMEWORK45 >= "#528040")]]>
-    </Condition>
+    <PropertyRef Id="WIX_IS_NETFRAMEWORK_48_OR_LATER_INSTALLED" />
+    <Launch Condition="Installed OR WIX_IS_NETFRAMEWORK_48_OR_LATER_INSTALLED" Message="[ProductName] requires .NET Framework 4.8 or later." />
 
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="AccessibilityInsightsFolder" Name="AccessibilityInsights" >
-          <Directory Id="INSTALLFOLDER" Name="1.1">
-            <Component Id="ProductComponent" Guid="21CE5D3B-FE98-4B24-B1CE-FE2FE646B2A2">
-              <File Id="FileExe" Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.exe" KeyPath="yes" >
-                <Shortcut Id="aiforwin" Directory="DesktopFolder" Name="Accessibility Insights For Windows"
-                          Description="Accessibility Insights For Windows v1.1" WorkingDirectory='INSTALLFOLDER' Icon="AccessibilityInsights.exe" IconIndex="0" Advertise="yes" />
-              </File>
-              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.exe.config" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.exe.manifest" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.CommonUxComponents.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.Extensions.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.Extensions.AzureDevOps.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.Extensions.GitHub.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.Extensions.GitHubAutoUpdate.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.Extensions.Telemetry.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.SetupLibrary.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.SharedUx.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.Win32.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.Actions.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.Core.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.Desktop.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.Rules.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.RuleSelection.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.SystemAbstractions.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.Telemetry.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Axe.Windows.Win32.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\CommandLine.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\HtmlAgilityPack.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.ApplicationInsights.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Azure.DevOps.Comments.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Azure.Pipelines.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Bcl.AsyncInterfaces.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Deployment.WindowsInstaller.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.IdentityModel.Abstractions.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.IdentityModel.JsonWebTokens.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.IdentityModel.Logging.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.IdentityModel.Tokens.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Build2.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Common.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Core.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Dashboards.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.DistributedTask.Common.Contracts.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Pipelines.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Policy.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.SourceControl.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Test.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.TestManagement.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Wiki.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.Work.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.WorkItemTracking.Process.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.VisualStudio.Services.Client.Interactive.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.VisualStudio.Services.Common.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.VisualStudio.Services.TestResults.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.VisualStudio.Services.WebApi.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Web.WebView2.Core.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Web.WebView2.WinForms.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Web.WebView2.Wpf.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Win32.Registry.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Xaml.Behaviors.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\Newtonsoft.Json.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Buffers.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Collections.Immutable.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Diagnostics.DiagnosticSource.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Drawing.Common.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.IdentityModel.Tokens.Jwt.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.IO.Packaging.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Memory.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Net.Http.Formatting.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Numerics.Vectors.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Reflection.Metadata.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Reflection.MetadataLoadContext.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Runtime.CompilerServices.Unsafe.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Security.AccessControl.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Security.Principal.Windows.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Text.Encodings.Web.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Text.Json.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Threading.Tasks.Extensions.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.ValueTuple.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Web.Http.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\System.Web.Http.WebHost.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\WebView2Loader.dll" />
-              <File Source="..\AccessibilityInsights\bin\Release\net48\ThirdPartyNotices.html"/>
-              <File Source="..\AccessibilityInsights\bin\Release\net48\eula.rtf"/>
-              <File Source="..\AccessibilityInsights\bin\Release\net48\links.json"/>
-              <File Source="..\AccessibilityInsights\bin\Release\net48\UIAccess.cmd"/>
-              <File Source="..\AccessibilityInsights\bin\Release\net48\UIAccess_Disabled.manifest"/>
-              <File Source="..\AccessibilityInsights\bin\Release\net48\UIAccess_Enabled.manifest"/>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="AccessibilityInsightsFolder" Name="AccessibilityInsights">
+        <Directory Id="INSTALLFOLDER" Name="1.1">
+          <Component Id="ProductComponent" Guid="21CE5D3B-FE98-4B24-B1CE-FE2FE646B2A2">
+            <File Id="FileExe" Source="AccessibilityInsights.exe" KeyPath="yes">
+              <Shortcut Id="aiforwin" Directory="DesktopFolder" Name="Accessibility Insights For Windows" Description="Accessibility Insights For Windows v1.1" WorkingDirectory="INSTALLFOLDER" Icon="AccessibilityInsights.exe" IconIndex="0" Advertise="yes" />
+            </File>
+            <File Id="AccessibilityInsights.exe.config" Source="AccessibilityInsights.exe.config" />
+            <File Id="AccessibilityInsights.exe.manifest" Source="AccessibilityInsights.exe.manifest" />
+            <File Id="AccessibilityInsights.CommonUxComponents.dll" Source="AccessibilityInsights.CommonUxComponents.dll" />
+            <File Id="AccessibilityInsights.Extensions.dll" Source="AccessibilityInsights.Extensions.dll" />
+            <File Id="AccessibilityInsights.Extensions.AzureDevOps.dll" Source="AccessibilityInsights.Extensions.AzureDevOps.dll" />
+            <File Id="AccessibilityInsights.Extensions.GitHub.dll" Source="AccessibilityInsights.Extensions.GitHub.dll" />
+            <File Id="AccessibilityInsights.Extensions.GitHubAutoUpdate.dll" Source="AccessibilityInsights.Extensions.GitHubAutoUpdate.dll" />
+            <File Id="AccessibilityInsights.Extensions.Telemetry.dll" Source="AccessibilityInsights.Extensions.Telemetry.dll" />
+            <File Id="AccessibilityInsights.SetupLibrary.dll" Source="AccessibilityInsights.SetupLibrary.dll" />
+            <File Id="AccessibilityInsights.SharedUx.dll" Source="AccessibilityInsights.SharedUx.dll" />
+            <File Id="AccessibilityInsights.Win32.dll" Source="AccessibilityInsights.Win32.dll" />
+            <File Id="Axe.Windows.Actions.dll" Source="Axe.Windows.Actions.dll" />
+            <File Id="Axe.Windows.Core.dll" Source="Axe.Windows.Core.dll" />
+            <File Id="Axe.Windows.Desktop.dll" Source="Axe.Windows.Desktop.dll" />
+            <File Id="Axe.Windows.Rules.dll" Source="Axe.Windows.Rules.dll" />
+            <File Id="Axe.Windows.RuleSelection.dll" Source="Axe.Windows.RuleSelection.dll" />
+            <File Id="Axe.Windows.SystemAbstractions.dll" Source="Axe.Windows.SystemAbstractions.dll" />
+            <File Id="Axe.Windows.Telemetry.dll" Source="Axe.Windows.Telemetry.dll" />
+            <File Id="Axe.Windows.Win32.dll" Source="Axe.Windows.Win32.dll" />
+            <File Id="CommandLine.dll" Source="CommandLine.dll" />
+            <File Id="HtmlAgilityPack.dll" Source="HtmlAgilityPack.dll" />
+            <File Id="Microsoft.ApplicationInsights.dll" Source="Microsoft.ApplicationInsights.dll" />
+            <File Id="Microsoft.Azure.DevOps.Comments.WebApi.dll" Source="Microsoft.Azure.DevOps.Comments.WebApi.dll" />
+            <File Id="Microsoft.Azure.Pipelines.WebApi.dll" Source="Microsoft.Azure.Pipelines.WebApi.dll" />
+            <File Id="Microsoft.Bcl.AsyncInterfaces.dll" Source="Microsoft.Bcl.AsyncInterfaces.dll" />
+            <File Id="WixToolset.Dtf.WindowsInstaller.dll" Source="WixToolset.Dtf.WindowsInstaller.dll" />
+            <File Id="Microsoft.IdentityModel.Abstractions.dll" Source="Microsoft.IdentityModel.Abstractions.dll" />
+            <File Id="Microsoft.IdentityModel.Clients.ActiveDirectory.dll" Source="Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
+            <File Id="Microsoft.IdentityModel.JsonWebTokens.dll" Source="Microsoft.IdentityModel.JsonWebTokens.dll" />
+            <File Id="Microsoft.IdentityModel.Logging.dll" Source="Microsoft.IdentityModel.Logging.dll" />
+            <File Id="Microsoft.IdentityModel.Tokens.dll" Source="Microsoft.IdentityModel.Tokens.dll" />
+            <File Id="Microsoft.TeamFoundation.Build2.WebApi.dll" Source="Microsoft.TeamFoundation.Build2.WebApi.dll" />
+            <File Id="Microsoft.TeamFoundation.Common.dll" Source="Microsoft.TeamFoundation.Common.dll" />
+            <File Id="Microsoft.TeamFoundation.Core.WebApi.dll" Source="Microsoft.TeamFoundation.Core.WebApi.dll" />
+            <File Id="Microsoft.TeamFoundation.Dashboards.WebApi.dll" Source="Microsoft.TeamFoundation.Dashboards.WebApi.dll" />
+            <File Id="Microsoft.TeamFoundation.DistributedTask.Common.Contracts.dll" Source="Microsoft.TeamFoundation.DistributedTask.Common.Contracts.dll" />
+            <File Id="Microsoft.TeamFoundation.Pipelines.WebApi.dll" Source="Microsoft.TeamFoundation.Pipelines.WebApi.dll" />
+            <File Id="Microsoft.TeamFoundation.Policy.WebApi.dll" Source="Microsoft.TeamFoundation.Policy.WebApi.dll" />
+            <File Id="Microsoft.TeamFoundation.SourceControl.WebApi.dll" Source="Microsoft.TeamFoundation.SourceControl.WebApi.dll" />
+            <File Id="Microsoft.TeamFoundation.Test.WebApi.dll" Source="Microsoft.TeamFoundation.Test.WebApi.dll" />
+            <File Id="Microsoft.TeamFoundation.TestManagement.WebApi.dll" Source="Microsoft.TeamFoundation.TestManagement.WebApi.dll" />
+            <File Id="Microsoft.TeamFoundation.Wiki.WebApi.dll" Source="Microsoft.TeamFoundation.Wiki.WebApi.dll" />
+            <File Id="Microsoft.TeamFoundation.Work.WebApi.dll" Source="Microsoft.TeamFoundation.Work.WebApi.dll" />
+            <File Id="Microsoft.TeamFoundation.WorkItemTracking.Process.WebApi.dll" Source="Microsoft.TeamFoundation.WorkItemTracking.Process.WebApi.dll" />
+            <File Id="Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll" Source="Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll" />
+            <File Id="Microsoft.VisualStudio.Services.Client.Interactive.dll" Source="Microsoft.VisualStudio.Services.Client.Interactive.dll" />
+            <File Id="Microsoft.VisualStudio.Services.Common.dll" Source="Microsoft.VisualStudio.Services.Common.dll" />
+            <File Id="Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.dll" Source="Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.dll" />
+            <File Id="Microsoft.VisualStudio.Services.TestResults.WebApi.dll" Source="Microsoft.VisualStudio.Services.TestResults.WebApi.dll" />
+            <File Id="Microsoft.VisualStudio.Services.WebApi.dll" Source="Microsoft.VisualStudio.Services.WebApi.dll" />
+            <File Id="Microsoft.Web.WebView2.Core.dll" Source="Microsoft.Web.WebView2.Core.dll" />
+            <File Id="Microsoft.Web.WebView2.WinForms.dll" Source="Microsoft.Web.WebView2.WinForms.dll" />
+            <File Id="Microsoft.Web.WebView2.Wpf.dll" Source="Microsoft.Web.WebView2.Wpf.dll" />
+            <File Id="Microsoft.Win32.Registry.dll" Source="Microsoft.Win32.Registry.dll" />
+            <File Id="Microsoft.Xaml.Behaviors.dll" Source="Microsoft.Xaml.Behaviors.dll" />
+            <File Id="Newtonsoft.Json.dll" Source="Newtonsoft.Json.dll" />
+            <File Id="System.Buffers.dll" Source="System.Buffers.dll" />
+            <File Id="System.Collections.Immutable.dll" Source="System.Collections.Immutable.dll" />
+            <File Id="System.Diagnostics.DiagnosticSource.dll" Source="System.Diagnostics.DiagnosticSource.dll" />
+            <File Id="System.Drawing.Common.dll" Source="System.Drawing.Common.dll" />
+            <File Id="System.IdentityModel.Tokens.Jwt.dll" Source="System.IdentityModel.Tokens.Jwt.dll" />
+            <File Id="System.IO.Packaging.dll" Source="System.IO.Packaging.dll" />
+            <File Id="System.Memory.dll" Source="System.Memory.dll" />
+            <File Id="System.Net.Http.Formatting.dll" Source="System.Net.Http.Formatting.dll" />
+            <File Id="System.Numerics.Vectors.dll" Source="System.Numerics.Vectors.dll" />
+            <File Id="System.Reflection.Metadata.dll" Source="System.Reflection.Metadata.dll" />
+            <File Id="System.Reflection.MetadataLoadContext.dll" Source="System.Reflection.MetadataLoadContext.dll" />
+            <File Id="System.Runtime.CompilerServices.Unsafe.dll" Source="System.Runtime.CompilerServices.Unsafe.dll" />
+            <File Id="System.Security.AccessControl.dll" Source="System.Security.AccessControl.dll" />
+            <File Id="System.Security.Principal.Windows.dll" Source="System.Security.Principal.Windows.dll" />
+            <File Id="System.Text.Encodings.Web.dll" Source="System.Text.Encodings.Web.dll" />
+            <File Id="System.Text.Json.dll" Source="System.Text.Json.dll" />
+            <File Id="System.Threading.Tasks.Extensions.dll" Source="System.Threading.Tasks.Extensions.dll" />
+            <File Id="System.ValueTuple.dll" Source="System.ValueTuple.dll" />
+            <File Id="System.Web.Http.dll" Source="System.Web.Http.dll" />
+            <File Id="System.Web.Http.WebHost.dll" Source="System.Web.Http.WebHost.dll" />
+            <File Id="WebView2Loader.dll" Source="WebView2Loader.dll" />
+            <File Id="ThirdPartyNotices.html" Source="ThirdPartyNotices.html" />
+            <File Id="eula.rtf" Source="eula.rtf" />
+            <File Id="links.json" Source="links.json" />
+            <File Id="UIAccess.cmd" Source="UIAccess.cmd" />
+            <File Id="UIAccess_Disabled.manifest" Source="UIAccess_Disabled.manifest" />
+            <File Id="UIAccess_Enabled.manifest" Source="UIAccess_Enabled.manifest" />
 
-              <ProgId Id='A11y.Test' Description='Accessibility Insights For Windows Test file'>
-                <Extension Id='a11ytest' ContentType='AccessibilityInsights Test File'>
-                  <Verb Id='open' Command='Open' TargetFile='FileExe' Argument='"%1"' />
-                </Extension>
-              </ProgId>
-              <ProgId Id='A11y.Event' Description='Accessibility Insights For Windows Events file'>
-                <Extension Id='a11yevent' ContentType='AccessibilityInsights Events File'>
-                  <Verb Id='open' Command='Open' TargetFile='FileExe' Argument='"%1"' />
-                </Extension>
-              </ProgId>
+            <ProgId Id="A11y.Test" Description="Accessibility Insights For Windows Test file">
+              <Extension Id="a11ytest" ContentType="AccessibilityInsights Test File">
+                <Verb Id="open" Command="Open" TargetFile="FileExe" Argument="&quot;%1&quot;" />
+              </Extension>
+            </ProgId>
+            <ProgId Id="A11y.Event" Description="Accessibility Insights For Windows Events file">
+              <Extension Id="a11yevent" ContentType="AccessibilityInsights Events File">
+                <Verb Id="open" Command="Open" TargetFile="FileExe" Argument="&quot;%1&quot;" />
+              </Extension>
+            </ProgId>
+          </Component>
+
+          <Directory Id="IssueTemplates" Name="IssueTemplates">
+            <Component Id="IssueTemplateComp" Guid="FEFD2999-2F07-4422-B0C7-BA349AF734B1">
+              <File Id="IssueNoFailures.json" Source="IssueTemplates\IssueNoFailures.json" />
+              <File Id="IssueNoFailures.html" Source="IssueTemplates\IssueNoFailures.html" />
+              <File Id="IssueSingleFailure.json" Source="IssueTemplates\IssueSingleFailure.json" />
+              <File Id="IssueSingleFailure.html" Source="IssueTemplates\IssueSingleFailure.html" />
+              <File Id="IssueColorContrast.json" Source="IssueTemplates\IssueColorContrast.json" />
+              <File Id="IssueColorContrast.html" Source="IssueTemplates\IssueColorContrast.html" />
             </Component>
-
-            <Directory Id="IssueTemplates" Name="IssueTemplates">
-              <Component Id="IssueTemplateComp" Guid="FEFD2999-2F07-4422-B0C7-BA349AF734B1">
-                <File Source="..\AccessibilityInsights\bin\Release\net48\IssueTemplates\IssueNoFailures.json"/>
-                <File Source="..\AccessibilityInsights\bin\Release\net48\IssueTemplates\IssueNoFailures.html"/>
-                <File Source="..\AccessibilityInsights\bin\Release\net48\IssueTemplates\IssueSingleFailure.json"/>
-                <File Source="..\AccessibilityInsights\bin\Release\net48\IssueTemplates\IssueSingleFailure.html"/>
-                <File Source="..\AccessibilityInsights\bin\Release\net48\IssueTemplates\IssueColorContrast.json"/>
-                <File Source="..\AccessibilityInsights\bin\Release\net48\IssueTemplates\IssueColorContrast.html"/>
-              </Component>
-            </Directory>
-
-            <Directory Id="VersionSwitcher" Name="VersionSwitcher">
-              <Component Id="VersionSwitcherComp" Guid="1AAD6099-09E1-4E8F-A28B-57806F4A29DF">
-                <!-- ID's are needed for these files, since several of them are also installed with the main app -->
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\AccessibilityInsights.VersionSwitcher.exe" Id="version_switcher"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\AccessibilityInsights.VersionSwitcher.exe.config" Id="version_switcher_config"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\AccessibilityInsights.SetupLibrary.dll" Id ="version_switcher_setuplibrary"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\AccessibilityInsights.Win32.dll" Id ="version_switcher_win32"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\System.Buffers.dll" Id ="version_switcher_buffers"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\System.Collections.Immutable.dll" Id ="version_switcher_collections"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\System.Memory.dll" Id ="version_switcher_memory"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\System.Numerics.Vectors.dll" Id ="version_switcher_vectors"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\System.Reflection.Metadata.dll" Id ="version_switcher_metadata"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\System.Reflection.MetadataLoadContext.dll" Id ="version_switcher_metadataloadcontext"/>
-                <File Source="..\AccessibilityInsights.VersionSwitcher\bin\Release\net48\System.Runtime.CompilerServices.Unsafe.dll" Id ="version_switcher_unsafe"/>
-                <!-- We sign the following assemblies in the main AccessibilityInsights project. To avoid duplicate signing, we reuse them below. -->
-                <File Source="..\AccessibilityInsights\bin\Release\net48\Microsoft.Deployment.WindowsInstaller.dll" Id ="version_switcher_deployment"/>
-                <File Source="..\AccessibilityInsights\bin\Release\net48\Newtonsoft.Json.dll" Id ="version_switcher_newtonsoft"/>
-              </Component>
-            </Directory>
-
           </Directory>
+
+          <Directory Id="VersionSwitcher" Name="VersionSwitcher">
+            <Component Id="VersionSwitcherComp" Guid="1AAD6099-09E1-4E8F-A28B-57806F4A29DF">
+              <!-- ID's are needed for these files, since several of them are also installed with the main app -->
+              <File Source="AccessibilityInsights.VersionSwitcher.exe" Id="version_switcher" />
+              <File Source="AccessibilityInsights.VersionSwitcher.exe.config" Id="version_switcher_config" />
+              <File Source="AccessibilityInsights.SetupLibrary.dll" Id="version_switcher_setuplibrary" />
+              <File Source="AccessibilityInsights.Win32.dll" Id="version_switcher_win32" />
+              <File Source="System.Buffers.dll" Id="version_switcher_buffers" />
+              <File Source="System.Collections.Immutable.dll" Id="version_switcher_collections" />
+              <File Source="System.Memory.dll" Id="version_switcher_memory" />
+              <File Source="System.Numerics.Vectors.dll" Id="version_switcher_vectors" />
+              <File Source="System.Reflection.Metadata.dll" Id="version_switcher_metadata" />
+              <File Source="System.Reflection.MetadataLoadContext.dll" Id="version_switcher_metadataloadcontext" />
+              <File Source="System.Runtime.CompilerServices.Unsafe.dll" Id="version_switcher_unsafe" />
+              <!-- We sign the following assemblies in the main AccessibilityInsights project. To avoid duplicate signing, we reuse them below. -->
+              <File Source="WixToolset.Dtf.WindowsInstaller.dll" Id="version_switcher_deployment" />
+              <File Source="Newtonsoft.Json.dll" Id="version_switcher_newtonsoft" />
+            </Component>
+          </Directory>
+
         </Directory>
       </Directory>
-      <Directory Id="DesktopFolder"/>
-      <Directory Id="ProgramMenuFolder">
-        <Directory Id="ApplicationProgramsFolder" Name="AccessibilityInsights"/>
-      </Directory>
-    </Directory>
+    </StandardDirectory>
+    <StandardDirectory Id="DesktopFolder" />
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Directory Id="ApplicationProgramsFolder" Name="AccessibilityInsights" />
+    </StandardDirectory>
 
-    <Icon Id="AccessibilityInsights.exe" SourceFile="..\AccessibilityInsights\bin\Release\net48\AccessibilityInsights.exe" />
+    <Icon Id="AccessibilityInsights.exe" SourceFile="..\AccessibilityInsights.SharedUx\Resources\Icons\BrandIconDesktop.ico" />
 
     <Property Id="WixShellExecTarget" Value="[#FileExe]"/>
-    <CustomAction Id="LaunchInstalledExe" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
-    <CustomAction Id="RemoveUserConfigFiles" BinaryKey="CustomActions" DllEntry="RemoveUserConfigFiles" Impersonate="yes" />
+    <CustomAction Id="LaunchInstalledExe" DllEntry="WixShellExec" Impersonate="yes" BinaryRef="Wix4UtilCA_X86" />
+    <CustomAction Id="RemoveUserConfigFiles" DllEntry="RemoveUserConfigFiles" Impersonate="yes" BinaryRef="CustomActions" />
 
     <InstallExecuteSequence>
-      <Custom Action='RemoveUserConfigFiles' After='InstallFinalize'>Installed and (REMOVE="ALL") and NOT UPGRADINGPRODUCTCODE</Custom>
-      <Custom Action='LaunchInstalledExe' After='RemoveUserConfigFiles'>NOT REMOVE and WIX_UPGRADE_DETECTED and NOT SECONDSEQUENCE</Custom>
+      <Custom Action="RemoveUserConfigFiles" After="InstallFinalize" Condition="Installed and (REMOVE=&quot;ALL&quot;) and NOT UPGRADINGPRODUCTCODE" />
+      <Custom Action="LaunchInstalledExe" After="RemoveUserConfigFiles" Condition="NOT REMOVE and WIX_UPGRADE_DETECTED and NOT SECONDSEQUENCE" />
     </InstallExecuteSequence>
 
     <DirectoryRef Id="ApplicationProgramsFolder">
@@ -211,5 +201,5 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
         <RegistryValue Root="HKCU" Key="Software\AccessibilityInsights" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
       </Component>
     </DirectoryRef>
-  </Product>
+  </Package>
 </Wix>

--- a/src/MSI/packages.config
+++ b/src/MSI/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" developmentDependency="true" />
-  <package id="WiX" version="3.11.2" />
-</packages>

--- a/src/Manifest/Manifest.csproj
+++ b/src/Manifest/Manifest.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\create-json-for-manifest.ps1 -Verbose -OctokitPath &quot;%UserProfile%\.nuget\packages\Octokit\6.1.0\lib\netstandard2.0\Octokit.dll&quot; -MsiBasePath $(SolutionDir)MSI\bin\Release\msi -IsMandatoryProdUpdate $(IsMandatoryProdUpdate) -OutputPath $(TargetDir) -OutputFile ReleaseInfo.json" />
+    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\create-json-for-manifest.ps1 -Verbose -OctokitPath &quot;%UserProfile%\.nuget\packages\Octokit\6.1.0\lib\netstandard2.0\Octokit.dll&quot; -MsiBasePath $(SolutionDir)MSI\bin\x86\Release\msi -IsMandatoryProdUpdate $(IsMandatoryProdUpdate) -OutputPath $(TargetDir) -OutputFile ReleaseInfo.json" />
   </Target>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/src/ManifestTests/IntegrationTests.cs
+++ b/src/ManifestTests/IntegrationTests.cs
@@ -16,7 +16,7 @@ namespace ManifestTests
     {
         private static readonly string RawManifestFilePath = Path.GetFullPath(Path.Combine(@"..\..\..\..", @"Manifest\bin\Release\net48\ReleaseInfo.json"));
         private static readonly string SignedManifestFilePath = Path.GetFullPath(Path.Combine(@"..\..\..\..", @"Manifest\bin\Release\net48\AccessibilityInsights.Manifest.dll"));
-        private static readonly string MsiFilePath = Path.GetFullPath(Path.Combine(@"..\..\..\..", @"MSI\bin\Release\AccessibilityInsights.msi"));
+        private static readonly string MsiFilePath = Path.GetFullPath(Path.Combine(@"..\..\..\..", @"MSI\bin\x86\Release\AccessibilityInsights.msi"));
         private static readonly ChannelInfo rawInfo = FileHelpers.LoadDataFromJSON<ChannelInfo>(RawManifestFilePath);
 
         [TestMethod]

--- a/src/MsiFileTests/WxsValidationTests.cs
+++ b/src/MsiFileTests/WxsValidationTests.cs
@@ -87,7 +87,7 @@ namespace MsiFileTests
                         else if (reader.Name == "File" && thisIsTheCorrectComponent)
                         {
                             string relativeFile = reader.GetAttribute("Source");
-                            filesInSection.Add(Path.GetFileName(relativeFile.Substring(2)));
+                            filesInSection.Add(Path.GetFileName(relativeFile));
                         }
                     }
                 }


### PR DESCRIPTION
#### Details

Upgrade WixToolset to v4.0.1

##### Motivation

Addresses issue #1641 

##### Context

In WiX v4, it's easier than ever to build MSIs for each platform (x86, x64, arm64) using the exact same sources (with no conditional code).

The default build output directory for the MSI changes from `bin\$(Configuration)\...` to `bin\$(Platform)\$(Configuration)\...` where Platform = `x86`

This MSI contains suboptimal authoring, especially concerning the Windows Installer Best Practices relating to Component/File relationships. Generally speaking, each Component should have only one File. You can create ComponentGroups to group components as needed, but ComponentGroups don't survive in the MSI (they are an authoring-only concept).

It is NOT considered a best practice to mess with any per-user data (configuration or otherwise) in per-machine installation packages. The primary reason is that it is extremely difficult to touch all the user profiles that may have been affected, and you WILL leave configuration behind especially when a different user removes the package from the user that installed it. It would be a very good idea to review your custom actions that touch profile data.

`AccessibilityInsights.CustomActions.Package` can probably be merged into `AccessibilityInsights.CustomActions` eliminating the need for `OverwriteWithSignedAssemblies`. Custom action projects are no longer non-standard projects, they are now modern SDK-style projects, like any other csproj that can host either net-core or net-framework code.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



