### PR TITLE
feat(oncall-vendor-transition): Move Dependabot to 08:30 UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "9:00"  # UTC
+    time: "8:30"  # UTC
   open-pull-requests-limit: 10 # We use 4 VS Studio assemblies that need to merge in a specific order. Default value of 5 has been problematic
   ignore:
   - dependency-name: Microsoft.ApplicationInsights

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "13:00"
+    time: "9:00"  # UTC
   open-pull-requests-limit: 10 # We use 4 VS Studio assemblies that need to merge in a specific order. Default value of 5 has been problematic
   ignore:
   - dependency-name: Microsoft.ApplicationInsights


### PR DESCRIPTION
#### Details
Dependabot for our repos is scheduled to run at fairly different times that are inconvenient for some geographies. This PR moves this repo's dependabot time to 08:30 UTC (14:00 IST, 01:30 PDT, 00:30 PST).

##### Motivation
Part of [Feature 2083093](https://mseng.visualstudio.com/1ES/_queries/edit/2083093) (internal access required to view).

#### Pull request checklist
- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.
