### PR TITLE
chore: Fix test irregularities

### DIFF
--- a/src/AccessibilityInsights.SharedUxTests/Settings/AppLayoutTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/AppLayoutTests.cs
@@ -8,20 +8,20 @@ using System.IO;
 
 namespace AccessibilityInsights.SharedUxTests.Settings
 {
-    [TestClass()]
+    [TestClass]
     public class AppLayoutTests
     {
         const string TestLayoutFile = "LayoutTest.Json";
         private static readonly FixedConfigSettingsProvider provider = FixedConfigSettingsProvider.CreateDefaultSettingsProvider();
         public static string folderPath = Path.Combine(provider.UserDataFolderPath, "AppLayoutTests");
 
-        [ClassInitialize()]
-        public static void ClassInit()
+        [ClassInitialize]
+        public static void ClassInit(TestContext _)
         {
             Directory.CreateDirectory(folderPath);
         }
 
-        [ClassCleanup()]
+        [ClassCleanup]
         public static void ClassCleanup()
         {
             Directory.Delete(folderPath);
@@ -32,7 +32,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
         /// and saving it, and then reading it back into a new AppLayout. Values are then
         /// compared to original values.
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void LoadDefaultAppLayoutTest()
         {
             string path = Path.Combine(provider.UserDataFolderPath, TestLayoutFile);
@@ -67,7 +67,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
         /// Tests AppLayout constructor against given values and expected
         /// default values.
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void AppLayoutTest()
         {
             AppLayout al = new AppLayout(10, 11);
@@ -93,7 +93,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
         /// a new AppLayout, and removing it. A backup is then verified to have
         /// been created.
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void RemoveConfigurationTest()
         {
             string path = Path.Combine(provider.UserDataFolderPath, TestLayoutFile);
@@ -126,7 +126,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
         /// <summary>
         /// Test: replacing old layout with new one if version is change.
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void LoadLayoutIfPrevVersionTest()
         {
             var al = FromJson("Resources/Layout_S122.json");

--- a/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
@@ -16,12 +16,12 @@ namespace AccessibilityInsights.SharedUxTests.Settings
     /// <summary>
     /// Tests for ConfigurationModel
     /// </summary>
-    [TestClass()]
+    [TestClass]
     public class ConfigurationModelTests
     {
         private static FixedConfigSettingsProvider testProvider;
 
-        [ClassInitialize()]
+        [ClassInitialize]
         public static void ClassInit(TestContext context)
         {
             string testBaseDirectory = Path.Combine(context.TestRunDirectory, context.FullyQualifiedTestClassName);
@@ -35,7 +35,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
         /// <summary>
         /// Check serialization of selected properties
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void ConfigurationModelTest()
         {
             string path = Path.Combine(testProvider.ConfigurationFolderPath, "config.test");
@@ -56,7 +56,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
             Assert.IsTrue(coreProps.SequenceEqual(newConfig.CoreProperties));
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void GetCurrentConfigurationTest()
         {
             const string expectedHotKeyForRecord = "Recording HotKey";

--- a/src/AccessibilityInsights.SharedUxTests/Settings/LayoutTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/LayoutTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using AccessibilityInsights.SharedUx.Settings;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -6,13 +6,13 @@ using System.Windows;
 
 namespace AccessibilityInsights.SharedUxTests.Tests
 {
-    [TestClass()]
+    [TestClass]
     public class LayoutTests
     {
         /// <summary>
         /// Ensures GetLayoutLive populates a Layout with proper default values.
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void GetLayoutLiveTest()
         {
             MainWindowLayout la = MainWindowLayout.GetLayoutLive();
@@ -29,7 +29,7 @@ namespace AccessibilityInsights.SharedUxTests.Tests
         /// <summary>
         /// Ensures GetLayoutSnapshot populates a Layout with proper default values.
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void GetLayoutSnapshotTest()
         {
             MainWindowLayout la = MainWindowLayout.GetLayoutSnapshot();

--- a/src/AccessibilityInsights.SharedUxTests/ViewModels/ViewModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/ViewModels/ViewModelTests.cs
@@ -16,7 +16,7 @@ namespace AccessibilityInsights.SharedUxTests.ViewModels
         /// <summary>
         /// Tests the descendant status counts in HierarchyNodeViewModel
         /// </summary>
-        [TestMethod()]
+        [TestMethod]
         public void GetDescendentStatusCounts()
         {
             A11yElement e = LoadA11yElementsFromJSON("./Snapshots/Taskbar.snapshot");


### PR DESCRIPTION
#### Details

I noticed today that the `AppLayoutTests` were not running as expected. In investigating, I found the following, which are fixed in this PR:
- The `AppLayoutTests.ClassInitialize` method needs to take a `TestContext` as a parameter--this is why the tests were being discovered but were not being run
- The `TestClass`, `TestMethod`, `ClassInitialize`, and `ClassCleanup` decorators aren't intended to have parentheses. They still work with the parentheses, but it is a nonstandard representation. I fixed these wherever I found them (4 test classes)

##### Motivation

Test coverage and consistency

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



