### PR TITLE
[DRAFT - CI validation only] Fix WixToolset.Sdk resolution under CFSClean feed pinning

### DIFF
--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -42,8 +42,14 @@ jobs:
     inputs:
       script: set
 
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate to NuGet feeds'
+
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
+    inputs:
+      feedsToUse: config
+      nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
@@ -52,6 +58,8 @@ jobs:
       projects: |
         **\*.csproj
         !**\CustomActions.Package.csproj
+      feedsToUse: config
+      nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'

--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -1,4 +1,4 @@
-﻿# Copyright (c) Microsoft. All rights reserved.
+# Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 # This template contains jobs to build and run unit tests
 
@@ -42,8 +42,7 @@ jobs:
     inputs:
       script: set
 
-  - task: NuGetAuthenticate@1
-    displayName: 'Authenticate to NuGet feeds'
+  - template: prepare-nuget.yml
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/build/build-and-unit-tests.yml
+++ b/build/build-and-unit-tests.yml
@@ -12,6 +12,8 @@ jobs:
   displayName: Build and run unit tests - ${{ parameters.configuration }}
   condition: succeeded()
   templateContext:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     outputs:
       - output: buildArtifacts
         artifactName: drop

--- a/build/check-dependencies.yml
+++ b/build/check-dependencies.yml
@@ -20,8 +20,14 @@ jobs:
     inputs:
       versionSpec: '5.x'
 
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate to NuGet feeds'
+
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
+    inputs:
+      feedsToUse: config
+      nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
   - task: PowerShell@2
     displayName: 'Check ClearlyDefined'

--- a/build/check-dependencies.yml
+++ b/build/check-dependencies.yml
@@ -1,4 +1,4 @@
-﻿# Copyright (c) Microsoft. All rights reserved.
+# Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 # This template checks for assemblies that may need harvesting in ClearlyDefined
 
@@ -13,15 +13,16 @@ jobs:
     name: $(a11yInsightsPool) # Name of your hosted pool
     image: windows-2022-secure # Name of the image in your pool. If not specified, first image of the pool is used
     os: windows # OS of the image. Allowed values: windows, linux, macOS
-    networkIsolationPolicy: Permissive,CFSClean
+  templateContext:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
   steps:
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'
     inputs:
       versionSpec: '5.x'
 
-  - task: NuGetAuthenticate@1
-    displayName: 'Authenticate to NuGet feeds'
+  - template: prepare-nuget.yml
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/build/check-dependencies.yml
+++ b/build/check-dependencies.yml
@@ -13,6 +13,7 @@ jobs:
     name: $(a11yInsightsPool) # Name of your hosted pool
     image: windows-2022-secure # Name of the image in your pool. If not specified, first image of the pool is used
     os: windows # OS of the image. Allowed values: windows, linux, macOS
+    networkIsolationPolicy: Permissive,CFSClean
   steps:
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'

--- a/build/prbuild.yml
+++ b/build/prbuild.yml
@@ -24,6 +24,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: Permissive,CFSClean
     # Update the pool with your team's 1ES hosted pool.
     pool:
       name: $(a11yInsightsPool) # Name of your hosted pool

--- a/build/prepare-nuget.yml
+++ b/build/prepare-nuget.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
-# Prepares NuGet for a solution restore: authenticates to the Azure Artifacts
-# feed, then pre-downloads the MSBuild project SDKs that MSI.wixproj needs.
+# Prepares NuGet for a solution restore by authenticating to the Azure Artifacts
+# feed declared in nuget.config.
 
 parameters:
 - name: nugetConfigPath
@@ -11,22 +11,3 @@ parameters:
 steps:
 - task: NuGetAuthenticate@1
   displayName: 'Authenticate to NuGet feeds'
