### PR TITLE
CG work item fix for System.Text.JSON package

### DIFF
--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.1.2" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <ProjectReference Include="..\AccessibilityInsights.CommonUxComponents\CommonUxComponents.csproj" />
     <ProjectReference Include="..\AccessibilityInsights.Extensions\Extensions.csproj" />

--- a/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
+++ b/src/AccessibilityInsights.Extensions.AzureDevOps/Extensions.AzureDevOps.csproj
@@ -24,20 +24,20 @@
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.66" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.65.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.6.3" />
-    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="7.6.3" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.6.3" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.1.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="8.1.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.1.2" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.227.0-preview" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.227.0-preview" />
     <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.227.0-preview" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.3" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.1.2" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <ProjectReference Include="..\AccessibilityInsights.CommonUxComponents\CommonUxComponents.csproj" />
     <ProjectReference Include="..\AccessibilityInsights.Extensions\Extensions.csproj" />

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -74,11 +74,11 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
             <File Id="Microsoft.Azure.DevOps.Comments.WebApi.dll" Source="Microsoft.Azure.DevOps.Comments.WebApi.dll" />
             <File Id="Microsoft.Azure.Pipelines.WebApi.dll" Source="Microsoft.Azure.Pipelines.WebApi.dll" />
             <File Id="Microsoft.Bcl.AsyncInterfaces.dll" Source="Microsoft.Bcl.AsyncInterfaces.dll" />
+            <File Id="Microsoft.Bcl.TimeProvider.dll" Source="Microsoft.Bcl.TimeProvider.dll" />
             <File Id="WixToolset.Dtf.WindowsInstaller.dll" Source="WixToolset.Dtf.WindowsInstaller.dll" />
             <File Id="Microsoft.Identity.Client.dll" Source="Microsoft.Identity.Client.dll" />
             <File Id="Microsoft.Identity.Client.Extensions.Msal.dll" Source="Microsoft.Identity.Client.Extensions.Msal.dll" />
             <File Id="Microsoft.IdentityModel.Abstractions.dll" Source="Microsoft.IdentityModel.Abstractions.dll" />
-            <File Id="Microsoft.Bcl.TimeProvider.dll" Source="Microsoft.Bcl.TimeProvider.dll" />
             <File Id="Microsoft.IdentityModel.JsonWebTokens.dll" Source="Microsoft.IdentityModel.JsonWebTokens.dll" />
             <File Id="Microsoft.IdentityModel.Logging.dll" Source="Microsoft.IdentityModel.Logging.dll" />
             <File Id="Microsoft.IdentityModel.Tokens.dll" Source="Microsoft.IdentityModel.Tokens.dll" />

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -78,6 +78,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
             <File Id="Microsoft.Identity.Client.dll" Source="Microsoft.Identity.Client.dll" />
             <File Id="Microsoft.Identity.Client.Extensions.Msal.dll" Source="Microsoft.Identity.Client.Extensions.Msal.dll" />
             <File Id="Microsoft.IdentityModel.Abstractions.dll" Source="Microsoft.IdentityModel.Abstractions.dll" />
+            <File Id="Microsoft.Bcl.TimeProvider.dll" Source="Microsoft.Bcl.TimeProvider.dll" />
             <File Id="Microsoft.IdentityModel.JsonWebTokens.dll" Source="Microsoft.IdentityModel.JsonWebTokens.dll" />
             <File Id="Microsoft.IdentityModel.Logging.dll" Source="Microsoft.IdentityModel.Logging.dll" />
             <File Id="Microsoft.IdentityModel.Tokens.dll" Source="Microsoft.IdentityModel.Tokens.dll" />

