### PR TITLE
chore: Add code to delete Canary releases

### DIFF
--- a/tools/scripts/pipeline/deploy/Prod/cleanup_old_releases.ps1
+++ b/tools/scripts/pipeline/deploy/Prod/cleanup_old_releases.ps1
@@ -176,6 +176,8 @@ $releases.Result | Select-Object -Property Name, TagName | Format-Table
 $releaseMap = SortReleases $releases
 
 $foundMinProdVersion = $false
+$foundLatestProdVersion = $false
+
 $deleteList = @()
 
 foreach($releaseKV in $releaseMap)
@@ -187,9 +189,23 @@ foreach($releaseKV in $releaseMap)
         continue
     }
 
-    if (($release.Prerelease -eq $false) -and (($($release.TagName) -eq $($minProdVersionTag))))
+    if ($release.Prerelease -eq $false)
     {
-        $foundMinProdVersion = $true
+        if ($foundLatestProdVersion -eq $true)
+        {
+            if ($($release.TagName) -eq $($minProdVersionTag))
+            {
+                $foundMinProdVersion = $true
+            }
+        }
+        else
+        {
+            $foundLatestProdVersion = $true
+        }
+    }
+    elseif ($foundLatestProdVersion -eq $true)
+    {
+        $deleteList += $release
     }
 }
 


### PR DESCRIPTION
#### Details

Update the release script to properly clean up all PreRelease (i.e., Canary) releases that are older than the version being released to prod. This used to be part of the Canary release but got lost at some point before we moved the scripts to the repo. Before this change, PreRelease releases only get cleaned up if they're older than `$minProdVersionTag`. After the change, we clean up all PreRelease releases that are older than the first non-PreRelease release.

##### Motivation

Automate Canary cleanup. Tested locally with a PAT.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.