-
-# MSBuild resolves MSI.wixproj's WixToolset.Sdk at evaluation time through the
-# NuGet SDK resolver, which cannot authenticate to the feed. Downloading the SDK
-# into the global packages folder first lets that resolution succeed offline.
-# The version is read from MSI.wixproj so the two can never drift apart.
-- task: PowerShell@2
-  displayName: 'Seed MSBuild SDK packages'
-  inputs:
-    targetType: inline
-    script: |
-      $ErrorActionPreference = 'Stop'
-      $wixproj = '$(Build.SourcesDirectory)/src/MSI/MSI.wixproj'
-      $match = Select-String -Path $wixproj -Pattern 'Sdk="WixToolset\.Sdk"\s+Version="([^"]+)"' | Select-Object -First 1
-      if (-not $match) { throw "Could not find a WixToolset.Sdk version in $wixproj" }
-      $version = $match.Matches[0].Groups[1].Value
-      Write-Host "Seeding WixToolset.Sdk $version"
-      $seed = Join-Path '$(Agent.TempDirectory)' 'sdk-seed.csproj'
-      Set-Content -Path $seed -Encoding UTF8 -Value "<Project Sdk='Microsoft.NET.Sdk'><PropertyGroup><TargetFramework>netstandard2.0</TargetFramework></PropertyGroup><ItemGroup><PackageDownload Include='WixToolset.Sdk' Version='[$version]' /></ItemGroup></Project>"
-      dotnet restore $seed --configfile '${{ parameters.nugetConfigPath }}'

--- a/build/prepare-nuget.yml
+++ b/build/prepare-nuget.yml
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+# Prepares NuGet for a solution restore: authenticates to the Azure Artifacts
+# feed, then pre-downloads the MSBuild project SDKs that MSI.wixproj needs.
+
+parameters:
+- name: nugetConfigPath
+  type: string
+  default: '$(Build.SourcesDirectory)/src/nuget.config'
+
+steps:
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate to NuGet feeds'
+
+# MSBuild resolves MSI.wixproj's WixToolset.Sdk at evaluation time through the
+# NuGet SDK resolver, which cannot authenticate to the feed. Downloading the SDK
+# into the global packages folder first lets that resolution succeed offline.
+# The version is read from MSI.wixproj so the two can never drift apart.
+- task: PowerShell@2
+  displayName: 'Seed MSBuild SDK packages'
+  inputs:
+    targetType: inline
+    script: |
+      $ErrorActionPreference = 'Stop'
+      $wixproj = '$(Build.SourcesDirectory)/src/MSI/MSI.wixproj'
+      $match = Select-String -Path $wixproj -Pattern 'Sdk="WixToolset\.Sdk"\s+Version="([^"]+)"' | Select-Object -First 1
+      if (-not $match) { throw "Could not find a WixToolset.Sdk version in $wixproj" }
+      $version = $match.Matches[0].Groups[1].Value
+      Write-Host "Seeding WixToolset.Sdk $version"
+      $seed = Join-Path '$(Agent.TempDirectory)' 'sdk-seed.csproj'
+      Set-Content -Path $seed -Encoding UTF8 -Value "<Project Sdk='Microsoft.NET.Sdk'><PropertyGroup><TargetFramework>netstandard2.0</TargetFramework></PropertyGroup><ItemGroup><PackageDownload Include='WixToolset.Sdk' Version='[$version]' /></ItemGroup></Project>"
+      dotnet restore $seed --configfile '${{ parameters.nugetConfigPath }}'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -68,6 +68,9 @@ extends:
 
         - task: NuGetCommand@2
           displayName: 'NuGet restore'
+          inputs:
+            feedsToUse: config
+            nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: DotNetCoreCLI@2
           displayName: 'dotnet restore'
@@ -76,6 +79,8 @@ extends:
             projects: |
               **\*.csproj
               !**\CustomActions.Package.csproj
+              feedsToUse: config
+              nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: VSBuild@1
           displayName: 'Build Solution **\*.sln'
@@ -128,6 +133,11 @@ extends:
 
         - task: NuGetCommand@2
           displayName: 'NuGet restore'
+          inputs:
+            command: 'restore'
+            restoreSolution: '$(Build.SourcesDirectory)\src\AccessibilityInsights.sln'
+            feedsToUse: config
+            nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: DotNetCoreCLI@2
           displayName: 'dotnet restore'
@@ -136,6 +146,8 @@ extends:
             projects: |
               **\*.csproj
               !**\CustomActions.Package.csproj
+              feedsToUse: config
+              nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: VSBuild@1
           displayName: 'Build Solution **\*.sln'
@@ -259,6 +271,9 @@ extends:
 
         - task: NuGetCommand@2
           displayName: 'NuGet restore'
+          inputs:
+            feedsToUse: config
+            nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: DotNetCoreCLI@2
           displayName: 'dotnet restore'
@@ -267,6 +282,8 @@ extends:
             projects: |
               **\*.csproj
               !**\CustomActions.Package.csproj
+              feedsToUse: config
+              nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
           displayName: 'Component Detection'