--- a/src/MsiFileTests/WxsValidationTests.cs
+++ b/src/MsiFileTests/WxsValidationTests.cs
@@ -37,15 +37,23 @@ namespace MsiFileTests
             string wxsFile, string wxsComponentId, HashSet<string> intentionalExclusions = null)
         {
             string dropPath = Path.Combine(repoRoot, relativeDropPath);
+            if (intentionalExclusions == null)
+            {
+                intentionalExclusions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+ 
+            // Add Microsoft.Bcl.TimeProvider.dll to intentional exclusions if needed
+            intentionalExclusions.Add("Microsoft.Bcl.TimeProvider.dll");
+ 
             HashSet<string> filesInDropPath = GetNonSymbolFilesInPath(dropPath, intentionalExclusions);
             HashSet<string> filesInWxsComponent = GetFilesIncludedInWxsComponent(wxsFile, wxsComponentId);
-
+ 
             Assert.AreNotEqual(0, filesInDropPath.Count, $"No files found under {dropPath}");
             Assert.AreNotEqual(0, filesInWxsComponent.Count, $"No files in Component {wxsComponentId}");
-
+ 
             filesInDropPath.ExceptWith(filesInWxsComponent);
-
-            Assert.IsFalse(filesInDropPath.Any(), $"{filesInDropPath.Count} drop files are missing from \"{wxsComponentId}\" of WXS: {string.Join(", ", filesInDropPath)}");
+ 
+            Assert.IsFalse(filesInDropPath.Count > 0, $"{filesInDropPath.Count} drop files are missing from \"{wxsComponentId}\" of WXS: {string.Join(", ", filesInDropPath)}");
         }
 
         private static HashSet<string> GetNonSymbolFilesInPath(string path, HashSet<string> intentionalExclusions)

--- a/src/MsiFileTests/WxsValidationTests.cs
+++ b/src/MsiFileTests/WxsValidationTests.cs
@@ -50,7 +50,6 @@ namespace MsiFileTests
 
             Assert.AreNotEqual(0, filesInDropPath.Count, $"No files found under {dropPath}");
             Assert.AreNotEqual(0, filesInWxsComponent.Count, $"No files in Component {wxsComponentId}");
- 
             filesInDropPath.ExceptWith(filesInWxsComponent);
 
             Assert.IsFalse(filesInDropPath.Any(), $"{filesInDropPath.Count} drop files are missing from \"{wxsComponentId}\" of WXS: {string.Join(", ", filesInDropPath)}");

--- a/src/MsiFileTests/WxsValidationTests.cs
+++ b/src/MsiFileTests/WxsValidationTests.cs
@@ -47,13 +47,13 @@ namespace MsiFileTests
  
             HashSet<string> filesInDropPath = GetNonSymbolFilesInPath(dropPath, intentionalExclusions);
             HashSet<string> filesInWxsComponent = GetFilesIncludedInWxsComponent(wxsFile, wxsComponentId);
- 
+
             Assert.AreNotEqual(0, filesInDropPath.Count, $"No files found under {dropPath}");
             Assert.AreNotEqual(0, filesInWxsComponent.Count, $"No files in Component {wxsComponentId}");
  
             filesInDropPath.ExceptWith(filesInWxsComponent);
- 
-            Assert.IsFalse(filesInDropPath.Count > 0, $"{filesInDropPath.Count} drop files are missing from \"{wxsComponentId}\" of WXS: {string.Join(", ", filesInDropPath)}");
+
+            Assert.IsFalse(filesInDropPath.Any(), $"{filesInDropPath.Count} drop files are missing from \"{wxsComponentId}\" of WXS: {string.Join(", ", filesInDropPath)}");
         }
 
         private static HashSet<string> GetNonSymbolFilesInPath(string path, HashSet<string> intentionalExclusions)

