### PR TITLE
chore: Pin Moq to 4.18.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,3 +51,6 @@ updates:
   - dependency-name: System.Drawing.Common
     versions:
     - 5.0.1
+  - dependency-name: Moq
+    versions:
+    - ">= 4.20"  # moq/moq#1372

--- a/src/AccessibilityInsights.CustomActionsUnitTests/CustomActionsUnitTests.csproj
+++ b/src/AccessibilityInsights.CustomActionsUnitTests/CustomActionsUnitTests.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
   </ItemGroup>

--- a/src/AccessibilityInsights.Extensions.AzureDevOpsTests/Extensions.AzureDevOpsTests.csproj
+++ b/src/AccessibilityInsights.Extensions.AzureDevOpsTests/Extensions.AzureDevOpsTests.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/src/AccessibilityInsights.Extensions.DiskLoggingTelemetryTests/Extensions.DiskLoggingTelemetryTests.csproj
+++ b/src/AccessibilityInsights.Extensions.DiskLoggingTelemetryTests/Extensions.DiskLoggingTelemetryTests.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
   </ItemGroup>

--- a/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/Extensions.GitHubAutoUpdateUnitTests.csproj
+++ b/src/AccessibilityInsights.Extensions.GitHubAutoUpdateUnitTests/Extensions.GitHubAutoUpdateUnitTests.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
   </ItemGroup>

--- a/src/AccessibilityInsights.Extensions.GitHubUnitTests/Extensions.GitHubUnitTests.csproj
+++ b/src/AccessibilityInsights.Extensions.GitHubUnitTests/Extensions.GitHubUnitTests.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
   </ItemGroup>

--- a/src/AccessibilityInsights.Extensions.TelemetryTests/Extensions.TelemetryTests.csproj
+++ b/src/AccessibilityInsights.Extensions.TelemetryTests/Extensions.TelemetryTests.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
   </ItemGroup>

--- a/src/AccessibilityInsights.ExtensionsTests/ExtensionsTests.csproj
+++ b/src/AccessibilityInsights.ExtensionsTests/ExtensionsTests.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
   </ItemGroup>

--- a/src/AccessibilityInsights.SetupLibraryUnitTests/SetupLibraryUnitTests.csproj
+++ b/src/AccessibilityInsights.SetupLibraryUnitTests/SetupLibraryUnitTests.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
   </ItemGroup>

--- a/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
+++ b/src/AccessibilityInsights.SharedUxTests/SharedUxTests.csproj
@@ -42,7 +42,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
   </ItemGroup>

--- a/src/AccessibilityInsights.VersionSwitcherUnitTests/VersionSwitcherUnitTests.csproj
+++ b/src/AccessibilityInsights.VersionSwitcherUnitTests/VersionSwitcherUnitTests.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/src/AccessibilityInsightsUnitTests/AccessibilityInsightsUnitTests.csproj
+++ b/src/AccessibilityInsightsUnitTests/AccessibilityInsightsUnitTests.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
   </ItemGroup>


### PR DESCRIPTION
#### Details

Since 4.20.x, Moq has introduced a privacy vulnerability that improperly handles user data. https://github.com/moq/moq/issues/1372 

This pins to 4.18.4 until we can confirm that those privacy concerns are resolved.

##### Motivation

Privacy/Security

##### Context


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