--- a/build/signedbuild.yml
+++ b/build/signedbuild.yml
@@ -1,4 +1,4 @@
-﻿# Copyright (c) Microsoft. All rights reserved.
+# Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 name: $(date:yyyy-MM-dd)$(rev:.rr)
 trigger: none
@@ -66,6 +66,8 @@ extends:
           inputs:
             script: set
 
+        - template: prepare-nuget.yml
+
         - task: NuGetCommand@2
           displayName: 'NuGet restore'
           inputs:
@@ -79,8 +81,8 @@ extends:
             projects: |
               **\*.csproj
               !**\CustomActions.Package.csproj
-              feedsToUse: config
-              nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
+            feedsToUse: config
+            nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: VSBuild@1
           displayName: 'Build Solution **\*.sln'
@@ -131,6 +133,8 @@ extends:
           inputs:
             script: set
 
+        - template: prepare-nuget.yml
+
         - task: NuGetCommand@2
           displayName: 'NuGet restore'
           inputs:
@@ -146,8 +150,8 @@ extends:
             projects: |
               **\*.csproj
               !**\CustomActions.Package.csproj
-              feedsToUse: config
-              nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
+            feedsToUse: config
+            nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: VSBuild@1
           displayName: 'Build Solution **\*.sln'
@@ -269,6 +273,8 @@ extends:
           inputs:
             script: set
 
+        - template: prepare-nuget.yml
+
         - task: NuGetCommand@2
           displayName: 'NuGet restore'
           inputs:
@@ -282,8 +288,8 @@ extends:
             projects: |
               **\*.csproj
               !**\CustomActions.Package.csproj
-              feedsToUse: config
-              nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
+            feedsToUse: config
+            nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
         - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
           displayName: 'Component Detection'

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -13,6 +13,9 @@ jobs:
     name: $(a11yInsightsPool) # Name of your hosted pool
     image: windows-2022-secure # Name of the image in your pool. If not specified, first image of the pool is used
     os: windows # OS of the image. Allowed values: windows, linux, macOS
+  templateContext:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean 
   steps:
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -1,4 +1,4 @@
-﻿# Copyright (c) Microsoft. All rights reserved.
+# Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 # This template contains jobs to run UI tests using WinAppDriver.
 
@@ -22,9 +22,7 @@ jobs:
     inputs:
       versionSpec: '5.x'
 
-  # Authenticate to the private Azure Artifacts feed defined in nuget.config
-  - task: NuGetAuthenticate@1
-    displayName: 'Authenticate to NuGet feeds'
+  - template: prepare-nuget.yml
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -32,7 +32,7 @@ jobs:
       command: restore
       restoreSolution: '**/*.sln'
       feedsToUse: config
-      nugetConfigPath: '$(Build.SourcesDirectory)/nuget.config'
+      nugetConfigPath: '$(Build.SourcesDirectory)/src/nuget.config'
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
@@ -40,7 +40,7 @@ jobs:
       vsVersion: 17.0
       platform: '$(BuildPlatform)'
       configuration: ${{ parameters.configuration }}
-      msbuildArgs: '/restore /p:RestoreConfigFile=$(Build.SourcesDirectory)/nuget.config'
+      msbuildArgs: '/restore /p:RestoreConfigFile=$(Build.SourcesDirectory)/src/nuget.config'
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Start - WinAppDriver'

--- a/build/ui-test-job.yml
+++ b/build/ui-test-job.yml
@@ -15,15 +15,24 @@ jobs:
     os: windows # OS of the image. Allowed values: windows, linux, macOS
   templateContext:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean 
+      networkIsolationPolicy: Permissive,CFSClean
   steps:
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 5.x'
     inputs:
       versionSpec: '5.x'
 
+  # Authenticate to the private Azure Artifacts feed defined in nuget.config
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate to NuGet feeds'
+
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
+    inputs:
+      command: restore
+      restoreSolution: '**/*.sln'
+      feedsToUse: config
+      nugetConfigPath: '$(Build.SourcesDirectory)/nuget.config'
 
   - task: VSBuild@1
     displayName: 'Build Solution **\*.sln'
@@ -31,6 +40,7 @@ jobs:
       vsVersion: 17.0
       platform: '$(BuildPlatform)'
       configuration: ${{ parameters.configuration }}
