### PR TITLE
chore: Update ado libraries to version 7.1.2

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
@@ -23,16 +23,16 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.57" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.0.3" />
-    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="7.0.3" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.0.3" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.1.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="7.1.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.1.2" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.227.0-preview" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.227.0-preview" />
     <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.227.0-preview" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2210.55" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />


### PR DESCRIPTION
#### Details

[CVE-2024-21319](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-21319) has been identified as a low risk DOS vulnerability. It is fixed in ADO libraries 7.1.2. Normally we'd let dependabot do this for us, but we ran into some complications that require a manual PR. The changes here made using the "Manage Nuget Packages for Solution" tool built into VisualStudio

##### Motivation

Address [CVE-2024-21319](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-21319)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - [2138421](https://mseng.visualstudio.com/DefaultCollection/1ES/_workitems/edit/2138421), [2138422](https://mseng.visualstudio.com/DefaultCollection/1ES/_workitems/edit/2138422), [2138423](https://mseng.visualstudio.com/DefaultCollection/1ES/_workitems/edit/2138423), and [2138424](https://mseng.visualstudio.com/DefaultCollection/1ES/_workitems/edit/2138424)
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



