### PR TITLE
fix: adding tooltip to search field

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/HierarchyControl.xaml
@@ -102,9 +102,11 @@
                                 <Setter Property="CaretBrush" Value="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsLiveMode, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:HierarchyControl}}" Value="False">
+                                        <Setter Property="ToolTip" Value="{x:Static Properties:Resources.SetterValueSearchByString}"/>
                                         <Setter Property="Placeholder" Value="{x:Static Properties:Resources.SetterValueSearchByString}"/>
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding IsLiveMode, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:HierarchyControl}}" Value="True">
+                                        <Setter Property="ToolTip" Value="{x:Static Properties:Resources.SetterValueSearchByName}"/>
                                         <Setter Property="Placeholder" Value="{x:Static Properties:Resources.SetterValueSearchByName}"/>
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding Text, ElementName=textboxSearch}" Value="">


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Added tooltip to the search field in "Live Inspect" to allow users to keep referring to it while they fill out the input field.

Below is screenshot for change (blue arrow is for reference and not included in UI)
![Screenshot 2025-02-18 141153](https://github.com/user-attachments/assets/c51ff40f-cb43-4489-b26b-ae295f7aac77)

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
adresses issue #1757

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #1757
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



