### PR TITLE
fix: Add license headers to .yml and .targets files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+﻿# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
 version: 2
 updates:
 - package-ecosystem: nuget

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -1,3 +1,5 @@
+﻿# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
 id: 
 name: GitOps.PullRequestIssueManagement
 description: GitOps.PullRequestIssueManagement primitive

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -1,5 +1,3 @@
-﻿# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
 id: 
 name: GitOps.PullRequestIssueManagement
 description: GitOps.PullRequestIssueManagement primitive

--- a/build/NetFrameworkAll.targets
+++ b/build/NetFrameworkAll.targets
@@ -1,4 +1,6 @@
-﻿<Project>
+﻿<!-- Copyright (c) Microsoft. All rights reserved.
+     Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
+<Project>
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>

--- a/build/NetFrameworkRelease.targets
+++ b/build/NetFrameworkRelease.targets
@@ -1,3 +1,5 @@
+﻿<!-- Copyright (c) Microsoft. All rights reserved.
+     Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
 <Project>
 
   <PropertyGroup>

--- a/build/NetFrameworkTest.targets
+++ b/build/NetFrameworkTest.targets
@@ -1,4 +1,6 @@
-﻿<Project>
+﻿<!-- Copyright (c) Microsoft. All rights reserved.
+     Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
+<Project>
 
   <PropertyGroup>
     <NoWarn>1701;1702;CA1707</NoWarn>

--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -28,7 +28,7 @@ jobs:
       inputs:
         targetType: "filePath"
         filePath: tools\scripts\verification.scripts\LicenseHeaderVerification.ps1
-        arguments: '-target  $(Build.Repository.LocalPath) -licenseHeaderPath tools\scripts\verification.scripts\LicenseHeader.txt -extensions *.xaml,*.xml,*.cs,*.ps1 -addIfAbsent $false'
+        arguments: '-target  $(Build.Repository.LocalPath) -licenseHeaderPath tools\scripts\verification.scripts\LicenseHeader.txt -extensions *.xaml,*.xml,*.cs,*.ps1,*.yml,*.targets -addIfAbsent $false'
 
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'

--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -1,3 +1,5 @@
+﻿# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
 # This template contains jobs to build and run unit tests
 
 parameters:

--- a/build/check-dependencies.yml
+++ b/build/check-dependencies.yml
@@ -1,3 +1,5 @@
+﻿# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
 # This template checks for assemblies that may need harvesting in ClearlyDefined
 
 parameters:

--- a/build/common.targets
+++ b/build/common.targets
@@ -1,3 +1,5 @@
+﻿<!-- Copyright (c) Microsoft. All rights reserved.
+     Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
 
   <!--

--- a/build/delaysign.targets
+++ b/build/delaysign.targets
@@ -1,3 +1,5 @@
+﻿<!-- Copyright (c) Microsoft. All rights reserved.
+     Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
   
   <!--

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -1,3 +1,5 @@
+﻿# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
 name: $(date:yyyy-MM-dd)$(rev:.rr)
 trigger: none
 pr: none

--- a/build/settings.targets
+++ b/build/settings.targets
@@ -1,3 +1,5 @@
+﻿<!-- Copyright (c) Microsoft. All rights reserved.
+     Licensed under the MIT license. See LICENSE file in the project root for full license information.-->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
   
   <!--

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -52,7 +52,7 @@ extends:
           inputs:
             targetType: "filePath"
             filePath: tools\scripts\verification.scripts\LicenseHeaderVerification.ps1
-            arguments: '-target  $(Build.Repository.LocalPath) -licenseHeaderPath tools\scripts\verification.scripts\LicenseHeader.txt -extensions *.xaml,*.xml,*.cs,*.ps1 -addIfAbsent $false'
+            arguments: '-target  $(Build.Repository.LocalPath) -licenseHeaderPath tools\scripts\verification.scripts\LicenseHeader.txt -extensions *.xaml,*.xml,*.cs,*.ps1,*.yml,*.targets -addIfAbsent $false'
 
         - task: NuGetToolInstaller@1
           displayName: 'Use NuGet 5.x'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -1,3 +1,5 @@
+﻿# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
 name: $(date:yyyy-MM-dd)$(rev:.rr)
 trigger: none
 pr: none

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -1,3 +1,5 @@
+﻿# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
 # This template contains jobs to run UI tests using WinAppDriver.
 
 parameters:

--- a/tools/scripts/verification.scripts/LicenseHeaderVerification.ps1
+++ b/tools/scripts/verification.scripts/LicenseHeaderVerification.ps1
@@ -40,13 +40,13 @@ function Get-FileText($pathToFile){
 function Get-CopyrightHeader($extension){
     switch ( $extension )
     {
-        {(($extension -eq '.xaml') -or ($extension -eq '.xml') -or ($extension -eq '.wxs'))}{
+        {(($extension -eq '.xaml') -or ($extension -eq '.xml') -or ($extension -eq '.wxs') -or ($extension -eq '.targets'))}{
             return $XmlLicense;
         }
         .cs {
             return $CSharpLicense;
         }
-        .ps1{
+        {(($extension -eq '.ps1') -or ($extension -eq '.yml'))}{
             return $PSLicense;
         }
         #Add more Extensions support here
@@ -101,17 +101,17 @@ function Get-BlockCommentedHeader($SplitVanillaLicenseHeader, $blockCommentStart
 }
 
 $SplitVanillaLicenseHeader = (Get-FileText $LicenseHeaderPath).split($NewLine)
-$XmlLicense = Get-BlockCommentedHeader $SplitVanillaLicenseHeader "<!--" "-->"
+$XmlLicense = (Get-BlockCommentedHeader $SplitVanillaLicenseHeader "<!--" "-->") + $NewLine
 $CSharpLicense =  Get-LineCommentedHeader $SplitVanillaLicenseHeader "//"
 $PSLicense= Get-LineCommentedHeader $SplitVanillaLicenseHeader "#"
 #Add more Extensions support here
 
 (Get-ChildItem $Target\* -Include $Extensions -Recurse) | Where {$_.FullName -notmatch $excludeList} | Foreach-Object {
     $path = $_.FullName
+	Write-Host "Path = $path"
     $copyRightHeader=Get-CopyrightHeader $_.Extension
     $fileContent=Get-FileText $path
     if($fileContent -ne $Null -and $fileContent.Contains($copyRightHeader)){
-        echo "$path has copyright header"
     } else {
        $FailedFiles += $path
        if($AddIfAbsent){

--- a/tools/scripts/verification.scripts/LicenseHeaderVerification.ps1
+++ b/tools/scripts/verification.scripts/LicenseHeaderVerification.ps1
@@ -113,10 +113,14 @@ $PSLicense= Get-LineCommentedHeader $SplitVanillaLicenseHeader "#"
     $fileContent=Get-FileText $path
     if($fileContent -ne $Null -and $fileContent.Contains($copyRightHeader)){
     } else {
-       $FailedFiles += $path
-       if($AddIfAbsent){
-           "$copyRightHeader" + $fileContent | Set-Content -NoNewLine $path -Encoding UTF8
-           echo "Added the header to $path"
+        if ($path.Contains('\.github\policies\')){
+            echo "Ignoring policy file: $path"
+        } else {
+            $FailedFiles += $path
+            if($AddIfAbsent){
+                "$copyRightHeader" + $fileContent | Set-Content -NoNewLine $path -Encoding UTF8
+                echo "Added the header to $path"
+            }
         }
     }
 }

--- a/tools/scripts/verification.scripts/LicenseHeaderVerification.ps1
+++ b/tools/scripts/verification.scripts/LicenseHeaderVerification.ps1
@@ -17,7 +17,7 @@ The extensions of the files in the target folder that will be processed. Current
 If a file with no license header is detected, whether a header should be added.
 
 .Example Usage 
-.\LicenseHeaderVerification.ps1 -Target '.\Powershell test\' -LicenseHeaderPath .\LicenseHeader.txt -Extensions *.xaml,*.xml,*.cs,*.ps1 -AddIfAbsent $false
+.\LicenseHeaderVerification.ps1 -Target '.\Powershell test\' -LicenseHeaderPath .\LicenseHeader.txt -Extensions *.xaml,*.xml,*.cs,*.ps1,*.yml,*.targets -AddIfAbsent $false
 #>
 
 param(


### PR DESCRIPTION
#### Details

While updating to 1ES pipeline templates, we realized that several of our files were missing copyright headers. This adds them and updates the tooling to ensure that we don't miss them in these files types in the future. Copyright headers were all added by running the script.

The policy service file can't have comments without breaking the bot, so an exception is made for any files under `.github\policies`.

##### Motivation

Address #1761 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue #1761
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



