### PR TITLE
Fix: Fix typo in filter text

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.Designer.cs
@@ -4444,7 +4444,7 @@ namespace AccessibilityInsights.SharedUx.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Filter the items in the both lists..
+        ///   Looks up a localized string similar to Filter the items in both lists..
         /// </summary>
         public static string textboxSearchAutomationPropertiesHelpText {
             get {

--- a/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
+++ b/src/AccessibilityInsights.SharedUx/Properties/Resources.resx
@@ -510,7 +510,7 @@
     <value>filter</value>
   </data>
   <data name="textboxSearchAutomationPropertiesHelpText" xml:space="preserve">
-    <value>Filter the items in the both lists.</value>
+    <value>Filter the items in both lists.</value>
   </data>
   <data name="lvLeftAutomationPropertiesName" xml:space="preserve">
     <value>Available</value>


### PR DESCRIPTION
#### Details
Fix a typo in the property picker's filter hint.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [n/a] Does this address an existing issue? If yes, Issue# - 
- [n/a] Includes UI changes?
  - [n/a] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [n/a] Attach any screenshots / GIF's that are applicable.