### PR TITLE
fix: Added skip tag setting for 1ESPT tags in PR run

### DIFF
--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -20,6 +20,8 @@ extends:
   # For productions pipelines, use "Official".
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
+    settings:
+      skipBuildTagsForGitHubPullRequests: true
     # Update the pool with your team's 1ES hosted pool.
     pool:
       name: $(a11yInsightsPool) # Name of your hosted pool


### PR DESCRIPTION
#### Details

1ES PT adds tags to pipeline runs using the access token provided by ADO. In the case of pipeline runs against forked repos of a GitHub repo, the access token does not have Edit build quality permissions and hence cannot add tags. To unblock those pipelines, skipped tagging by using the option SkipBuildTagsForGitHubPullRequests.

Verified that the only change in the pipeline run is that it do not add "1ES.PT.Unofficial" tag on the Run. In place of that it adds below warning message.

##[warning]1ES PT Warning: Skipping build tags as this build is a pull request form github which does not have permissions to add tags.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [na] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [na] Does this address an existing issue? If yes, Issue# - 
- [na] Includes UI changes?
  - [na] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [na] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



