### PR TITLE
chore: Enable chromium content scanning (advanced feature, not for general use)

### DIFF
--- a/docs/TelemetryDetails.md
+++ b/docs/TelemetryDetails.md
@@ -155,6 +155,7 @@ Name | Value
 --- | ---
 `customDimensions.By` | The trigger mechanism. Current values are `HotKey`, `Beaker`, `HierarchyMode`, or `Timer`.
 `customDimensions.Scope` | The scope of the selection. Current values are `App` or `Element`.
+`customDimensions.ShouldTestAllChromiumContent` | If the user has enabled the advanced option to test all Chromium content (intended for debugging by browser development teams).
 
 #### Upgrade_DoInstallation
 Trigger: The user completes an install from the Upgrade dialog.  

--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationConstants.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationConstants.cs
@@ -61,6 +61,7 @@ namespace AccessibilityInsights.SharedUx.Settings
         private const string KeySelectedIssueReporter = "SelectedIssueReporter";
         private const string KeySelectionByFocus = "SelectionByFocus";
         private const string KeySelectionByMouse = "SelectionByMouse";
+        private const string KeyShouldTestAllChromiumContent = "ShouldTestAllChromiumContent";
         private const string KeyShowAllProperties = "ShowAllProperties";
         private const string KeyShowAncestry = "ShowAncestry";
         private const string KeyShowTelemetryDialog = "ShowTelemetryDialog";

--- a/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
+++ b/src/AccessibilityInsights.SharedUx/Settings/ConfigurationModel.cs
@@ -344,6 +344,15 @@ namespace AccessibilityInsights.SharedUx.Settings
         }
 
         /// <summary>
+        /// if it is true, tell Axe.Windows to run rules against all Chromium content.
+        /// </summary>
+        public bool ShouldTestAllChromiumContent
+        {
+            get => GetDataValue<bool>(KeyShouldTestAllChromiumContent);
+            set => SetDataValue<bool>(KeyShouldTestAllChromiumContent, value);
+        }
+
+        /// <summary>
         /// if it is true, show the full list of ancestors up to desktop in snap mode.
         /// </summary>
         public bool ShowAncestry

--- a/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
+++ b/src/AccessibilityInsights.SharedUx/Telemetry/TelemetryProperty.cs
@@ -58,5 +58,6 @@ namespace AccessibilityInsights.SharedUx.Telemetry
         ActualMsiSha512,
         NewChannel,
         ExecutionTimeInMilliseconds,
+        ShouldTestAllChromiumContent,
     }
 }

--- a/src/AccessibilityInsights.SharedUxTests/Resources/ConfigSettings.json
+++ b/src/AccessibilityInsights.SharedUxTests/Resources/ConfigSettings.json
@@ -38,6 +38,7 @@
     "SelectedIssueReporter": "{27f21dff-2fb3-4833-be55-25787fce3e17}",
     "SerializedCachedConnections": "[]",
     "SerializedSavedConnection": "",
+    "ShouldTestAllChromiumContent": true,
     "ShowAllProperties": false,
     "ShowAncestry": true,
     "ShowTelemetryDialog": false,

--- a/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
+++ b/src/AccessibilityInsights.SharedUxTests/Settings/ConfigurationModelTests.cs
@@ -115,6 +115,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
             Assert.IsTrue(config.SelectionByFocus);
             Assert.IsTrue(config.SelectionByMouse);
             Assert.IsFalse(config.ShowAllProperties);
+            Assert.IsFalse(config.ShouldTestAllChromiumContent);
             Assert.IsTrue(config.ShowAncestry);
             Assert.IsTrue(config.ShowTelemetryDialog);
             Assert.IsFalse(config.ShowUncertain);
@@ -124,7 +125,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
             Assert.AreEqual(TreeViewMode.Control, config.TreeViewMode);
             Assert.AreEqual(ReleaseChannel.Production, config.ReleaseChannel);
             Assert.AreEqual("1.1.10", config.Version);
-            Assert.AreEqual(36, typeof(ConfigurationModel).GetProperties().Length, "Count of ConfigurationModel properties has changed! Please ensure that you are testing the default value for all properties, then update the expected value");
+            Assert.AreEqual(37, typeof(ConfigurationModel).GetProperties().Length, "Count of ConfigurationModel properties has changed! Please ensure that you are testing the default value for all properties, then update the expected value");
         }
 
         [TestMethod]
@@ -144,6 +145,7 @@ namespace AccessibilityInsights.SharedUxTests.Settings
                 issueReporterSerializedConfigs: @"{""27f21dff-2fb3-4833-be55-25787fce3e17"":""hello world""}",
                 selectedIssueReporter: new Guid("{27f21dff-2fb3-4833-be55-25787fce3e17}"),
                 releaseChannel: ReleaseChannel.Canary,
+                shouldTestAllChromiumContent: true,
                 soundMode: SoundFeedbackMode.Always // Verify that a true PlayScanningSound (legacy key) maps to Always
             );
         }
