### PR TITLE
Chore: Fix Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "8:30"  # UTC
+    time: "08:30"  # UTC
   open-pull-requests-limit: 10 # We use 4 VS Studio assemblies that need to merge in a specific order. Default value of 5 has been problematic
   ignore:
   - dependency-name: Microsoft.ApplicationInsights


### PR DESCRIPTION
Add a leading zero to the time in the Dependabot config.