### PR TITLE
chore: update binskim to optout 4.3.1 version

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -27,7 +27,7 @@ extends:
       name: MSEngSS-MicroBuild2022-1ES
     sdl:
       binskim:
-        # #1093: Hold BinSkim back at 4.3.1 to resolve a pipeline incompatibility
+        # #1903: Hold BinSkim back at 4.3.1 to resolve a pipeline incompatibility
         preReleaseVersion: ''
         # If you modify this list, you also need to modify the list in the Run BinSkim task in Signed Release Job or vice-versa to keep them in sync
         analyzeTargetGlob: "src\\AccessibilityInsights\\**\\*.exe;\

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -27,6 +27,8 @@ extends:
       name: MSEngSS-MicroBuild2022-1ES
     sdl:
       binskim:
+        # #1093: Hold BinSkim back at 4.3.1 to resolve a pipeline incompatibility
+        preReleaseVersion: ''
         # If you modify this list, you also need to modify the list in the Run BinSkim task in Signed Release Job or vice-versa to keep them in sync
         analyzeTargetGlob: "src\\AccessibilityInsights\\**\\*.exe;\
                             src\\AccessibilityInsights\\**\\AccessibilityInsights.*.dll;\


### PR DESCRIPTION
#### Details
This is new pre release version used in 1ES pipeline templates. But our TSA upload task still uses the older version (1.9.5) so this conflict is resulting into pipeline failure.

For now updating pipeline to optout for new version.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context
There will be separate work item to update binskim to 4.3.1 version as new rules in 4.3.1 might discover issues which also need to be resolved so that pipeline does not break.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [ ] Does this address an existing issue? If yes, Issue# - 
- [ ] Includes UI changes?
  - [ ] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [ ] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



