### PR TITLE
chore: Enable .NET Framework 4.8.1 accessibility fixes

### DIFF
--- a/src/AccessibilityInsights/App.config
+++ b/src/AccessibilityInsights/App.config
@@ -9,6 +9,6 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
   <runtime>
-    <AppContextSwitchOverrides value="Switch.UseLegacyAccessibilityFeatures=false;Switch.UseLegacyAccessibilityFeatures.2=false;Switch.UseLegacyAccessibilityFeatures.3=false;Switch.UseLegacyAccessibilityFeatures.4=false;Switch.UseLegacyToolTipDisplay=false" />
+    <AppContextSwitchOverrides value="Switch.UseLegacyAccessibilityFeatures=false;Switch.UseLegacyAccessibilityFeatures.2=false;Switch.UseLegacyAccessibilityFeatures.3=false;Switch.UseLegacyAccessibilityFeatures.4=false;Switch.UseLegacyAccessibilityFeatures.5=false;Switch.UseLegacyToolTipDisplay=false" />
   </runtime>
 </configuration>


### PR DESCRIPTION
#### Details

.NET Framework 4.8.1 included several accessibility-related fixes that we want to enable in our code. They're disabled by default, so we need to update the `app.config` file to give .NET Framework permission to use the updated behavior. No bugs have been files on these, so this is a bit of a preemptive strike.

##### Motivation

Leverage accessibility improvements where they're available to us.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



