### PR TITLE
chore: Sync latest ClearlyDefined changes

### DIFF
--- a/tools/scripts/pipeline/build/clearly-defined/ValidateScript.bat
+++ b/tools/scripts/pipeline/build/clearly-defined/ValidateScript.bat
@@ -59,6 +59,24 @@ if errorlevel 1 goto fail
 echo OK
 echo.
 
+@echo Passing case: local PR build of dependabot branch with github_actions type
+set BUILD_SOURCEBRANCH=
+set GITHUB_HEAD_REF=
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/github_actions/actions/checkout-1.2.3
+pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/github_actions/actions/checkout-1.2.3
+if errorlevel 1 goto fail
+echo OK
+echo.
+
+@echo Passing case: local PR build of dependabot branch with @types namespace
+set BUILD_SOURCEBRANCH=
+set GITHUB_HEAD_REF=
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/npm_and_yarn/types/jest-1.10000.1
+pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/npm_and_yarn/types/jest-1.10000.1
+if errorlevel 1 goto fail
+echo OK
+echo.
+
 @echo Failing case: Package that does not exist in ClearlyDefined
 echo pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/nuget/src/Axe.Windows-2.99.99
 pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/nuget/src/Axe.Windows-2.99.99


### PR DESCRIPTION
#### Details

Bring ClearlyDefined tooling in sync with https://github.com/microsoft/accessibility-insights-web/pull/7046 and https://github.com/microsoft/accessibility-insights-web/pull/7055. 

##### Motivation

Keep duplicated files in sync since we don't yet have a single place to store these

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



