### PR TITLE
fix: updated dependabot.yml directory to check for projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@
 version: 2
 updates:
 - package-ecosystem: nuget
-  directory: "/"
+  directory: "/src"
   schedule:
     interval: daily
     time: "08:30"  # UTC


### PR DESCRIPTION
#### Details

Dependabot stopped generating new PRs and logs show no project found. 
```
/opt/nuget/NuGetUpdater/NuGetUpdater.Cli discover --repo-root /home/dependabot/dependabot-updater/repo --workspace / --output /tmp/.dependabot/discovery.1.json --verbose
updater | Discovering build files in workspace [/home/dependabot/dependabot-updater/repo].
  No dotnet-tools.json file found.
  No global.json file found.
  Discovering projects beneath [.].
  No project files found.
  Central Package Management is not enabled.
Discovery complete.
updater | 2024/07/12 08:09:07 INFO <job_854906625> Discovery JSON content: {
  "Path": "",
  "IsSuccess": true,
  "Projects": [],
  "DirectoryPackagesProps": null,
  "GlobalJson": null,
  "DotNetToolsJson": null
}
```

Implementing fix as per https://github.com/dependabot/dependabot-core/issues/10145. We can only verify the changes once it is merged to master.


##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [na] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [na] Does this address an existing issue? If yes, Issue# - 
- [na] Includes UI changes?
  - [na] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [na] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



