### PR TITLE
chore: Update clearly defined script to exclude docker dependabot pull requests

### DIFF
--- a/tools/scripts/pipeline/build/clearly-defined/ValidateScript.bat
+++ b/tools/scripts/pipeline/build/clearly-defined/ValidateScript.bat
@@ -13,6 +13,13 @@ if errorlevel 1 goto fail
 echo OK
 echo.
 
+@echo Passing case: Docker playwright image
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/docker/playwright-v1.37.1-focal
+pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/docker/playwright-v1.37.1-focal
+if errorlevel 1 goto fail
+echo OK
+echo.
+
 echo Passing case: ADO PR build of dependabot branch
 echo set SYSTEM_PULLREQUEST_SOURCEBRANCH=dependabot/nuget/src/Moq-4.18.4
 set SYSTEM_PULLREQUEST_SOURCEBRANCH=dependabot/nuget/src/Moq-4.18.4


### PR DESCRIPTION
#### Details

This keeps the ClearlyDefined script up to date with changes made in the web repository, where the script needed to exclude dependabot PRs updating the playwright docker image.

##### Motivation

keep the ClearlyDefined script in sync with web, per https://github.com/microsoft/accessibility-insights-web/pull/6917 

##### Context

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



