### PR TITLE
Added CFSClean networkIsolationPolicy

### DIFF
--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -42,8 +42,14 @@ jobs:
     inputs:
       script: set
 
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate to NuGet feeds'
+
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
+    inputs:
+      feedsToUse: config
+      nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
@@ -52,6 +58,8 @@ jobs:
       projects: |
         **\*.csproj
         !**\CustomActions.Package.csproj
+      feedsToUse: config
+      nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'

--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -12,6 +12,8 @@ jobs:
   displayName: Build and run unit tests - ${{ parameters.configuration }}
   condition: succeeded()
   templateContext:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     outputs:
       - output: buildArtifacts
         artifactName: drop

--- a/build/check-dependencies.yml
+++ b/build/check-dependencies.yml
@@ -20,8 +20,14 @@ jobs:
     inputs:
       versionSpec: '5.x'
 
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate to NuGet feeds'
+
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
+    inputs:
+      feedsToUse: config
+      nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
   - task: PowerShell@2
     displayName: 'Check ClearlyDefined'

--- a/build/check-dependencies.yml
+++ b/build/check-dependencies.yml
@@ -13,6 +13,7 @@ jobs:
     name: $(a11yInsightsPool) # Name of your hosted pool
     image: windows-2022-secure # Name of the image in your pool. If not specified, first image of the pool is used
     os: windows # OS of the image. Allowed values: windows, linux, macOS
+    networkIsolationPolicy: Permissive,CFSClean
   steps:
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'

--- a/build/check-dependencies.yml
+++ b/build/check-dependencies.yml
@@ -13,7 +13,9 @@ jobs:
     name: $(a11yInsightsPool) # Name of your hosted pool
     image: windows-2022-secure # Name of the image in your pool. If not specified, first image of the pool is used
     os: windows # OS of the image. Allowed values: windows, linux, macOS
-    networkIsolationPolicy: Permissive,CFSClean
+  templateContext:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
   steps:
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -24,6 +24,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: Permissive,CFSClean
     # Update the pool with your team's 1ES hosted pool.
     pool:
       name: $(a11yInsightsPool) # Name of your hosted pool

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -68,6 +68,9 @@ extends:
 
         - task: NuGetCommand@2
           displayName: 'NuGet restore'
+          inputs:
+            feedsToUse: config
+            nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: DotNetCoreCLI@2
           displayName: 'dotnet restore'
@@ -76,6 +79,8 @@ extends:
             projects: |
               **\*.csproj
               !**\CustomActions.Package.csproj
+              feedsToUse: config
+              nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: VSBuild@1
           displayName: 'Build Solution **\*.sln'
@@ -128,6 +133,11 @@ extends:
 
         - task: NuGetCommand@2
           displayName: 'NuGet restore'
+          inputs:
+            command: 'restore'
+            restoreSolution: '$(Build.SourcesDirectory)\src\AccessibilityInsights.sln'
+            feedsToUse: config
+            nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: DotNetCoreCLI@2
           displayName: 'dotnet restore'
@@ -136,6 +146,8 @@ extends:
             projects: |
               **\*.csproj
               !**\CustomActions.Package.csproj
+              feedsToUse: config
+              nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: VSBuild@1
           displayName: 'Build Solution **\*.sln'
@@ -259,6 +271,9 @@ extends:
 
         - task: NuGetCommand@2
           displayName: 'NuGet restore'
+          inputs:
+            feedsToUse: config
+            nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: DotNetCoreCLI@2
           displayName: 'dotnet restore'
@@ -267,6 +282,8 @@ extends:
             projects: |
               **\*.csproj
               !**\CustomActions.Package.csproj
+              feedsToUse: config
+              nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
           displayName: 'Component Detection'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -66,6 +66,9 @@ extends:
           inputs:
             script: set
 
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate to NuGet feeds'
+
         - task: NuGetCommand@2
           displayName: 'NuGet restore'
           inputs:
@@ -79,8 +82,8 @@ extends:
             projects: |
               **\*.csproj
               !**\CustomActions.Package.csproj
-              feedsToUse: config
-              nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
+            feedsToUse: config
+            nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: VSBuild@1
           displayName: 'Build Solution **\*.sln'
@@ -131,6 +134,9 @@ extends:
           inputs:
             script: set
 
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate to NuGet feeds'
+
         - task: NuGetCommand@2
           displayName: 'NuGet restore'
           inputs:
@@ -146,8 +152,8 @@ extends:
             projects: |
               **\*.csproj
               !**\CustomActions.Package.csproj
-              feedsToUse: config
-              nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
+            feedsToUse: config
+            nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: VSBuild@1
           displayName: 'Build Solution **\*.sln'
