### PR TITLE
fix: Allow nuget cache location override when building manifest

### DIFF
--- a/src/Manifest/Manifest.csproj
+++ b/src/Manifest/Manifest.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\create-json-for-manifest.ps1 -Verbose -OctokitPath &quot;%UserProfile%\.nuget\packages\Octokit\9.0.0\lib\netstandard2.0\Octokit.dll&quot; -MsiBasePath $(SolutionDir)MSI\bin\x86\Release\msi -IsMandatoryProdUpdate $(IsMandatoryProdUpdate) -OutputPath $(TargetDir) -OutputFile ReleaseInfo.json" />
+    <Exec Command="powershell -f $(SolutionDir)..\tools\scripts\create-json-for-manifest.ps1 -Verbose -OctokitRelativePath Octokit\9.0.0\lib\netstandard2.0\Octokit.dll -MsiBasePath $(SolutionDir)MSI\bin\x86\Release\msi -IsMandatoryProdUpdate $(IsMandatoryProdUpdate) -OutputPath $(TargetDir) -OutputFile ReleaseInfo.json" />
   </Target>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/tools/scripts/create-json-for-manifest.ps1
+++ b/tools/scripts/create-json-for-manifest.ps1
@@ -32,7 +32,7 @@ Set-StrictMode -Version Latest
 $script:ErrorActionPreference = 'Stop'
 
 # Uncomment the next line for debugging
-$VerbosePreference='continue'
+#$VerbosePreference='continue'
 
 Set-Variable MsiName -Option Readonly -Value "AccessibilityInsights.msi"
 


### PR DESCRIPTION
#### Details

The script to create the release manifest file requires the fully qualified path to the Octokit package. This path used to get passed in as the `OctokitPath` parameter, and the calling code assumed the default cache location. This assumption was recently invalidated in the signed build pipeline, so the pipeline broke.

With this change, the passed-in parameter is now renamed to `OctokitRelativePath` and represents the _relative_ path from the cache root to the Octokit package, The script chooses the cache root location based on the `NUGET_PACKAGES` environment variable (see [docs](https://learn.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders)). If this variable is set, then it is used as the cache root location; otherwise the default cache root location is used.

Validation build: https://mseng.visualstudio.com/1ES/_build/results?buildId=24501872&view=results
- [ComplianceRelease](https://mseng.visualstudio.com/1ES/_build/results?buildId=24501872&view=logs&j=06f1c8b2-7bb0-5c49-9f03-01a8f16e24cf&t=2acb71e8-ef96-559d-aac7-01a44dcbd48d&l=2546) uses the default cache location:
```
  VERBOSE:     Entering Get-Client
  VERBOSE:       Relative path to OctoKit.dll = Octokit\9.0.0\lib\netstandard2.0\Octokit.dll
  VERBOSE:       Full path to OctoKit.dll = 
  C:\Users\VssAdministrator\.nuget\packages\Octokit\9.0.0\lib\netstandard2.0\Octokit.dll
  VERBOSE:     Exiting Get-Client
```
- [SignedRelease](https://mseng.visualstudio.com/1ES/_build/results?buildId=24501872&view=logs&j=7c3ebc89-e7dd-5791-8c02-2ea1f3a27b50&t=9b81c1c0-976a-538f-a1e1-f4d170544876&l=3070) uses an overridden cache location:
```
  VERBOSE:     Entering Get-Client
  VERBOSE:       Relative path to OctoKit.dll = Octokit\9.0.0\lib\netstandard2.0\Octokit.dll
  VERBOSE:       Full path to OctoKit.dll = C:\NuGetPackages\Octokit\9.0.0\lib\netstandard2.0\Octokit.dll
  VERBOSE:     Exiting Get-Client
```

##### Motivation

Fix the signed build pipeline

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
I noticed a minor bug in the script that I'll cover in a separate PR

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



