### PR TITLE
Replace deprecated pool name with VSEng-MicroBuildVSStable

### DIFF
--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -24,7 +24,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     pool: 
-      name: MSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
     sdl:
       binskim:
         # #1903: Hold BinSkim back at 4.3.1 to resolve a pipeline incompatibility


### PR DESCRIPTION
This pull request updates the build pipeline configuration to use a different build pool. The only change is switching the pool name from `MSEngSS-MicroBuild2022-1ES` to `VSEng-MicroBuildVSStable` in the `build/signedbuild.yml` file. This likely reflects a move to a more stable or recommended build environment "VSEng-MicroBuildVSStable".  Available pools are https://eng.ms/docs/initiatives/1es-permissions-service/perms/devdiv/microbuild/pools 