@@ -155,11 +157,13 @@ namespace AccessibilityInsights.SharedUxTests.Settings
 
         private static void ConfirmOverrideConfigMatchesExpectation(ConfigurationModel config,
             Guid? selectedIssueReporter = null, string issueReporterSerializedConfigs = null,
-            ReleaseChannel? releaseChannel = null, SoundFeedbackMode soundMode=SoundFeedbackMode.Auto)
+            ReleaseChannel? releaseChannel = null, SoundFeedbackMode soundMode=SoundFeedbackMode.Auto,
+            bool shouldTestAllChromiumContent = false)
         {
             Assert.IsFalse(config.AlwaysOnTop);
             Assert.AreEqual("1.1.", config.AppVersion.Substring(0, 4));
             Assert.AreNotEqual("1.1.700.1", config.AppVersion);
+            Assert.AreEqual(shouldTestAllChromiumContent, config.ShouldTestAllChromiumContent);
 
             ConfirmEnumerablesMatchExpectations(
                 new int[] { 30005, 30003, 30004, 30009, 30001, 30007, 30006, 30013, 30102, 30101 },

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -201,7 +201,8 @@ namespace AccessibilityInsights
             sa.IsFocusSelectOn = ConfigurationManager.GetDefaultInstance().AppConfig.SelectionByFocus;
             sa.IsMouseSelectOn = ConfigurationManager.GetDefaultInstance().AppConfig.SelectionByMouse;
             sa.TreeViewMode = ConfigurationManager.GetDefaultInstance().AppConfig.TreeViewMode;
-
+            // TODO: Enable this once Axe.Windows is updated
+            //SelectAction.ShouldTestAllChromiumContent = ConfigurationManager.GetDefaultInstance().AppConfig.ShouldTestAllChromiumContent;
         }
 
         /// <summary>

--- a/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/Initialize.cs
@@ -201,8 +201,7 @@ namespace AccessibilityInsights
             sa.IsFocusSelectOn = ConfigurationManager.GetDefaultInstance().AppConfig.SelectionByFocus;
             sa.IsMouseSelectOn = ConfigurationManager.GetDefaultInstance().AppConfig.SelectionByMouse;
             sa.TreeViewMode = ConfigurationManager.GetDefaultInstance().AppConfig.TreeViewMode;
-            // TODO: Enable this once Axe.Windows is updated
-            //SelectAction.ShouldTestAllChromiumContent = ConfigurationManager.GetDefaultInstance().AppConfig.ShouldTestAllChromiumContent;
+            SelectAction.ShouldTestAllChromiumContent = ConfigurationManager.GetDefaultInstance().AppConfig.ShouldTestAllChromiumContent;
         }
 
         /// <summary>

--- a/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
+++ b/src/AccessibilityInsights/MainWindowHelpers/StateMachine.cs
@@ -242,7 +242,7 @@ namespace AccessibilityInsights
                 StartTestMode(TestView.AutomatedTestResults);
 
                 Logger.PublishTelemetryEvent(TelemetryEventFactory.ForTestRequested(
-                    method.ToString(), SelectAction.GetDefaultInstance().Scope.ToString()));
+                    method.ToString(), SelectAction.GetDefaultInstance().Scope.ToString(), ConfigurationManager.GetDefaultInstance().AppConfig.ShouldTestAllChromiumContent));
             }
             HollowHighlightDriver.GetDefaultInstance().Clear();
             UpdateMainWindowUI();

--- a/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
+++ b/src/AccessibilityInsights/Misc/TelemetryEventFactory.cs
@@ -33,13 +33,14 @@ namespace AccessibilityInsights.Misc
                 });
         }
 
-        public static TelemetryEvent ForTestRequested(string method, string scope)
+        public static TelemetryEvent ForTestRequested(string method, string scope, bool shouldTestAllChromiumContent)
         {
             return new TelemetryEvent(TelemetryAction.Test_Requested,
                 new Dictionary<TelemetryProperty, string>
                 {
                     { TelemetryProperty.By, method },
                     { TelemetryProperty.Scope, scope },
+                    { TelemetryProperty.ShouldTestAllChromiumContent, shouldTestAllChromiumContent.ToString(CultureInfo.InvariantCulture) },
                 });
         }
 


### PR DESCRIPTION
#### Details

Provide an option to include Chromium HTML content in test results. This is intentionally _not_ exposed in the UI, as this is intended uniquely for browser development teams who can reasonably edit their config file by hand. To enable this functionality, do the following:

1. Run Accessibility Insights for Windows at least once, then exit the program. This will create the config file.
2. Using your preferred text editor, edit `%localappdata%\AccessibilityInsights\V1\Configurations\Configuration.json`
3. Add the following line in the json--not at the bottom of the file or the comma will be off
```
  "ShouldTestAllChromiumContent": true,
```
4. Save the JSON file
5. Restart Accessibility Insights for Windows

Chromium HTML content will now be included in rule checks.

Since we aren't supporting this in the UI, the setting gets locked in when the app initializes. Changing the setting requires shutting down the app, manually modifying the JSON file, then restarting the app.

##### Motivation

Feature requested by the Edge team

##### Comparing old and new

These results were on the same instance of Edge, using the modified version of AIWin. The only difference was the state of the config file when AIWin was launched.

Error | Count Before | Count After | Are extra results HTML content
--- | --- | --- | ---
An element must not have the same Name and LocalizedControlType as its parent | 0 | 6 | Yes
An element of the given ControlType must support the Text pattern | 0 | 1 | Yes
An on-screen element must not have a null BoundingRectangle property | 5 | 5 | n/a
Chromium components should be scanned with the web-based scanner | 2 | 2 | n/a
The Name must not include the same text as the LocalizedControlType | 1 | 1 | n/a
The Name property must not include the element's control type | 1 | 2 | Yes
The Name property of a focusable element must not be null | 0 | 1 | Yes
**TOTAL** | 9 | 18 | Yes

For anyone who may want to delve more deeply, both a11ytest files are contained in [Comparison.zip](https://github.com/microsoft/accessibility-insights-windows/files/12580328/Comparison.zip)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue?
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