+      msbuildArgs: '/restore /p:RestoreConfigFile=$(Build.SourcesDirectory)/nuget.config'
 
   - task: WinAppDriver.winappdriver-pipelines-task.winappdriver-pipelines-task.Windows Application Driver@0
     displayName: 'Start - WinAppDriver'

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -2,11 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="a11y-insights-public" value="https://accessibility-insights.pkgs.visualstudio.com/_packaging/a11y-insights-public/nuget/v3/index.json" />
+    <add key="a11y-insights-public" value="https://pkgs.dev.azure.com/accessibility-insights/_packaging/a11y-insights-public/nuget/v3/index.json" />
   </packageSources>
-  <packageSourceMapping>
-    <packageSource key="a11y-insights-public">
-      <package pattern="*" />
-    </packageSource>    
-  </packageSourceMapping>
 </configuration>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="a11y-insights-windows" value="https://pkgs.dev.azure.com/accessibility-insights-private/c79273f4-2dcc-480f-852b-0267a30c82db/_packaging/a11y-insights-windows/nuget/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="a11y-insights-windows">
+      <package pattern="*" />
+    </packageSource>    
+  </packageSourceMapping>
+</configuration>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -2,10 +2,10 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="a11y-insights-windows" value="https://pkgs.dev.azure.com/accessibility-insights-private/c79273f4-2dcc-480f-852b-0267a30c82db/_packaging/a11y-insights-windows/nuget/v3/index.json" />
+    <add key="a11y-insights-public" value="https://accessibility-insights.pkgs.visualstudio.com/_packaging/a11y-insights-public/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="a11y-insights-windows">
+    <packageSource key="a11y-insights-public">
       <package pattern="*" />
     </packageSource>    
   </packageSourceMapping>


### PR DESCRIPTION
> **Draft / CI validation only — do not merge.**
> Throwaway branch to exercise the pipeline. The real change is #1947; this exists so that PR is not polluted with test commits.

## Purpose

#1947 pins all restores to the private Azure Artifacts feed for SFI-ES4.2.4 (CFSClean). Every job in it currently fails:

```
MSI.wixproj(2,3): error : Could not resolve SDK "WixToolset.Sdk".
  Unable to find package WixToolset.Sdk. No packages exist with this id in source(s): a11y-insights-public
  warning : Unable to load the service index for source https://pkgs.dev.azure.com/.../a11y-insights-public/...
MSI.wixproj(2,31): error MSB4236: The SDK 'WixToolset.Sdk/4.0.1' specified could not be found.
```

## Root cause

`src/MSI/MSI.wixproj` imports `WixToolset.Sdk` as an **MSBuild project SDK**. MSBuild resolves project SDKs at *evaluation* time via the NuGet SDK resolver, which is a different code path from package restore: it does not use the Azure Artifacts credential provider and ignores `nugetConfigPath` (NuGet/Home#7855, NuGet/Home#10178).

So it can reach neither the private feed (401) nor nuget.org (blocked by CFSClean). It is the **only** NuGet-delivered MSBuild SDK in the repo — the other 29 projects use the in-box `Microsoft.NET.Sdk*`, which resolve from disk.

Notably this is **not** a permissions issue: `Project Collection Build Service` already has Collaborator on the feed, `NuGetAuthenticate@1` succeeds, and `WixToolset.Sdk 4.0.1` is cached there.

## Change

`build/prepare-nuget.yml` — a shared step template that authenticates, then downloads the SDK into the NuGet global packages folder before anything evaluates the solution, so resolution succeeds offline. The version is read from `MSI.wixproj` so the two cannot drift. It also replaces the `NuGetAuthenticate@1` step duplicated across six call sites.

Plus two correctness fixes:
- `check-dependencies.yml` — `networkIsolationPolicy` moved from `pool:` to `templateContext.settings`
- `signedbuild.yml` — `feedsToUse`/`nugetConfigPath` un-nested from the `projects: |` block scalar in all three `DotNetCoreCLI@2` restores, where they were being parsed as project globs

## Verified locally

- Script extracted from the YAML, macros expanded, executed verbatim → SDK downloaded
- Real `MSI.wixproj` resolves its SDK against a **completely unreachable feed**
- Control: empty packages folder + unreachable feed reproduces the exact `MSB4236` failure

## What this PR is meant to prove

1. Nested template resolution (`- template: prepare-nuget.yml`) works in ADO
2. The seed step runs correctly on the hosted agent
3. The full restore/build/test completes with the feed pinned
4. `Stop Network Isolation` reports **CFSClean COMPLIANT**
