### PR TITLE
fix: Make the search box border consistent in all themes

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -88,7 +88,7 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <Border Height="24" Margin="8,5,8,5" Background="{DynamicResource ResourceKey=SearchPanelBGBrush}" BorderBrush="{DynamicResource ResourceKey=SearchPanelBorderBrush}" BorderThickness="{DynamicResource ResourceKey=SearchPanelBorderThickness}">
+            <Border Height="24" Margin="8,5,8,5" Background="{DynamicResource ResourceKey=SearchPanelBGBrush}" BorderBrush="{DynamicResource ResourceKey=SearchPanelBorderBrush}" BorderThickness="1">
                 <DockPanel>
                     <controls:FabricIconControl DockPanel.Dock="Left" Margin="5,0,5,0" GlyphName="Search" FontSize="{StaticResource ConstStandardTextSize}" GlyphSize="Custom" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource ResourceKey=IconBrush}" ShowInControlView="False"/>
                     <controls:PlaceholderTextBox x:Name="textboxSearch" TextChanged="textboxSearch_TextChanged"

--- a/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Dark/Brushes.xaml
@@ -76,7 +76,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemSelectedFGBrush" Color="#FFFFFF"/>
 
     <!-- NEW SETTINGS -->
-    <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">1</Thickness>          <!-- (UPDATED) Thickness of border around search panel -->
     <Thickness po:Freeze="True" x:Key="TestModeBorderThickness">0</Thickness>             <!-- (UPDATED) Thickness of border around test mode view -->
     <Thickness po:Freeze="True" x:Key="ActionsButtonBorderThickness">0</Thickness>        <!-- Thickness of border around Actions buttons (patterns view) -->
 

--- a/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/HighContrast/Brushes.xaml
@@ -63,7 +63,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemSelectedFGBrush" Color="{x:Static SystemColors.HighlightTextColor}"/>
 
     <!-- NEW SETTINGS -->
-    <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">0</Thickness>
     <Thickness po:Freeze="True" x:Key="TestModeBorderThickness">1</Thickness>
     <Thickness po:Freeze="True" x:Key="ActionsButtonBorderThickness">1</Thickness>
 
@@ -72,7 +71,7 @@
     <SolidColorBrush x:Key="SearchAndIconForegroundBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush x:Key="SearchPlaceholderFGBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush x:Key="SearchPanelBGBrush" Color="Transparent"/>
-    <SolidColorBrush x:Key="SearchPanelBorderBrush" Color="Transparent"/>
+    <SolidColorBrush x:Key="SearchPanelBorderBrush" Color="{x:Static SystemColors.ControlTextColor}"/>
     <SolidColorBrush x:Key="GenericBorderBrush" Color="#A6A6A6 "/>  <!-- TODO: Find better value for this? -->
     <SolidColorBrush x:Key="StartupBackgroundBrush" Color="#0C5086 "/>
     <SolidColorBrush x:Key="StartupVideoBorder" Color="#403E3E "/>

--- a/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
+++ b/src/AccessibilityInsights.SharedUx/Resources/Light/Brushes.xaml
@@ -76,7 +76,6 @@
     <SolidColorBrush po:Freeze="True" x:Key="TestViewTabItemSelectedFGBrush" Color="#000000"/>
 
     <!-- NEW SETTINGS -->
-    <Thickness po:Freeze="True" x:Key="SearchPanelBorderThickness">0</Thickness>
     <Thickness po:Freeze="True" x:Key="TestModeBorderThickness">1</Thickness>
     <Thickness po:Freeze="True" x:Key="ActionsButtonBorderThickness">0</Thickness>
 
@@ -85,7 +84,7 @@
     <SolidColorBrush x:Key="SearchAndIconForegroundBrush" Color="#333333"/>
     <SolidColorBrush x:Key="SearchPlaceholderFGBrush" Color="#333333"/>
     <SolidColorBrush x:Key="SearchPanelBGBrush" Color="#F4F4F4"/>
-    <SolidColorBrush x:Key="SearchPanelBorderBrush" Color="Transparent"/>
+    <SolidColorBrush x:Key="SearchPanelBorderBrush" Color="#000000"/>
     <SolidColorBrush x:Key="GenericBorderBrush" Color="#A6A6A6"/>
     <SolidColorBrush x:Key="StartupBackgroundBrush" Color="#0C5086"/>
     <SolidColorBrush x:Key="StartupVideoBorder" Color="#403E3E"/>


### PR DESCRIPTION
#### Details

As called out in #1758, the search box doesn't meet non-text color contrast requirements. This PR changes the border so that it's consistently displayed in all themes.

##### Motivation

Address #1758

##### Screenshots

Mode | Before (only dark mode has border) | After (all modes have border)
--- | --- | ---
Light | ![image](https://github.com/microsoft/accessibility-insights-windows/assets/45672944/84b2dab8-afa1-4179-9acd-95f77d80a226) | ![image](https://github.com/microsoft/accessibility-insights-windows/assets/45672944/183dff19-de12-4db9-899d-02523fd44086)
Dark | ![image](https://github.com/microsoft/accessibility-insights-windows/assets/45672944/91c498c7-f64c-4dff-8948-2a2cf91fb8db) | ![image](https://github.com/microsoft/accessibility-insights-windows/assets/45672944/67eb11c7-7904-4ccb-a549-d8c74f0c235a)
Aquatic | ![image](https://github.com/microsoft/accessibility-insights-windows/assets/45672944/1cc060ba-774f-4090-bb2a-1b6f207c0529) | ![image](https://github.com/microsoft/accessibility-insights-windows/assets/45672944/220dbebc-ec2e-4bdc-9b90-5bddfc8cbe7b)
Desert | ![image](https://github.com/microsoft/accessibility-insights-windows/assets/45672944/92482f5c-fa25-40d3-805b-77bcbdd9780c) | ![image](https://github.com/microsoft/accessibility-insights-windows/assets/45672944/188512a1-15e4-459e-af49-42d58ccb699a)
Dusk | ![image](https://github.com/microsoft/accessibility-insights-windows/assets/45672944/e1f07522-d18e-45f5-a375-33d20f3ed582) | ![image](https://github.com/microsoft/accessibility-insights-windows/assets/45672944/6c340b31-b555-414c-b704-1d316591b3bc)
Night Sky | ![image](https://github.com/microsoft/accessibility-insights-windows/assets/45672944/bcbb5291-7b5b-4a78-8710-338575b8b922) | ![image](https://github.com/microsoft/accessibility-insights-windows/assets/45672944/c39a1fb6-a38b-46e8-8cda-52ac16f6b4fe)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
Since the `SearchPanelBorderThickness` value is now always 1, I replaced the variable (originally added for dark mode) with a hardcoded value

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - 1758
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



