### PR TITLE
fix: enable text color in color picker to change based on windows theme

### DIFF
--- a/src/AccessibilityInsights.SharedUx/Controls/ColorPicker/ColorPickerControl.xaml
+++ b/src/AccessibilityInsights.SharedUx/Controls/ColorPicker/ColorPickerControl.xaml
@@ -107,21 +107,21 @@
                     <RowDefinition Height="4" />
                     <RowDefinition Height="32" />
                 </Grid.RowDefinitions>
-                <Label Grid.Column="0" Grid.Row="0" Padding="0" Name="lblHex" Content="{x:Static Properties:Resources.lblHexContent}"/>
+                <Label Grid.Column="0" Grid.Row="0" Padding="0" Name="lblHex" Content="{x:Static Properties:Resources.lblHexContent}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                 <TextBox Grid.Column="0" Grid.Row="2" FontSize="14"
                     MaxLength="9" Padding="3" AutomationProperties.LabeledBy="{Binding ElementName=lblHex}"
                     Text="{Binding HexadecimalString, Mode=TwoWay, ElementName=Root}" />
-                <Label Grid.Column="2" Grid.Row="0" Padding="0" Name="lblRed" Content="{x:Static Properties:Resources.lblRedContent}" />
+                <Label Grid.Column="2" Grid.Row="0" Padding="0" Name="lblRed" Content="{x:Static Properties:Resources.lblRedContent}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                 <TextBox FontSize="14" AutomationProperties.LabeledBy="{Binding ElementName=lblRed}"
                     Grid.Column="2" Grid.Row="2"
                     MaxLength="3" Padding="3"
                     Text="{Binding Red, Mode=TwoWay, ElementName=Root}" />
-                <Label Grid.Column="4" Grid.Row="0" Padding="0" Name="lblGreen" Content="{x:Static Properties:Resources.lblGreenContent}" />
+                <Label Grid.Column="4" Grid.Row="0" Padding="0" Name="lblGreen" Content="{x:Static Properties:Resources.lblGreenContent}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                 <TextBox FontSize="14" AutomationProperties.LabeledBy="{Binding ElementName=lblGreen}"
                     Grid.Column="4" Grid.Row="2"
                     MaxLength="3" Padding="3"
                     Text="{Binding Green, Mode=TwoWay, ElementName=Root}" />
-                <Label Grid.Column="6" Grid.Row="0" Padding="0" Name="lblBlue" Content="{x:Static Properties:Resources.lblBlueContent}"/>
+                <Label Grid.Column="6" Grid.Row="0" Padding="0" Name="lblBlue" Content="{x:Static Properties:Resources.lblBlueContent}" Foreground="{DynamicResource ResourceKey=PrimaryFGBrush}"/>
                 <TextBox FontSize="14" 
                         Grid.Column="6" Grid.Row="2"
                         MaxLength="3" Padding="3" AutomationProperties.LabeledBy="{Binding ElementName=lblBlue}"


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
The input labels in the color picker do not have sufficient contrast with the background when using the dark theme. This PR fixes the issue.

Theme | Screenshot
--- | ---
Windows(Light) | ![Screenshot 2025-04-03 161322](https://github.com/user-attachments/assets/8b9bfbd4-3ce0-42f0-8936-925979993e9c)
Windows(Dark) | ![Screenshot 2025-04-03 161032](https://github.com/user-attachments/assets/edce14cd-7bd9-47c5-a40c-97d338833faa)
Aquatic | ![Screenshot 2025-04-03 161130](https://github.com/user-attachments/assets/8fce8456-f1af-4405-988f-e7301a3026cb)
Dessert | ![Screenshot 2025-04-03 161200](https://github.com/user-attachments/assets/ea36b526-59cb-4e4b-b5fc-5cca6b3281cc)
Dusk | ![Screenshot 2025-04-03 161228](https://github.com/user-attachments/assets/36e69368-be05-4766-85c3-b121ac63386f)
Night Sky | ![Screenshot 2025-04-03 161249](https://github.com/user-attachments/assets/feb87d70-5fba-4db6-b4c2-17549c4f0909)

##### Motivation
<!-- This can be as simple as "addresses issue #123" -->
addresses issue #1927 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Run through of all [test scenarios](https://github.com/Microsoft/accessibility-insights-windows/blob/main/docs/Scenarios.md) completed?
- [x] Does this address an existing issue? If yes, Issue# - #1927 
- [x] Includes UI changes?
  - [x] Run the production version of Accessibility Insights for Windows against a version with changes.
  - [x] Attach any screenshots / GIF's that are applicable.

> Note: After the PR has been created, certain checks will be kicked off. All of these checks must pass before a merge. 