--- a/src/MsiFileTests/WxsValidationTests.cs
+++ b/src/MsiFileTests/WxsValidationTests.cs
@@ -37,14 +37,7 @@ namespace MsiFileTests
             string wxsFile, string wxsComponentId, HashSet<string> intentionalExclusions = null)
         {
             string dropPath = Path.Combine(repoRoot, relativeDropPath);
-            if (intentionalExclusions == null)
-            {
-                intentionalExclusions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            }
- 
-            // Add Microsoft.Bcl.TimeProvider.dll to intentional exclusions if needed
-            intentionalExclusions.Add("Microsoft.Bcl.TimeProvider.dll");
- 
+
             HashSet<string> filesInDropPath = GetNonSymbolFilesInPath(dropPath, intentionalExclusions);
             HashSet<string> filesInWxsComponent = GetFilesIncludedInWxsComponent(wxsFile, wxsComponentId);
 

--- a/src/MsiFileTests/WxsValidationTests.cs
+++ b/src/MsiFileTests/WxsValidationTests.cs
@@ -50,6 +50,7 @@ namespace MsiFileTests
 
             Assert.AreNotEqual(0, filesInDropPath.Count, $"No files found under {dropPath}");
             Assert.AreNotEqual(0, filesInWxsComponent.Count, $"No files in Component {wxsComponentId}");
+            
             filesInDropPath.ExceptWith(filesInWxsComponent);
 
             Assert.IsFalse(filesInDropPath.Any(), $"{filesInDropPath.Count} drop files are missing from \"{wxsComponentId}\" of WXS: {string.Join(", ", filesInDropPath)}");

--- a/src/MsiFileTests/WxsValidationTests.cs
+++ b/src/MsiFileTests/WxsValidationTests.cs
@@ -37,7 +37,6 @@ namespace MsiFileTests
             string wxsFile, string wxsComponentId, HashSet<string> intentionalExclusions = null)
         {
             string dropPath = Path.Combine(repoRoot, relativeDropPath);
-
             HashSet<string> filesInDropPath = GetNonSymbolFilesInPath(dropPath, intentionalExclusions);
             HashSet<string> filesInWxsComponent = GetFilesIncludedInWxsComponent(wxsFile, wxsComponentId);
 

--- a/src/MsiFileTests/WxsValidationTests.cs
+++ b/src/MsiFileTests/WxsValidationTests.cs
@@ -50,7 +50,7 @@ namespace MsiFileTests
 
             Assert.AreNotEqual(0, filesInDropPath.Count, $"No files found under {dropPath}");
             Assert.AreNotEqual(0, filesInWxsComponent.Count, $"No files in Component {wxsComponentId}");
-            
+
             filesInDropPath.ExceptWith(filesInWxsComponent);
 
             Assert.IsFalse(filesInDropPath.Any(), $"{filesInDropPath.Count} drop files are missing from \"{wxsComponentId}\" of WXS: {string.Join(", ", filesInDropPath)}");


### PR DESCRIPTION
#### Details

Updated System.Text.Json to 8.0.5 to address https://github.com/advisories/GHSA-hh2w-p6rv-4g7w. This will fix CG issue https://dev.azure.com/mseng/1ES/_workitems/edit/2221678/?view=edit
Along with this updated its root dependencies to latest.

**NOTE: After updating the version, test case was failing in pipeline with below error**

**Error Log:**
Failed AllDropFilesAreAccountedFor [136 ms]

**Error Message:**
   Assert.IsFalse failed. 1 drop files are missing from "ProductComponent" of WXS: Microsoft.Bcl.TimeProvider.dll
  
**Stack Trace:
     at MsiFileTests.WxsValidationTests.CompareWxsSectionToDropPath(String repoRoot, String relativeDropPath, String wxsFile, String wxsComponentId, HashSet`1 intentionalExclusions) in D:\a\_work\1\s\src\MsiFileTests\WxsValidationTests.cs:line 48
   at MsiFileTests.WxsValidationTests.AllDropFilesAreAccountedFor() in D:\a\_work\1\s\src\MsiFileTests\WxsValidationTests.cs:line 25**
Results File: D:\a\_work\_temp\TestResults\cloudtest_d22066dec000000_2024-10-17_06_24_32.trx

To fix above, made changes in **Product.wxs** as below

**Added below code to fix the error in pipeline:**
 `<File Id="Microsoft.Bcl.TimeProvider.dll" Source="Microsoft.Bcl.TimeProvider.dll" />`

##### Motivation

CVE

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



