### PR TITLE
Chore: Migrate from ADAL to MSAL

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
@@ -26,9 +26,9 @@
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.0.0" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.205.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.205.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="16.205.1" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.227.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.227.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.227.0-preview" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2045.28" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/ForcedDependencies.cs
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/ForcedDependencies.cs
@@ -33,7 +33,6 @@ namespace AccessibilityInsights.Extensions.AzureDevOps
         private static void ManuallyEnforcedDependencies()
         {
             // Types that we can't detect via unit tests. Namespace generally matches the package.
-            ForceDependency(typeof(Microsoft.IdentityModel.Clients.ActiveDirectory.AdalClaimChallengeException));
             ForceDependency(typeof(Microsoft.IdentityModel.JsonWebTokens.JsonClaimValueTypes));
             ForceDependency(typeof(Microsoft.IdentityModel.Logging.IdentityModelEventSource));
             ForceDependency(typeof(Microsoft.IdentityModel.Tokens.AsymmetricSecurityKey));

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -76,7 +76,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
             <File Id="Microsoft.Bcl.AsyncInterfaces.dll" Source="Microsoft.Bcl.AsyncInterfaces.dll" />
             <File Id="WixToolset.Dtf.WindowsInstaller.dll" Source="WixToolset.Dtf.WindowsInstaller.dll" />
             <File Id="Microsoft.IdentityModel.Abstractions.dll" Source="Microsoft.IdentityModel.Abstractions.dll" />
-            <File Id="Microsoft.IdentityModel.Clients.ActiveDirectory.dll" Source="Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
             <File Id="Microsoft.IdentityModel.JsonWebTokens.dll" Source="Microsoft.IdentityModel.JsonWebTokens.dll" />
             <File Id="Microsoft.IdentityModel.Logging.dll" Source="Microsoft.IdentityModel.Logging.dll" />
             <File Id="Microsoft.IdentityModel.Tokens.dll" Source="Microsoft.IdentityModel.Tokens.dll" />

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -75,6 +75,8 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
             <File Id="Microsoft.Azure.Pipelines.WebApi.dll" Source="Microsoft.Azure.Pipelines.WebApi.dll" />
             <File Id="Microsoft.Bcl.AsyncInterfaces.dll" Source="Microsoft.Bcl.AsyncInterfaces.dll" />
             <File Id="WixToolset.Dtf.WindowsInstaller.dll" Source="WixToolset.Dtf.WindowsInstaller.dll" />
+            <File Id="Microsoft.Identity.Client.dll" Source="Microsoft.Identity.Client.dll" />
+            <File Id="Microsoft.Identity.Client.Extensions.Msal.dll" Source="Microsoft.Identity.Client.Extensions.Msal.dll" />
             <File Id="Microsoft.IdentityModel.Abstractions.dll" Source="Microsoft.IdentityModel.Abstractions.dll" />
             <File Id="Microsoft.IdentityModel.JsonWebTokens.dll" Source="Microsoft.IdentityModel.JsonWebTokens.dll" />
             <File Id="Microsoft.IdentityModel.Logging.dll" Source="Microsoft.IdentityModel.Logging.dll" />


### PR DESCRIPTION
#### Details

ADAL (Active Directory Authentication Library) is being replaced by MSAL (Microsoft Authentication Library) across all products. Our auth is a transitive dependency of the Visual Studio client assemblies, so our upgrade path is to to upgrade the Visual Studio client packages. These packages are still in preview with no publicly announced ETA for the full release, but there are reasons to make this change sooner, rather than later. In conversations with the teams that own the Visual Studio packages, no significant changes are expected between now and the fully released issues, so we're making the change now.

Change was tested by building an MSI, installing it on a machine, and ensuring that ADO bug filing works as expected.

##### Motivation

Complete update requirement

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