@@ -269,6 +275,9 @@ extends:
           inputs:
             script: set
 
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate to NuGet feeds'
+
         - task: NuGetCommand@2
           displayName: 'NuGet restore'
           inputs:
@@ -282,8 +291,8 @@ extends:
             projects: |
               **\*.csproj
               !**\CustomActions.Package.csproj
-              feedsToUse: config
-              nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
+            feedsToUse: config
+            nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
           displayName: 'Component Detection'

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -13,6 +13,9 @@ jobs:
     name: $(a11yInsightsPool) # Name of your hosted pool
     image: windows-2022-secure # Name of the image in your pool. If not specified, first image of the pool is used
     os: windows # OS of the image. Allowed values: windows, linux, macOS
+  templateContext:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean 
   steps:
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -32,7 +32,7 @@ jobs:
       command: restore
       restoreSolution: '**/*.sln'
       feedsToUse: config
-      nugetConfigPath: '$(Build.SourcesDirectory)/nuget.config'
+      nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
@@ -40,7 +40,7 @@ jobs:
       vsVersion: 17.0
       platform: '$(BuildPlatform)'
       configuration: ${{ parameters.configuration }}
-      msbuildArgs: '/restore /p:RestoreConfigFile=$(Build.SourcesDirectory)/nuget.config'
+      msbuildArgs: '/restore /p:RestoreConfigFile=$(Build.SourcesDirectory)/src/nuget.config'
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Start - WinAppDriver'

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -15,15 +15,24 @@ jobs:
     os: windows # OS of the image. Allowed values: windows, linux, macOS
   templateContext:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean 
+      networkIsolationPolicy: Permissive,CFSClean
   steps:
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'
     inputs:
       versionSpec: '5.x'
 
+  # Authenticate to the private Azure Artifacts feed defined in nuget.config
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate to NuGet feeds'
+
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
+    inputs:
+      command: restore
+      restoreSolution: '**/*.sln'
+      feedsToUse: config
+      nugetConfigPath: '$(Build.SourcesDirectory)/nuget.config'
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
@@ -31,6 +40,7 @@ jobs:
       vsVersion: 17.0
       platform: '$(BuildPlatform)'
       configuration: ${{ parameters.configuration }}
+      msbuildArgs: '/restore /p:RestoreConfigFile=$(Build.SourcesDirectory)/nuget.config'
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Start - WinAppDriver'

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -2,11 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="a11y-insights-public" value="https://accessibility-insights.pkgs.visualstudio.com/_packaging/a11y-insights-public/nuget/v3/index.json" />
+    <add key="a11y-insights-public" value="https://pkgs.dev.azure.com/accessibility-insights/_packaging/a11y-insights-public/nuget/v3/index.json" />
   </packageSources>
-  <packageSourceMapping>
-    <packageSource key="a11y-insights-public">
-      <package pattern="*" />
-    </packageSource>    
-  </packageSourceMapping>
 </configuration>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="a11y-insights-windows" value="https://pkgs.dev.azure.com/accessibility-insights-private/c79273f4-2dcc-480f-852b-0267a30c82db/_packaging/a11y-insights-windows/nuget/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="a11y-insights-windows">
+      <package pattern="*" />
+    </packageSource>    
+  </packageSourceMapping>
+</configuration>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -2,10 +2,10 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="a11y-insights-windows" value="https://pkgs.dev.azure.com/accessibility-insights-private/c79273f4-2dcc-480f-852b-0267a30c82db/_packaging/a11y-insights-windows/nuget/v3/index.json" />
+    <add key="a11y-insights-public" value="https://accessibility-insights.pkgs.visualstudio.com/_packaging/a11y-insights-public/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="a11y-insights-windows">
+    <packageSource key="a11y-insights-public">
       <package pattern="*" />
     </packageSource>    
   </packageSourceMapping>


### PR DESCRIPTION
This pull request updates several Azure Pipelines YAML files to explicitly set the `networkIsolationPolicy` to `Permissive,CFSClean` for various build, test, and dependency check jobs. This change ensures consistent network isolation settings across the pipeline, which may be required for compliance or security reasons.

**Pipeline configuration updates:**

* Added `networkIsolationPolicy: Permissive,CFSClean` to the job pool settings in `build/check-dependencies.yml` to control network isolation during dependency checks.
* Added `networkIsolationPolicy: Permissive,CFSClean` under `settings` in the `templateContext` for the build and unit test job in `build/build-and-unit-tests.yml`.
* Added `networkIsolationPolicy: Permissive,CFSClean` to the `settings` parameters in `build/prbuild.yml` for PR builds.
* Added `networkIsolationPolicy: Permissive,CFSClean` under `settings` in the `templateContext` for the UI test job in `build/ui-test-job.yml`.
* Adds a nuget.config with the feed details.